### PR TITLE
security: HMAC-sign userEmail cookie to prevent forgery

### DIFF
--- a/src/app/api/accounts/route.ts
+++ b/src/app/api/accounts/route.ts
@@ -1,11 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function GET(request: NextRequest) {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });

--- a/src/app/api/accounts/update-entity/route.ts
+++ b/src/app/api/accounts/update-entity/route.ts
@@ -1,11 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function POST(request: NextRequest) {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/src/app/api/agenda/[id]/route.ts
+++ b/src/app/api/agenda/[id]/route.ts
@@ -1,12 +1,11 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function GET(request: Request, { params }: { params: Promise<{ id: string }> }) {
   try {
     const { id } = await params;
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
@@ -36,8 +35,7 @@ export async function GET(request: Request, { params }: { params: Promise<{ id: 
 export async function PATCH(request: Request, { params }: { params: Promise<{ id: string }> }) {
   try {
     const { id } = await params;
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/src/app/api/agenda/route.ts
+++ b/src/app/api/agenda/route.ts
@@ -1,11 +1,10 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function GET() {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
@@ -56,8 +55,7 @@ export async function GET() {
 
 export async function POST(request: Request) {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/src/app/api/ai/cart-plan/route.ts
+++ b/src/app/api/ai/cart-plan/route.ts
@@ -1,8 +1,8 @@
 import { requireTier } from '@/lib/auth-helpers';
 import { NextRequest, NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
 import OpenAI from 'openai';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 type CartCategory = 'clothing' | 'hygiene' | 'cleaning' | 'kitchen';
 
@@ -74,8 +74,7 @@ Do NOT include: appliances (blender, toaster, etc.), cookware (pots, pans), dinn
 
 export async function POST(request: NextRequest) {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/src/app/api/ai/convergence-synthesis/route.ts
+++ b/src/app/api/ai/convergence-synthesis/route.ts
@@ -1,10 +1,10 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
 import { requireTier } from '@/lib/auth-helpers';
 import Anthropic from '@anthropic-ai/sdk';
 import { runPipeline } from '@/lib/convergence/pipeline';
 import type { PipelineResult } from '@/lib/convergence/pipeline';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export const maxDuration = 300;
 
@@ -165,8 +165,7 @@ function prepareSynthesisPayload(pipeline: PipelineResult): object {
 
 export async function GET(request: Request) {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/src/app/api/ai/market-brief/route.ts
+++ b/src/app/api/ai/market-brief/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
 import { requireTier } from '@/lib/auth-helpers';
 import Anthropic from '@anthropic-ai/sdk';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 async function callWithRetry(client: Anthropic, params: any, maxRetries = 3): Promise<any> {
   for (let i = 0; i < maxRetries; i++) {
@@ -126,8 +126,7 @@ Respond with ONLY valid JSON, no markdown, no code blocks, no preamble:
 
 export async function POST(request: Request) {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/src/app/api/ai/meal-plan/route.ts
+++ b/src/app/api/ai/meal-plan/route.ts
@@ -1,8 +1,8 @@
 import { requireTier } from '@/lib/auth-helpers';
 import { NextRequest, NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
 import OpenAI from 'openai';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 interface MealProfile {
   peopleCount: number;
@@ -40,8 +40,7 @@ const COMPLEXITY_TIME: Record<string, { prep: number; cook: number }> = {
 
 export async function POST(request: NextRequest) {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/src/app/api/ai/meal-planner/route.ts
+++ b/src/app/api/ai/meal-planner/route.ts
@@ -1,8 +1,8 @@
 import { requireTier } from '@/lib/auth-helpers';
 import { NextRequest, NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
 import OpenAI from 'openai';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 const SYSTEM_PROMPT = `You are a personalized shopping assistant for Temple Stuart, a financial OS. Your job is to help users create smart shopping lists across ALL categories with appropriate purchase frequencies.
 
@@ -71,8 +71,7 @@ Be conversational, helpful, and budget-conscious. Focus on quality essentials ov
 
 export async function POST(req: NextRequest) {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/src/app/api/ai/spending-insights/route.ts
+++ b/src/app/api/ai/spending-insights/route.ts
@@ -1,13 +1,12 @@
 import { requireTier } from '@/lib/auth-helpers';
 import { NextRequest, NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
 import OpenAI from 'openai';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function POST(req: NextRequest) {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/src/app/api/ai/strategy-analysis/route.ts
+++ b/src/app/api/ai/strategy-analysis/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
 import { requireTier } from '@/lib/auth-helpers';
 import Anthropic from '@anthropic-ai/sdk';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 async function callWithRetry(client: Anthropic, params: any, maxRetries = 3): Promise<any> {
   for (let i = 0; i < maxRetries; i++) {
@@ -102,8 +102,7 @@ No markdown. No code blocks. No preamble. Just the JSON array.`;
 
 export async function POST(request: Request) {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -4,6 +4,7 @@ import GitHubProvider from 'next-auth/providers/github';
 import { PrismaAdapter } from '@auth/prisma-adapter';
 import { PrismaClient } from '@prisma/client';
 import { cookies } from 'next/headers';
+import { signCookie } from '@/lib/cookie-auth';
 
 const prisma = new PrismaClient();
 
@@ -45,7 +46,7 @@ const handler = NextAuth({
         
         // Set the userEmail cookie for API routes
         const cookieStore = await cookies();
-        cookieStore.set('userEmail', user.email, {
+        cookieStore.set('userEmail', signCookie(user.email), {
           httpOnly: true,
           secure: process.env.NODE_ENV === 'production',
           sameSite: 'lax',

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import bcrypt from 'bcryptjs';
 import { prisma } from '@/lib/prisma';
+import { signCookie } from '@/lib/cookie-auth';
 
 export async function POST(request: Request) {
   try {
@@ -48,7 +49,7 @@ export async function POST(request: Request) {
       user: { email: user.email, name: user.name }
     });
 
-    response.cookies.set('userEmail', user.email, {
+    response.cookies.set('userEmail', signCookie(user.email), {
       httpOnly: true,
       secure: true,
       sameSite: 'lax',

--- a/src/app/api/auth/me/route.ts
+++ b/src/app/api/auth/me/route.ts
@@ -1,11 +1,10 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function GET() {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
 
     if (!userEmail) {
       return NextResponse.json(

--- a/src/app/api/auth/register/route.ts
+++ b/src/app/api/auth/register/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import bcrypt from 'bcryptjs';
 import { prisma } from '@/lib/prisma';
 import { v4 as uuidv4 } from 'uuid';
+import { signCookie } from '@/lib/cookie-auth';
 
 export async function POST(request: Request) {
   try {
@@ -52,7 +53,7 @@ export async function POST(request: Request) {
       user: { email: user.email, name: user.name }
     });
 
-    response.cookies.set('userEmail', user.email, {
+    response.cookies.set('userEmail', signCookie(user.email), {
       httpOnly: true,
       secure: true,
       sameSite: 'lax',

--- a/src/app/api/auth/signup/route.ts
+++ b/src/app/api/auth/signup/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { cookies } from 'next/headers';
 import bcrypt from 'bcryptjs';
 import { prisma } from '@/lib/prisma';
+import { signCookie } from '@/lib/cookie-auth';
 
 export async function POST(request: Request) {
   try {
@@ -45,7 +46,7 @@ export async function POST(request: Request) {
 
     // Set secure cookie
     const cookieStore = await cookies();
-    cookieStore.set('userEmail', user.email, {
+    cookieStore.set('userEmail', signCookie(user.email), {
       httpOnly: true,
       secure: process.env.NODE_ENV === 'production',
       sameSite: 'strict',

--- a/src/app/api/auto/[id]/route.ts
+++ b/src/app/api/auto/[id]/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
 import { randomUUID } from 'crypto';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 const MODULE = 'auto';
 const ICON = '🚗';
@@ -10,8 +10,7 @@ const COLOR = 'gray';
 export async function PATCH(request: Request, { params }: { params: Promise<{ id: string }> }) {
   try {
     const { id } = await params;
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     
     const user = await prisma.users.findFirst({ where: { email: userEmail } });

--- a/src/app/api/auto/route.ts
+++ b/src/app/api/auto/route.ts
@@ -1,13 +1,12 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 const MODULE = 'auto';
 
 export async function GET() {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     
     const user = await prisma.users.findFirst({ where: { email: userEmail } });
@@ -24,8 +23,7 @@ export async function GET() {
 
 export async function POST(request: Request) {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     
     const user = await prisma.users.findFirst({ where: { email: userEmail } });

--- a/src/app/api/bank-reconciliations/route.ts
+++ b/src/app/api/bank-reconciliations/route.ts
@@ -1,11 +1,10 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function GET(request: Request) {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
     const user = await prisma.users.findFirst({
@@ -37,8 +36,7 @@ export async function GET(request: Request) {
 
 export async function POST(request: Request) {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
     const user = await prisma.users.findFirst({

--- a/src/app/api/budgets/route.ts
+++ b/src/app/api/budgets/route.ts
@@ -1,11 +1,10 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function GET(request: Request) {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
     const user = await prisma.users.findFirst({
@@ -29,8 +28,7 @@ export async function GET(request: Request) {
 
 export async function POST(request: Request) {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
     const user = await prisma.users.findFirst({

--- a/src/app/api/business/[id]/route.ts
+++ b/src/app/api/business/[id]/route.ts
@@ -1,14 +1,13 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 const MODULE = 'business';
 
 export async function PATCH(request: Request, { params }: { params: Promise<{ id: string }> }) {
   try {
     const { id } = await params;
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     
     const user = await prisma.users.findFirst({ where: { email: userEmail } });
@@ -126,8 +125,7 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ id
 export async function DELETE(request: Request, { params }: { params: Promise<{ id: string }> }) {
   try {
     const { id } = await params;
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     
     const user = await prisma.users.findFirst({ where: { email: userEmail } });

--- a/src/app/api/business/route.ts
+++ b/src/app/api/business/route.ts
@@ -1,13 +1,12 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 const MODULE = 'business';
 
 export async function GET() {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     
     const user = await prisma.users.findFirst({ where: { email: userEmail } });
@@ -37,8 +36,7 @@ export async function GET() {
 
 export async function POST(request: Request) {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     
     const user = await prisma.users.findFirst({ where: { email: userEmail } });

--- a/src/app/api/calendar/route.ts
+++ b/src/app/api/calendar/route.ts
@@ -1,11 +1,10 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function GET(request: Request) {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/src/app/api/chart-of-accounts/balances/route.ts
+++ b/src/app/api/chart-of-accounts/balances/route.ts
@@ -1,11 +1,10 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function GET() {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/src/app/api/chart-of-accounts/route.ts
+++ b/src/app/api/chart-of-accounts/route.ts
@@ -1,11 +1,10 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function GET(request: Request) {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
 
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });

--- a/src/app/api/closing-periods/close/route.ts
+++ b/src/app/api/closing-periods/close/route.ts
@@ -1,13 +1,12 @@
 import { randomUUID } from 'crypto';
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
 import { journalEntryService } from '@/lib/journal-entry-service';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function POST(request: Request) {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/src/app/api/closing-periods/reopen/route.ts
+++ b/src/app/api/closing-periods/reopen/route.ts
@@ -1,11 +1,10 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function POST(request: Request) {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/src/app/api/closing-periods/route.ts
+++ b/src/app/api/closing-periods/route.ts
@@ -1,11 +1,10 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function GET() {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/src/app/api/corporate-actions/route.ts
+++ b/src/app/api/corporate-actions/route.ts
@@ -1,13 +1,12 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
 import { v4 as uuidv4 } from 'uuid';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 // GET: List corporate actions for a symbol or all
 export async function GET(request: Request) {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
     const user = await prisma.users.findFirst({
@@ -39,8 +38,7 @@ export async function GET(request: Request) {
 // POST: Record a corporate action (split, dividend, etc.)
 export async function POST(request: Request) {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
     const user = await prisma.users.findFirst({

--- a/src/app/api/developer/prospects/[id]/route.ts
+++ b/src/app/api/developer/prospects/[id]/route.ts
@@ -1,14 +1,13 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function PATCH(
   request: Request,
   context: { params: Promise<{ id: string }> }
 ) {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
@@ -33,8 +32,7 @@ export async function DELETE(
   context: { params: Promise<{ id: string }> }
 ) {
   try {
-    const cookieStore2 = await cookies();
-    const userEmail2 = cookieStore2.get('userEmail')?.value;
+    const userEmail2 = await getVerifiedEmail();
     if (!userEmail2) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/src/app/api/developer/prospects/route.ts
+++ b/src/app/api/developer/prospects/route.ts
@@ -1,11 +1,10 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function GET() {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/src/app/api/fetch-og/route.ts
+++ b/src/app/api/fetch-og/route.ts
@@ -1,11 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function POST(request: NextRequest) {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/src/app/api/finnhub/ticker-context/route.ts
+++ b/src/app/api/finnhub/ticker-context/route.ts
@@ -1,10 +1,9 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function GET(request: Request) {
-  const cookieStore = await cookies();
-  const userEmail = cookieStore.get('userEmail')?.value;
+  const userEmail = await getVerifiedEmail();
   if (!userEmail) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }

--- a/src/app/api/flights/book/route.ts
+++ b/src/app/api/flights/book/route.ts
@@ -1,12 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
 import { getOffer, createOrder, PassengerDetails } from '@/lib/duffel';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function POST(request: NextRequest) {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/src/app/api/flights/search/route.ts
+++ b/src/app/api/flights/search/route.ts
@@ -1,12 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
 import { searchFlights, parseOffer } from '@/lib/duffel';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function GET(request: NextRequest) {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/src/app/api/growth/[id]/route.ts
+++ b/src/app/api/growth/[id]/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
 import { randomUUID } from 'crypto';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 const MODULE = 'growth';
 const ICON = '📚';
@@ -10,8 +10,7 @@ const COLOR = 'blue';
 export async function PATCH(request: Request, { params }: { params: Promise<{ id: string }> }) {
   try {
     const { id } = await params;
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     
     const user = await prisma.users.findFirst({ where: { email: userEmail } });

--- a/src/app/api/growth/route.ts
+++ b/src/app/api/growth/route.ts
@@ -1,13 +1,12 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 const MODULE = 'growth';
 
 export async function GET() {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     
     const user = await prisma.users.findFirst({ where: { email: userEmail } });
@@ -24,8 +23,7 @@ export async function GET() {
 
 export async function POST(request: Request) {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     
     const user = await prisma.users.findFirst({ where: { email: userEmail } });

--- a/src/app/api/health/[id]/route.ts
+++ b/src/app/api/health/[id]/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
 import { randomUUID } from 'crypto';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 const MODULE = 'health';
 const ICON = '💪';
@@ -10,8 +10,7 @@ const COLOR = 'green';
 export async function PATCH(request: Request, { params }: { params: Promise<{ id: string }> }) {
   try {
     const { id } = await params;
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     
     const user = await prisma.users.findFirst({ where: { email: userEmail } });

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,13 +1,12 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 const MODULE = 'health';
 
 export async function GET() {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     
     const user = await prisma.users.findFirst({ where: { email: userEmail } });
@@ -24,8 +23,7 @@ export async function GET() {
 
 export async function POST(request: Request) {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     
     const user = await prisma.users.findFirst({ where: { email: userEmail } });

--- a/src/app/api/home/[id]/route.ts
+++ b/src/app/api/home/[id]/route.ts
@@ -1,13 +1,12 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
 import { randomUUID } from 'crypto';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function PATCH(request: Request, { params }: { params: Promise<{ id: string }> }) {
   try {
     const { id } = await params;
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/src/app/api/home/route.ts
+++ b/src/app/api/home/route.ts
@@ -1,11 +1,10 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function GET() {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
@@ -89,8 +88,7 @@ export async function GET() {
 
 export async function POST(request: Request) {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/src/app/api/hub/business-budget/route.ts
+++ b/src/app/api/hub/business-budget/route.ts
@@ -1,14 +1,13 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function GET(request: Request) {
   try {
     const { searchParams } = new URL(request.url);
     const year = parseInt(searchParams.get('year') || new Date().getFullYear().toString());
     
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
 
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });

--- a/src/app/api/hub/nomad-budget/route.ts
+++ b/src/app/api/hub/nomad-budget/route.ts
@@ -1,14 +1,13 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function GET(request: Request) {
   try {
     const { searchParams } = new URL(request.url);
     const year = parseInt(searchParams.get('year') || new Date().getFullYear().toString());
     
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
 
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });

--- a/src/app/api/hub/trips/route.ts
+++ b/src/app/api/hub/trips/route.ts
@@ -1,11 +1,10 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function GET() {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
 
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });

--- a/src/app/api/hub/year-calendar/route.ts
+++ b/src/app/api/hub/year-calendar/route.ts
@@ -1,14 +1,13 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function GET(request: Request) {
   try {
     const { searchParams } = new URL(request.url);
     const year = parseInt(searchParams.get('year') || new Date().getFullYear().toString());
     
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
 
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });

--- a/src/app/api/income/route.ts
+++ b/src/app/api/income/route.ts
@@ -1,11 +1,10 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function GET() {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/src/app/api/investment-transactions/analyze/route.ts
+++ b/src/app/api/investment-transactions/analyze/route.ts
@@ -1,11 +1,10 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function GET() {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
     const user = await prisma.users.findFirst({

--- a/src/app/api/investment-transactions/assign-coa/route.ts
+++ b/src/app/api/investment-transactions/assign-coa/route.ts
@@ -1,11 +1,10 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function POST(request: Request) {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
 
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });

--- a/src/app/api/investment-transactions/commit-to-ledger/route.ts
+++ b/src/app/api/investment-transactions/commit-to-ledger/route.ts
@@ -1,12 +1,11 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
 import { positionTrackerService } from '@/lib/position-tracker-service';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function POST(request: Request) {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/src/app/api/investment-transactions/fix-orphan/route.ts
+++ b/src/app/api/investment-transactions/fix-orphan/route.ts
@@ -1,12 +1,11 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 // POST: Fix orphaned transactions that were processed but not marked
 export async function POST(request: Request) {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
     const { transactionId, tradeNum, strategy, accountCode } = await request.json();

--- a/src/app/api/investment-transactions/max-trade-num/route.ts
+++ b/src/app/api/investment-transactions/max-trade-num/route.ts
@@ -1,11 +1,10 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function GET() {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
     const user = await prisma.users.findFirst({

--- a/src/app/api/investment-transactions/opens/route.ts
+++ b/src/app/api/investment-transactions/opens/route.ts
@@ -1,11 +1,10 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function GET() {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
     const user = await prisma.users.findFirst({

--- a/src/app/api/investment-transactions/route.ts
+++ b/src/app/api/investment-transactions/route.ts
@@ -1,11 +1,10 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function GET() {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
 
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });

--- a/src/app/api/investment-transactions/uncommit/route.ts
+++ b/src/app/api/investment-transactions/uncommit/route.ts
@@ -1,11 +1,10 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function POST(request: Request) {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/src/app/api/investments/analyze/route.ts
+++ b/src/app/api/investments/analyze/route.ts
@@ -1,12 +1,11 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
 import { plaidClient } from '@/lib/plaid';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function GET() {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
 
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });

--- a/src/app/api/investments/assignment-exercise/route.ts
+++ b/src/app/api/investments/assignment-exercise/route.ts
@@ -1,12 +1,11 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
 import { positionTrackerService } from '@/lib/position-tracker-service';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function POST(request: Request) {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/src/app/api/investments/route.ts
+++ b/src/app/api/investments/route.ts
@@ -1,12 +1,11 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
 import { plaidClient } from '@/lib/plaid';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function GET() {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
 
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });

--- a/src/app/api/journal-entries/manual/route.ts
+++ b/src/app/api/journal-entries/manual/route.ts
@@ -1,12 +1,11 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
 import { journalEntryService } from '@/lib/journal-entry-service';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function POST(request: Request) {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/src/app/api/journal-entries/route.ts
+++ b/src/app/api/journal-entries/route.ts
@@ -1,11 +1,10 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function GET() {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
     const user = await prisma.users.findFirst({
@@ -28,8 +27,7 @@ export async function GET() {
 
 export async function POST(request: Request) {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
     const user = await prisma.users.findFirst({

--- a/src/app/api/ledger/route.ts
+++ b/src/app/api/ledger/route.ts
@@ -1,11 +1,10 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function GET() {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/src/app/api/merchant-mappings/route.ts
+++ b/src/app/api/merchant-mappings/route.ts
@@ -1,12 +1,11 @@
 import { randomUUID } from 'crypto';
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function GET(request: Request) {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
@@ -61,8 +60,7 @@ export async function GET(request: Request) {
 
 export async function POST(request: Request) {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/src/app/api/metrics/route.ts
+++ b/src/app/api/metrics/route.ts
@@ -1,11 +1,10 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function GET() {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/src/app/api/net-worth/route.ts
+++ b/src/app/api/net-worth/route.ts
@@ -1,11 +1,10 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function GET() {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/src/app/api/period-closes/route.ts
+++ b/src/app/api/period-closes/route.ts
@@ -1,11 +1,10 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function GET(request: Request) {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
     const user = await prisma.users.findFirst({
@@ -30,8 +29,7 @@ export async function GET(request: Request) {
 
 export async function POST(request: Request) {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
     const user = await prisma.users.findFirst({

--- a/src/app/api/personal/[id]/route.ts
+++ b/src/app/api/personal/[id]/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
 import { randomUUID } from 'crypto';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 const MODULE = 'personal';
 const ICON = '👤';
@@ -10,8 +10,7 @@ const COLOR = 'purple';
 export async function PATCH(request: Request, { params }: { params: Promise<{ id: string }> }) {
   try {
     const { id } = await params;
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     
     const user = await prisma.users.findFirst({ where: { email: userEmail } });

--- a/src/app/api/personal/route.ts
+++ b/src/app/api/personal/route.ts
@@ -1,13 +1,12 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 const MODULE = 'personal';
 
 export async function GET() {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     
     const user = await prisma.users.findFirst({ where: { email: userEmail } });
@@ -24,8 +23,7 @@ export async function GET() {
 
 export async function POST(request: Request) {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     
     const user = await prisma.users.findFirst({ where: { email: userEmail } });

--- a/src/app/api/plaid/exchange-token/route.ts
+++ b/src/app/api/plaid/exchange-token/route.ts
@@ -1,14 +1,13 @@
 import { requireTier } from '@/lib/auth-helpers';
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
 import { plaidClient } from '@/lib/plaid';
 import { CountryCode } from 'plaid';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function POST(request: Request) {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
 
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });

--- a/src/app/api/plaid/items/route.ts
+++ b/src/app/api/plaid/items/route.ts
@@ -1,12 +1,11 @@
 import { requireTier } from '@/lib/auth-helpers';
 import { NextRequest, NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function GET(request: NextRequest) {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });

--- a/src/app/api/plaid/link-token/route.ts
+++ b/src/app/api/plaid/link-token/route.ts
@@ -1,14 +1,13 @@
 import { requireTier } from '@/lib/auth-helpers';
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
 import { plaidClient } from '@/lib/plaid';
 import { Products, CountryCode } from 'plaid';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function POST() {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
 
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });

--- a/src/app/api/plaid/sync/route.ts
+++ b/src/app/api/plaid/sync/route.ts
@@ -1,8 +1,8 @@
 import { requireTier } from '@/lib/auth-helpers';
 import { NextRequest, NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
 import { Configuration, PlaidApi, PlaidEnvironments } from 'plaid';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 const plaidConfig = new Configuration({
   basePath: PlaidEnvironments.production,
@@ -18,8 +18,7 @@ const plaidClient = new PlaidApi(plaidConfig);
 export async function POST(request: NextRequest) {
   try {
     // Verify user
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });

--- a/src/app/api/robinhood/append-history/route.ts
+++ b/src/app/api/robinhood/append-history/route.ts
@@ -1,13 +1,12 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
 import fs from 'fs/promises';
 import path from 'path';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function POST(request: Request) {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/src/app/api/robinhood/get-history/route.ts
+++ b/src/app/api/robinhood/get-history/route.ts
@@ -1,13 +1,12 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
 import fs from 'fs/promises';
 import path from 'path';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function GET() {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/src/app/api/shopping/[id]/route.ts
+++ b/src/app/api/shopping/[id]/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
 import { randomUUID } from 'crypto';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 const MODULE = 'shopping';
 const ICON = '🛒';
@@ -10,8 +10,7 @@ const COLOR = 'pink';
 export async function PATCH(request: Request, { params }: { params: Promise<{ id: string }> }) {
   try {
     const { id } = await params;
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     
     const user = await prisma.users.findFirst({ where: { email: userEmail } });
@@ -134,8 +133,7 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ id
 
 export async function DELETE(request: Request, { params }: { params: Promise<{ id: string }> }) {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     const user = await prisma.users.findFirst({ where: { email: userEmail } });
     if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });

--- a/src/app/api/shopping/commit/route.ts
+++ b/src/app/api/shopping/commit/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
 import { randomUUID } from 'crypto';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 const MODULE = 'shopping';
 const ICON = '🛒';
@@ -9,8 +9,7 @@ const COLOR = 'pink';
 
 export async function POST(request: NextRequest) {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
     const user = await prisma.users.findFirst({ where: { email: { equals: userEmail, mode: 'insensitive' } } });

--- a/src/app/api/shopping/route.ts
+++ b/src/app/api/shopping/route.ts
@@ -1,13 +1,12 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 const MODULE = 'shopping';
 
 export async function GET() {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     
     const user = await prisma.users.findFirst({ where: { email: userEmail } });
@@ -24,8 +23,7 @@ export async function GET() {
 
 export async function POST(request: Request) {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     
     const user = await prisma.users.findFirst({ where: { email: userEmail } });

--- a/src/app/api/statements/analysis/route.ts
+++ b/src/app/api/statements/analysis/route.ts
@@ -1,11 +1,10 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function GET(request: Request) {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/src/app/api/statements/route.ts
+++ b/src/app/api/statements/route.ts
@@ -1,11 +1,10 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function GET() {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/src/app/api/stats/route.ts
+++ b/src/app/api/stats/route.ts
@@ -1,11 +1,10 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function GET() {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
 
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });

--- a/src/app/api/stock-lots/commit/route.ts
+++ b/src/app/api/stock-lots/commit/route.ts
@@ -1,13 +1,12 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
 import { v4 as uuidv4 } from 'uuid';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 // POST: Commit a sale using the selected matching method
 export async function POST(request: Request) {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
     const user = await prisma.users.findFirst({

--- a/src/app/api/stock-lots/delete/route.ts
+++ b/src/app/api/stock-lots/delete/route.ts
@@ -1,12 +1,11 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 // POST: Delete stock lots (for cleanup)
 export async function POST(request: Request) {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
     const user = await prisma.users.findFirst({

--- a/src/app/api/stock-lots/match/route.ts
+++ b/src/app/api/stock-lots/match/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 interface Lot {
   id: string;
@@ -34,8 +34,7 @@ interface MatchResult {
 // POST: Calculate matching scenarios for a potential sale
 export async function POST(request: Request) {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
     const user = await prisma.users.findFirst({

--- a/src/app/api/stock-lots/route.ts
+++ b/src/app/api/stock-lots/route.ts
@@ -1,13 +1,12 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
 import { positionTrackerService } from '@/lib/position-tracker-service';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 // GET: List open lots for a symbol (or all symbols)
 export async function GET(request: Request) {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
     const user = await prisma.users.findFirst({
@@ -59,8 +58,7 @@ export async function GET(request: Request) {
 // POST: Create lots from investment transactions WITH journal entries
 export async function POST(request: Request) {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
     const user = await prisma.users.findFirst({

--- a/src/app/api/stripe/checkout/route.ts
+++ b/src/app/api/stripe/checkout/route.ts
@@ -1,12 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
 import { getStripe, getPriceIdFromTier } from '@/lib/stripe';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function POST(request: NextRequest) {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/src/app/api/stripe/portal/route.ts
+++ b/src/app/api/stripe/portal/route.ts
@@ -1,12 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
 import { getStripe } from '@/lib/stripe';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function POST(request: NextRequest) {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/src/app/api/tastytrade/balances/route.ts
+++ b/src/app/api/tastytrade/balances/route.ts
@@ -1,12 +1,11 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
 import { getAuthenticatedClient, getTastytradeConnection } from '@/lib/tastytrade';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function GET() {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/src/app/api/tastytrade/callback/route.ts
+++ b/src/app/api/tastytrade/callback/route.ts
@@ -1,14 +1,13 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
 import { getTastytradeClient } from '@/lib/tastytrade';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 // With OAuth, the SDK auto-refreshes access tokens.
 // This endpoint validates the OAuth client still works and updates lastUsedAt.
 export async function POST() {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/src/app/api/tastytrade/chains/route.ts
+++ b/src/app/api/tastytrade/chains/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
 import { getAuthenticatedClient } from '@/lib/tastytrade';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 // Convert OCC symbol (e.g. "SPY   260221P00690000") to DXFeed format (".SPY260221P690")
 function occToDxFeed(occ: string): string | null {
@@ -18,8 +18,7 @@ function occToDxFeed(occ: string): string | null {
 
 export async function POST(request: Request) {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/src/app/api/tastytrade/connect/route.ts
+++ b/src/app/api/tastytrade/connect/route.ts
@@ -1,12 +1,11 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
 import { getTastytradeClient } from '@/lib/tastytrade';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function POST() {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/src/app/api/tastytrade/disconnect/route.ts
+++ b/src/app/api/tastytrade/disconnect/route.ts
@@ -1,11 +1,10 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function POST() {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/src/app/api/tastytrade/greeks/route.ts
+++ b/src/app/api/tastytrade/greeks/route.ts
@@ -1,13 +1,12 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
 import { getAuthenticatedClient } from '@/lib/tastytrade';
 import { MarketDataSubscriptionType } from '@tastytrade/api';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function POST(request: Request) {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/src/app/api/tastytrade/positions/route.ts
+++ b/src/app/api/tastytrade/positions/route.ts
@@ -1,12 +1,11 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
 import { getAuthenticatedClient, getTastytradeConnection } from '@/lib/tastytrade';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function GET() {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/src/app/api/tastytrade/quotes/route.ts
+++ b/src/app/api/tastytrade/quotes/route.ts
@@ -1,13 +1,12 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
 import { getAuthenticatedClient } from '@/lib/tastytrade';
 import { MarketDataSubscriptionType } from '@tastytrade/api';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function POST(request: Request) {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/src/app/api/tastytrade/scanner/route.ts
+++ b/src/app/api/tastytrade/scanner/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
 import { getAuthenticatedClient } from '@/lib/tastytrade';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 const POPULAR_SYMBOLS = [
   'SPY','QQQ','IWM','AAPL','MSFT','GOOGL','AMZN','TSLA','NVDA','META',
@@ -151,8 +151,7 @@ const BATCH_SIZE = 50;
 
 export async function GET(request: Request) {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/src/app/api/tastytrade/status/route.ts
+++ b/src/app/api/tastytrade/status/route.ts
@@ -1,12 +1,11 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
 import { isTastytradeConnected } from '@/lib/tastytrade';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function GET() {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/src/app/api/test/convergence/route.ts
+++ b/src/app/api/test/convergence/route.ts
@@ -1,5 +1,4 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
 import { getTastytradeClient } from '@/lib/tastytrade';
 import { CandleType } from '@tastytrade/api';
@@ -8,6 +7,7 @@ import { fetchFredMacro, fetchAnnualFinancials, fetchOptionsFlow, fetchNewsSenti
 import { fetchChainAndBuildCards } from '@/lib/convergence/chain-fetcher';
 import type { ChainTickerInput } from '@/lib/convergence/chain-fetcher';
 import { generateTradeCards } from '@/lib/convergence/trade-cards';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 import type {
   CandleData,
   TTScannerData,
@@ -201,8 +201,7 @@ async function fetchFinnhubEarnings(symbol: string, apiKey: string): Promise<{ d
 // ===== MAIN ROUTE =====
 
 export async function GET(request: Request) {
-  const cookieStore = await cookies();
-  const userEmail = cookieStore.get('userEmail')?.value;
+  const userEmail = await getVerifiedEmail();
   if (!userEmail) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }

--- a/src/app/api/trading-journal/route.ts
+++ b/src/app/api/trading-journal/route.ts
@@ -1,11 +1,10 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function GET() {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
     const user = await prisma.users.findFirst({
@@ -27,8 +26,7 @@ export async function GET() {
 
 export async function POST(request: Request) {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
     const user = await prisma.users.findFirst({
@@ -90,8 +88,7 @@ export async function POST(request: Request) {
 
 export async function DELETE(request: Request) {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
     const user = await prisma.users.findFirst({

--- a/src/app/api/trading-positions/open/route.ts
+++ b/src/app/api/trading-positions/open/route.ts
@@ -1,11 +1,10 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function GET() {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/src/app/api/trading/route.ts
+++ b/src/app/api/trading/route.ts
@@ -1,11 +1,10 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function GET() {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/src/app/api/trading/trades/route.ts
+++ b/src/app/api/trading/trades/route.ts
@@ -1,11 +1,10 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function GET() {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
     const user = await prisma.users.findFirst({

--- a/src/app/api/transactions/assign-coa/route.ts
+++ b/src/app/api/transactions/assign-coa/route.ts
@@ -1,11 +1,10 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function POST(request: Request) {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/src/app/api/transactions/auto-categorize/route.ts
+++ b/src/app/api/transactions/auto-categorize/route.ts
@@ -1,12 +1,11 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
 import { autoCategorizationService } from '@/lib/auto-categorization-service';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function POST() {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/src/app/api/transactions/commit-to-ledger/route.ts
+++ b/src/app/api/transactions/commit-to-ledger/route.ts
@@ -1,13 +1,12 @@
 import { randomUUID } from 'crypto';
 import { NextRequest, NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
 import { journalEntryService } from '@/lib/journal-entry-service';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function POST(request: NextRequest) {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/src/app/api/transactions/fix-categories/route.ts
+++ b/src/app/api/transactions/fix-categories/route.ts
@@ -1,12 +1,11 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
 import { plaidClient } from '@/lib/plaid';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function POST() {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
 
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });

--- a/src/app/api/transactions/review-queue/route.ts
+++ b/src/app/api/transactions/review-queue/route.ts
@@ -1,11 +1,10 @@
 import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
-import { cookies } from 'next/headers';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function GET() {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
 
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });

--- a/src/app/api/transactions/route.ts
+++ b/src/app/api/transactions/route.ts
@@ -1,11 +1,10 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function GET() {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });

--- a/src/app/api/transactions/sync-complete/route.ts
+++ b/src/app/api/transactions/sync-complete/route.ts
@@ -1,12 +1,11 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
 import { plaidClient } from '@/lib/plaid';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function POST() {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
 
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });

--- a/src/app/api/transactions/sync-full/route.ts
+++ b/src/app/api/transactions/sync-full/route.ts
@@ -1,12 +1,11 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
 import { plaidClient } from '@/lib/plaid';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function POST() {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
 
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });

--- a/src/app/api/transactions/sync/route.ts
+++ b/src/app/api/transactions/sync/route.ts
@@ -1,12 +1,11 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
 import { plaidClient } from '@/lib/plaid';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function POST() {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
 
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });

--- a/src/app/api/transactions/update-sub-account/route.ts
+++ b/src/app/api/transactions/update-sub-account/route.ts
@@ -1,11 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function POST(request: NextRequest) {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/src/app/api/travel/flights/route.ts
+++ b/src/app/api/travel/flights/route.ts
@@ -1,11 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { searchFlights } from '@/lib/amadeus';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function GET(request: NextRequest) {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/src/app/api/travel/hotels/route.ts
+++ b/src/app/api/travel/hotels/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 // Amadeus Hotel Search
 async function getAccessToken(): Promise<string> {
@@ -31,8 +31,7 @@ async function getAccessToken(): Promise<string> {
 
 export async function GET(request: NextRequest) {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/src/app/api/travel/quote/route.ts
+++ b/src/app/api/travel/quote/route.ts
@@ -1,12 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { searchFlights } from '@/lib/amadeus';
 import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function GET(request: NextRequest) {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/src/app/api/travel/transfers/route.ts
+++ b/src/app/api/travel/transfers/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { searchTransfers } from '@/lib/amadeus';
 import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 // Map resort names to their nearest town/city for Amadeus API
 const RESORT_CITY_MAP: Record<string, string> = {
@@ -51,8 +51,7 @@ const RESORT_CITY_MAP: Record<string, string> = {
 
 export async function GET(request: NextRequest) {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/src/app/api/trips/[id]/activities/route.ts
+++ b/src/app/api/trips/[id]/activities/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function GET(request: Request, { params }: { params: Promise<{ id: string }> }) {
   try {
@@ -19,8 +19,7 @@ export async function GET(request: Request, { params }: { params: Promise<{ id: 
 export async function POST(request: Request, { params }: { params: Promise<{ id: string }> }) {
   try {
     const { id } = await params;
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
     const { category, title, vendor, url, price, is_per_person, per_person, notes } = await request.json();

--- a/src/app/api/trips/[id]/ai-assistant/route.ts
+++ b/src/app/api/trips/[id]/ai-assistant/route.ts
@@ -1,10 +1,10 @@
 import { requireTier } from '@/lib/auth-helpers';
 import { NextRequest, NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
 import { analyzeWithLiveSearch } from '@/lib/grokAgent';
 import { searchPlaces, CATEGORY_SEARCHES } from '@/lib/placesSearch';
 import { getCachedPlaces, cachePlaces, isCacheFresh } from '@/lib/placesCache';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 // Trip-type focused profile
 interface TravelerProfile {
@@ -52,8 +52,7 @@ export async function POST(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/src/app/api/trips/[id]/budget/route.ts
+++ b/src/app/api/trips/[id]/budget/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function GET(
   request: Request,
@@ -8,8 +8,7 @@ export async function GET(
 ) {
   try {
     const { id } = await params;
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
 
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });

--- a/src/app/api/trips/[id]/commit/route.ts
+++ b/src/app/api/trips/[id]/commit/route.ts
@@ -1,12 +1,11 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function POST(request: Request, { params }: { params: Promise<{ id: string }> }) {
   try {
     const { id } = await params;
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
@@ -246,8 +245,7 @@ export async function POST(request: Request, { params }: { params: Promise<{ id:
 export async function DELETE(request: Request, { params }: { params: Promise<{ id: string }> }) {
   try {
     const { id } = await params;
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/src/app/api/trips/[id]/destinations/route.ts
+++ b/src/app/api/trips/[id]/destinations/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 // Map activity to table name
 const ACTIVITY_TABLE_MAP: Record<string, string> = {
@@ -202,8 +202,7 @@ export async function GET(
 ) {
   try {
     const { id } = await params;
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
 
     if (!userEmail) {
       return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
@@ -244,8 +243,7 @@ export async function POST(
 ) {
   try {
     const { id } = await params;
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
 
     if (!userEmail) {
       return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
@@ -295,8 +293,7 @@ export async function DELETE(
 ) {
   try {
     const { id } = await params;
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
 
     if (!userEmail) {
       return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });

--- a/src/app/api/trips/[id]/expenses/route.ts
+++ b/src/app/api/trips/[id]/expenses/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
 import { Decimal } from '@prisma/client/runtime/library';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 // GET all expenses for a trip
 export async function GET(
@@ -10,8 +10,7 @@ export async function GET(
 ) {
   try {
     const { id } = await params;
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
 
     if (!userEmail) {
       return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
@@ -74,8 +73,7 @@ export async function POST(
 ) {
   try {
     const { id } = await params;
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
 
     if (!userEmail) {
       return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });

--- a/src/app/api/trips/[id]/lodging/route.ts
+++ b/src/app/api/trips/[id]/lodging/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function GET(request: Request, { params }: { params: Promise<{ id: string }> }) {
   try {
@@ -22,8 +22,7 @@ export async function GET(request: Request, { params }: { params: Promise<{ id: 
 export async function POST(request: Request, { params }: { params: Promise<{ id: string }> }) {
   try {
     const { id } = await params;
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
     const { url, title, image_url, location, price_per_night, total_price, taxes_estimate, per_person, notes } = await request.json();

--- a/src/app/api/trips/[id]/participants/route.ts
+++ b/src/app/api/trips/[id]/participants/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
 import { randomBytes } from 'crypto';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 // GET all participants for a trip
 export async function GET(
@@ -10,8 +10,7 @@ export async function GET(
 ) {
   try {
     const { id } = await params;
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
 
     if (!userEmail) {
       return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
@@ -74,8 +73,7 @@ export async function POST(
 ) {
   try {
     const { id } = await params;
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
 
     if (!userEmail) {
       return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
@@ -155,8 +153,7 @@ export async function DELETE(
 ) {
   try {
     const { id } = await params;
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
 
     if (!userEmail) {
       return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });

--- a/src/app/api/trips/[id]/route.ts
+++ b/src/app/api/trips/[id]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 // GET single trip
 export async function GET(
@@ -9,8 +9,7 @@ export async function GET(
 ) {
   try {
     const { id } = await params;
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
 
     if (!userEmail) {
       return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
@@ -95,8 +94,7 @@ export async function DELETE(
 ) {
   try {
     const { id } = await params;
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
 
     if (!userEmail) {
       return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
@@ -158,8 +156,7 @@ export async function PATCH(
 ) {
   try {
     const { id } = await params;
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
 
     if (!userEmail) {
       return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });

--- a/src/app/api/trips/[id]/transfers/route.ts
+++ b/src/app/api/trips/[id]/transfers/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function GET(request: Request, { params }: { params: Promise<{ id: string }> }) {
   try {
@@ -19,8 +19,7 @@ export async function GET(request: Request, { params }: { params: Promise<{ id: 
 export async function POST(request: Request, { params }: { params: Promise<{ id: string }> }) {
   try {
     const { id } = await params;
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
     const { url, transfer_type, direction, title, vendor, price, per_person, notes } = await request.json();

--- a/src/app/api/trips/[id]/vehicles/route.ts
+++ b/src/app/api/trips/[id]/vehicles/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function GET(request: Request, { params }: { params: Promise<{ id: string }> }) {
   try {
@@ -19,8 +19,7 @@ export async function GET(request: Request, { params }: { params: Promise<{ id: 
 export async function POST(request: Request, { params }: { params: Promise<{ id: string }> }) {
   try {
     const { id } = await params;
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
     const { url, vehicle_type, title, vendor, price_per_day, total_price, per_person, notes } = await request.json();

--- a/src/app/api/trips/route.ts
+++ b/src/app/api/trips/route.ts
@@ -1,13 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
 import { randomBytes } from 'crypto';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 // GET all trips for current user
 export async function GET() {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
 
     if (!userEmail) {
       return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
@@ -56,8 +55,7 @@ export async function GET() {
 // POST create new trip
 export async function POST(request: NextRequest) {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
 
     if (!userEmail) {
       return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -67,11 +67,8 @@ export default function Dashboard() {
   const [isAssigning, setIsAssigning] = useState(false);
   const [activeSection, setActiveSection] = useState<string>('accounts');
 
-  useEffect(() => {
-    if (session?.user?.email) {
-      document.cookie = `userEmail=${session.user.email}; path=/; max-age=${60 * 60 * 24 * 30}; samesite=lax`;
-    }
-  }, [session]);
+  // Cookie is now HMAC-signed server-side (login/register/nextauth).
+  // Client-side writes removed to prevent overwriting signed cookies.
 
   const loadData = useCallback(async () => {
     try {

--- a/src/components/ui/AppLayout.tsx
+++ b/src/components/ui/AppLayout.tsx
@@ -58,11 +58,8 @@ export default function AppLayout({ children }: AppLayoutProps) {
     checkCookieAuth();
   }, []);
 
-  useEffect(() => {
-    if (session?.user?.email) {
-      document.cookie = `userEmail=${session.user.email}; path=/; max-age=${60 * 60 * 24 * 30}; samesite=lax`;
-    }
-  }, [session]);
+  // Cookie is now HMAC-signed server-side (login/register/nextauth).
+  // Client-side writes removed to prevent overwriting signed cookies.
 
   const isAuthenticated = session?.user || cookieUser;
   const currentUser = session?.user || cookieUser;

--- a/src/lib/auth-helpers.ts
+++ b/src/lib/auth-helpers.ts
@@ -1,15 +1,14 @@
-import { cookies } from 'next/headers';
 import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { canAccess, TierConfig } from '@/lib/tiers';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 /**
- * Get current authenticated user from cookie.
- * Returns null if not authenticated.
+ * Get current authenticated user from HMAC-verified cookie.
+ * Returns null if not authenticated or cookie signature is invalid.
  */
 export async function getCurrentUser() {
-  const cookieStore = await cookies();
-  const userEmail = cookieStore.get('userEmail')?.value;
+  const userEmail = await getVerifiedEmail();
 
   if (!userEmail) return null;
 

--- a/src/lib/cookie-auth.ts
+++ b/src/lib/cookie-auth.ts
@@ -1,0 +1,59 @@
+import crypto from 'crypto';
+import { cookies } from 'next/headers';
+
+function getSecret(): string {
+  const secret = process.env.JWT_SECRET;
+  if (!secret) {
+    throw new Error('JWT_SECRET environment variable is required for cookie signing');
+  }
+  return secret;
+}
+
+/**
+ * Sign an email string with HMAC-SHA256.
+ * Format: email.hmacHexDigest
+ */
+export function signCookie(email: string): string {
+  const secret = getSecret();
+  const hmac = crypto.createHmac('sha256', secret).update(email).digest('hex');
+  return `${email}.${hmac}`;
+}
+
+/**
+ * Verify an HMAC-signed cookie value.
+ * Returns the email if valid, null if tampered or malformed.
+ */
+export function verifyCookie(cookieValue: string): string | null {
+  try {
+    const secret = getSecret();
+    const lastDot = cookieValue.lastIndexOf('.');
+    if (lastDot === -1) return null;
+
+    const email = cookieValue.substring(0, lastDot);
+    const signature = cookieValue.substring(lastDot + 1);
+
+    const expected = crypto.createHmac('sha256', secret).update(email).digest('hex');
+
+    // Timing-safe comparison to prevent timing attacks
+    if (signature.length !== expected.length) return null;
+    const sigBuffer = Buffer.from(signature, 'utf8');
+    const expBuffer = Buffer.from(expected, 'utf8');
+    if (!crypto.timingSafeEqual(sigBuffer, expBuffer)) return null;
+
+    return email;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Read and verify the userEmail cookie from the request.
+ * Returns the verified email, or null if missing/tampered.
+ * Use in API routes (Node.js runtime).
+ */
+export async function getVerifiedEmail(): Promise<string | null> {
+  const cookieStore = await cookies();
+  const raw = cookieStore.get('userEmail')?.value;
+  if (!raw) return null;
+  return verifyCookie(raw);
+}


### PR DESCRIPTION
Previously the userEmail cookie was a plain-text email string. Anyone who knew a valid email could forge the cookie with curl and access that user's data.

Changes:
- Create src/lib/cookie-auth.ts with signCookie() and verifyCookie() using crypto.createHmac('sha256', JWT_SECRET) + timingSafeEqual
- Sign cookie on write: login, register, signup, NextAuth signIn
- Verify signature on read: middleware (Edge-compatible Web Crypto), auth-helpers getCurrentUser(), and all ~120 API route handlers via getVerifiedEmail() helper
- Remove client-side cookie writes in AppLayout and dashboard that would overwrite signed cookies with unsigned ones
- Cookie format: email.hmacHexDigest (split on last dot)
- Fail closed: missing JWT_SECRET throws, invalid signature returns null
- Old unsigned cookies are intentionally invalidated

https://claude.ai/code/session_01GQdtsdAsLVrdzssQLJxMRq