### PR TITLE
feat: audit trail UI - Journal and Ledger tabs with reversal visibili…

### DIFF
--- a/src/app/api/journal-transactions/route.ts
+++ b/src/app/api/journal-transactions/route.ts
@@ -1,0 +1,82 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
+
+export async function GET() {
+  try {
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const user = await prisma.users.findFirst({
+      where: { email: { equals: userEmail, mode: 'insensitive' } }
+    });
+    if (!user) {
+      return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    }
+
+    // SECURITY: journal_transactions don't have userId directly.
+    // Scope via ledger_entries -> chart_of_accounts.userId.
+    const transactions = await prisma.journal_transactions.findMany({
+      where: {
+        ledger_entries: {
+          some: {
+            chart_of_accounts: { userId: user.id }
+          }
+        }
+      },
+      include: {
+        ledger_entries: {
+          include: {
+            chart_of_accounts: {
+              select: {
+                code: true,
+                name: true,
+                account_type: true
+              }
+            }
+          }
+        }
+      },
+      orderBy: [
+        { transaction_date: 'desc' },
+        { created_at: 'desc' }
+      ]
+    });
+
+    const reversalCount = transactions.filter(t => t.is_reversal).length;
+
+    const entries = transactions.map(t => ({
+      id: t.id,
+      transaction_date: t.transaction_date,
+      description: t.description,
+      is_reversal: t.is_reversal,
+      reverses_journal_id: t.reverses_journal_id,
+      reversed_by_transaction_id: t.reversed_by_transaction_id,
+      reversal_date: t.reversal_date,
+      account_code: t.account_code,
+      amount: t.amount,
+      strategy: t.strategy,
+      trade_num: t.trade_num,
+      created_at: t.created_at,
+      posted_at: t.posted_at,
+      ledger_entries: t.ledger_entries.map(entry => ({
+        id: entry.id,
+        account_id: entry.account_id,
+        amount: Number(entry.amount),
+        entry_type: entry.entry_type,
+        chart_of_accounts: entry.chart_of_accounts
+      }))
+    }));
+
+    return NextResponse.json({
+      entries,
+      totalCount: entries.length,
+      reversalCount
+    });
+  } catch (error) {
+    console.error('Journal transactions fetch error:', error);
+    return NextResponse.json({ error: 'Failed to fetch journal transactions' }, { status: 500 });
+  }
+}

--- a/src/app/api/ledger/route.ts
+++ b/src/app/api/ledger/route.ts
@@ -1,8 +1,8 @@
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 
-export async function GET() {
+export async function GET(request: NextRequest) {
   try {
     const userEmail = await getVerifiedEmail();
     if (!userEmail) {
@@ -16,10 +16,17 @@ export async function GET() {
       return NextResponse.json({ error: 'User not found' }, { status: 404 });
     }
 
+    // Optional filter by account code
+    const { searchParams } = new URL(request.url);
+    const accountCode = searchParams.get('accountCode');
+
     // SECURITY: Scoped to user's COA only
     const ledgerEntries = await prisma.ledger_entries.findMany({
       where: {
-        chart_of_accounts: { userId: user.id }
+        chart_of_accounts: {
+          userId: user.id,
+          ...(accountCode ? { code: accountCode } : {})
+        }
       },
       include: {
         chart_of_accounts: true,
@@ -36,7 +43,7 @@ export async function GET() {
 
     ledgerEntries.forEach(entry => {
       const accountId = entry.account_id;
-      
+
       if (!accountMap.has(accountId)) {
         accountMap.set(accountId, {
           accountCode: entry.chart_of_accounts.code,
@@ -49,7 +56,7 @@ export async function GET() {
       }
 
       const account = accountMap.get(accountId);
-      
+
       const isNormalBalance = entry.entry_type === entry.chart_of_accounts.balance_type;
       const change = isNormalBalance ? Number(entry.amount) : -Number(entry.amount);
       account.runningBalance += change;
@@ -60,7 +67,10 @@ export async function GET() {
         description: entry.journal_transactions.description || 'No description',
         entryType: entry.entry_type,
         amount: Number(entry.amount) / 100,
-        runningBalance: account.runningBalance / 100
+        runningBalance: account.runningBalance / 100,
+        journal_id: entry.journal_transactions.id,
+        is_reversal: entry.journal_transactions.is_reversal ?? false,
+        reversed_by_transaction_id: entry.journal_transactions.reversed_by_transaction_id ?? null
       });
     });
 
@@ -68,6 +78,7 @@ export async function GET() {
       accountCode: account.accountCode,
       accountName: account.accountName,
       accountType: account.accountType,
+      balanceType: account.balanceType,
       entries: account.entries,
       openingBalance: 0,
       closingBalance: account.runningBalance / 100

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -113,7 +113,7 @@ export default function Dashboard() {
       }
       if (invRes.ok) { const data = await invRes.json(); setInvestmentTransactions(data.transactions || data.investments || data || []); }
       
-      const jeRes = await fetch('/api/journal-entries');
+      const jeRes = await fetch('/api/journal-transactions');
       if (jeRes.ok) { const jeData = await jeRes.json(); setJournalEntries(jeData.entries || []); }
       const reconRes = await fetch("/api/bank-reconciliations");
       if (reconRes.ok) { const reconData = await reconRes.json(); setReconciliations(reconData.reconciliations || []); }
@@ -605,21 +605,15 @@ export default function Dashboard() {
 
               {/* General Ledger */}
               {activeSection === 'ledger' && (
-                <div>
-                  <div className="bg-[#2d1b4e] text-white px-4 py-2 text-sm font-semibold">General Ledger</div>
-                  <div className="p-4">
-                    <GeneralLedger transactions={transactions} coaOptions={coaOptions} onUpdate={handleLedgerUpdate} />
-                  </div>
+                <div className="p-4">
+                  <GeneralLedger coaOptions={coaOptions} onReload={loadData} />
                 </div>
               )}
 
               {/* Journal Entries */}
               {activeSection === 'journal' && (
-                <div>
-                  <div className="bg-[#2d1b4e] text-white px-4 py-2 text-sm font-semibold">Journal Entries</div>
-                  <div className="p-4">
-                    <JournalEntryEngine entries={journalEntries} coaOptions={coaOptions} onSave={saveJournalEntry} onReload={loadData} />
-                  </div>
+                <div className="p-4">
+                  <JournalEntryEngine journalTransactions={journalEntries} coaOptions={coaOptions} onSave={saveJournalEntry} onReload={loadData} />
                 </div>
               )}
 

--- a/src/components/dashboard/GeneralLedger.tsx
+++ b/src/components/dashboard/GeneralLedger.tsx
@@ -1,311 +1,699 @@
 'use client';
 
-import { useState, useMemo } from 'react';
+import { useState, useEffect, useMemo, useRef, useCallback, Fragment } from 'react';
+import { useVirtualizer } from '@tanstack/react-virtual';
 
-interface Transaction {
-  id: string;
-  date: string;
-  name: string;
-  amount: number;
-  accountCode: string | null;
-  subAccount: string | null;
-}
+/* ------------------------------------------------------------------ */
+/*  Types                                                              */
+/* ------------------------------------------------------------------ */
 
 interface CoaOption {
   id: string;
   code: string;
   name: string;
   accountType: string;
+  balanceType: string;
+  entity_type?: string | null;
 }
 
 interface GeneralLedgerProps {
-  transactions: Transaction[];
   coaOptions: CoaOption[];
-  onUpdate: (id: string, field: 'accountCode' | 'subAccount', value: string) => Promise<void>;
+  onReload: () => void;
 }
 
-export default function GeneralLedger({ transactions, coaOptions, onUpdate }: GeneralLedgerProps) {
-  const [filterAccount, setFilterAccount] = useState<string>('all');
-  const [filterDateFrom, setFilterDateFrom] = useState('');
-  const [filterDateTo, setFilterDateTo] = useState('');
-  const [filterSearch, setFilterSearch] = useState('');
-  const [editingCell, setEditingCell] = useState<{ id: string; field: 'accountCode' | 'subAccount' } | null>(null);
-  const [editValue, setEditValue] = useState('');
-  const [saving, setSaving] = useState(false);
-  const [visibleCount, setVisibleCount] = useState(100);
+interface LedgerEntry {
+  id: string;
+  date: string;
+  description: string;
+  entryType: string; // 'D' or 'C'
+  amount: number;
+  runningBalance: number;
+  journal_id: string;
+  is_reversal: boolean;
+  reversed_by_transaction_id: string | null;
+}
 
-  // Group COA by type for dropdown
-  const coaGrouped = useMemo(() => {
-    const g: Record<string, CoaOption[]> = {};
-    coaOptions.forEach(o => {
-      if (!g[o.accountType]) g[o.accountType] = [];
-      g[o.accountType].push(o);
+interface LedgerAccount {
+  accountCode: string;
+  accountName: string;
+  accountType: string;
+  balanceType: string;
+  entries: LedgerEntry[];
+  openingBalance: number;
+  closingBalance: number;
+}
+
+interface LedgerApiResponse {
+  ledgers: LedgerAccount[];
+}
+
+type SortField = 'date' | 'description' | 'amount' | 'balance';
+type SortDir = 'asc' | 'desc';
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                            */
+/* ------------------------------------------------------------------ */
+
+const ROW_HEIGHT = 40;
+
+const fmtMoney = (n: number): string =>
+  '$' +
+  Math.abs(n).toLocaleString('en-US', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+
+const fmtDate = (iso: string): string => {
+  const d = new Date(iso);
+  const mm = String(d.getMonth() + 1).padStart(2, '0');
+  const dd = String(d.getDate()).padStart(2, '0');
+  const yyyy = d.getFullYear();
+  return `${mm}/${dd}/${yyyy}`;
+};
+
+const entryStatus = (e: LedgerEntry): 'Active' | 'Reversed' | 'Reversal' => {
+  if (e.is_reversal) return 'Reversal';
+  if (e.reversed_by_transaction_id) return 'Reversed';
+  return 'Active';
+};
+
+/* ------------------------------------------------------------------ */
+/*  Component                                                          */
+/* ------------------------------------------------------------------ */
+
+export default function GeneralLedger({ coaOptions, onReload }: GeneralLedgerProps) {
+  /* ---- state ---- */
+  const [ledgers, setLedgers] = useState<LedgerAccount[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [selectedCode, setSelectedCode] = useState<string | null>(null);
+  const [accountSearch, setAccountSearch] = useState('');
+  const [accountDropdownOpen, setAccountDropdownOpen] = useState(false);
+
+  const [dateFrom, setDateFrom] = useState('');
+  const [dateTo, setDateTo] = useState('');
+  const [keyword, setKeyword] = useState('');
+
+  const [sortField, setSortField] = useState<SortField>('date');
+  const [sortDir, setSortDir] = useState<SortDir>('asc');
+
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  /* ---- fetch helper ---- */
+  const fetchLedger = useCallback(async (accountCode?: string | null) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const url = accountCode
+        ? `/api/ledger?accountCode=${encodeURIComponent(accountCode)}`
+        : '/api/ledger';
+      const res = await fetch(url);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data: LedgerApiResponse = await res.json();
+      setLedgers(data.ledgers);
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : 'Failed to fetch ledger data');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  /* ---- initial load ---- */
+  useEffect(() => {
+    fetchLedger();
+  }, [fetchLedger]);
+
+  /* ---- refetch when account changes ---- */
+  useEffect(() => {
+    fetchLedger(selectedCode);
+  }, [selectedCode, fetchLedger]);
+
+  /* ---- close dropdown on outside click ---- */
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
+        setAccountDropdownOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, []);
+
+  /* ---- derived: selected account ---- */
+  const selectedAccount = useMemo(
+    () => (selectedCode ? ledgers.find((l) => l.accountCode === selectedCode) ?? null : null),
+    [ledgers, selectedCode],
+  );
+
+  /* ---- account list for selector, grouped by entity_type ---- */
+  const groupedAccounts = useMemo(() => {
+    const groups: Record<string, { code: string; name: string; balance: number }[]> = {};
+    const search = accountSearch.toLowerCase();
+
+    ledgers.forEach((l) => {
+      if (search && !l.accountCode.toLowerCase().includes(search) && !l.accountName.toLowerCase().includes(search)) {
+        return;
+      }
+      const coaMatch = coaOptions.find((c) => c.code === l.accountCode);
+      const group = coaMatch?.entity_type || 'Other';
+      if (!groups[group]) groups[group] = [];
+      groups[group].push({ code: l.accountCode, name: l.accountName, balance: l.closingBalance });
     });
-    return g;
-  }, [coaOptions]);
 
-  // Get unique accounts used
-  const usedAccounts = useMemo(() => {
-    const codes = new Set<string>();
-    transactions.forEach(t => { if (t.accountCode) codes.add(t.accountCode); });
-    return Array.from(codes).map(code => {
-      const coa = coaOptions.find(c => c.code === code);
-      return { code, name: coa?.name || code };
-    }).sort((a, b) => a.code.localeCompare(b.code));
-  }, [transactions, coaOptions]);
+    // Also include COA options that may not have entries yet
+    coaOptions.forEach((c) => {
+      if (search && !c.code.toLowerCase().includes(search) && !c.name.toLowerCase().includes(search)) {
+        return;
+      }
+      const group = c.entity_type || 'Other';
+      if (!groups[group]) groups[group] = [];
+      const exists = groups[group].some((a) => a.code === c.code);
+      if (!exists) {
+        groups[group].push({ code: c.code, name: c.name, balance: 0 });
+      }
+    });
 
-  // Get unique vendors
-  const vendors = useMemo(() => {
-    const v = new Set<string>();
-    transactions.forEach(t => { if (t.subAccount) v.add(t.subAccount); });
-    return Array.from(v).sort();
-  }, [transactions]);
+    // Sort within each group
+    Object.values(groups).forEach((arr) => arr.sort((a, b) => a.code.localeCompare(b.code)));
 
-  // Filter transactions
-  const filtered = useMemo(() => {
-    return transactions
-      .filter(t => {
-        if (filterAccount !== 'all' && t.accountCode !== filterAccount) return false;
-        if (filterDateFrom && new Date(t.date) < new Date(filterDateFrom)) return false;
-        if (filterDateTo && new Date(t.date) > new Date(filterDateTo)) return false;
-        if (filterSearch) {
-          const s = filterSearch.toLowerCase();
-          if (!t.name.toLowerCase().includes(s) && !t.subAccount?.toLowerCase().includes(s)) return false;
-        }
-        return true;
-      })
-      .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
-  }, [transactions, filterAccount, filterDateFrom, filterDateTo, filterSearch]);
+    return groups;
+  }, [ledgers, coaOptions, accountSearch]);
 
-  // Calculate running balance per account
-  const withBalance = useMemo(() => {
-    const balances: Record<string, number> = {};
-    const sorted = [...filtered].sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
-    
-    return sorted.map(t => {
-      const code = t.accountCode || 'uncategorized';
-      if (!balances[code]) balances[code] = 0;
-      balances[code] += t.amount;
-      return { ...t, runningBalance: balances[code] };
-    }).reverse();
-  }, [filtered]);
+  /* ---- filtered + sorted entries ---- */
+  const filteredEntries = useMemo(() => {
+    if (!selectedAccount) return [];
+    let entries = [...selectedAccount.entries];
 
-  const getCoaName = (code: string | null) => {
-    if (!code) return 'Uncategorized';
-    return coaOptions.find(c => c.code === code)?.name || code;
-  };
+    // date range filter
+    if (dateFrom) {
+      const from = new Date(dateFrom);
+      entries = entries.filter((e) => new Date(e.date) >= from);
+    }
+    if (dateTo) {
+      const to = new Date(dateTo);
+      to.setHours(23, 59, 59, 999);
+      entries = entries.filter((e) => new Date(e.date) <= to);
+    }
 
-  const handleEdit = (id: string, field: 'accountCode' | 'subAccount', currentValue: string | null) => {
-    setEditingCell({ id, field });
-    setEditValue(currentValue || '');
-  };
+    // keyword search
+    if (keyword) {
+      const kw = keyword.toLowerCase();
+      entries = entries.filter((e) => e.description.toLowerCase().includes(kw));
+    }
 
-  const handleSave = async () => {
-    if (!editingCell) return;
-    setSaving(true);
-    await onUpdate(editingCell.id, editingCell.field, editValue);
-    setEditingCell(null);
-    setEditValue('');
-    setSaving(false);
-  };
+    // sort
+    entries.sort((a, b) => {
+      let cmp = 0;
+      switch (sortField) {
+        case 'date':
+          cmp = new Date(a.date).getTime() - new Date(b.date).getTime();
+          break;
+        case 'description':
+          cmp = a.description.localeCompare(b.description);
+          break;
+        case 'amount':
+          cmp = a.amount - b.amount;
+          break;
+        case 'balance':
+          cmp = a.runningBalance - b.runningBalance;
+          break;
+      }
+      return sortDir === 'asc' ? cmp : -cmp;
+    });
 
-  const handleCancel = () => {
-    setEditingCell(null);
-    setEditValue('');
-  };
+    return entries;
+  }, [selectedAccount, dateFrom, dateTo, keyword, sortField, sortDir]);
 
-  const formatDebitCredit = (amount: number) => {
-    // Positive = expense (debit), Negative = income (credit)
-    if (amount > 0) {
-      return { debit: `$${amount.toFixed(2)}`, credit: '-' };
+  /* ---- virtualizer ---- */
+  const virtualizer = useVirtualizer({
+    count: filteredEntries.length,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: () => ROW_HEIGHT,
+    overscan: 20,
+  });
+
+  /* ---- totals ---- */
+  const totalDebits = useMemo(
+    () => filteredEntries.filter((e) => e.entryType === 'D').reduce((s, e) => s + e.amount, 0),
+    [filteredEntries],
+  );
+  const totalCredits = useMemo(
+    () => filteredEntries.filter((e) => e.entryType === 'C').reduce((s, e) => s + e.amount, 0),
+    [filteredEntries],
+  );
+
+  /* ---- sort handler ---- */
+  const handleSort = (field: SortField) => {
+    if (sortField === field) {
+      setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
     } else {
-      return { debit: '-', credit: `$${Math.abs(amount).toFixed(2)}` };
+      setSortField(field);
+      setSortDir('asc');
     }
   };
 
+  const sortArrow = (field: SortField) => {
+    if (sortField !== field) return ' \u2195';
+    return sortDir === 'asc' ? ' \u2191' : ' \u2193';
+  };
+
+  /* ---- CSV export ---- */
+  const handleExportCSV = () => {
+    if (!selectedAccount) return;
+    const header = ['Date', 'Entry #', 'Description', 'Debit', 'Credit', 'Balance', 'Status'];
+    const rows = filteredEntries.map((e) => {
+      const status = entryStatus(e);
+      return [
+        fmtDate(e.date),
+        e.journal_id.substring(0, 8),
+        `"${e.description.replace(/"/g, '""')}"`,
+        e.entryType === 'D' ? fmtMoney(e.amount) : '',
+        e.entryType === 'C' ? fmtMoney(e.amount) : '',
+        fmtMoney(e.runningBalance),
+        status,
+      ];
+    });
+
+    const csv = [header.join(','), ...rows.map((r) => r.join(','))].join('\n');
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `ledger_${selectedAccount.accountCode}_${new Date().toISOString().slice(0, 10)}.csv`;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  /* ---- grouped summary for "no account selected" view ---- */
+  const accountsByType = useMemo(() => {
+    const groups: Record<string, LedgerAccount[]> = {};
+    const typeOrder = ['Revenue', 'Expense', 'Asset', 'Liability', 'Equity'];
+
+    ledgers.forEach((l) => {
+      const t = l.accountType || 'Other';
+      if (!groups[t]) groups[t] = [];
+      groups[t].push(l);
+    });
+
+    // Sort groups by predefined order
+    const ordered: [string, LedgerAccount[]][] = [];
+    typeOrder.forEach((t) => {
+      if (groups[t]) {
+        ordered.push([t, groups[t].sort((a, b) => a.accountCode.localeCompare(b.accountCode))]);
+        delete groups[t];
+      }
+    });
+    // Append remaining
+    Object.entries(groups).forEach(([t, accts]) => {
+      ordered.push([t, accts.sort((a, b) => a.accountCode.localeCompare(b.accountCode))]);
+    });
+
+    return ordered;
+  }, [ledgers]);
+
+  /* ================================================================ */
+  /*  RENDER                                                           */
+  /* ================================================================ */
+
   return (
-    <div className="bg-white rounded-xl border overflow-hidden">
-      {/* Filters */}
-      <div className="p-3 border-b bg-gray-50 flex flex-wrap gap-2">
-        <select
-          value={filterAccount}
-          onChange={(e) => setFilterAccount(e.target.value)}
-          className="px-3 py-2 border rounded-lg text-sm min-w-[180px]"
-        >
-          <option value="all">All Accounts</option>
-          {usedAccounts.map(a => (
-            <option key={a.code} value={a.code}>{a.code} - {a.name}</option>
-          ))}
-        </select>
+    <div className="bg-white rounded-xl border border-gray-200 overflow-hidden">
+      {/* ---- Header ---- */}
+      <div className="bg-[#2d1b4e] text-white px-4 py-3 flex items-center justify-between">
+        <h2 className="text-sm font-semibold tracking-wide">General Ledger</h2>
+        {selectedCode && (
+          <button
+            onClick={handleExportCSV}
+            className="px-3 py-1 text-xs border border-white/30 rounded hover:bg-white/10 transition"
+          >
+            Export CSV
+          </button>
+        )}
+      </div>
+
+      {/* ---- Controls bar ---- */}
+      <div className="p-3 border-b bg-gray-50 flex flex-wrap gap-2 items-center">
+        {/* Account selector */}
+        <div className="relative min-w-[260px]" ref={dropdownRef}>
+          <input
+            type="text"
+            value={
+              accountDropdownOpen
+                ? accountSearch
+                : selectedCode
+                  ? `${selectedCode} - ${selectedAccount?.accountName || ''}`
+                  : ''
+            }
+            onChange={(e) => {
+              setAccountSearch(e.target.value);
+              setAccountDropdownOpen(true);
+            }}
+            onFocus={() => {
+              setAccountDropdownOpen(true);
+              setAccountSearch('');
+            }}
+            placeholder="Search accounts..."
+            className="w-full px-3 py-2 border rounded-lg text-xs pr-8"
+          />
+          {selectedCode && (
+            <button
+              onClick={() => {
+                setSelectedCode(null);
+                setAccountSearch('');
+                setAccountDropdownOpen(false);
+              }}
+              className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-700 text-sm"
+              title="Clear selection"
+            >
+              x
+            </button>
+          )}
+          {accountDropdownOpen && (
+            <div className="absolute z-30 top-full left-0 right-0 mt-1 bg-white border border-gray-200 rounded-lg shadow-lg max-h-72 overflow-y-auto">
+              {Object.entries(groupedAccounts).length === 0 && (
+                <div className="px-3 py-2 text-xs text-gray-400">No accounts found</div>
+              )}
+              {Object.entries(groupedAccounts).map(([group, accounts]) => (
+                <div key={group}>
+                  <div className="px-3 py-1.5 text-[10px] font-semibold text-gray-500 bg-gray-50 uppercase tracking-wider">
+                    {group}
+                  </div>
+                  {accounts.map((a) => (
+                    <button
+                      key={a.code}
+                      onClick={() => {
+                        setSelectedCode(a.code);
+                        setAccountSearch('');
+                        setAccountDropdownOpen(false);
+                      }}
+                      className="w-full text-left px-3 py-1.5 text-xs hover:bg-[#2d1b4e]/[.07] flex justify-between items-center"
+                    >
+                      <span>
+                        <span className="font-medium">{a.code}</span>{' '}
+                        <span className="text-gray-600">- {a.name}</span>
+                      </span>
+                      <span className="text-gray-500 ml-2 tabular-nums">{fmtMoney(a.balance)}</span>
+                    </button>
+                  ))}
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Date range */}
         <input
           type="date"
-          value={filterDateFrom}
-          onChange={(e) => setFilterDateFrom(e.target.value)}
-          className="px-3 py-2 border rounded-lg text-sm"
+          value={dateFrom}
+          onChange={(e) => setDateFrom(e.target.value)}
+          className="px-3 py-2 border rounded-lg text-xs"
           placeholder="From"
         />
         <input
           type="date"
-          value={filterDateTo}
-          onChange={(e) => setFilterDateTo(e.target.value)}
-          className="px-3 py-2 border rounded-lg text-sm"
+          value={dateTo}
+          onChange={(e) => setDateTo(e.target.value)}
+          className="px-3 py-2 border rounded-lg text-xs"
           placeholder="To"
         />
+
+        {/* Keyword search */}
         <input
           type="text"
-          value={filterSearch}
-          onChange={(e) => setFilterSearch(e.target.value)}
-          placeholder="Search description..."
-          className="flex-1 min-w-[150px] px-3 py-2 border rounded-lg text-sm"
+          value={keyword}
+          onChange={(e) => setKeyword(e.target.value)}
+          placeholder="Search descriptions..."
+          className="flex-1 min-w-[150px] px-3 py-2 border rounded-lg text-xs"
         />
-      </div>
 
-      {/* Legend */}
-      <div className="px-4 py-2 bg-blue-50 border-b text-xs text-blue-700 flex items-center gap-4">
-        <span>✏️ = Click to edit</span>
-        <span>🔒 = Locked (source data)</span>
-        <span className="ml-auto">{filtered.length} entries</span>
-      </div>
-
-      {/* Table */}
-      <div className="overflow-x-auto max-h-[600px] overflow-y-auto">
-        <table className="w-full text-sm min-w-[900px]">
-          <thead className="bg-gray-100 sticky top-0 z-10">
-            <tr>
-              <th className="px-3 py-2 text-left font-semibold w-24">Date 🔒</th>
-              <th className="px-3 py-2 text-left font-semibold w-32">Account ✏️</th>
-              <th className="px-3 py-2 text-left font-semibold w-32">Vendor ✏️</th>
-              <th className="px-3 py-2 text-left font-semibold">Description 🔒</th>
-              <th className="px-3 py-2 text-right font-semibold w-24">Debit 🔒</th>
-              <th className="px-3 py-2 text-right font-semibold w-24">Credit 🔒</th>
-              <th className="px-3 py-2 text-right font-semibold w-28 bg-gray-200">Balance</th>
-            </tr>
-          </thead>
-          <tbody className="divide-y">
-            {withBalance.slice(0, visibleCount).map(txn => {
-              const { debit, credit } = formatDebitCredit(txn.amount);
-              const isEditingAccount = editingCell?.id === txn.id && editingCell?.field === 'accountCode';
-              const isEditingVendor = editingCell?.id === txn.id && editingCell?.field === 'subAccount';
-
-              return (
-                <tr key={txn.id} className={`hover:bg-gray-50 ${!txn.accountCode ? 'bg-amber-50/50' : ''}`}>
-                  {/* Date - Locked */}
-                  <td className="px-3 py-2 text-gray-600 whitespace-nowrap">
-                    {new Date(txn.date).toLocaleDateString()}
-                  </td>
-
-                  {/* Account - Editable */}
-                  <td className="px-3 py-2">
-                    {isEditingAccount ? (
-                      <div className="flex items-center gap-1">
-                        <select
-                          value={editValue}
-                          onChange={(e) => setEditValue(e.target.value)}
-                          className="w-full px-2 py-1 border rounded text-xs"
-                          autoFocus
-                        >
-                          <option value="">Select...</option>
-                          {Object.entries(coaGrouped).map(([type, opts]) => (
-                            <optgroup key={type} label={type}>
-                              {opts.map(o => <option key={o.id} value={o.code}>{o.code}</option>)}
-                            </optgroup>
-                          ))}
-                        </select>
-                        <button onClick={handleSave} disabled={saving} className="text-green-600 hover:text-green-800">✓</button>
-                        <button onClick={handleCancel} className="text-red-600 hover:text-red-800">✕</button>
-                      </div>
-                    ) : (
-                      <button
-                        onClick={() => handleEdit(txn.id, 'accountCode', txn.accountCode)}
-                        className={`text-left hover:bg-blue-100 px-1 py-0.5 rounded w-full truncate ${txn.accountCode ? 'text-gray-900' : 'text-amber-500 font-medium'}`}
-                      >
-                        {txn.accountCode || '+ Add'}
-                      </button>
-                    )}
-                  </td>
-
-                  {/* Vendor - Editable */}
-                  <td className="px-3 py-2">
-                    {isEditingVendor ? (
-                      <div className="flex items-center gap-1">
-                        <input
-                          type="text"
-                          value={editValue}
-                          onChange={(e) => setEditValue(e.target.value)}
-                          list="vendor-list"
-                          className="w-full px-2 py-1 border rounded text-xs"
-                          autoFocus
-                        />
-                        <datalist id="vendor-list">
-                          {vendors.map(v => <option key={v} value={v} />)}
-                        </datalist>
-                        <button onClick={handleSave} disabled={saving} className="text-green-600 hover:text-green-800">✓</button>
-                        <button onClick={handleCancel} className="text-red-600 hover:text-red-800">✕</button>
-                      </div>
-                    ) : (
-                      <button
-                        onClick={() => handleEdit(txn.id, 'subAccount', txn.subAccount)}
-                        className={`text-left hover:bg-blue-100 px-1 py-0.5 rounded w-full truncate ${txn.subAccount ? 'text-gray-700' : 'text-gray-400'}`}
-                      >
-                        {txn.subAccount || '+ Add'}
-                      </button>
-                    )}
-                  </td>
-
-                  {/* Description - Locked */}
-                  <td className="px-3 py-2 text-gray-600 truncate max-w-[300px]" title={txn.name}>
-                    {txn.name}
-                  </td>
-
-                  {/* Debit - Locked */}
-                  <td className={`px-3 py-2 text-right font-mono tabular-nums ${debit !== '-' ? 'text-red-600' : 'text-gray-300'}`}>
-                    {debit}
-                  </td>
-
-                  {/* Credit - Locked */}
-                  <td className={`px-3 py-2 text-right font-mono tabular-nums ${credit !== '-' ? 'text-green-600' : 'text-gray-300'}`}>
-                    {credit}
-                  </td>
-
-                  {/* Running Balance */}
-                  <td className={`px-3 py-2 text-right font-mono tabular-nums bg-gray-50 ${txn.runningBalance >= 0 ? 'text-gray-900' : 'text-red-600'}`}>
-                    ${Math.abs(txn.runningBalance).toFixed(2)}
-                  </td>
-                </tr>
-              );
-            })}
-          </tbody>
-        </table>
-      </div>
-
-      {/* Load More */}
-      {visibleCount < filtered.length && (
+        {/* Reload */}
         <button
-          onClick={() => setVisibleCount(v => v + 100)}
-          className="w-full py-3 text-sm text-[#2d1b4e] hover:bg-gray-50 border-t"
+          onClick={() => {
+            onReload();
+            fetchLedger(selectedCode);
+          }}
+          className="px-3 py-2 text-xs border rounded-lg hover:bg-gray-100"
         >
-          Load more ({filtered.length - visibleCount} remaining)
+          Reload
         </button>
+      </div>
+
+      {/* ---- Loading / Error ---- */}
+      {loading && (
+        <div className="p-8 text-center text-xs text-gray-500">Loading ledger data...</div>
+      )}
+      {error && (
+        <div className="p-4 text-center text-xs text-red-600 bg-red-50">
+          Error: {error}
+          <button onClick={() => fetchLedger(selectedCode)} className="ml-2 underline">
+            Retry
+          </button>
+        </div>
       )}
 
-      {/* Summary Footer */}
-      <div className="px-4 py-3 bg-gray-50 border-t flex justify-between text-sm">
-        <span className="text-gray-600">
-          Total Debits: <span className="font-semibold text-red-600">
-            ${filtered.filter(t => t.amount > 0).reduce((s, t) => s + t.amount, 0).toLocaleString()}
-          </span>
-        </span>
-        <span className="text-gray-600">
-          Total Credits: <span className="font-semibold text-green-600">
-            ${Math.abs(filtered.filter(t => t.amount < 0).reduce((s, t) => s + t.amount, 0)).toLocaleString()}
-          </span>
-        </span>
-        <span className="text-gray-600">
-          Net: <span className={`font-semibold ${filtered.reduce((s, t) => s + t.amount, 0) >= 0 ? 'text-red-600' : 'text-green-600'}`}>
-            ${Math.abs(filtered.reduce((s, t) => s + t.amount, 0)).toLocaleString()}
-          </span>
-        </span>
-      </div>
+      {/* ---- No account selected: show summary grid ---- */}
+      {!loading && !error && !selectedCode && (
+        <div className="overflow-x-auto">
+          <table className="w-full text-xs min-w-[700px]">
+            <thead>
+              <tr className="bg-[#2d1b4e] text-white">
+                <th className="px-3 py-2 text-left font-semibold">Account Code</th>
+                <th className="px-3 py-2 text-left font-semibold">Account Name</th>
+                <th className="px-3 py-2 text-left font-semibold">Type</th>
+                <th className="px-3 py-2 text-right font-semibold">Balance</th>
+              </tr>
+            </thead>
+            <tbody>
+              {accountsByType.map(([type, accounts]) => (
+                <Fragment key={type}>
+                  <tr>
+                    <td
+                      colSpan={4}
+                      className="px-3 py-2 text-[10px] font-bold text-gray-500 bg-gray-100 uppercase tracking-wider"
+                    >
+                      {type}
+                    </td>
+                  </tr>
+                  {accounts.map((acct, idx) => (
+                    <tr
+                      key={acct.accountCode}
+                      onClick={() => setSelectedCode(acct.accountCode)}
+                      className={`cursor-pointer hover:bg-[#2d1b4e]/[.07] ${
+                        idx % 2 === 0 ? 'bg-white' : 'bg-gray-50/50'
+                      }`}
+                    >
+                      <td className="px-3 py-2 font-medium">{acct.accountCode}</td>
+                      <td className="px-3 py-2 text-gray-700">{acct.accountName}</td>
+                      <td className="px-3 py-2 text-gray-500">{acct.accountType}</td>
+                      <td className="px-3 py-2 text-right font-mono tabular-nums">
+                        {fmtMoney(acct.closingBalance)}
+                      </td>
+                    </tr>
+                  ))}
+                </Fragment>
+              ))}
+              {accountsByType.length === 0 && (
+                <tr>
+                  <td colSpan={4} className="px-3 py-8 text-center text-gray-400">
+                    No ledger entries found. Post journal entries first.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {/* ---- Account selected: summary + entries ---- */}
+      {!loading && !error && selectedCode && selectedAccount && (
+        <>
+          {/* Account summary row */}
+          <div className="px-4 py-3 bg-gray-50 border-b flex flex-wrap gap-6 text-xs">
+            <div>
+              <span className="text-gray-500">Opening Balance</span>
+              <div className="font-semibold tabular-nums mt-0.5">
+                {fmtMoney(selectedAccount.openingBalance)}
+              </div>
+            </div>
+            <div>
+              <span className="text-gray-500">Total Debits</span>
+              <div className="font-semibold text-red-600 tabular-nums mt-0.5">
+                {fmtMoney(
+                  selectedAccount.entries
+                    .filter((e) => e.entryType === 'D')
+                    .reduce((s, e) => s + e.amount, 0),
+                )}
+              </div>
+            </div>
+            <div>
+              <span className="text-gray-500">Total Credits</span>
+              <div className="font-semibold text-green-600 tabular-nums mt-0.5">
+                {fmtMoney(
+                  selectedAccount.entries
+                    .filter((e) => e.entryType === 'C')
+                    .reduce((s, e) => s + e.amount, 0),
+                )}
+              </div>
+            </div>
+            <div>
+              <span className="text-gray-500">Closing Balance</span>
+              <div className="font-semibold tabular-nums mt-0.5">
+                {fmtMoney(selectedAccount.closingBalance)}
+              </div>
+            </div>
+            <div className="ml-auto self-center text-gray-500">
+              {selectedAccount.accountCode} - {selectedAccount.accountName} ({selectedAccount.accountType})
+            </div>
+          </div>
+
+          {/* Virtualized table */}
+          <div className="overflow-x-auto border border-gray-200">
+            {/* Column headers */}
+            <div className="min-w-[900px]">
+              <div className="bg-[#2d1b4e] text-white flex text-xs font-semibold sticky top-0 z-10">
+                <button
+                  onClick={() => handleSort('date')}
+                  className="px-3 py-2 text-left w-[100px] hover:bg-white/10 shrink-0"
+                >
+                  Date{sortArrow('date')}
+                </button>
+                <div className="px-3 py-2 text-left w-[90px] shrink-0">Entry #</div>
+                <button
+                  onClick={() => handleSort('description')}
+                  className="px-3 py-2 text-left flex-1 hover:bg-white/10"
+                >
+                  Description{sortArrow('description')}
+                </button>
+                <button
+                  onClick={() => handleSort('amount')}
+                  className="px-3 py-2 text-right w-[100px] hover:bg-white/10 shrink-0"
+                >
+                  Debit{sortArrow('amount')}
+                </button>
+                <div className="px-3 py-2 text-right w-[100px] shrink-0">Credit</div>
+                <button
+                  onClick={() => handleSort('balance')}
+                  className="px-3 py-2 text-right w-[110px] hover:bg-white/10 shrink-0"
+                >
+                  Balance{sortArrow('balance')}
+                </button>
+                <div className="px-3 py-2 text-center w-[90px] shrink-0">Status</div>
+              </div>
+
+              {/* Scroll container */}
+              <div ref={scrollRef} className="max-h-[600px] overflow-y-auto">
+                <div
+                  style={{ height: `${virtualizer.getTotalSize()}px`, position: 'relative' }}
+                >
+                  {virtualizer.getVirtualItems().map((vRow) => {
+                    const entry = filteredEntries[vRow.index];
+                    const status = entryStatus(entry);
+                    const isReversed = status === 'Reversed';
+                    const isReversal = status === 'Reversal';
+                    const rowIdx = vRow.index;
+
+                    return (
+                      <div
+                        key={entry.id}
+                        style={{
+                          position: 'absolute',
+                          top: 0,
+                          left: 0,
+                          width: '100%',
+                          height: `${vRow.size}px`,
+                          transform: `translateY(${vRow.start}px)`,
+                        }}
+                        className={[
+                          'flex items-center text-xs',
+                          rowIdx % 2 === 0 ? 'bg-white' : 'bg-gray-50/50',
+                          'hover:bg-[#2d1b4e]/[.07]',
+                          isReversed ? 'text-gray-400' : '',
+                          isReversal ? 'border-l-[3px] border-amber-400' : '',
+                        ].join(' ')}
+                      >
+                        {/* Date */}
+                        <div className="px-3 py-2 w-[100px] shrink-0 whitespace-nowrap">
+                          {fmtDate(entry.date)}
+                        </div>
+
+                        {/* Entry # */}
+                        <div className="px-3 py-2 w-[90px] shrink-0 font-mono text-[11px] truncate">
+                          {entry.journal_id.substring(0, 8)}
+                        </div>
+
+                        {/* Description */}
+                        <div
+                          className={`px-3 py-2 flex-1 truncate ${isReversed ? 'line-through' : ''}`}
+                          title={entry.description}
+                        >
+                          {entry.description}
+                        </div>
+
+                        {/* Debit */}
+                        <div className="px-3 py-2 w-[100px] shrink-0 text-right font-mono tabular-nums">
+                          {entry.entryType === 'D' ? fmtMoney(entry.amount) : ''}
+                        </div>
+
+                        {/* Credit */}
+                        <div className="px-3 py-2 w-[100px] shrink-0 text-right font-mono tabular-nums">
+                          {entry.entryType === 'C' ? fmtMoney(entry.amount) : ''}
+                        </div>
+
+                        {/* Balance */}
+                        <div className="px-3 py-2 w-[110px] shrink-0 text-right font-mono tabular-nums">
+                          {fmtMoney(entry.runningBalance)}
+                        </div>
+
+                        {/* Status */}
+                        <div className="px-3 py-2 w-[90px] shrink-0 text-center">
+                          {status === 'Active' && (
+                            <span className="inline-block px-1.5 py-0.5 rounded text-[10px] bg-green-100 text-green-700">
+                              Active
+                            </span>
+                          )}
+                          {status === 'Reversed' && (
+                            <span className="inline-block px-1.5 py-0.5 rounded text-[10px] bg-gray-200 text-gray-500">
+                              Reversed
+                            </span>
+                          )}
+                          {status === 'Reversal' && (
+                            <span className="inline-block px-1.5 py-0.5 rounded text-[10px] bg-amber-100 text-amber-700">
+                              Reversal
+                            </span>
+                          )}
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* Footer summary */}
+          <div className="px-4 py-3 bg-gray-50 border-t flex justify-between text-xs">
+            <span className="text-gray-600">
+              {filteredEntries.length} {filteredEntries.length === 1 ? 'entry' : 'entries'}
+            </span>
+            <span className="text-gray-600">
+              Total Debits:{' '}
+              <span className="font-semibold text-red-600">{fmtMoney(totalDebits)}</span>
+            </span>
+            <span className="text-gray-600">
+              Total Credits:{' '}
+              <span className="font-semibold text-green-600">{fmtMoney(totalCredits)}</span>
+            </span>
+          </div>
+        </>
+      )}
+
+      {/* Account selected but not found in data */}
+      {!loading && !error && selectedCode && !selectedAccount && (
+        <div className="p-8 text-center text-xs text-gray-400">
+          No ledger entries for account {selectedCode}.
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/dashboard/JournalEntryEngine.tsx
+++ b/src/components/dashboard/JournalEntryEngine.tsx
@@ -1,23 +1,38 @@
 'use client';
 
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useRef, useEffect, useCallback } from 'react';
+import { createPortal } from 'react-dom';
+import { useVirtualizer } from '@tanstack/react-virtual';
 
-interface JournalEntryLine {
-  id?: string;
-  accountCode: string;
-  description: string;
-  debit: string;
-  credit: string;
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+interface LedgerEntry {
+  id: string;
+  account_id: string;
+  amount: number; // cents (BigInt serialized as number)
+  entry_type: string; // 'D' or 'C'
+  chart_of_accounts: {
+    code: string;
+    name: string;
+    account_type: string;
+  };
 }
 
-interface JournalEntry {
+interface JournalTxn {
   id: string;
-  entryNumber: number;
-  date: string;
-  type: string;
-  memo: string | null;
-  status: string;
-  lines: JournalEntryLine[];
+  transaction_date: string;
+  description: string | null;
+  is_reversal: boolean;
+  reverses_journal_id: string | null;
+  reversed_by_transaction_id: string | null;
+  reversal_date: string | null;
+  account_code: string | null;
+  amount: number | null; // cents
+  strategy: string | null;
+  trade_num: string | null;
+  created_at: string;
+  posted_at: string | null;
+  ledger_entries: LedgerEntry[];
 }
 
 interface CoaOption {
@@ -25,13 +40,43 @@ interface CoaOption {
   code: string;
   name: string;
   accountType: string;
+  balanceType: string;
+  entity_type?: string | null;
 }
 
 interface JournalEntryEngineProps {
-  entries: JournalEntry[];
+  journalTransactions: JournalTxn[];
   coaOptions: CoaOption[];
   onSave: (entry: any) => Promise<void>;
   onReload: () => void;
+}
+
+type SortField = 'date' | 'description' | 'type' | 'status' | 'debits' | 'credits';
+type SortDir = 'asc' | 'desc';
+
+type ColumnFilterValue =
+  | { type: 'checkbox'; selected: string[] }
+  | { type: 'dateRange'; from: string; to: string }
+  | { type: 'amountRange'; min: string; max: string }
+  | { type: 'search'; term: string };
+
+type ColumnFilters = Partial<Record<SortField, ColumnFilterValue>>;
+
+const COLUMN_FILTER_TYPE: Record<SortField, 'checkbox' | 'dateRange' | 'amountRange' | 'search'> = {
+  date: 'dateRange',
+  description: 'search',
+  type: 'checkbox',
+  status: 'checkbox',
+  debits: 'amountRange',
+  credits: 'amountRange',
+};
+
+interface JournalEntryLine {
+  id?: string;
+  accountCode: string;
+  description: string;
+  debit: string;
+  credit: string;
 }
 
 const ENTRY_TYPES = [
@@ -42,25 +87,372 @@ const ENTRY_TYPES = [
   { value: 'closing', label: 'Closing Entry' },
 ];
 
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const ROW_HEIGHT = 44;
+
+function formatDate(d: string): string {
+  const dt = new Date(d);
+  return `${String(dt.getMonth() + 1).padStart(2, '0')}/${String(dt.getDate()).padStart(2, '0')}/${dt.getFullYear()}`;
+}
+
+function formatMoney(cents: number): string {
+  return '$' + (Math.abs(cents) / 100).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+}
+
+function formatMoneyDollars(dollars: number): string {
+  return '$' + Math.abs(dollars).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+}
+
+function getDerivedType(txn: JournalTxn): string {
+  return txn.is_reversal ? 'Reversal' : 'Original';
+}
+
+function getDerivedStatus(txn: JournalTxn): string {
+  if (txn.is_reversal) return 'Reversal';
+  if (txn.reversed_by_transaction_id) return 'Reversed';
+  return 'Active';
+}
+
+function getDebits(txn: JournalTxn): number {
+  return txn.ledger_entries.filter(e => e.entry_type === 'D').reduce((s, e) => s + e.amount, 0) / 100;
+}
+
+function getCredits(txn: JournalTxn): number {
+  return txn.ledger_entries.filter(e => e.entry_type === 'C').reduce((s, e) => s + e.amount, 0) / 100;
+}
+
+function truncateId(id: string): string {
+  return id.length > 8 ? id.slice(0, 8) + '...' : id;
+}
+
+function getFieldValue(txn: JournalTxn, field: SortField): string {
+  switch (field) {
+    case 'date': return txn.transaction_date;
+    case 'description': return txn.description || '';
+    case 'type': return getDerivedType(txn);
+    case 'status': return getDerivedStatus(txn);
+    case 'debits': return String(getDebits(txn));
+    case 'credits': return String(getCredits(txn));
+  }
+}
+
+function getUniqueValues(txns: JournalTxn[], field: SortField): [string, number][] {
+  const m = new Map<string, number>();
+  txns.forEach(t => {
+    const v = getFieldValue(t, field);
+    if (v) m.set(v, (m.get(v) || 0) + 1);
+  });
+  return Array.from(m.entries()).sort((a, b) => a[0].localeCompare(b[0]));
+}
+
+function sortTxns(txns: JournalTxn[], field: SortField, dir: SortDir): JournalTxn[] {
+  const sorted = [...txns];
+  sorted.sort((a, b) => {
+    let cmp = 0;
+    switch (field) {
+      case 'date': cmp = new Date(a.transaction_date).getTime() - new Date(b.transaction_date).getTime(); break;
+      case 'description': cmp = (a.description || '').localeCompare(b.description || ''); break;
+      case 'type': cmp = getDerivedType(a).localeCompare(getDerivedType(b)); break;
+      case 'status': cmp = getDerivedStatus(a).localeCompare(getDerivedStatus(b)); break;
+      case 'debits': cmp = getDebits(a) - getDebits(b); break;
+      case 'credits': cmp = getCredits(a) - getCredits(b); break;
+    }
+    return dir === 'asc' ? cmp : -cmp;
+  });
+  return sorted;
+}
+
+function applyColumnFilters(txns: JournalTxn[], colFilters: ColumnFilters): JournalTxn[] {
+  let result = txns;
+  for (const [field, filter] of Object.entries(colFilters) as [SortField, ColumnFilterValue][]) {
+    if (!filter) continue;
+    switch (filter.type) {
+      case 'checkbox':
+        if (filter.selected.length > 0)
+          result = result.filter(t => filter.selected.includes(getFieldValue(t, field)));
+        break;
+      case 'dateRange':
+        if (filter.from) { const f = new Date(filter.from); result = result.filter(t => new Date(t.transaction_date) >= f); }
+        if (filter.to) { const to = new Date(filter.to); to.setHours(23, 59, 59, 999); result = result.filter(t => new Date(t.transaction_date) <= to); }
+        break;
+      case 'amountRange': {
+        if (filter.min) { const min = parseFloat(filter.min); if (!isNaN(min)) result = result.filter(t => parseFloat(getFieldValue(t, field)) >= min); }
+        if (filter.max) { const max = parseFloat(filter.max); if (!isNaN(max)) result = result.filter(t => parseFloat(getFieldValue(t, field)) <= max); }
+        break;
+      }
+      case 'search':
+        if (filter.term) { const lower = filter.term.toLowerCase(); result = result.filter(t => getFieldValue(t, field).toLowerCase().includes(lower)); }
+        break;
+    }
+  }
+  return result;
+}
+
+function columnFilterLabel(field: SortField): string {
+  const labels: Record<SortField, string> = {
+    date: 'Date',
+    description: 'Description',
+    type: 'Type',
+    status: 'Status',
+    debits: 'Debits',
+    credits: 'Credits',
+  };
+  return labels[field];
+}
+
+function columnFilterSummary(filter: ColumnFilterValue): string {
+  switch (filter.type) {
+    case 'checkbox': return filter.selected.slice(0, 2).join(', ') + (filter.selected.length > 2 ? ` +${filter.selected.length - 2}` : '');
+    case 'dateRange': return [filter.from, filter.to].filter(Boolean).join(' \u2013 ');
+    case 'amountRange': return ['$' + filter.min, '$' + filter.max].filter(v => v !== '$').join(' \u2013 ');
+    case 'search': return `"${filter.term}"`;
+  }
+}
+
+function countActiveColumnFilters(colFilters: ColumnFilters): number {
+  return Object.values(colFilters).filter(f => {
+    if (!f) return false;
+    switch (f.type) {
+      case 'checkbox': return f.selected.length > 0;
+      case 'dateRange': return !!(f.from || f.to);
+      case 'amountRange': return !!(f.min || f.max);
+      case 'search': return f.term.length > 0;
+    }
+  }).length;
+}
+
 const emptyLine = (): JournalEntryLine => ({
   accountCode: '',
   description: '',
   debit: '',
-  credit: ''
+  credit: '',
 });
 
-export default function JournalEntryEngine({ entries, coaOptions, onSave, onReload }: JournalEntryEngineProps) {
-  const [showForm, setShowForm] = useState(false);
+// ─── Column Filter Dropdown (portal) ─────────────────────────────────────────
+
+function JournalColumnFilterDropdown({
+  field, filterType, allTransactions, currentFilter, onApply, onCancel, anchorEl,
+  sortField, sortDir, onSortWithDir,
+}: {
+  field: SortField;
+  filterType: 'checkbox' | 'dateRange' | 'amountRange' | 'search';
+  allTransactions: JournalTxn[];
+  currentFilter: ColumnFilterValue | undefined;
+  onApply: (filter: ColumnFilterValue | undefined) => void;
+  onCancel: () => void;
+  anchorEl: HTMLElement | null;
+  sortField: SortField;
+  sortDir: SortDir;
+  onSortWithDir: (field: SortField, dir: SortDir) => void;
+}) {
+  const panelRef = useRef<HTMLDivElement>(null);
+  const searchRef = useRef<HTMLInputElement>(null);
+
+  const [localSearch, setLocalSearch] = useState('');
+  const [localSelected, setLocalSelected] = useState<Set<string>>(() =>
+    currentFilter?.type === 'checkbox' ? new Set(currentFilter.selected) : new Set()
+  );
+  const [localFrom, setLocalFrom] = useState(() => currentFilter?.type === 'dateRange' ? currentFilter.from : '');
+  const [localTo, setLocalTo] = useState(() => currentFilter?.type === 'dateRange' ? currentFilter.to : '');
+  const [localMin, setLocalMin] = useState(() => currentFilter?.type === 'amountRange' ? currentFilter.min : '');
+  const [localMax, setLocalMax] = useState(() => currentFilter?.type === 'amountRange' ? currentFilter.max : '');
+  const [localTerm, setLocalTerm] = useState(() => currentFilter?.type === 'search' ? currentFilter.term : '');
+
+  const uniqueValues = useMemo(() => filterType === 'checkbox' ? getUniqueValues(allTransactions, field) : [], [allTransactions, field, filterType]);
+  const filteredValues = useMemo(() => {
+    if (!localSearch) return uniqueValues;
+    const lower = localSearch.toLowerCase();
+    return uniqueValues.filter(([val]) => val.toLowerCase().includes(lower));
+  }, [uniqueValues, localSearch]);
+
+  const [pos, setPos] = useState({ top: 0, left: 0, alignRight: false });
+  useEffect(() => {
+    if (!anchorEl) return;
+    const rect = anchorEl.getBoundingClientRect();
+    const alignRight = rect.left > window.innerWidth * 0.6;
+    setPos({ top: rect.bottom + 4, left: alignRight ? 0 : rect.left, alignRight });
+  }, [anchorEl]);
+
+  useEffect(() => { const t = setTimeout(() => searchRef.current?.focus(), 50); return () => clearTimeout(t); }, []);
+
+  useEffect(() => {
+    const handler = (e: MouseEvent) => { if (panelRef.current && !panelRef.current.contains(e.target as Node)) onCancel(); };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [onCancel]);
+
+  const handleApply = () => {
+    switch (filterType) {
+      case 'checkbox': onApply(localSelected.size > 0 ? { type: 'checkbox', selected: Array.from(localSelected) } : undefined); break;
+      case 'dateRange': onApply(localFrom || localTo ? { type: 'dateRange', from: localFrom, to: localTo } : undefined); break;
+      case 'amountRange': onApply(localMin || localMax ? { type: 'amountRange', min: localMin, max: localMax } : undefined); break;
+      case 'search': onApply(localTerm ? { type: 'search', term: localTerm } : undefined); break;
+    }
+  };
+
+  const isNumeric = field === 'debits' || field === 'credits';
+  const sortAscLabel = field === 'date' ? 'Sort Oldest First' : isNumeric ? 'Sort Low \u2192 High' : 'Sort A \u2192 Z';
+  const sortDescLabel = field === 'date' ? 'Sort Newest First' : isNumeric ? 'Sort High \u2192 Low' : 'Sort Z \u2192 A';
+  const isSortedAsc = sortField === field && sortDir === 'asc';
+  const isSortedDesc = sortField === field && sortDir === 'desc';
+
+  const panelStyle: React.CSSProperties = {
+    top: pos.top,
+    ...(pos.alignRight && anchorEl
+      ? { right: window.innerWidth - anchorEl.getBoundingClientRect().right }
+      : { left: pos.left }),
+  };
+
+  return createPortal(
+    <div ref={panelRef} className="fixed bg-white border border-gray-200 rounded-lg shadow-xl z-[100] w-64" style={panelStyle}>
+      <div className="border-b border-gray-100 p-2 space-y-1">
+        <button onClick={() => { onSortWithDir(field, 'asc'); onCancel(); }}
+          className={`w-full text-left px-2 py-1.5 text-xs rounded hover:bg-gray-50 flex items-center gap-2 ${isSortedAsc ? 'text-[#2d1b4e] font-semibold bg-[#2d1b4e]/5' : 'text-gray-600'}`}>
+          <span className="text-[10px]">{'\u25B2'}</span> {sortAscLabel}
+        </button>
+        <button onClick={() => { onSortWithDir(field, 'desc'); onCancel(); }}
+          className={`w-full text-left px-2 py-1.5 text-xs rounded hover:bg-gray-50 flex items-center gap-2 ${isSortedDesc ? 'text-[#2d1b4e] font-semibold bg-[#2d1b4e]/5' : 'text-gray-600'}`}>
+          <span className="text-[10px]">{'\u25BC'}</span> {sortDescLabel}
+        </button>
+      </div>
+
+      <div className="p-2">
+        {filterType === 'checkbox' && (
+          <>
+            {uniqueValues.length > 6 && (
+              <input ref={searchRef} type="text" placeholder="Search..." value={localSearch}
+                onChange={e => setLocalSearch(e.target.value)}
+                className="w-full px-2 py-1.5 text-xs border rounded mb-2 outline-none focus:border-[#2d1b4e]" />
+            )}
+            <div className="flex items-center justify-between mb-1 px-1">
+              <button onClick={() => setLocalSelected(new Set(filteredValues.map(([v]) => v)))} className="text-[10px] text-[#2d1b4e] hover:underline">Select All</button>
+              <button onClick={() => setLocalSelected(new Set())} className="text-[10px] text-red-500 hover:underline">Clear All</button>
+            </div>
+            <div className="max-h-[300px] overflow-auto border rounded">
+              {filteredValues.map(([val, count]) => (
+                <label key={val} className="flex items-center gap-2 px-2 py-1.5 hover:bg-gray-50 cursor-pointer text-xs">
+                  <input type="checkbox" checked={localSelected.has(val)}
+                    onChange={() => setLocalSelected(prev => { const next = new Set(prev); if (next.has(val)) next.delete(val); else next.add(val); return next; })}
+                    className="w-3.5 h-3.5 rounded flex-shrink-0" />
+                  <span className="truncate flex-1">{val}</span>
+                  <span className="text-gray-400 text-[10px] flex-shrink-0">({count})</span>
+                </label>
+              ))}
+              {filteredValues.length === 0 && <div className="px-2 py-3 text-center text-gray-400 text-xs">No values found</div>}
+            </div>
+          </>
+        )}
+
+        {filterType === 'dateRange' && (
+          <div className="space-y-2">
+            <div><label className="block text-[10px] text-gray-500 mb-1">From</label>
+              <input ref={searchRef} type="date" value={localFrom} onChange={e => setLocalFrom(e.target.value)} className="w-full px-2 py-1.5 text-xs border rounded outline-none focus:border-[#2d1b4e]" /></div>
+            <div><label className="block text-[10px] text-gray-500 mb-1">To</label>
+              <input type="date" value={localTo} onChange={e => setLocalTo(e.target.value)} className="w-full px-2 py-1.5 text-xs border rounded outline-none focus:border-[#2d1b4e]" /></div>
+          </div>
+        )}
+
+        {filterType === 'amountRange' && (
+          <div className="space-y-2">
+            <div><label className="block text-[10px] text-gray-500 mb-1">Min</label>
+              <input ref={searchRef} type="number" placeholder="0" value={localMin} onChange={e => setLocalMin(e.target.value)} className="w-full px-2 py-1.5 text-xs border rounded outline-none focus:border-[#2d1b4e]" /></div>
+            <div><label className="block text-[10px] text-gray-500 mb-1">Max</label>
+              <input type="number" placeholder="999999" value={localMax} onChange={e => setLocalMax(e.target.value)} className="w-full px-2 py-1.5 text-xs border rounded outline-none focus:border-[#2d1b4e]" /></div>
+          </div>
+        )}
+
+        {filterType === 'search' && (
+          <input ref={searchRef} type="text" placeholder="Search..." value={localTerm}
+            onChange={e => setLocalTerm(e.target.value)}
+            className="w-full px-2 py-1.5 text-xs border rounded outline-none focus:border-[#2d1b4e]" />
+        )}
+      </div>
+
+      <div className="border-t border-gray-100 p-2 flex justify-between gap-2">
+        <button onClick={() => onApply(undefined)} className="text-[10px] text-red-500 hover:underline">Clear</button>
+        <div className="flex gap-2">
+          <button onClick={onCancel} className="px-3 py-1 text-xs border rounded hover:bg-gray-50">Cancel</button>
+          <button onClick={handleApply} className="px-3 py-1 text-xs bg-[#2d1b4e] text-white rounded hover:bg-[#3d2b5e]">Apply</button>
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+}
+
+// ─── Filterable Header ──────────────────────────────────────────────────────
+
+function JournalFilterableHeader({
+  label, field, sortField, sortDir, onSort, filterType, allTransactions,
+  columnFilter, onApplyColumnFilter, className,
+}: {
+  label: string;
+  field: SortField;
+  sortField: SortField;
+  sortDir: SortDir;
+  onSort: (f: SortField, dir?: SortDir) => void;
+  filterType: 'checkbox' | 'dateRange' | 'amountRange' | 'search';
+  allTransactions: JournalTxn[];
+  columnFilter: ColumnFilterValue | undefined;
+  onApplyColumnFilter: (field: SortField, value: ColumnFilterValue | undefined) => void;
+  className?: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const btnRef = useRef<HTMLButtonElement>(null);
+  const isSortActive = sortField === field;
+  const hasFilter = !!columnFilter;
+
+  return (
+    <th className={`px-2 py-2.5 text-xs font-semibold select-none ${className || ''}`}>
+      <span className="flex items-center gap-0.5">
+        <span className="cursor-pointer hover:underline truncate" onClick={() => onSort(field)}>
+          {label}
+          {isSortActive && <span className="text-[10px] ml-0.5">{sortDir === 'asc' ? '\u25B2' : '\u25BC'}</span>}
+        </span>
+        <button ref={btnRef} onClick={e => { e.stopPropagation(); setOpen(!open); }}
+          className={`ml-auto w-4 h-4 flex items-center justify-center rounded text-[9px] flex-shrink-0 ${
+            hasFilter ? 'text-amber-400 bg-amber-400/20' : 'text-white/40 hover:text-white/80 hover:bg-white/10'
+          }`}>
+          {'\u25BC'}
+        </button>
+      </span>
+      {open && (
+        <JournalColumnFilterDropdown
+          field={field} filterType={filterType} allTransactions={allTransactions}
+          currentFilter={columnFilter}
+          onApply={(val) => { onApplyColumnFilter(field, val); setOpen(false); }}
+          onCancel={() => setOpen(false)}
+          anchorEl={btnRef.current}
+          sortField={sortField} sortDir={sortDir}
+          onSortWithDir={(f, d) => onSort(f, d)}
+        />
+      )}
+    </th>
+  );
+}
+
+// ─── Main Component ──────────────────────────────────────────────────────────
+
+export default function JournalEntryEngine({ journalTransactions, coaOptions, onSave, onReload }: JournalEntryEngineProps) {
+  const parentRef = useRef<HTMLDivElement>(null);
+
+  // State
+  const [search, setSearch] = useState('');
+  const [sortField, setSortField] = useState<SortField>('date');
+  const [sortDir, setSortDir] = useState<SortDir>('desc');
+  const [columnFilters, setColumnFilters] = useState<ColumnFilters>({});
   const [expandedId, setExpandedId] = useState<string | null>(null);
-  const [filterType, setFilterType] = useState('all');
-  const [filterStatus, setFilterStatus] = useState('all');
-  const [saving, setSaving] = useState(false);
+  const [showForm, setShowForm] = useState(false);
 
   // New entry form state
   const [newDate, setNewDate] = useState(new Date().toISOString().split('T')[0]);
   const [newType, setNewType] = useState('adjusting');
   const [newMemo, setNewMemo] = useState('');
   const [newLines, setNewLines] = useState<JournalEntryLine[]>([emptyLine(), emptyLine()]);
+  const [saving, setSaving] = useState(false);
+
+  const txns = journalTransactions;
 
   // Group COA by type
   const coaGrouped = useMemo(() => {
@@ -72,18 +464,51 @@ export default function JournalEntryEngine({ entries, coaOptions, onSave, onRelo
     return g;
   }, [coaOptions]);
 
-  const getCoaName = (code: string) => coaOptions.find(c => c.code === code)?.name || code;
+  // Stats
+  const reversalCount = useMemo(() => txns.filter(t => t.is_reversal).length, [txns]);
 
-  // Filter entries
-  const filtered = useMemo(() => {
-    return entries.filter(e => {
-      if (filterType !== 'all' && e.type !== filterType) return false;
-      if (filterStatus !== 'all' && e.status !== filterStatus) return false;
-      return true;
+  const handleSort = useCallback((field: SortField, forcedDir?: SortDir) => {
+    if (forcedDir) { setSortField(field); setSortDir(forcedDir); return; }
+    if (sortField === field) { setSortDir(d => d === 'asc' ? 'desc' : 'asc'); }
+    else { setSortField(field); setSortDir(field === 'date' ? 'desc' : 'asc'); }
+  }, [sortField]);
+
+  const handleApplyColumnFilter = useCallback((field: SortField, value: ColumnFilterValue | undefined) => {
+    setColumnFilters(prev => {
+      const next = { ...prev };
+      if (value) next[field] = value; else delete next[field];
+      return next;
     });
-  }, [entries, filterType, filterStatus]);
+  }, []);
 
-  // Calculate totals for new entry
+  // Filter pipeline
+  const filtered = useMemo(() => {
+    let result = txns;
+    // Keyword search
+    if (search) {
+      const lower = search.toLowerCase();
+      result = result.filter(t =>
+        (t.description || '').toLowerCase().includes(lower)
+      );
+    }
+    // Column filters
+    result = applyColumnFilters(result, columnFilters);
+    // Sort
+    result = sortTxns(result, sortField, sortDir);
+    return result;
+  }, [txns, search, columnFilters, sortField, sortDir]);
+
+  const virtualizer = useVirtualizer({
+    count: filtered.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => ROW_HEIGHT,
+    overscan: 20,
+  });
+
+  const activeColFilterCount = countActiveColumnFilters(columnFilters);
+
+  // ─── New Entry Form Logic ────────────────────────────────────────────────
+
   const totalDebits = newLines.reduce((sum, l) => sum + (parseFloat(l.debit) || 0), 0);
   const totalCredits = newLines.reduce((sum, l) => sum + (parseFloat(l.credit) || 0), 0);
   const isBalanced = Math.abs(totalDebits - totalCredits) < 0.01 && totalDebits > 0;
@@ -113,7 +538,7 @@ export default function JournalEntryEngine({ entries, coaOptions, onSave, onRelo
 
   const handleSave = async (status: 'draft' | 'posted') => {
     if (!isBalanced) return;
-    
+
     const validLines = newLines.filter(l => l.accountCode && (l.debit || l.credit));
     if (validLines.length < 2) return;
 
@@ -123,7 +548,7 @@ export default function JournalEntryEngine({ entries, coaOptions, onSave, onRelo
       type: newType,
       memo: newMemo || null,
       status,
-      lines: validLines
+      lines: validLines,
     });
     resetForm();
     setShowForm(false);
@@ -131,49 +556,31 @@ export default function JournalEntryEngine({ entries, coaOptions, onSave, onRelo
     onReload();
   };
 
-  const getEntryTotals = (entry: JournalEntry) => {
-    const debits = entry.lines.reduce((sum, l) => sum + (parseFloat(l.debit) || 0), 0);
-    const credits = entry.lines.reduce((sum, l) => sum + (parseFloat(l.credit) || 0), 0);
-    return { debits, credits };
-  };
+  // ─── Render ──────────────────────────────────────────────────────────────
 
   return (
     <div className="bg-white rounded-xl border overflow-hidden">
       {/* Header */}
-      <div className="px-4 py-3 border-b bg-gray-50 flex flex-wrap items-center justify-between gap-2">
-        <div className="flex items-center gap-2">
-          <select
-            value={filterType}
-            onChange={(e) => setFilterType(e.target.value)}
-            className="px-3 py-1.5 border rounded-lg text-sm"
-          >
-            <option value="all">All Types</option>
-            {ENTRY_TYPES.map(t => <option key={t.value} value={t.value}>{t.label}</option>)}
-          </select>
-          <select
-            value={filterStatus}
-            onChange={(e) => setFilterStatus(e.target.value)}
-            className="px-3 py-1.5 border rounded-lg text-sm"
-          >
-            <option value="all">All Status</option>
-            <option value="draft">Draft</option>
-            <option value="posted">Posted</option>
-            <option value="voided">Voided</option>
-          </select>
+      <div className="bg-[#2d1b4e] text-white px-4 py-3 flex items-center justify-between">
+        <div>
+          <h3 className="text-sm font-semibold">Journal Entries</h3>
+          <p className="text-[10px] text-gray-300 font-mono">
+            {txns.length} journal entries ({reversalCount} reversals)
+          </p>
         </div>
         <button
           onClick={() => setShowForm(!showForm)}
-          className="px-4 py-1.5 bg-[#2d1b4e] text-white rounded-lg text-sm font-medium"
+          className="px-4 py-1.5 bg-white/10 hover:bg-white/20 text-white rounded-lg text-xs font-medium transition-colors"
         >
-          {showForm ? '✕ Cancel' : '+ New Entry'}
+          {showForm ? '\u2715 Cancel' : '+ New Entry'}
         </button>
       </div>
 
       {/* New Entry Form */}
       {showForm && (
         <div className="p-4 border-b bg-blue-50">
-          <h4 className="font-semibold mb-3">New Journal Entry</h4>
-          
+          <h4 className="font-semibold mb-3 text-sm">New Journal Entry</h4>
+
           {/* Entry Header */}
           <div className="flex flex-wrap gap-3 mb-4">
             <div>
@@ -268,7 +675,7 @@ export default function JournalEntryEngine({ entries, coaOptions, onSave, onRelo
                   </td>
                   <td className="px-1">
                     {newLines.length > 2 && (
-                      <button onClick={() => removeLine(idx)} className="text-red-400 hover:text-red-600">✕</button>
+                      <button onClick={() => removeLine(idx)} className="text-red-400 hover:text-red-600">{'\u2715'}</button>
                     )}
                   </td>
                 </tr>
@@ -283,9 +690,9 @@ export default function JournalEntryEngine({ entries, coaOptions, onSave, onRelo
                 <td className="px-2 py-2 text-right">${totalCredits.toFixed(2)}</td>
                 <td className="px-1">
                   {isBalanced ? (
-                    <span className="text-green-600">✓</span>
+                    <span className="text-green-600">{'\u2713'}</span>
                   ) : (
-                    <span className="text-red-600">≠</span>
+                    <span className="text-red-600">{'\u2260'}</span>
                   )}
                 </td>
               </tr>
@@ -321,84 +728,244 @@ export default function JournalEntryEngine({ entries, coaOptions, onSave, onRelo
         </div>
       )}
 
-      {/* Entries List */}
-      <div className="divide-y">
-        {filtered.length === 0 ? (
-          <div className="p-8 text-center text-gray-400">
-            No journal entries yet. Click "+ New Entry" to create one.
+      {/* Search + filter pills */}
+      <div className="bg-gray-50 border-x border-gray-200 px-4 py-2 space-y-2">
+        <div className="flex items-center gap-2">
+          <input
+            type="text"
+            placeholder="Search descriptions..."
+            value={search}
+            onChange={e => setSearch(e.target.value)}
+            className="flex-1 px-3 py-1.5 text-xs border border-gray-200 rounded-lg outline-none focus:border-[#2d1b4e] focus:ring-1 focus:ring-[#2d1b4e]"
+          />
+          {(search || activeColFilterCount > 0) && (
+            <button onClick={() => { setSearch(''); setColumnFilters({}); }}
+              className="px-2 py-1.5 text-[10px] text-red-500 hover:text-red-700">
+              Clear All
+            </button>
+          )}
+        </div>
+
+        {/* Column filter pills */}
+        {activeColFilterCount > 0 && (
+          <div className="flex flex-wrap gap-1">
+            {(Object.entries(columnFilters) as [SortField, ColumnFilterValue][]).map(([field, filter]) => {
+              if (!filter) return null;
+              const hasContent = filter.type === 'checkbox' ? filter.selected.length > 0
+                : filter.type === 'dateRange' ? !!(filter.from || filter.to)
+                : filter.type === 'amountRange' ? !!(filter.min || filter.max)
+                : filter.term.length > 0;
+              if (!hasContent) return null;
+              return (
+                <span key={field} className="inline-flex items-center gap-1 px-2 py-0.5 bg-amber-100 text-amber-800 text-[10px] rounded-full">
+                  <span className="font-semibold">{columnFilterLabel(field)}:</span>
+                  <span className="truncate max-w-[120px]">{columnFilterSummary(filter)}</span>
+                  <button onClick={() => handleApplyColumnFilter(field, undefined)} className="text-amber-500 hover:text-amber-700 ml-0.5">&times;</button>
+                </span>
+              );
+            })}
           </div>
-        ) : (
-          filtered.map(entry => {
-            const { debits, credits } = getEntryTotals(entry);
-            const isExpanded = expandedId === entry.id;
-
-            return (
-              <div key={entry.id}>
-                <button
-                  onClick={() => setExpandedId(isExpanded ? null : entry.id)}
-                  className="w-full px-4 py-3 flex items-center justify-between hover:bg-gray-50 text-left"
-                >
-                  <div className="flex items-center gap-4">
-                    <span className={`text-xs transition-transform ${isExpanded ? 'rotate-90' : ''}`}>▶</span>
-                    <span className="font-mono text-sm text-gray-500">JE-{String(entry.entryNumber).padStart(3, '0')}</span>
-                    <span className="text-sm">{new Date(entry.date).toLocaleDateString()}</span>
-                    <span className="px-2 py-0.5 bg-gray-100 rounded text-xs capitalize">{entry.type}</span>
-                    <span className="text-sm text-gray-600 truncate max-w-[200px]">{entry.memo || '-'}</span>
-                  </div>
-                  <div className="flex items-center gap-4">
-                    <span className="text-sm font-mono">${debits.toFixed(2)}</span>
-                    <span className={`px-2 py-0.5 rounded text-xs font-medium ${
-                      entry.status === 'posted' ? 'bg-green-100 text-green-700' :
-                      entry.status === 'voided' ? 'bg-red-100 text-red-700' :
-                      'bg-yellow-100 text-yellow-700'
-                    }`}>
-                      {entry.status}
-                    </span>
-                  </div>
-                </button>
-
-                {isExpanded && (
-                  <div className="px-4 pb-4 bg-gray-50">
-                    <table className="w-full text-sm">
-                      <thead className="bg-gray-100">
-                        <tr>
-                          <th className="px-3 py-2 text-left font-medium">Account</th>
-                          <th className="px-3 py-2 text-left font-medium">Description</th>
-                          <th className="px-3 py-2 text-right font-medium">Debit</th>
-                          <th className="px-3 py-2 text-right font-medium">Credit</th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                        {entry.lines.map((line, idx) => (
-                          <tr key={idx} className="border-b border-gray-200">
-                            <td className="px-3 py-2">
-                              <span className="font-mono text-xs">{line.accountCode}</span>
-                              <span className="ml-2 text-gray-600">{getCoaName(line.accountCode)}</span>
-                            </td>
-                            <td className="px-3 py-2 text-gray-600">{line.description || '-'}</td>
-                            <td className="px-3 py-2 text-right font-mono">
-                              {line.debit ? `$${parseFloat(line.debit).toFixed(2)}` : '-'}
-                            </td>
-                            <td className="px-3 py-2 text-right font-mono">
-                              {line.credit ? `$${parseFloat(line.credit).toFixed(2)}` : '-'}
-                            </td>
-                          </tr>
-                        ))}
-                      </tbody>
-                      <tfoot className="bg-gray-100 font-semibold">
-                        <tr>
-                          <td colSpan={2} className="px-3 py-2">Total</td>
-                          <td className="px-3 py-2 text-right font-mono">${debits.toFixed(2)}</td>
-                          <td className="px-3 py-2 text-right font-mono">${credits.toFixed(2)}</td>
-                        </tr>
-                      </tfoot>
-                    </table>
-                  </div>
-                )}
-              </div>
-            );
-          })
         )}
+      </div>
+
+      {/* Virtualized Table */}
+      <div ref={parentRef} className="overflow-auto border border-gray-200 border-t-0" style={{ maxHeight: '600px' }}>
+        <table className="w-full text-xs border-collapse min-w-[1000px]">
+          <thead className="bg-[#2d1b4e] text-white sticky top-0 z-10">
+            <tr>
+              <JournalFilterableHeader label="Date" field="date" sortField={sortField} sortDir={sortDir} onSort={handleSort}
+                filterType="dateRange" allTransactions={txns} columnFilter={columnFilters.date} onApplyColumnFilter={handleApplyColumnFilter} className="w-24" />
+              <JournalFilterableHeader label="Description" field="description" sortField={sortField} sortDir={sortDir} onSort={handleSort}
+                filterType="search" allTransactions={txns} columnFilter={columnFilters.description} onApplyColumnFilter={handleApplyColumnFilter} className="min-w-[200px]" />
+              <JournalFilterableHeader label="Type" field="type" sortField={sortField} sortDir={sortDir} onSort={handleSort}
+                filterType="checkbox" allTransactions={txns} columnFilter={columnFilters.type} onApplyColumnFilter={handleApplyColumnFilter} className="w-24" />
+              <JournalFilterableHeader label="Status" field="status" sortField={sortField} sortDir={sortDir} onSort={handleSort}
+                filterType="checkbox" allTransactions={txns} columnFilter={columnFilters.status} onApplyColumnFilter={handleApplyColumnFilter} className="w-24" />
+              <JournalFilterableHeader label="Debits" field="debits" sortField={sortField} sortDir={sortDir} onSort={handleSort}
+                filterType="amountRange" allTransactions={txns} columnFilter={columnFilters.debits} onApplyColumnFilter={handleApplyColumnFilter} className="w-24 text-right" />
+              <JournalFilterableHeader label="Credits" field="credits" sortField={sortField} sortDir={sortDir} onSort={handleSort}
+                filterType="amountRange" allTransactions={txns} columnFilter={columnFilters.credits} onApplyColumnFilter={handleApplyColumnFilter} className="w-24 text-right" />
+              <th className="px-2 py-2.5 text-xs font-semibold w-16 text-center">Balanced</th>
+              <th className="px-2 py-2.5 text-xs font-semibold w-36">Related</th>
+            </tr>
+          </thead>
+          <tbody>
+            {/* top spacer */}
+            {virtualizer.getVirtualItems().length > 0 && (
+              <tr style={{ height: virtualizer.getVirtualItems()[0]?.start || 0 }}>
+                <td colSpan={8} />
+              </tr>
+            )}
+            {virtualizer.getVirtualItems().map(vRow => {
+              const txn = filtered[vRow.index];
+              const derivedType = getDerivedType(txn);
+              const derivedStatus = getDerivedStatus(txn);
+              const debits = getDebits(txn);
+              const credits = getCredits(txn);
+              const balanced = Math.abs(debits - credits) < 0.005;
+              const isReversed = derivedStatus === 'Reversed';
+              const isReversal = txn.is_reversal;
+              const isExpanded = expandedId === txn.id;
+
+              const rowBg = vRow.index % 2 === 0 ? 'bg-white' : 'bg-gray-50/50';
+              const textClass = isReversed ? 'text-gray-400' : '';
+              const borderClass = isReversal ? 'border-l-[3px] border-amber-400' : '';
+
+              return (
+                <tr key={txn.id} data-index={vRow.index}>
+                  {/* Main row */}
+                  <td colSpan={8} className="p-0">
+                    <div
+                      className={`${rowBg} ${borderClass} hover:bg-[#2d1b4e]/[.07] transition-colors cursor-pointer flex items-center ${textClass}`}
+                      style={{ height: ROW_HEIGHT }}
+                      onClick={() => setExpandedId(isExpanded ? null : txn.id)}
+                    >
+                      {/* Date */}
+                      <div className="px-2 py-1 w-24 flex-shrink-0 whitespace-nowrap font-mono">
+                        {formatDate(txn.transaction_date)}
+                      </div>
+                      {/* Description */}
+                      <div className="px-2 py-1 min-w-[200px] flex-1 truncate">
+                        <span className={isReversed ? 'line-through' : ''}>
+                          {isReversal ? 'REVERSAL: ' : ''}{txn.description || '\u2014'}
+                        </span>
+                      </div>
+                      {/* Type */}
+                      <div className="px-2 py-1 w-24 flex-shrink-0">
+                        <span className={`text-[10px] font-medium px-1.5 py-0.5 rounded ${
+                          derivedType === 'Reversal' ? 'bg-amber-100 text-amber-700' : 'bg-gray-100 text-gray-600'
+                        }`}>
+                          {derivedType}
+                        </span>
+                      </div>
+                      {/* Status */}
+                      <div className="px-2 py-1 w-24 flex-shrink-0">
+                        <span className={`text-[10px] font-medium px-1.5 py-0.5 rounded ${
+                          derivedStatus === 'Active' ? 'bg-green-100 text-green-700' :
+                          derivedStatus === 'Reversed' ? 'bg-red-100 text-red-700' :
+                          'bg-amber-100 text-amber-700'
+                        }`}>
+                          {derivedStatus}
+                        </span>
+                      </div>
+                      {/* Debits */}
+                      <div className="px-2 py-1 w-24 flex-shrink-0 text-right font-mono">
+                        {debits > 0 ? formatMoneyDollars(debits) : '\u2014'}
+                      </div>
+                      {/* Credits */}
+                      <div className="px-2 py-1 w-24 flex-shrink-0 text-right font-mono">
+                        {credits > 0 ? formatMoneyDollars(credits) : '\u2014'}
+                      </div>
+                      {/* Balanced */}
+                      <div className="px-2 py-1 w-16 flex-shrink-0 text-center">
+                        {balanced ? (
+                          <span className="text-green-600 font-bold">{'\u2713'}</span>
+                        ) : (
+                          <span className="text-red-600 font-bold">{'\u2717'}</span>
+                        )}
+                      </div>
+                      {/* Related */}
+                      <div className="px-2 py-1 w-36 flex-shrink-0">
+                        {isReversal && txn.reverses_journal_id && (
+                          <button
+                            onClick={(e) => { e.stopPropagation(); setExpandedId(txn.reverses_journal_id); }}
+                            className="text-[10px] text-[#2d1b4e] hover:underline truncate block"
+                          >
+                            Reversal of {truncateId(txn.reverses_journal_id)}
+                          </button>
+                        )}
+                        {isReversed && txn.reversed_by_transaction_id && (
+                          <button
+                            onClick={(e) => { e.stopPropagation(); setExpandedId(txn.reversed_by_transaction_id); }}
+                            className="text-[10px] text-[#2d1b4e] hover:underline truncate block"
+                          >
+                            Reversed by {truncateId(txn.reversed_by_transaction_id)}
+                          </button>
+                        )}
+                      </div>
+                    </div>
+
+                    {/* Expanded detail */}
+                    {isExpanded && (
+                      <div className="bg-gray-50 px-6 py-3 border-t border-gray-200">
+                        <table className="w-full text-xs">
+                          <thead className="bg-gray-100">
+                            <tr>
+                              <th className="px-3 py-2 text-left font-medium">COA Code</th>
+                              <th className="px-3 py-2 text-left font-medium">COA Name</th>
+                              <th className="px-3 py-2 text-right font-medium">Debit</th>
+                              <th className="px-3 py-2 text-right font-medium">Credit</th>
+                            </tr>
+                          </thead>
+                          <tbody>
+                            {txn.ledger_entries.map((leg) => {
+                              const legDebit = leg.entry_type === 'D' ? leg.amount : 0;
+                              const legCredit = leg.entry_type === 'C' ? leg.amount : 0;
+                              return (
+                                <tr key={leg.id} className={`border-b border-gray-200 ${isReversed ? 'text-gray-400' : ''}`}>
+                                  <td className={`px-3 py-2 font-mono ${isReversed ? 'line-through' : ''}`}>
+                                    {leg.chart_of_accounts.code}
+                                  </td>
+                                  <td className={`px-3 py-2 ${isReversed ? 'line-through' : ''}`}>
+                                    {leg.chart_of_accounts.name}
+                                  </td>
+                                  <td className={`px-3 py-2 text-right font-mono ${isReversed ? 'line-through' : ''}`}>
+                                    {legDebit > 0 ? formatMoney(legDebit) : '\u2014'}
+                                  </td>
+                                  <td className={`px-3 py-2 text-right font-mono ${isReversed ? 'line-through' : ''}`}>
+                                    {legCredit > 0 ? formatMoney(legCredit) : '\u2014'}
+                                  </td>
+                                </tr>
+                              );
+                            })}
+                          </tbody>
+                          <tfoot className="bg-gray-100 font-semibold">
+                            <tr>
+                              <td colSpan={2} className="px-3 py-2">Total</td>
+                              <td className="px-3 py-2 text-right font-mono">{formatMoneyDollars(debits)}</td>
+                              <td className="px-3 py-2 text-right font-mono">{formatMoneyDollars(credits)}</td>
+                            </tr>
+                          </tfoot>
+                        </table>
+                        {txn.strategy && (
+                          <div className="mt-2 text-[10px] text-gray-500">
+                            Strategy: <span className="font-medium text-gray-700">{txn.strategy}</span>
+                            {txn.trade_num && <> | Trade #: <span className="font-medium text-gray-700">{txn.trade_num}</span></>}
+                          </div>
+                        )}
+                      </div>
+                    )}
+                  </td>
+                </tr>
+              );
+            })}
+            {/* bottom spacer */}
+            {virtualizer.getVirtualItems().length > 0 && (
+              <tr style={{
+                height: virtualizer.getTotalSize() - (virtualizer.getVirtualItems()[virtualizer.getVirtualItems().length - 1]?.end || 0)
+              }}>
+                <td colSpan={8} />
+              </tr>
+            )}
+          </tbody>
+        </table>
+        {filtered.length === 0 && (
+          <div className="px-4 py-8 text-center text-gray-400 text-xs">
+            {search || activeColFilterCount > 0 ? 'No journal entries match your filters.' : 'No journal entries yet. Click "+ New Entry" to create one.'}
+          </div>
+        )}
+      </div>
+
+      {/* Footer summary */}
+      <div className="bg-gray-100 border border-gray-200 border-t-0 px-4 py-2 flex items-center justify-between text-xs">
+        <span className="text-gray-500">
+          {filtered.length === txns.length ? txns.length : `${filtered.length} of ${txns.length}`} entries
+        </span>
+        <span className="font-mono font-medium">
+          Debits: {formatMoneyDollars(filtered.reduce((s, t) => s + getDebits(t), 0))}
+          {' \u00B7 '}
+          Credits: {formatMoneyDollars(filtered.reduce((s, t) => s + getCredits(t), 0))}
+        </span>
       </div>
     </div>
   );


### PR DESCRIPTION
…ty and full entry history

Journal tab (JournalEntryEngine):
- Complete rewrite to show journal_transactions (double-entry system)
- Virtualized scrolling, portal-based column filter dropdowns, sortable columns
- Reversal indicators: Active/Reversed/Reversal status badges
- Reversed entries show strikethrough + "Reversed by [id]" link
- Reversal entries show amber border + "Reversal of [id]" link
- Expandable rows showing debit/credit ledger legs per entry
- Balanced indicator (green check / red X) per entry
- Keyword search + column filters (date, type, status, amounts)
- Manual entry creation form preserved

Ledger tab (GeneralLedger):
- Complete rewrite to show per-account ledger_entries activity
- Self-fetching from GET /api/ledger with account filter
- Searchable account selector grouped by entity type
- Account summary bar (opening/debits/credits/closing balance)
- Virtualized activity table with running balance column
- Reversal indicators matching journal tab treatment
- Date range filter, keyword search, sortable columns
- Export to CSV functionality
- All-accounts summary grid when no account selected

API endpoints:
- New GET /api/journal-transactions: returns all journal_transactions with nested ledger_entries, COA info, and reversal fields
- Upgraded GET /api/ledger: adds accountCode filter param, includes reversal status (is_reversal, reversed_by_transaction_id) per entry

Dashboard wiring:
- Loads from /api/journal-transactions instead of /api/journal-entries
- Updated props for both components

https://claude.ai/code/session_01CCk1pA3MvtFBBKegqHhhhs