### PR TITLE
feat: replace journal entry deletion with reversing entries for CPA a…

### DIFF
--- a/prisma/migrations/20260221_add_reversal_fields/migration.sql
+++ b/prisma/migrations/20260221_add_reversal_fields/migration.sql
@@ -1,0 +1,7 @@
+-- Add reversal tracking fields to journal_transactions for CPA audit trail
+-- Instead of deleting journal entries on uncommit, we now create reversing entries
+
+ALTER TABLE journal_transactions
+  ADD COLUMN IF NOT EXISTS is_reversal BOOLEAN NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS reverses_journal_id UUID,
+  ADD COLUMN IF NOT EXISTS reversal_date TIMESTAMPTZ;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -152,6 +152,9 @@ model journal_transactions {
   amount                     Int?
   strategy                   String?                @db.VarChar(50)
   trade_num                  String?                @db.VarChar(20)
+  is_reversal                Boolean                @default(false)
+  reverses_journal_id        String?                @db.Uuid
+  reversal_date              DateTime?
   journal_transactions       journal_transactions?  @relation("journal_transactionsTojournal_transactions", fields: [reversed_by_transaction_id], references: [id])
   other_journal_transactions journal_transactions[] @relation("journal_transactionsTojournal_transactions")
   ledger_entries             ledger_entries[]


### PR DESCRIPTION
…udit trail

Proper accounting never deletes journal entries. Instead of deleting on uncommit, both endpoints now create REVERSING ENTRIES — new journal entries with opposite debits/credits, dated today, linked to the original.

Schema changes (journal_transactions):
- is_reversal: Boolean flag marking reversal entries
- reverses_journal_id: FK from reversal → original it reverses
- reversal_date: when the reversal was created
- reversed_by_transaction_id: already existed, now used to link original → its reversal

Spending uncommit (/api/transactions/uncommit):
- Finds non-reversed original journal entries for the transactions
- Creates reversing journal entry (REVERSAL: prefix, is_reversal=true)
- Creates opposite ledger entries (D→C, C→D) with COA balance updates
- Links original ↔ reversal bidirectionally
- Clears transaction accountCode/subAccount, resets to pending_review
- Returns reversalEntryIds in response for audit trail
- Also fixed auth to use getVerifiedEmail() (was using raw cookies)

Investment uncommit (/api/investment-transactions/uncommit):
- Same reversing entry pattern for journal entries
- Still deletes stock_lots, lot_dispositions, trading_positions (operational records, not accounting records)

No journal_transactions or ledger_entries are ever deleted. Period.

https://claude.ai/code/session_01CCk1pA3MvtFBBKegqHhhhs