### PR TITLE
security: harden admin verify, fix auth masking, add Plaid pagination

### DIFF
--- a/src/app/api/admin/verify/route.ts
+++ b/src/app/api/admin/verify/route.ts
@@ -1,4 +1,39 @@
 import { NextResponse } from 'next/server';
+import crypto from 'crypto';
+import { getCurrentUser } from '@/lib/auth-helpers';
+import { logAuth } from '@/lib/audit-log';
+
+// In-memory brute-force tracking: ip → { count, resetAt }
+const attempts = new Map<string, { count: number; resetAt: number }>();
+const MAX_ATTEMPTS = 5;
+const LOCKOUT_MS = 15 * 60 * 1000; // 15 minutes
+
+function getIp(request: Request): string {
+  return (request as any).headers?.get?.('x-forwarded-for')?.split(',')[0]?.trim() ?? 'unknown';
+}
+
+function isLockedOut(ip: string): boolean {
+  const entry = attempts.get(ip);
+  if (!entry) return false;
+  if (Date.now() > entry.resetAt) {
+    attempts.delete(ip);
+    return false;
+  }
+  return entry.count >= MAX_ATTEMPTS;
+}
+
+function recordAttempt(ip: string): void {
+  const entry = attempts.get(ip);
+  if (!entry || Date.now() > entry.resetAt) {
+    attempts.set(ip, { count: 1, resetAt: Date.now() + LOCKOUT_MS });
+  } else {
+    entry.count++;
+  }
+}
+
+function clearAttempts(ip: string): void {
+  attempts.delete(ip);
+}
 
 export async function POST(request: Request) {
   const adminPassword = process.env.ADMIN_PASSWORD;
@@ -6,11 +41,46 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: 'Admin access is not configured' }, { status: 403 });
   }
 
-  const { password } = await request.json();
+  const ip = getIp(request);
 
-  if (password === adminPassword) {
+  // Require valid session before accepting password
+  const user = await getCurrentUser();
+  if (!user) {
+    logAuth('admin_verify_no_session', 'anonymous', ip);
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  if (isLockedOut(ip)) {
+    logAuth('admin_verify_locked_out', user.email, ip);
+    return NextResponse.json({ error: 'Too many attempts. Try again later.' }, { status: 429 });
+  }
+
+  let password: unknown;
+  try {
+    ({ password } = await request.json());
+  } catch {
+    return NextResponse.json({ error: 'Invalid request body' }, { status: 400 });
+  }
+
+  if (typeof password !== 'string') {
+    return NextResponse.json({ error: 'Invalid password' }, { status: 400 });
+  }
+
+  // Timing-safe comparison
+  const inputBuf = Buffer.from(password);
+  const expectedBuf = Buffer.from(adminPassword);
+  const maxLen = Math.max(inputBuf.length, expectedBuf.length);
+  const paddedInput = Buffer.concat([inputBuf, Buffer.alloc(maxLen - inputBuf.length)]);
+  const paddedExpected = Buffer.concat([expectedBuf, Buffer.alloc(maxLen - expectedBuf.length)]);
+  const match = crypto.timingSafeEqual(paddedInput, paddedExpected) && inputBuf.length === expectedBuf.length;
+
+  if (match) {
+    clearAttempts(ip);
+    logAuth('admin_verify_success', user.email, ip);
     return NextResponse.json({ success: true });
   } else {
+    recordAttempt(ip);
+    logAuth('admin_verify_failed', user.email, ip);
     return NextResponse.json({ error: 'Invalid password' }, { status: 401 });
   }
 }

--- a/src/app/api/ai/market-brief/route.ts
+++ b/src/app/api/ai/market-brief/route.ts
@@ -125,20 +125,20 @@ Respond with ONLY valid JSON, no markdown, no code blocks, no preamble:
 }`;
 
 export async function POST(request: Request) {
-  try {
-    const userEmail = await getVerifiedEmail();
-    if (!userEmail) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
-    const user = await prisma.users.findFirst({
-      where: { email: { equals: userEmail, mode: 'insensitive' } }
-    });
-    if (!user) {
-      return NextResponse.json({ error: 'User not found' }, { status: 404 });
-    }
-    const tierGate = requireTier(user.tier, 'ai');
-    if (tierGate) return tierGate;
+  const userEmail = await getVerifiedEmail();
+  if (!userEmail) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const user = await prisma.users.findFirst({
+    where: { email: { equals: userEmail, mode: 'insensitive' } }
+  });
+  if (!user) {
+    return NextResponse.json({ error: 'User not found' }, { status: 404 });
+  }
+  const tierGate = requireTier(user.tier, 'ai');
+  if (tierGate) return tierGate;
 
+  try {
     const apiKey = process.env.ANTHROPIC_API_KEY;
     if (!apiKey) {
       return NextResponse.json({ error: 'API key not configured' }, { status: 500 });

--- a/src/app/api/transactions/resync-with-rich-data/route.ts
+++ b/src/app/api/transactions/resync-with-rich-data/route.ts
@@ -1,43 +1,55 @@
-import { NextRequest, NextResponse } from 'next/server';
-import { verifyAuth } from '@/lib/auth';
+import { NextResponse } from 'next/server';
+import { getCurrentUser } from '@/lib/auth-helpers';
 import { plaidClient } from '@/lib/plaid';
 import { prisma } from '@/lib/prisma';
 
-export async function POST(request: NextRequest) {
+export async function POST() {
   try {
-    const userId = await verifyAuth(request);
-    if (!userId) {
+    const user = await getCurrentUser();
+    if (!user) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
     const plaidItems = await prisma.plaid_items.findMany({
-      where: { userId },
+      where: { userId: user.id },
       include: { accounts: true }
     });
-    
+
     let updated = 0;
     const endDate = new Date().toISOString().split('T')[0];
     const startDate = new Date(Date.now() - 730 * 24 * 60 * 60 * 1000).toISOString().split('T')[0]; // 2 years
-    
+
     for (const item of plaidItems) {
-      const response = await plaidClient.transactionsGet({
-        access_token: item.accessToken,
-        start_date: startDate,
-        end_date: endDate,
-        options: { 
-          count: 500, 
-          offset: 0,
-          include_personal_finance_category: true
-        }
-      });
-      
-      for (const txn of response.data.transactions) {
-        // Use 'any' type to bypass TypeScript checking for Plaid response
+      let offset = 0;
+      const count = 500;
+      let totalTransactions = Infinity;
+      const allTransactions: any[] = [];
+
+      while (offset < totalTransactions) {
+        const response = await plaidClient.transactionsGet({
+          access_token: item.accessToken,
+          start_date: startDate,
+          end_date: endDate,
+          options: {
+            count,
+            offset,
+            include_personal_finance_category: true
+          }
+        });
+
+        allTransactions.push(...response.data.transactions);
+        totalTransactions = response.data.total_transactions;
+        offset += response.data.transactions.length;
+
+        if (response.data.transactions.length === 0) break;
+      }
+
+      for (const txn of allTransactions) {
         const transaction: any = txn;
-        
+
         await prisma.$executeRaw`
-          UPDATE transactions 
-          SET 
+          UPDATE transactions
+          SET
             personal_finance_category = ${JSON.stringify(transaction.personal_finance_category || null)}::jsonb,
             payment_channel = ${transaction.payment_channel || null},
             location = ${JSON.stringify(transaction.location || null)}::jsonb,
@@ -47,8 +59,8 @@ export async function POST(request: NextRequest) {
         updated++;
       }
     }
-    
-    return NextResponse.json({ 
+
+    return NextResponse.json({
       success: true,
       updated,
       message: `Updated ${updated} transactions with rich data!`

--- a/src/components/Providers.tsx
+++ b/src/components/Providers.tsx
@@ -1,7 +1,33 @@
 'use client';
 
 import { SessionProvider } from 'next-auth/react';
+import { useEffect } from 'react';
+
+function AuthGuard({ children }: { children: React.ReactNode }) {
+  useEffect(() => {
+    const originalFetch = window.fetch;
+    window.fetch = async (...args) => {
+      const res = await originalFetch(...args);
+      if (res.status === 401) {
+        const raw = typeof args[0] === 'string' ? args[0] : (args[0] as Request).url;
+        const pathname = raw.startsWith('/') ? raw : new URL(raw).pathname;
+        // Only redirect for our API routes, not external calls or auth endpoints
+        if (pathname.startsWith('/api/') && !pathname.startsWith('/api/auth/')) {
+          window.location.href = '/';
+        }
+      }
+      return res;
+    };
+    return () => { window.fetch = originalFetch; };
+  }, []);
+
+  return <>{children}</>;
+}
 
 export default function Providers({ children }: { children: React.ReactNode }) {
-  return <SessionProvider>{children}</SessionProvider>;
+  return (
+    <SessionProvider>
+      <AuthGuard>{children}</AuthGuard>
+    </SessionProvider>
+  );
 }

--- a/src/lib/audit-log.ts
+++ b/src/lib/audit-log.ts
@@ -1,0 +1,28 @@
+/**
+ * Lightweight structured audit logger.
+ * Outputs JSON to stdout — Vercel captures these automatically.
+ */
+import { createHash } from 'crypto';
+
+function hashEmail(email: string): string {
+  return createHash('sha256').update(email).digest('hex');
+}
+
+export function logAuth(event: string, email: string, ip?: string): void {
+  console.log(JSON.stringify({
+    type: 'auth',
+    event,
+    emailHash: hashEmail(email),
+    ip: ip ?? null,
+    ts: new Date().toISOString(),
+  }));
+}
+
+export function logAccess(route: string, userId: string): void {
+  console.log(JSON.stringify({
+    type: 'access',
+    route,
+    userId,
+    ts: new Date().toISOString(),
+  }));
+}


### PR DESCRIPTION
## Summary

- **Admin verify hardening**: Require authenticated session before accepting password, timing-safe comparison with length-oracle padding, IP-based rate limiting (5 attempts / 15 min lockout), structured audit logging with SHA-256 hashed emails
- **Auth error masking fix**: Move auth check outside try-catch in market-brief route so 401 returns correctly instead of being swallowed as 500
- **Plaid resync pagination**: Migrate from legacy `verifyAuth` to `getCurrentUser`, add pagination loop to fetch all transactions (was silently capped at first 500)
- **Client-side AuthGuard**: Intercept 401 API responses and redirect to login, with safe URL parsing to prevent open-redirect via absolute URLs

## Test plan

- [ ] Admin verify: confirm unauthenticated requests get 401 (not password prompt)
- [ ] Admin verify: confirm 6th failed attempt within 15 min returns 429
- [ ] Admin verify: confirm correct password still works after lockout expires
- [ ] Market brief: confirm unauthenticated request returns 401 (not 500)
- [ ] Plaid resync: confirm accounts with >500 transactions fetch all pages
- [ ] AuthGuard: confirm stale session triggers redirect to landing page
- [ ] AuthGuard: confirm external API 401s don't trigger redirect

🤖 Generated with [Claude Code](https://claude.com/claude-code)