### PR TITLE
security: add auth + tier gating to unprotected AI and market data AP…

### DIFF
--- a/src/app/api/ai/market-brief/route.ts
+++ b/src/app/api/ai/market-brief/route.ts
@@ -1,4 +1,7 @@
 import { NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import { prisma } from '@/lib/prisma';
+import { requireTier } from '@/lib/auth-helpers';
 import Anthropic from '@anthropic-ai/sdk';
 
 async function callWithRetry(client: Anthropic, params: any, maxRetries = 3): Promise<any> {
@@ -123,6 +126,20 @@ Respond with ONLY valid JSON, no markdown, no code blocks, no preamble:
 
 export async function POST(request: Request) {
   try {
+    const cookieStore = await cookies();
+    const userEmail = cookieStore.get('userEmail')?.value;
+    if (!userEmail) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    const user = await prisma.users.findFirst({
+      where: { email: { equals: userEmail, mode: 'insensitive' } }
+    });
+    if (!user) {
+      return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    }
+    const tierGate = requireTier(user.tier, 'ai');
+    if (tierGate) return tierGate;
+
     const apiKey = process.env.ANTHROPIC_API_KEY;
     if (!apiKey) {
       return NextResponse.json({ error: 'API key not configured' }, { status: 500 });

--- a/src/app/api/finnhub/ticker-context/route.ts
+++ b/src/app/api/finnhub/ticker-context/route.ts
@@ -1,6 +1,20 @@
 import { NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import { prisma } from '@/lib/prisma';
 
 export async function GET(request: Request) {
+  const cookieStore = await cookies();
+  const userEmail = cookieStore.get('userEmail')?.value;
+  if (!userEmail) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const user = await prisma.users.findFirst({
+    where: { email: { equals: userEmail, mode: 'insensitive' } }
+  });
+  if (!user) {
+    return NextResponse.json({ error: 'User not found' }, { status: 404 });
+  }
+
   const { searchParams } = new URL(request.url);
   const symbol = searchParams.get('symbol');
 

--- a/src/app/api/test/convergence/route.ts
+++ b/src/app/api/test/convergence/route.ts
@@ -1,4 +1,6 @@
 import { NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import { prisma } from '@/lib/prisma';
 import { getTastytradeClient } from '@/lib/tastytrade';
 import { CandleType } from '@tastytrade/api';
 import { scoreAll } from '@/lib/convergence/composite';
@@ -199,6 +201,18 @@ async function fetchFinnhubEarnings(symbol: string, apiKey: string): Promise<{ d
 // ===== MAIN ROUTE =====
 
 export async function GET(request: Request) {
+  const cookieStore = await cookies();
+  const userEmail = cookieStore.get('userEmail')?.value;
+  if (!userEmail) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const user = await prisma.users.findFirst({
+    where: { email: { equals: userEmail, mode: 'insensitive' } }
+  });
+  if (!user) {
+    return NextResponse.json({ error: 'User not found' }, { status: 404 });
+  }
+
   const pipelineStart = Date.now();
   const { searchParams } = new URL(request.url);
   const symbol = (searchParams.get('symbol') || 'AAPL').toUpperCase();

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -15,7 +15,6 @@ const PUBLIC_PATHS = [
   '/favicon.ico',
   '/pricing',
   '/api/stripe/webhook',
-  '/api/test/convergence',
   '/opengraph-image',
   '/terms',
   '/privacy',


### PR DESCRIPTION
…I routes

- Remove /api/test/convergence from PUBLIC_PATHS (was fully public, makes 10 external API calls)
- Add cookie auth + DB lookup + requireTier('ai') to convergence-synthesis (Anthropic)
- Add cookie auth + DB lookup + requireTier('ai') to market-brief (Anthropic)
- Add cookie auth + DB lookup + requireTier('ai') to strategy-analysis (Anthropic)
- Add cookie auth + DB lookup to finnhub/ticker-context (Finnhub)
- Add cookie auth + DB lookup to test/convergence as defense-in-depth (Finnhub, FRED, Tastytrade)

All auth follows the exact same pattern as the existing secured route (api/ai/cart-plan): cookies() → userEmail → prisma lookup → requireTier.

https://claude.ai/code/session_01GQdtsdAsLVrdzssQLJxMRq