### PR TITLE
fix: Grok API model/input format + GPT meal plan JSON parsing

### DIFF
--- a/src/lib/grokAgent.ts
+++ b/src/lib/grokAgent.ts
@@ -198,8 +198,8 @@ IMPORTANT:
         'Authorization': `Bearer ${apiKey}`,
       },
       body: JSON.stringify({
-        model: 'grok-4-1-fast',
-        input: prompt,
+        model: 'grok-4-1-fast-reasoning',
+        input: [{ role: 'user', content: prompt }],
         tools: [
           { type: 'web_search' },
           { type: 'x_search' },
@@ -213,7 +213,14 @@ IMPORTANT:
       throw new Error(`Grok API error: ${response.status}`);
     }
 
-    const data: XAIResponse = await response.json();
+    const responseText = await response.text();
+    let data: XAIResponse;
+    try {
+      data = JSON.parse(responseText);
+    } catch (jsonErr) {
+      console.error('[GrokAgent] API returned non-JSON response:', responseText.substring(0, 500));
+      throw new Error('Grok API returned invalid JSON response');
+    }
     
     // Extract text content and citations
     let textContent = '';


### PR DESCRIPTION
Grok API (grokAgent.ts):
- Model: grok-4-1-fast → grok-4-1-fast-reasoning (per xAI docs)
- Input: plain string → message array format (required by /v1/responses)
- Add safe JSON parsing with error logging for non-JSON responses

Meal Plan API (route.ts):
- Add response_format: json_object to force valid JSON from GPT-4o
- Increase max_tokens 8000 → 16000 (meal-prep plans were truncating)
- Add fallback JSON object extraction when code block regex misses

https://claude.ai/code/session_014rERbaTZWEcvs8J7phaJh8