### PR TITLE
security: fix auth info leak, add user-scoping to all data queries

### DIFF
--- a/src/app/api/agenda/[id]/route.ts
+++ b/src/app/api/agenda/[id]/route.ts
@@ -10,8 +10,11 @@ export async function GET(request: Request, { params }: { params: Promise<{ id: 
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
+    const user = await prisma.users.findFirst({ where: { email: userEmail } });
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+
     const items = await prisma.$queryRaw`
-      SELECT * FROM agenda_items WHERE id = ${id}::uuid
+      SELECT * FROM agenda_items WHERE id = ${id}::uuid AND user_id = ${user.id}
     ` as any[];
 
     if (!items.length) {
@@ -50,14 +53,14 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ id
     // Handle commit action
     if (body.action === 'commit') {
       await prisma.$queryRaw`
-        UPDATE agenda_items 
+        UPDATE agenda_items
         SET status = 'committed', committed_at = NOW(), updated_at = NOW()
-        WHERE id = ${id}::uuid
+        WHERE id = ${id}::uuid AND user_id = ${user.id}
       `;
 
       // Get the item
       const items = await prisma.$queryRaw`
-        SELECT * FROM agenda_items WHERE id = ${id}::uuid
+        SELECT * FROM agenda_items WHERE id = ${id}::uuid AND user_id = ${user.id}
       ` as any[];
 
       if (items.length) {
@@ -159,7 +162,7 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ id
         coa_code = COALESCE(${coaCode}, coa_code),
         budget_amount = COALESCE(${budgetAmount}, budget_amount),
         updated_at = NOW()
-      WHERE id = ${id}::uuid
+      WHERE id = ${id}::uuid AND user_id = ${user.id}
     `;
 
     return NextResponse.json({ success: true });
@@ -172,15 +175,19 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ id
 export async function DELETE(request: Request, { params }: { params: Promise<{ id: string }> }) {
   try {
     const { id } = await params;
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    const user = await prisma.users.findFirst({ where: { email: userEmail } });
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
 
     // Delete calendar events
-    await prisma.$queryRaw`DELETE FROM calendar_events WHERE source = 'agenda' AND source_id = ${id}::uuid`;
-    
+    await prisma.$queryRaw`DELETE FROM calendar_events WHERE source = 'agenda' AND source_id = ${id}::uuid AND user_id = ${user.id}`;
+
     // Delete checkins
-    await prisma.$queryRaw`DELETE FROM agenda_checkins WHERE agenda_item_id = ${id}::uuid`;
-    
+    await prisma.$queryRaw`DELETE FROM agenda_checkins WHERE agenda_item_id = ${id}::uuid AND agenda_item_id IN (SELECT id FROM agenda_items WHERE user_id = ${user.id})`;
+
     // Delete the item
-    await prisma.$queryRaw`DELETE FROM agenda_items WHERE id = ${id}::uuid`;
+    await prisma.$queryRaw`DELETE FROM agenda_items WHERE id = ${id}::uuid AND user_id = ${user.id}`;
 
     return NextResponse.json({ success: true });
   } catch (error) {

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -6,45 +6,37 @@ import { signCookie } from '@/lib/cookie-auth';
 export async function POST(request: Request) {
   try {
     const { email, password } = await request.json();
-    console.log('[LOGIN] Attempt for:', email);
 
     if (!email || !password) {
-      console.log('[LOGIN] Missing email or password');
       return NextResponse.json(
-        { error: 'Missing email or password' },
-        { status: 400 }
+        { error: 'Invalid email or password' },
+        { status: 401 }
       );
     }
 
     const user = await prisma.users.findFirst({
-      where: { 
+      where: {
         email: { equals: email, mode: 'insensitive' }
       }
     });
 
-    console.log('[LOGIN] User found:', user?.email, 'ID:', user?.id);
-
     if (!user) {
-      console.log('[LOGIN] No user found for email:', email);
       return NextResponse.json(
-        { error: 'Invalid credentials' },
+        { error: 'Invalid email or password' },
         { status: 401 }
       );
     }
 
     const isValid = await bcrypt.compare(password, user.password);
-    console.log('[LOGIN] Password valid:', isValid);
-    
+
     if (!isValid) {
-      console.log('[LOGIN] Invalid password for:', email);
       return NextResponse.json(
-        { error: 'Invalid credentials' },
+        { error: 'Invalid email or password' },
         { status: 401 }
       );
     }
 
-    // Create response with cookie set via headers (more reliable on Vercel)
-    const response = NextResponse.json({ 
+    const response = NextResponse.json({
       success: true,
       user: { email: user.email, name: user.name }
     });
@@ -57,7 +49,6 @@ export async function POST(request: Request) {
       path: '/',
     });
 
-    console.log('[LOGIN] Cookie set for:', user.email);
     return response;
   } catch (error) {
     console.error('[LOGIN] Error:', error);

--- a/src/app/api/auth/register/route.ts
+++ b/src/app/api/auth/register/route.ts
@@ -22,16 +22,15 @@ export async function POST(request: Request) {
       );
     }
 
-    // Check if user already exists
+    const genericMessage = 'If this email is valid, you will receive a confirmation.';
+
+    // Check if user already exists — return same response to prevent enumeration
     const existing = await prisma.users.findFirst({
       where: { email: { equals: email, mode: 'insensitive' } }
     });
 
     if (existing) {
-      return NextResponse.json(
-        { error: 'An account with this email already exists' },
-        { status: 409 }
-      );
+      return NextResponse.json({ message: genericMessage });
     }
 
     const hashedPassword = await bcrypt.hash(password, 12);
@@ -48,10 +47,7 @@ export async function POST(request: Request) {
     });
 
     // Set auth cookie
-    const response = NextResponse.json({
-      success: true,
-      user: { email: user.email, name: user.name }
-    });
+    const response = NextResponse.json({ message: genericMessage });
 
     response.cookies.set('userEmail', signCookie(user.email), {
       httpOnly: true,

--- a/src/app/api/auth/signup/route.ts
+++ b/src/app/api/auth/signup/route.ts
@@ -15,25 +15,21 @@ export async function POST(request: Request) {
       );
     }
 
-    // Check if user exists in Azure
+    const genericMessage = 'If this email is valid, you will receive a confirmation.';
+
+    // Check if user exists — return same response to prevent enumeration
     const existingUser = await prisma.users.findUnique({
       where: { email }
     });
 
     if (existingUser) {
-      return NextResponse.json(
-        { error: 'Email already registered' },
-        { status: 400 }
-      );
+      return NextResponse.json({ message: genericMessage });
     }
 
-    // Hash password with bcrypt (bank-level security)
     const hashedPassword = await bcrypt.hash(password, 12);
 
-    // Generate unique ID
     const userId = `user_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
 
-    // Save to Azure database with all required fields
     const user = await prisma.users.create({
       data: {
         id: userId,
@@ -53,10 +49,7 @@ export async function POST(request: Request) {
       maxAge: 60 * 60 * 24 * 7 // 7 days
     });
 
-    return NextResponse.json({ 
-      success: true,
-      user: { email: user.email, name: user.name }
-    });
+    return NextResponse.json({ message: genericMessage });
   } catch (error) {
     console.error('Signup error:', error);
     return NextResponse.json(

--- a/src/app/api/auto/[id]/route.ts
+++ b/src/app/api/auto/[id]/route.ts
@@ -19,18 +19,18 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ id
     const { action } = await request.json();
 
     if (action === 'uncommit') {
-      await prisma.$queryRaw`DELETE FROM calendar_events WHERE source = ${MODULE} AND source_id::text = ${id}`;
-      await prisma.$queryRaw`UPDATE module_expenses SET status = 'draft', committed_at = NULL WHERE id = ${id}::uuid`;
+      await prisma.$queryRaw`DELETE FROM calendar_events WHERE source = ${MODULE} AND source_id::text = ${id} AND user_id = ${user.id}`;
+      await prisma.$queryRaw`UPDATE module_expenses SET status = 'draft', committed_at = NULL WHERE id = ${id}::uuid AND user_id = ${user.id}`;
       return NextResponse.json({ success: true });
     }
 
     if (action === 'commit') {
-      const expenses = await prisma.$queryRaw`SELECT * FROM module_expenses WHERE id = ${id}::uuid` as any[];
+      const expenses = await prisma.$queryRaw`SELECT * FROM module_expenses WHERE id = ${id}::uuid AND user_id = ${user.id}` as any[];
       if (!expenses.length) return NextResponse.json({ error: 'Not found' }, { status: 404 });
       const expense = expenses[0];
 
       // Clear old events
-      await prisma.$queryRaw`DELETE FROM calendar_events WHERE source = ${MODULE} AND source_id::text = ${id}`;
+      await prisma.$queryRaw`DELETE FROM calendar_events WHERE source = ${MODULE} AND source_id::text = ${id} AND user_id = ${user.id}`;
 
       const targetDate = expense.target_date ? new Date(expense.target_date) : new Date();
       const amount = Number(expense.amount);
@@ -120,7 +120,7 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ id
         `;
       }
 
-      await prisma.$queryRaw`UPDATE module_expenses SET status = 'committed', committed_at = NOW() WHERE id = ${id}::uuid`;
+      await prisma.$queryRaw`UPDATE module_expenses SET status = 'committed', committed_at = NOW() WHERE id = ${id}::uuid AND user_id = ${user.id}`;
       return NextResponse.json({ success: true, eventsCreated: events.length });
     }
 
@@ -134,8 +134,13 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ id
 export async function DELETE(request: Request, { params }: { params: Promise<{ id: string }> }) {
   try {
     const { id } = await params;
-    await prisma.$queryRaw`DELETE FROM calendar_events WHERE source = ${MODULE} AND source_id::text = ${id}`;
-    await prisma.$queryRaw`DELETE FROM module_expenses WHERE id = ${id}::uuid`;
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    const user = await prisma.users.findFirst({ where: { email: userEmail } });
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+
+    await prisma.$queryRaw`DELETE FROM calendar_events WHERE source = ${MODULE} AND source_id::text = ${id} AND user_id = ${user.id}`;
+    await prisma.$queryRaw`DELETE FROM module_expenses WHERE id = ${id}::uuid AND user_id = ${user.id}`;
     return NextResponse.json({ success: true });
   } catch (error) {
     return NextResponse.json({ error: 'Failed to delete' }, { status: 500 });

--- a/src/app/api/business/[id]/route.ts
+++ b/src/app/api/business/[id]/route.ts
@@ -23,12 +23,12 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ id
         AND source = ${MODULE} 
         AND description LIKE ${'expense:' + id + '%'}
       `;
-      await prisma.$queryRaw`UPDATE module_expenses SET status = 'draft', committed_at = NULL WHERE id = ${id}::uuid`;
+      await prisma.$queryRaw`UPDATE module_expenses SET status = 'draft', committed_at = NULL WHERE id = ${id}::uuid AND user_id = ${user.id}`;
       return NextResponse.json({ success: true });
     }
 
     if (action === 'commit') {
-      const expenses = await prisma.$queryRaw`SELECT * FROM module_expenses WHERE id = ${id}::uuid` as any[];
+      const expenses = await prisma.$queryRaw`SELECT * FROM module_expenses WHERE id = ${id}::uuid AND user_id = ${user.id}` as any[];
       if (!expenses.length) return NextResponse.json({ error: 'Not found' }, { status: 404 });
       const expense = expenses[0];
 
@@ -111,7 +111,7 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ id
         }
       }
 
-      await prisma.$queryRaw`UPDATE module_expenses SET status = 'committed', committed_at = NOW() WHERE id = ${id}::uuid`;
+      await prisma.$queryRaw`UPDATE module_expenses SET status = 'committed', committed_at = NOW() WHERE id = ${id}::uuid AND user_id = ${user.id}`;
       return NextResponse.json({ success: true, itemsCreated: dates.length });
     }
 
@@ -138,7 +138,7 @@ export async function DELETE(request: Request, { params }: { params: Promise<{ i
       AND source = ${MODULE} 
       AND description LIKE ${'expense:' + id + '%'}
     `;
-    await prisma.$queryRaw`DELETE FROM module_expenses WHERE id = ${id}::uuid`;
+    await prisma.$queryRaw`DELETE FROM module_expenses WHERE id = ${id}::uuid AND user_id = ${user.id}`;
     return NextResponse.json({ success: true });
   } catch (error) {
     console.error('Business DELETE error:', error);

--- a/src/app/api/business/route.ts
+++ b/src/app/api/business/route.ts
@@ -19,6 +19,7 @@ export async function GET() {
     // Also get available business COA codes
     const coaAccounts = await prisma.chart_of_accounts.findMany({
       where: {
+        userId: user.id,
         code: { startsWith: 'B-' },
         account_type: 'expense',
         is_archived: false

--- a/src/app/api/chart-of-accounts/route.ts
+++ b/src/app/api/chart-of-accounts/route.ts
@@ -23,7 +23,7 @@ export async function GET(request: Request) {
     
     const accounts = await prisma.chart_of_accounts.findMany({
       where: {
-        // userId: user.id, // COA is shared
+        userId: user.id,
         is_archived: false,
         ...(entity_type && { entity_type })
       },

--- a/src/app/api/closing-periods/close/route.ts
+++ b/src/app/api/closing-periods/close/route.ts
@@ -95,6 +95,7 @@ export async function POST(request: Request) {
 
     if (lines.length >= 2) {
       const entry = await journalEntryService.createJournalEntry({
+        userId: user.id,
         date: new Date(periodEnd),
         description: `Closing entry for ${periodType} period ending ${periodEnd}`,
         lines

--- a/src/app/api/growth/[id]/route.ts
+++ b/src/app/api/growth/[id]/route.ts
@@ -19,18 +19,18 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ id
     const { action } = await request.json();
 
     if (action === 'uncommit') {
-      await prisma.$queryRaw`DELETE FROM calendar_events WHERE source = ${MODULE} AND source_id::text = ${id}`;
-      await prisma.$queryRaw`UPDATE module_expenses SET status = 'draft', committed_at = NULL WHERE id = ${id}::uuid`;
+      await prisma.$queryRaw`DELETE FROM calendar_events WHERE source = ${MODULE} AND source_id::text = ${id} AND user_id = ${user.id}`;
+      await prisma.$queryRaw`UPDATE module_expenses SET status = 'draft', committed_at = NULL WHERE id = ${id}::uuid AND user_id = ${user.id}`;
       return NextResponse.json({ success: true });
     }
 
     if (action === 'commit') {
-      const expenses = await prisma.$queryRaw`SELECT * FROM module_expenses WHERE id = ${id}::uuid` as any[];
+      const expenses = await prisma.$queryRaw`SELECT * FROM module_expenses WHERE id = ${id}::uuid AND user_id = ${user.id}` as any[];
       if (!expenses.length) return NextResponse.json({ error: 'Not found' }, { status: 404 });
       const expense = expenses[0];
 
       // Clear old events
-      await prisma.$queryRaw`DELETE FROM calendar_events WHERE source = ${MODULE} AND source_id::text = ${id}`;
+      await prisma.$queryRaw`DELETE FROM calendar_events WHERE source = ${MODULE} AND source_id::text = ${id} AND user_id = ${user.id}`;
 
       const targetDate = expense.target_date ? new Date(expense.target_date) : new Date();
       const amount = Number(expense.amount);
@@ -120,7 +120,7 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ id
         `;
       }
 
-      await prisma.$queryRaw`UPDATE module_expenses SET status = 'committed', committed_at = NOW() WHERE id = ${id}::uuid`;
+      await prisma.$queryRaw`UPDATE module_expenses SET status = 'committed', committed_at = NOW() WHERE id = ${id}::uuid AND user_id = ${user.id}`;
       return NextResponse.json({ success: true, eventsCreated: events.length });
     }
 
@@ -134,8 +134,13 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ id
 export async function DELETE(request: Request, { params }: { params: Promise<{ id: string }> }) {
   try {
     const { id } = await params;
-    await prisma.$queryRaw`DELETE FROM calendar_events WHERE source = ${MODULE} AND source_id::text = ${id}`;
-    await prisma.$queryRaw`DELETE FROM module_expenses WHERE id = ${id}::uuid`;
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    const user = await prisma.users.findFirst({ where: { email: userEmail } });
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+
+    await prisma.$queryRaw`DELETE FROM calendar_events WHERE source = ${MODULE} AND source_id::text = ${id} AND user_id = ${user.id}`;
+    await prisma.$queryRaw`DELETE FROM module_expenses WHERE id = ${id}::uuid AND user_id = ${user.id}`;
     return NextResponse.json({ success: true });
   } catch (error) {
     return NextResponse.json({ error: 'Failed to delete' }, { status: 500 });

--- a/src/app/api/health/[id]/route.ts
+++ b/src/app/api/health/[id]/route.ts
@@ -19,18 +19,18 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ id
     const { action } = await request.json();
 
     if (action === 'uncommit') {
-      await prisma.$queryRaw`DELETE FROM calendar_events WHERE source = ${MODULE} AND source_id::text = ${id}`;
-      await prisma.$queryRaw`UPDATE module_expenses SET status = 'draft', committed_at = NULL WHERE id = ${id}::uuid`;
+      await prisma.$queryRaw`DELETE FROM calendar_events WHERE source = ${MODULE} AND source_id::text = ${id} AND user_id = ${user.id}`;
+      await prisma.$queryRaw`UPDATE module_expenses SET status = 'draft', committed_at = NULL WHERE id = ${id}::uuid AND user_id = ${user.id}`;
       return NextResponse.json({ success: true });
     }
 
     if (action === 'commit') {
-      const expenses = await prisma.$queryRaw`SELECT * FROM module_expenses WHERE id = ${id}::uuid` as any[];
+      const expenses = await prisma.$queryRaw`SELECT * FROM module_expenses WHERE id = ${id}::uuid AND user_id = ${user.id}` as any[];
       if (!expenses.length) return NextResponse.json({ error: 'Not found' }, { status: 404 });
       const expense = expenses[0];
 
       // Clear old events
-      await prisma.$queryRaw`DELETE FROM calendar_events WHERE source = ${MODULE} AND source_id::text = ${id}`;
+      await prisma.$queryRaw`DELETE FROM calendar_events WHERE source = ${MODULE} AND source_id::text = ${id} AND user_id = ${user.id}`;
 
       const targetDate = expense.target_date ? new Date(expense.target_date) : new Date();
       const amount = Number(expense.amount);
@@ -120,7 +120,7 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ id
         `;
       }
 
-      await prisma.$queryRaw`UPDATE module_expenses SET status = 'committed', committed_at = NOW() WHERE id = ${id}::uuid`;
+      await prisma.$queryRaw`UPDATE module_expenses SET status = 'committed', committed_at = NOW() WHERE id = ${id}::uuid AND user_id = ${user.id}`;
       return NextResponse.json({ success: true, eventsCreated: events.length });
     }
 
@@ -134,8 +134,13 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ id
 export async function DELETE(request: Request, { params }: { params: Promise<{ id: string }> }) {
   try {
     const { id } = await params;
-    await prisma.$queryRaw`DELETE FROM calendar_events WHERE source = ${MODULE} AND source_id::text = ${id}`;
-    await prisma.$queryRaw`DELETE FROM module_expenses WHERE id = ${id}::uuid`;
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    const user = await prisma.users.findFirst({ where: { email: userEmail } });
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+
+    await prisma.$queryRaw`DELETE FROM calendar_events WHERE source = ${MODULE} AND source_id::text = ${id} AND user_id = ${user.id}`;
+    await prisma.$queryRaw`DELETE FROM module_expenses WHERE id = ${id}::uuid AND user_id = ${user.id}`;
     return NextResponse.json({ success: true });
   } catch (error) {
     return NextResponse.json({ error: 'Failed to delete' }, { status: 500 });

--- a/src/app/api/home/route.ts
+++ b/src/app/api/home/route.ts
@@ -23,7 +23,7 @@ export async function GET() {
 
     // Get historical transactions for home COA codes
     const homeCodes = await prisma.chart_of_accounts.findMany({
-      where: { module: 'home' },
+      where: { userId: user.id, module: 'home' },
       select: { code: true, name: true }
     });
 

--- a/src/app/api/hub/year-calendar/route.ts
+++ b/src/app/api/hub/year-calendar/route.ts
@@ -65,7 +65,8 @@ export async function GET(request: Request) {
     
     // Get COA codes grouped by module
     const coaByModule = await prisma.chart_of_accounts.findMany({
-      where: { 
+      where: {
+        userId: user.id,
         module: { in: modules },
         is_archived: false
       },

--- a/src/app/api/income/route.ts
+++ b/src/app/api/income/route.ts
@@ -31,7 +31,7 @@ export async function GET() {
     }
 
     const incomeCodes = await prisma.chart_of_accounts.findMany({
-      where: { module: 'income' },
+      where: { userId: user.id, module: 'income' },
       select: { code: true, name: true }
     });
 

--- a/src/app/api/investment-transactions/assign-coa/route.ts
+++ b/src/app/api/investment-transactions/assign-coa/route.ts
@@ -10,13 +10,26 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
+    const user = await prisma.users.findFirst({
+      where: { email: { equals: userEmail, mode: 'insensitive' } }
+    });
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+
     const { transactionIds, accountCode, subAccount, strategy, tradeNum } = await request.json();
 
     console.log('Investment transaction IDs received:', transactionIds);
 
+    // Verify ownership of all transactions
+    const ownedTxns = await prisma.investment_transactions.findMany({
+      where: { id: { in: transactionIds }, accounts: { userId: user.id } }
+    });
+    if (ownedTxns.length !== transactionIds.length) {
+      return NextResponse.json({ error: 'Forbidden: not all transactions belong to user' }, { status: 403 });
+    }
+
     await prisma.investment_transactions.updateMany({
       where: {
-        id: { in: transactionIds }
+        id: { in: ownedTxns.map(t => t.id) }
       },
       data: {
         accountCode: accountCode || null,

--- a/src/app/api/investment-transactions/fix-orphan/route.ts
+++ b/src/app/api/investment-transactions/fix-orphan/route.ts
@@ -8,10 +8,23 @@ export async function POST(request: Request) {
     const userEmail = await getVerifiedEmail();
     if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
+    const user = await prisma.users.findFirst({
+      where: { email: { equals: userEmail, mode: 'insensitive' } }
+    });
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+
     const { transactionId, tradeNum, strategy, accountCode } = await request.json();
 
     if (!transactionId || !tradeNum) {
       return NextResponse.json({ error: 'Required: transactionId, tradeNum' }, { status: 400 });
+    }
+
+    // Verify ownership of the transaction
+    const txn = await prisma.investment_transactions.findFirst({
+      where: { id: transactionId, accounts: { userId: user.id } }
+    });
+    if (!txn) {
+      return NextResponse.json({ error: 'Forbidden: transaction not found or does not belong to user' }, { status: 403 });
     }
 
     const result = await prisma.investment_transactions.update({

--- a/src/app/api/journal-entries/manual/route.ts
+++ b/src/app/api/journal-entries/manual/route.ts
@@ -31,6 +31,7 @@ export async function POST(request: Request) {
     }
 
     await journalEntryService.createJournalEntry({
+      userId: user.id,
       date: new Date(date),
       description,
       lines: lines.map((l: any) => ({

--- a/src/app/api/merchant-mappings/route.ts
+++ b/src/app/api/merchant-mappings/route.ts
@@ -21,6 +21,9 @@ export async function GET(request: Request) {
     const merchantName = searchParams.get('merchantName');
     const categoryPrimary = searchParams.get('categoryPrimary');
 
+    // TODO: Known multi-tenant issue — merchant_coa_mappings table has no userId column.
+    // All mappings are globally shared across users. A userId column should be added
+    // to this table and all queries below should be scoped by userId for proper tenant isolation.
     let mappings;
 
     if (merchantName) {

--- a/src/app/api/net-worth/route.ts
+++ b/src/app/api/net-worth/route.ts
@@ -31,7 +31,8 @@ export async function GET() {
     }
 
     const accounts = await prisma.chart_of_accounts.findMany({
-      where: { 
+      where: {
+        userId: user.id,
         module: { in: ['assets', 'debt', 'equity'] },
         entity_type: 'personal'
       },

--- a/src/app/api/personal/[id]/route.ts
+++ b/src/app/api/personal/[id]/route.ts
@@ -19,18 +19,18 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ id
     const { action } = await request.json();
 
     if (action === 'uncommit') {
-      await prisma.$queryRaw`DELETE FROM calendar_events WHERE source = ${MODULE} AND source_id::text = ${id}`;
-      await prisma.$queryRaw`UPDATE module_expenses SET status = 'draft', committed_at = NULL WHERE id = ${id}::uuid`;
+      await prisma.$queryRaw`DELETE FROM calendar_events WHERE source = ${MODULE} AND source_id::text = ${id} AND user_id = ${user.id}`;
+      await prisma.$queryRaw`UPDATE module_expenses SET status = 'draft', committed_at = NULL WHERE id = ${id}::uuid AND user_id = ${user.id}`;
       return NextResponse.json({ success: true });
     }
 
     if (action === 'commit') {
-      const expenses = await prisma.$queryRaw`SELECT * FROM module_expenses WHERE id = ${id}::uuid` as any[];
+      const expenses = await prisma.$queryRaw`SELECT * FROM module_expenses WHERE id = ${id}::uuid AND user_id = ${user.id}` as any[];
       if (!expenses.length) return NextResponse.json({ error: 'Not found' }, { status: 404 });
       const expense = expenses[0];
 
       // Clear old events
-      await prisma.$queryRaw`DELETE FROM calendar_events WHERE source = ${MODULE} AND source_id::text = ${id}`;
+      await prisma.$queryRaw`DELETE FROM calendar_events WHERE source = ${MODULE} AND source_id::text = ${id} AND user_id = ${user.id}`;
 
       const targetDate = expense.target_date ? new Date(expense.target_date) : new Date();
       const amount = Number(expense.amount);
@@ -120,7 +120,7 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ id
         `;
       }
 
-      await prisma.$queryRaw`UPDATE module_expenses SET status = 'committed', committed_at = NOW() WHERE id = ${id}::uuid`;
+      await prisma.$queryRaw`UPDATE module_expenses SET status = 'committed', committed_at = NOW() WHERE id = ${id}::uuid AND user_id = ${user.id}`;
       return NextResponse.json({ success: true, eventsCreated: events.length });
     }
 
@@ -134,8 +134,13 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ id
 export async function DELETE(request: Request, { params }: { params: Promise<{ id: string }> }) {
   try {
     const { id } = await params;
-    await prisma.$queryRaw`DELETE FROM calendar_events WHERE source = ${MODULE} AND source_id::text = ${id}`;
-    await prisma.$queryRaw`DELETE FROM module_expenses WHERE id = ${id}::uuid`;
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    const user = await prisma.users.findFirst({ where: { email: userEmail } });
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+
+    await prisma.$queryRaw`DELETE FROM calendar_events WHERE source = ${MODULE} AND source_id::text = ${id} AND user_id = ${user.id}`;
+    await prisma.$queryRaw`DELETE FROM module_expenses WHERE id = ${id}::uuid AND user_id = ${user.id}`;
     return NextResponse.json({ success: true });
   } catch (error) {
     return NextResponse.json({ error: 'Failed to delete' }, { status: 500 });

--- a/src/app/api/shopping/[id]/route.ts
+++ b/src/app/api/shopping/[id]/route.ts
@@ -20,12 +20,12 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ id
 
     if (action === 'uncommit') {
       await prisma.$queryRaw`DELETE FROM calendar_events WHERE source = ${MODULE} AND source_id::text = ${id} AND user_id = ${user.id}`;
-      await prisma.$queryRaw`UPDATE module_expenses SET status = 'draft', committed_at = NULL WHERE id = ${id}::uuid`;
+      await prisma.$queryRaw`UPDATE module_expenses SET status = 'draft', committed_at = NULL WHERE id = ${id}::uuid AND user_id = ${user.id}`;
       return NextResponse.json({ success: true });
     }
 
     if (action === 'commit') {
-      const expenses = await prisma.$queryRaw`SELECT * FROM module_expenses WHERE id = ${id}::uuid` as any[];
+      const expenses = await prisma.$queryRaw`SELECT * FROM module_expenses WHERE id = ${id}::uuid AND user_id = ${user.id}` as any[];
       if (!expenses.length) return NextResponse.json({ error: 'Not found' }, { status: 404 });
       const expense = expenses[0];
 
@@ -120,7 +120,7 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ id
         `;
       }
 
-      await prisma.$queryRaw`UPDATE module_expenses SET status = 'committed', committed_at = NOW() WHERE id = ${id}::uuid`;
+      await prisma.$queryRaw`UPDATE module_expenses SET status = 'committed', committed_at = NOW() WHERE id = ${id}::uuid AND user_id = ${user.id}`;
       return NextResponse.json({ success: true, eventsCreated: events.length });
     }
 

--- a/src/app/api/stock-lots/commit/route.ts
+++ b/src/app/api/stock-lots/commit/route.ts
@@ -180,7 +180,7 @@ export async function POST(request: Request) {
 
       // Get next trade number
       const maxResult = await tx.investment_transactions.findMany({
-        where: { tradeNum: { not: null } },
+        where: { tradeNum: { not: null }, accounts: { userId: user.id } },
         select: { tradeNum: true }
       });
       const maxNum = maxResult.reduce((max, t) => {

--- a/src/app/api/stock-lots/route.ts
+++ b/src/app/api/stock-lots/route.ts
@@ -76,7 +76,7 @@ export async function POST(request: Request) {
     let actualTradeNum = tradeNum;
     if (!actualTradeNum) {
       const maxResult = await prisma.investment_transactions.findMany({
-        where: { tradeNum: { not: null } },
+        where: { tradeNum: { not: null }, accounts: { userId: user.id } },
         select: { tradeNum: true }
       });
       const maxNum = maxResult.reduce((max, t) => {
@@ -88,12 +88,16 @@ export async function POST(request: Request) {
 
     // Fetch the investment transactions
     const transactions = await prisma.investment_transactions.findMany({
-      where: { id: { in: transactionIds } },
+      where: { id: { in: transactionIds }, accounts: { userId: user.id } },
       include: { security: true }
     });
 
     if (transactions.length === 0) {
       return NextResponse.json({ error: 'No transactions found' }, { status: 404 });
+    }
+
+    if (transactions.length !== transactionIds.length) {
+      return NextResponse.json({ error: 'Forbidden: not all transactions belong to user' }, { status: 403 });
     }
 
 

--- a/src/app/api/trading/convergence/route.ts
+++ b/src/app/api/trading/convergence/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { runPipeline } from '@/lib/convergence/pipeline';
 import type { PipelineResult } from '@/lib/convergence/pipeline';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export const maxDuration = 300;
 
@@ -39,6 +40,11 @@ function setCache(limit: number, data: PipelineResult): void {
 
 export async function GET(request: Request) {
   try {
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
     const { searchParams } = new URL(request.url);
 
     // Parse query params

--- a/src/app/api/transactions/auto-categorize/route.ts
+++ b/src/app/api/transactions/auto-categorize/route.ts
@@ -17,7 +17,7 @@ export async function POST() {
       return NextResponse.json({ error: 'User not found' }, { status: 404 });
     }
 
-    const result = await autoCategorizationService.categorizePendingTransactions();
+    const result = await autoCategorizationService.categorizePendingTransactions(user.id);
 
     return NextResponse.json({
       success: true,

--- a/src/app/api/transactions/commit-to-ledger/route.ts
+++ b/src/app/api/transactions/commit-to-ledger/route.ts
@@ -66,7 +66,8 @@ export async function POST(request: NextRequest) {
         const journalEntry = await journalEntryService.convertPlaidTransaction(
           plaidTxn.transactionId,
           bankAccountCode,
-          accountCode
+          accountCode,
+          user.id
         );
 
         const wasOverridden = !!(plaidTxn.predicted_coa_code &&

--- a/src/app/api/trips/[id]/activities/route.ts
+++ b/src/app/api/trips/[id]/activities/route.ts
@@ -5,6 +5,15 @@ import { getVerifiedEmail } from '@/lib/cookie-auth';
 export async function GET(request: Request, { params }: { params: Promise<{ id: string }> }) {
   try {
     const { id } = await params;
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const user = await prisma.users.findFirst({ where: { email: userEmail } });
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+
+    const trip = await prisma.trips.findFirst({ where: { id, userId: user.id } });
+    if (!trip) return NextResponse.json({ error: 'Trip not found' }, { status: 404 });
+
     const options = await prisma.$queryRaw`
       SELECT * FROM trip_activity_expenses 
       WHERE trip_id = ${id}
@@ -21,6 +30,12 @@ export async function POST(request: Request, { params }: { params: Promise<{ id:
     const { id } = await params;
     const userEmail = await getVerifiedEmail();
     if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const user = await prisma.users.findFirst({ where: { email: userEmail } });
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+
+    const trip = await prisma.trips.findFirst({ where: { id, userId: user.id } });
+    if (!trip) return NextResponse.json({ error: 'Trip not found' }, { status: 404 });
 
     const { category, title, vendor, url, price, is_per_person, per_person, notes } = await request.json();
 

--- a/src/app/api/trips/[id]/commit/route.ts
+++ b/src/app/api/trips/[id]/commit/route.ts
@@ -21,9 +21,9 @@ export async function POST(request: Request, { params }: { params: Promise<{ id:
     
     console.log('Commit received:', { startDay, budgetItems });
 
-    // Get the trip
-    const trip = await prisma.trips.findUnique({
-      where: { id }
+    // Get the trip (verify ownership)
+    const trip = await prisma.trips.findFirst({
+      where: { id, userId: user.id }
     });
 
     if (!trip) {
@@ -255,9 +255,9 @@ export async function DELETE(request: Request, { params }: { params: Promise<{ i
       return NextResponse.json({ error: 'User not found' }, { status: 404 });
     }
 
-    // Get trip with budget items
-    const trip = await prisma.trips.findUnique({
-      where: { id },
+    // Get trip with budget items (verify ownership)
+    const trip = await prisma.trips.findFirst({
+      where: { id, userId: user.id },
       include: { budget_line_items: true }
     });
 

--- a/src/app/api/trips/[id]/transfers/[optionId]/route.ts
+++ b/src/app/api/trips/[id]/transfers/[optionId]/route.ts
@@ -1,9 +1,18 @@
 import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function PATCH(request: Request, { params }: { params: Promise<{ id: string; optionId: string }> }) {
   try {
     const { id, optionId } = await params;
+
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    const user = await prisma.users.findFirst({ where: { email: userEmail } });
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    const trip = await prisma.trips.findFirst({ where: { id, userId: user.id } });
+    if (!trip) return NextResponse.json({ error: 'Trip not found' }, { status: 404 });
+
     const body = await request.json();
     
     if (body.action === 'vote_up') {
@@ -47,7 +56,15 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ id
 
 export async function DELETE(request: Request, { params }: { params: Promise<{ id: string; optionId: string }> }) {
   try {
-    const { optionId } = await params;
+    const { id, optionId } = await params;
+
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    const user = await prisma.users.findFirst({ where: { email: userEmail } });
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    const trip = await prisma.trips.findFirst({ where: { id, userId: user.id } });
+    if (!trip) return NextResponse.json({ error: 'Trip not found' }, { status: 404 });
+
     await prisma.$queryRaw`DELETE FROM trip_transfer_options WHERE id = ${optionId}::uuid`;
     return NextResponse.json({ success: true });
   } catch (error) {

--- a/src/app/api/trips/[id]/transfers/route.ts
+++ b/src/app/api/trips/[id]/transfers/route.ts
@@ -5,6 +5,14 @@ import { getVerifiedEmail } from '@/lib/cookie-auth';
 export async function GET(request: Request, { params }: { params: Promise<{ id: string }> }) {
   try {
     const { id } = await params;
+
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    const user = await prisma.users.findFirst({ where: { email: userEmail } });
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    const trip = await prisma.trips.findFirst({ where: { id, userId: user.id } });
+    if (!trip) return NextResponse.json({ error: 'Trip not found' }, { status: 404 });
+
     const options = await prisma.$queryRaw`
       SELECT * FROM trip_transfer_options 
       WHERE trip_id = ${id}
@@ -21,6 +29,10 @@ export async function POST(request: Request, { params }: { params: Promise<{ id:
     const { id } = await params;
     const userEmail = await getVerifiedEmail();
     if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    const user = await prisma.users.findFirst({ where: { email: userEmail } });
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    const trip = await prisma.trips.findFirst({ where: { id, userId: user.id } });
+    if (!trip) return NextResponse.json({ error: 'Trip not found' }, { status: 404 });
 
     const { url, transfer_type, direction, title, vendor, price, per_person, notes } = await request.json();
     

--- a/src/app/api/trips/[id]/vehicles/[optionId]/route.ts
+++ b/src/app/api/trips/[id]/vehicles/[optionId]/route.ts
@@ -1,9 +1,18 @@
 import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 export async function PATCH(request: Request, { params }: { params: Promise<{ id: string; optionId: string }> }) {
   try {
     const { id, optionId } = await params;
+
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    const user = await prisma.users.findFirst({ where: { email: userEmail } });
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    const trip = await prisma.trips.findFirst({ where: { id, userId: user.id } });
+    if (!trip) return NextResponse.json({ error: 'Trip not found' }, { status: 404 });
+
     const body = await request.json();
     
     if (body.action === 'vote_up') {
@@ -44,7 +53,15 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ id
 
 export async function DELETE(request: Request, { params }: { params: Promise<{ id: string; optionId: string }> }) {
   try {
-    const { optionId } = await params;
+    const { id, optionId } = await params;
+
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    const user = await prisma.users.findFirst({ where: { email: userEmail } });
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    const trip = await prisma.trips.findFirst({ where: { id, userId: user.id } });
+    if (!trip) return NextResponse.json({ error: 'Trip not found' }, { status: 404 });
+
     await prisma.$queryRaw`DELETE FROM trip_vehicle_options WHERE id = ${optionId}::uuid`;
     return NextResponse.json({ success: true });
   } catch (error) {

--- a/src/app/api/trips/[id]/vehicles/route.ts
+++ b/src/app/api/trips/[id]/vehicles/route.ts
@@ -5,6 +5,14 @@ import { getVerifiedEmail } from '@/lib/cookie-auth';
 export async function GET(request: Request, { params }: { params: Promise<{ id: string }> }) {
   try {
     const { id } = await params;
+
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    const user = await prisma.users.findFirst({ where: { email: userEmail } });
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    const trip = await prisma.trips.findFirst({ where: { id, userId: user.id } });
+    if (!trip) return NextResponse.json({ error: 'Trip not found' }, { status: 404 });
+
     const options = await prisma.$queryRaw`
       SELECT * FROM trip_vehicle_options 
       WHERE trip_id = ${id}
@@ -21,6 +29,10 @@ export async function POST(request: Request, { params }: { params: Promise<{ id:
     const { id } = await params;
     const userEmail = await getVerifiedEmail();
     if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    const user = await prisma.users.findFirst({ where: { email: userEmail } });
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    const trip = await prisma.trips.findFirst({ where: { id, userId: user.id } });
+    if (!trip) return NextResponse.json({ error: 'Trip not found' }, { status: 404 });
 
     const { url, vehicle_type, title, vendor, price_per_day, total_price, per_person, notes } = await request.json();
     

--- a/src/lib/auto-categorization-service.ts
+++ b/src/lib/auto-categorization-service.ts
@@ -75,14 +75,15 @@ export class AutoCategorizationService {
   /**
    * Categorize all pending transactions
    */
-  async categorizePendingTransactions(): Promise<{
+  async categorizePendingTransactions(userId?: string): Promise<{
     categorized: number;
     failed: number;
   }> {
     const pendingTransactions = await prisma.transactions.findMany({
       where: {
         accountCode: null,
-        predicted_coa_code: null
+        predicted_coa_code: null,
+        ...(userId ? { accounts: { userId } } : {})
       }
     });
     


### PR DESCRIPTION
FIX A — Auth info leak prevention:
- register/signup: Return identical generic response whether email exists or not
- login: Unified error message "Invalid email or password" for all failure cases
- login: Removed verbose debug logging that leaked user existence info

FIX B — User-scope all database queries (39 files):
- Module [id] routes (auto, growth, health, personal, home, business, shopping, agenda): Added user_id filters to all SELECT/UPDATE/DELETE raw SQL queries. Added auth + user lookup to all DELETE handlers that had none.
- Trip sub-routes (activities, lodging, transfers, vehicles, commit, destinations): Added trip ownership verification (trips.findFirst with userId) to all handlers. Added full auth to previously unauthenticated GET/PATCH/DELETE handlers.
- Investment routes (assign-coa, fix-orphan, stock-lots, stock-lots/commit): Added ownership verification before modifying investment_transactions. Scoped max trade number queries by userId.
- chart-of-accounts: Uncommented userId filter that was disabled.
- journal-entry-service: Added userId parameter; COA lookups now scoped.
- auto-categorization-service: Added optional userId parameter for user-scoped runs.
- trading/convergence: Added auth guard to previously public endpoint.
- COA queries in business, home, year-calendar, income, net-worth: Added userId filter.

https://claude.ai/code/session_01GQdtsdAsLVrdzssQLJxMRq