### PR TITLE
fix: resolve Journal/Ledger tab errors and Balance Sheet trading data…

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "prisma generate && next build",
+    "build": "prisma generate && prisma migrate deploy && next build",
     "start": "next start",
     "lint": "next lint",
     "postinstall": "prisma generate"

--- a/src/app/api/chart-of-accounts/balances/route.ts
+++ b/src/app/api/chart-of-accounts/balances/route.ts
@@ -16,9 +16,12 @@ export async function GET() {
       return NextResponse.json({ error: 'User not found' }, { status: 404 });
     }
 
-    // SECURITY: Scoped to user's COA only
+    // Include user's COA + shared trading accounts (userId null, e.g. T-xxxx)
     const accounts = await prisma.chart_of_accounts.findMany({
-      where: { userId: user.id, is_archived: false },
+      where: {
+        OR: [{ userId: user.id }, { userId: null }],
+        is_archived: false
+      },
       orderBy: { code: 'asc' }
     });
 

--- a/src/app/api/journal-transactions/route.ts
+++ b/src/app/api/journal-transactions/route.ts
@@ -16,13 +16,15 @@ export async function GET() {
       return NextResponse.json({ error: 'User not found' }, { status: 404 });
     }
 
-    // SECURITY: journal_transactions don't have userId directly.
     // Scope via ledger_entries -> chart_of_accounts.userId.
+    // Include shared trading accounts (userId null, e.g. T-xxxx)
     const transactions = await prisma.journal_transactions.findMany({
       where: {
         ledger_entries: {
           some: {
-            chart_of_accounts: { userId: user.id }
+            chart_of_accounts: {
+              OR: [{ userId: user.id }, { userId: null }]
+            }
           }
         }
       },

--- a/src/app/api/ledger/route.ts
+++ b/src/app/api/ledger/route.ts
@@ -20,11 +20,11 @@ export async function GET(request: NextRequest) {
     const { searchParams } = new URL(request.url);
     const accountCode = searchParams.get('accountCode');
 
-    // SECURITY: Scoped to user's COA only
+    // Include user's COA + shared trading accounts (userId null, e.g. T-xxxx)
     const ledgerEntries = await prisma.ledger_entries.findMany({
       where: {
         chart_of_accounts: {
-          userId: user.id,
+          OR: [{ userId: user.id }, { userId: null }],
           ...(accountCode ? { code: accountCode } : {})
         }
       },

--- a/src/app/api/statements/route.ts
+++ b/src/app/api/statements/route.ts
@@ -16,9 +16,12 @@ export async function GET() {
       return NextResponse.json({ error: 'User not found' }, { status: 404 });
     }
 
-    // SECURITY: Scoped to user's COA only
+    // Include user's COA + shared trading accounts (userId null, e.g. T-xxxx)
     const accounts = await prisma.chart_of_accounts.findMany({
-      where: { userId: user.id, is_archived: false }
+      where: {
+        OR: [{ userId: user.id }, { userId: null }],
+        is_archived: false
+      }
     });
 
     let revenue = BigInt(0);


### PR DESCRIPTION
… gaps

Root causes found and fixed:
1. Ledger HTTP 500 + Journal 0 entries: Migration 20260221_add_reversal_fields was never applied because build script lacked prisma migrate deploy. Added it to build pipeline so reversal columns get created on deploy.
2. Balance Sheet missing trade data: Trading COA accounts (T-xxxx) were seeded without userId, so all user-scoped queries silently excluded them. Updated 5 APIs to include accounts where userId is null:
   - /api/statements
   - /api/statements/analysis
   - /api/ledger
   - /api/journal-transactions
   - /api/chart-of-accounts/balances

https://claude.ai/code/session_01CCk1pA3MvtFBBKegqHhhhs