### PR TITLE
fix: use getVerifiedEmail in COA POST handler after upstream auth ref…

### DIFF
--- a/src/app/api/chart-of-accounts/route.ts
+++ b/src/app/api/chart-of-accounts/route.ts
@@ -66,8 +66,7 @@ const BALANCE_TYPE_MAP: Record<string, string> = {
 
 export async function POST(request: Request) {
   try {
-    const cookieStore = await cookies();
-    const userEmail = cookieStore.get('userEmail')?.value;
+    const userEmail = await getVerifiedEmail();
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }


### PR DESCRIPTION
…actor

The upstream merged HMAC-signed cookie auth (cookie-auth.ts) and replaced raw cookies() calls with getVerifiedEmail(). The POST handler we added still used the old pattern, causing a build error.

https://claude.ai/code/session_01CCk1pA3MvtFBBKegqHhhhs