### PR TITLE
feat: Balance Sheet monthly view with running balances per account

### DIFF
--- a/src/app/api/statements/analysis/route.ts
+++ b/src/app/api/statements/analysis/route.ts
@@ -35,11 +35,20 @@ export async function GET(request: Request) {
           }
         }
       },
-      orderBy: { transaction_date: 'desc' }
+      orderBy: { transaction_date: 'asc' }
     });
 
-    // Group by period
-    const periodMap = new Map<string, any>();
+    // Build per-account activity by period
+    // Key: accountCode, Value: { name, type, balanceType, periods: { periodKey: netChange } }
+    const accountActivity = new Map<string, {
+      name: string;
+      type: string;
+      balanceType: string;
+      periods: Map<string, number>;
+    }>();
+
+    // Track all period keys for ordering
+    const allPeriodKeys = new Set<string>();
 
     journalEntries.forEach(je => {
       const date = new Date(je.transaction_date);
@@ -54,48 +63,120 @@ export async function GET(request: Request) {
         periodKey = `${date.getFullYear()}`;
       }
 
-      if (!periodMap.has(periodKey)) {
-        periodMap.set(periodKey, {
-          period: periodKey,
-          revenue: 0,
-          expenses: 0,
-          assets: 0,
-          liabilities: 0,
-          equity: 0
-        });
-      }
-
-      const periodData = periodMap.get(periodKey);
+      allPeriodKeys.add(periodKey);
 
       je.ledger_entries.forEach(le => {
         if (le.chart_of_accounts.userId !== user.id) return;
+
+        const code = le.chart_of_accounts.code;
+        if (!accountActivity.has(code)) {
+          accountActivity.set(code, {
+            name: le.chart_of_accounts.name,
+            type: le.chart_of_accounts.account_type.toLowerCase(),
+            balanceType: le.chart_of_accounts.balance_type,
+            periods: new Map()
+          });
+        }
+
+        const account = accountActivity.get(code)!;
         const amount = Number(le.amount) / 100;
-        const accountType = le.chart_of_accounts.account_type.toLowerCase();
         const isNormalBalance = le.entry_type === le.chart_of_accounts.balance_type;
         const effectiveAmount = isNormalBalance ? amount : -amount;
 
-        if (accountType === 'revenue') {
-          periodData.revenue += effectiveAmount;
-        } else if (accountType === 'expense') {
-          periodData.expenses += effectiveAmount;
-        } else if (accountType === 'asset') {
-          periodData.assets += effectiveAmount;
-        } else if (accountType === 'liability') {
-          periodData.liabilities += effectiveAmount;
-        } else if (accountType === 'equity') {
-          periodData.equity += effectiveAmount;
-        }
+        const current = account.periods.get(periodKey) || 0;
+        account.periods.set(periodKey, current + effectiveAmount);
       });
     });
+
+    // Sort period keys chronologically
+    const sortedPeriods = Array.from(allPeriodKeys).sort();
+
+    // Build type-level period summaries (for backwards compat)
+    const periodMap = new Map<string, {
+      period: string;
+      revenue: number;
+      expenses: number;
+      assets: number;
+      liabilities: number;
+      equity: number;
+    }>();
+
+    for (const pk of sortedPeriods) {
+      periodMap.set(pk, {
+        period: pk,
+        revenue: 0,
+        expenses: 0,
+        assets: 0,
+        liabilities: 0,
+        equity: 0
+      });
+    }
+
+    // Build account-level output with running balances for B/S accounts
+    const BS_TYPES = new Set(['asset', 'liability', 'equity']);
+
+    const accounts: Array<{
+      code: string;
+      name: string;
+      type: string;
+      periods: Record<string, number>;
+    }> = [];
+
+    for (const [code, acct] of accountActivity) {
+      const isBSAccount = BS_TYPES.has(acct.type);
+      const periodsOut: Record<string, number> = {};
+
+      if (isBSAccount) {
+        // Running balance: cumulative sum through each period
+        let cumulative = 0;
+        for (const pk of sortedPeriods) {
+          const activity = acct.periods.get(pk) || 0;
+          cumulative += activity;
+          periodsOut[pk] = Math.round(cumulative * 100) / 100;
+        }
+      } else {
+        // Income/Expense: activity per period
+        for (const pk of sortedPeriods) {
+          periodsOut[pk] = Math.round((acct.periods.get(pk) || 0) * 100) / 100;
+        }
+      }
+
+      accounts.push({
+        code,
+        name: acct.name,
+        type: acct.type,
+        periods: periodsOut
+      });
+
+      // Also aggregate type-level summaries
+      for (const pk of sortedPeriods) {
+        const pd = periodMap.get(pk)!;
+        const val = periodsOut[pk] || 0;
+        if (acct.type === 'revenue') pd.revenue += val;
+        else if (acct.type === 'expense') pd.expenses += val;
+        else if (acct.type === 'asset') pd.assets += val;
+        else if (acct.type === 'liability') pd.liabilities += val;
+        else if (acct.type === 'equity') pd.equity += val;
+      }
+    }
 
     const periods = Array.from(periodMap.values())
       .map(p => ({
         ...p,
-        netIncome: p.revenue - p.expenses
+        revenue: Math.round(p.revenue * 100) / 100,
+        expenses: Math.round(p.expenses * 100) / 100,
+        assets: Math.round(p.assets * 100) / 100,
+        liabilities: Math.round(p.liabilities * 100) / 100,
+        equity: Math.round(p.equity * 100) / 100,
+        netIncome: Math.round((p.revenue - p.expenses) * 100) / 100
       }))
       .sort((a, b) => b.period.localeCompare(a.period));
 
-    return NextResponse.json({ periods });
+    return NextResponse.json({
+      periods,
+      accounts: accounts.sort((a, b) => a.code.localeCompare(b.code)),
+      periodKeys: sortedPeriods
+    });
   } catch (error) {
     console.error('Analysis error:', error);
     return NextResponse.json({ error: 'Failed to generate analysis' }, { status: 500 });

--- a/src/components/dashboard/ThreeStatementAnalysisTab.tsx
+++ b/src/components/dashboard/ThreeStatementAnalysisTab.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 
 interface PeriodData {
   period: string;
@@ -12,10 +12,20 @@ interface PeriodData {
   equity: number;
 }
 
+interface AccountData {
+  code: string;
+  name: string;
+  type: string;
+  periods: Record<string, number>;
+}
+
 export default function ThreeStatementAnalysisTab() {
-  const [data, setData] = useState<PeriodData[]>([]);
+  const [periods, setPeriods] = useState<PeriodData[]>([]);
+  const [accounts, setAccounts] = useState<AccountData[]>([]);
+  const [periodKeys, setPeriodKeys] = useState<string[]>([]);
   const [loading, setLoading] = useState(true);
   const [periodType, setPeriodType] = useState<'monthly' | 'quarterly' | 'yearly'>('monthly');
+  const [activeTab, setActiveTab] = useState<'income' | 'balance'>('balance');
 
   useEffect(() => {
     loadAnalysis();
@@ -27,7 +37,9 @@ export default function ThreeStatementAnalysisTab() {
       const res = await fetch(`/api/statements/analysis?period=${periodType}`);
       if (res.ok) {
         const result = await res.json();
-        setData(result.periods || []);
+        setPeriods(result.periods || []);
+        setAccounts(result.accounts || []);
+        setPeriodKeys(result.periodKeys || []);
       }
     } catch (error) {
       console.error('Error loading analysis:', error);
@@ -35,14 +47,86 @@ export default function ThreeStatementAnalysisTab() {
     setLoading(false);
   };
 
-  const calculateChange = (current: number, previous: number) => {
-    if (previous === 0) return 0;
-    return ((current - previous) / Math.abs(previous)) * 100;
+  // Group accounts by type
+  const revenueAccounts = useMemo(() => accounts.filter(a => a.type === 'revenue'), [accounts]);
+  const expenseAccounts = useMemo(() => accounts.filter(a => a.type === 'expense'), [accounts]);
+  const assetAccounts = useMemo(() => accounts.filter(a => a.type === 'asset'), [accounts]);
+  const liabilityAccounts = useMemo(() => accounts.filter(a => a.type === 'liability'), [accounts]);
+  const equityAccounts = useMemo(() => accounts.filter(a => a.type === 'equity'), [accounts]);
+
+  const formatAmount = (val: number) => {
+    if (val === 0) return '-';
+    const abs = Math.abs(val);
+    const formatted = abs >= 1000
+      ? `$${abs.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
+      : `$${abs.toFixed(2)}`;
+    return val < 0 ? `(${formatted})` : formatted;
+  };
+
+  const formatPeriodLabel = (pk: string) => {
+    if (periodType === 'monthly') {
+      const [year, month] = pk.split('-');
+      const monthNames = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+      return `${monthNames[parseInt(month) - 1]} ${year}`;
+    }
+    return pk;
+  };
+
+  const getSectionTotal = (accts: AccountData[], pk: string) => {
+    return accts.reduce((sum, a) => sum + (a.periods[pk] || 0), 0);
   };
 
   if (loading) {
     return <div className="p-8 text-center">Loading analysis...</div>;
   }
+
+  const renderAccountSection = (
+    title: string,
+    accts: AccountData[],
+    bgClass: string,
+    textClass: string
+  ) => {
+    if (accts.length === 0) return null;
+    return (
+      <>
+        <tr className={bgClass}>
+          <td colSpan={periodKeys.length + 2} className={`px-3 py-2 font-bold text-sm ${textClass}`}>
+            {title}
+          </td>
+        </tr>
+        {accts.map(acct => (
+          <tr key={acct.code} className="border-b border-gray-100 hover:bg-gray-50">
+            <td className="px-3 py-2 whitespace-nowrap sticky left-0 bg-white z-10">
+              <span className="font-mono text-xs text-gray-400">{acct.code}</span>
+              <span className="ml-2 text-sm">{acct.name}</span>
+            </td>
+            {periodKeys.map(pk => {
+              const val = acct.periods[pk] || 0;
+              return (
+                <td key={pk} className={`px-3 py-2 text-right text-sm ${val !== 0 ? '' : 'text-gray-300'}`}>
+                  {formatAmount(val)}
+                </td>
+              );
+            })}
+            <td className="px-3 py-2 text-right text-sm font-semibold bg-gray-50">
+              {formatAmount(acct.periods[periodKeys[periodKeys.length - 1]] || 0)}
+            </td>
+          </tr>
+        ))}
+        <tr className={`${bgClass} border-b-2`}>
+          <td className={`px-3 py-2 font-semibold text-sm sticky left-0 ${bgClass} z-10 ${textClass}`}>Total {title}</td>
+          {periodKeys.map(pk => (
+            <td key={pk} className={`px-3 py-2 text-right font-semibold text-sm ${textClass}`}>
+              {formatAmount(getSectionTotal(accts, pk))}
+            </td>
+          ))}
+          <td className={`px-3 py-2 text-right font-bold text-sm bg-gray-50 ${textClass}`}>
+            {formatAmount(getSectionTotal(accts, periodKeys[periodKeys.length - 1] || ''))}
+          </td>
+        </tr>
+      </>
+    );
+  };
 
   return (
     <div className="space-y-6">
@@ -52,7 +136,7 @@ export default function ThreeStatementAnalysisTab() {
           <p className="text-sm text-gray-600 mt-1">Comparative financial statement analysis</p>
         </div>
         <div className="flex gap-2">
-          <select 
+          <select
             value={periodType}
             onChange={(e) => setPeriodType(e.target.value as any)}
             className="px-4 py-2 border rounded-lg text-sm"
@@ -61,7 +145,7 @@ export default function ThreeStatementAnalysisTab() {
             <option value="quarterly">Quarterly</option>
             <option value="yearly">Yearly</option>
           </select>
-          <button 
+          <button
             onClick={loadAnalysis}
             className="px-4 py-2 bg-[#2d1b4e] text-white rounded-lg text-sm"
           >
@@ -70,153 +154,196 @@ export default function ThreeStatementAnalysisTab() {
         </div>
       </div>
 
-      {data.length === 0 ? (
+      {periodKeys.length === 0 ? (
         <div className="bg-white border rounded-xl p-8 text-center text-gray-500">
           No data available for analysis
         </div>
       ) : (
         <>
-          {/* Income Statement Comparison */}
-          <div className="bg-white border rounded-xl overflow-hidden">
-            <div className="bg-gray-50 px-6 py-4 border-b">
-              <h3 className="text-lg font-semibold">Income Statement</h3>
-            </div>
-            <div className="overflow-auto">
-              <table className="w-full">
-                <thead className="bg-gray-50">
-                  <tr>
-                    <th className="px-4 py-3 text-left text-xs font-semibold text-gray-600">Period</th>
-                    <th className="px-4 py-3 text-right text-xs font-semibold text-gray-600">Revenue</th>
-                    <th className="px-4 py-3 text-right text-xs font-semibold text-gray-600">Expenses</th>
-                    <th className="px-4 py-3 text-right text-xs font-semibold text-gray-600">Net Income</th>
-                    <th className="px-4 py-3 text-right text-xs font-semibold text-gray-600">Margin %</th>
-                    <th className="px-4 py-3 text-right text-xs font-semibold text-gray-600">Change</th>
-                  </tr>
-                </thead>
-                <tbody className="divide-y">
-                  {data.map((period, idx) => {
-                    const margin = period.revenue !== 0 ? (period.netIncome / period.revenue) * 100 : 0;
-                    const prevPeriod = idx > 0 ? data[idx - 1] : null;
-                    const change = prevPeriod ? calculateChange(period.netIncome, prevPeriod.netIncome) : 0;
-
-                    return (
-                      <tr key={period.period} className="hover:bg-gray-50">
-                        <td className="px-4 py-3 text-sm font-medium">{period.period}</td>
-                        <td className="px-4 py-3 text-right text-sm text-green-600 font-semibold">
-                          ${period.revenue.toFixed(2)}
-                        </td>
-                        <td className="px-4 py-3 text-right text-sm text-red-600 font-semibold">
-                          ${period.expenses.toFixed(2)}
-                        </td>
-                        <td className="px-4 py-3 text-right text-sm font-bold">
-                          <span className={period.netIncome >= 0 ? 'text-green-600' : 'text-red-600'}>
-                            ${period.netIncome.toFixed(2)}
-                          </span>
-                        </td>
-                        <td className="px-4 py-3 text-right text-sm">
-                          {margin.toFixed(1)}%
-                        </td>
-                        <td className="px-4 py-3 text-right text-sm">
-                          {prevPeriod && (
-                            <span className={change >= 0 ? 'text-green-600' : 'text-red-600'}>
-                              {change >= 0 ? '↑' : '↓'} {Math.abs(change).toFixed(1)}%
-                            </span>
-                          )}
-                        </td>
-                      </tr>
-                    );
-                  })}
-                </tbody>
-              </table>
-            </div>
+          {/* Statement Tabs */}
+          <div className="flex border-b">
+            {[
+              { key: 'balance', label: 'Balance Sheet' },
+              { key: 'income', label: 'Income Statement' },
+            ].map(tab => (
+              <button
+                key={tab.key}
+                onClick={() => setActiveTab(tab.key as any)}
+                className={`px-5 py-3 text-sm font-medium transition-colors ${
+                  activeTab === tab.key
+                    ? 'border-b-2 border-[#2d1b4e] text-[#2d1b4e] bg-white'
+                    : 'text-gray-500 hover:text-gray-700 bg-gray-50'
+                }`}
+              >
+                {tab.label}
+              </button>
+            ))}
           </div>
 
-          {/* Balance Sheet Comparison */}
-          <div className="bg-white border rounded-xl overflow-hidden">
-            <div className="bg-gray-50 px-6 py-4 border-b">
-              <h3 className="text-lg font-semibold">Balance Sheet</h3>
-            </div>
-            <div className="overflow-auto">
-              <table className="w-full">
-                <thead className="bg-gray-50">
-                  <tr>
-                    <th className="px-4 py-3 text-left text-xs font-semibold text-gray-600">Period</th>
-                    <th className="px-4 py-3 text-right text-xs font-semibold text-gray-600">Assets</th>
-                    <th className="px-4 py-3 text-right text-xs font-semibold text-gray-600">Liabilities</th>
-                    <th className="px-4 py-3 text-right text-xs font-semibold text-gray-600">Equity</th>
-                    <th className="px-4 py-3 text-right text-xs font-semibold text-gray-600">Current Ratio</th>
-                    <th className="px-4 py-3 text-right text-xs font-semibold text-gray-600">Change</th>
-                  </tr>
-                </thead>
-                <tbody className="divide-y">
-                  {data.map((period, idx) => {
-                    const currentRatio = period.liabilities !== 0 
-                      ? (period.assets / Math.abs(period.liabilities)).toFixed(2) 
-                      : 'N/A';
-                    const prevPeriod = idx > 0 ? data[idx - 1] : null;
-                    const change = prevPeriod ? calculateChange(period.assets, prevPeriod.assets) : 0;
+          {/* Balance Sheet — account-level detail with running balances */}
+          {activeTab === 'balance' && (
+            <div className="bg-white border rounded-xl overflow-hidden">
+              <div className="bg-gray-50 px-6 py-4 border-b flex justify-between items-center">
+                <h3 className="text-lg font-semibold">Balance Sheet</h3>
+                <span className="text-xs text-gray-500">Cumulative running balances at each period-end</span>
+              </div>
+              <div className="overflow-auto">
+                <table className="w-full text-sm">
+                  <thead className="bg-gray-100">
+                    <tr>
+                      <th className="px-3 py-2 text-left font-semibold min-w-[220px] sticky left-0 bg-gray-100 z-10">Account</th>
+                      {periodKeys.map(pk => (
+                        <th key={pk} className="px-3 py-2 text-right font-semibold whitespace-nowrap min-w-[100px]">
+                          {formatPeriodLabel(pk)}
+                        </th>
+                      ))}
+                      <th className="px-3 py-2 text-right font-semibold min-w-[100px] bg-gray-100">Current</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {renderAccountSection('Assets', assetAccounts, 'bg-blue-50', 'text-blue-800')}
+                    {renderAccountSection('Liabilities', liabilityAccounts, 'bg-orange-50', 'text-orange-800')}
+                    {renderAccountSection('Equity', equityAccounts, 'bg-purple-50', 'text-purple-800')}
 
-                    return (
-                      <tr key={period.period} className="hover:bg-gray-50">
-                        <td className="px-4 py-3 text-sm font-medium">{period.period}</td>
-                        <td className="px-4 py-3 text-right text-sm font-semibold">
-                          ${period.assets.toFixed(2)}
-                        </td>
-                        <td className="px-4 py-3 text-right text-sm font-semibold">
-                          ${Math.abs(period.liabilities).toFixed(2)}
-                        </td>
-                        <td className="px-4 py-3 text-right text-sm font-semibold">
-                          ${period.equity.toFixed(2)}
-                        </td>
-                        <td className="px-4 py-3 text-right text-sm">
-                          {currentRatio}
-                        </td>
-                        <td className="px-4 py-3 text-right text-sm">
-                          {prevPeriod && (
-                            <span className={change >= 0 ? 'text-green-600' : 'text-red-600'}>
-                              {change >= 0 ? '↑' : '↓'} {Math.abs(change).toFixed(1)}%
-                            </span>
-                          )}
-                        </td>
-                      </tr>
-                    );
-                  })}
-                </tbody>
-              </table>
+                    {/* Accounting equation check */}
+                    {periodKeys.length > 0 && (
+                      <>
+                        <tr className="bg-gray-200 border-t-2">
+                          <td className="px-3 py-2 font-bold text-sm sticky left-0 bg-gray-200 z-10">L + E</td>
+                          {periodKeys.map(pk => {
+                            const le = getSectionTotal(liabilityAccounts, pk) + getSectionTotal(equityAccounts, pk);
+                            return (
+                              <td key={pk} className="px-3 py-2 text-right font-bold text-sm">
+                                {formatAmount(le)}
+                              </td>
+                            );
+                          })}
+                          <td className="px-3 py-2 text-right font-bold text-sm bg-gray-200">
+                            {formatAmount(
+                              getSectionTotal(liabilityAccounts, periodKeys[periodKeys.length - 1] || '') +
+                              getSectionTotal(equityAccounts, periodKeys[periodKeys.length - 1] || '')
+                            )}
+                          </td>
+                        </tr>
+                        <tr className="bg-gray-100">
+                          <td className="px-3 py-2 font-bold text-sm sticky left-0 bg-gray-100 z-10">A = L + E Check</td>
+                          {periodKeys.map(pk => {
+                            const a = getSectionTotal(assetAccounts, pk);
+                            const le = getSectionTotal(liabilityAccounts, pk) + getSectionTotal(equityAccounts, pk);
+                            const diff = Math.abs(a - le);
+                            const balanced = diff < 0.02;
+                            return (
+                              <td key={pk} className={`px-3 py-2 text-right text-sm font-semibold ${balanced ? 'text-green-600' : 'text-red-600'}`}>
+                                {balanced ? 'Balanced' : `Off $${diff.toFixed(2)}`}
+                              </td>
+                            );
+                          })}
+                          <td className="px-3 py-2 text-right text-sm font-semibold bg-gray-100">
+                            {(() => {
+                              const lastPk = periodKeys[periodKeys.length - 1] || '';
+                              const a = getSectionTotal(assetAccounts, lastPk);
+                              const le = getSectionTotal(liabilityAccounts, lastPk) + getSectionTotal(equityAccounts, lastPk);
+                              const diff = Math.abs(a - le);
+                              return diff < 0.02
+                                ? <span className="text-green-600">Balanced</span>
+                                : <span className="text-red-600">Off ${diff.toFixed(2)}</span>;
+                            })()}
+                          </td>
+                        </tr>
+                      </>
+                    )}
+                  </tbody>
+                </table>
+              </div>
             </div>
-          </div>
+          )}
 
-          {/* Key Metrics Summary */}
-          <div className="grid grid-cols-4 gap-4">
-            {data.length > 0 && (
-              <>
-                <div className="bg-white border rounded-lg p-4">
-                  <div className="text-xs text-gray-600 mb-1">Latest Revenue</div>
-                  <div className="text-2xl font-bold text-green-600">
-                    ${data[0].revenue.toFixed(2)}
-                  </div>
+          {/* Income Statement — periodic activity */}
+          {activeTab === 'income' && (
+            <div className="bg-white border rounded-xl overflow-hidden">
+              <div className="bg-gray-50 px-6 py-4 border-b flex justify-between items-center">
+                <h3 className="text-lg font-semibold">Income Statement</h3>
+                <span className="text-xs text-gray-500">Activity per period</span>
+              </div>
+              <div className="overflow-auto">
+                <table className="w-full text-sm">
+                  <thead className="bg-gray-100">
+                    <tr>
+                      <th className="px-3 py-2 text-left font-semibold min-w-[220px] sticky left-0 bg-gray-100 z-10">Account</th>
+                      {periodKeys.map(pk => (
+                        <th key={pk} className="px-3 py-2 text-right font-semibold whitespace-nowrap min-w-[100px]">
+                          {formatPeriodLabel(pk)}
+                        </th>
+                      ))}
+                      <th className="px-3 py-2 text-right font-semibold min-w-[100px] bg-gray-100">YTD</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {renderAccountSection('Revenue', revenueAccounts, 'bg-green-50', 'text-green-800')}
+                    {renderAccountSection('Expenses', expenseAccounts, 'bg-red-50', 'text-red-800')}
+
+                    {/* Net Income */}
+                    <tr className="bg-yellow-100 font-bold border-t-2 border-yellow-400">
+                      <td className="px-3 py-2 sticky left-0 bg-yellow-100 z-10">Net Income</td>
+                      {periodKeys.map(pk => {
+                        const rev = getSectionTotal(revenueAccounts, pk);
+                        const exp = getSectionTotal(expenseAccounts, pk);
+                        const ni = rev - exp;
+                        return (
+                          <td key={pk} className={`px-3 py-2 text-right ${ni >= 0 ? 'text-green-700' : 'text-red-700'}`}>
+                            {formatAmount(ni)}
+                          </td>
+                        );
+                      })}
+                      <td className="px-3 py-2 text-right bg-yellow-200">
+                        {(() => {
+                          const totalRev = periodKeys.reduce((s, pk) => s + getSectionTotal(revenueAccounts, pk), 0);
+                          const totalExp = periodKeys.reduce((s, pk) => s + getSectionTotal(expenseAccounts, pk), 0);
+                          const ni = totalRev - totalExp;
+                          return <span className={ni >= 0 ? 'text-green-700' : 'text-red-700'}>{formatAmount(ni)}</span>;
+                        })()}
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          )}
+
+          {/* Key Metrics */}
+          {periods.length > 0 && (
+            <div className="grid grid-cols-4 gap-4">
+              <div className="bg-white border rounded-lg p-4">
+                <div className="text-xs text-gray-600 mb-1">Latest Revenue</div>
+                <div className="text-2xl font-bold text-green-600">
+                  {formatAmount(periods[0].revenue)}
                 </div>
-                <div className="bg-white border rounded-lg p-4">
-                  <div className="text-xs text-gray-600 mb-1">Latest Net Income</div>
-                  <div className={`text-2xl font-bold ${data[0].netIncome >= 0 ? 'text-green-600' : 'text-red-600'}`}>
-                    ${data[0].netIncome.toFixed(2)}
-                  </div>
+              </div>
+              <div className="bg-white border rounded-lg p-4">
+                <div className="text-xs text-gray-600 mb-1">Latest Net Income</div>
+                <div className={`text-2xl font-bold ${periods[0].netIncome >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+                  {formatAmount(periods[0].netIncome)}
                 </div>
-                <div className="bg-white border rounded-lg p-4">
-                  <div className="text-xs text-gray-600 mb-1">Total Assets</div>
-                  <div className="text-2xl font-bold">
-                    ${data[0].assets.toFixed(2)}
-                  </div>
+              </div>
+              <div className="bg-white border rounded-lg p-4">
+                <div className="text-xs text-gray-600 mb-1">Total Assets</div>
+                <div className="text-2xl font-bold">
+                  {formatAmount(periods[0].assets)}
                 </div>
-                <div className="bg-white border rounded-lg p-4">
-                  <div className="text-xs text-gray-600 mb-1">Avg Profit Margin</div>
-                  <div className="text-2xl font-bold">
-                    {(data.reduce((sum, p) => sum + (p.revenue !== 0 ? (p.netIncome / p.revenue) * 100 : 0), 0) / data.length).toFixed(1)}%
-                  </div>
+              </div>
+              <div className="bg-white border rounded-lg p-4">
+                <div className="text-xs text-gray-600 mb-1">A = L + E</div>
+                <div className="text-2xl font-bold">
+                  {(() => {
+                    const diff = Math.abs(periods[0].assets - (periods[0].liabilities + periods[0].equity));
+                    return diff < 0.02
+                      ? <span className="text-green-600">Balanced</span>
+                      : <span className="text-red-600">Off ${diff.toFixed(2)}</span>;
+                  })()}
                 </div>
-              </>
-            )}
-          </div>
+              </div>
+            </div>
+          )}
         </>
       )}
     </div>


### PR DESCRIPTION
API (statements/analysis):
- Return per-account data with period-level detail (new `accounts` and `periodKeys` fields in response)
- Balance sheet accounts (asset, liability, equity) now compute cumulative running balances through each period-end, not just period activity
- Income/expense accounts remain as periodic activity (correct for I/S)
- Backwards-compatible: `periods` array still returned with type-level aggregates

UI (ThreeStatementAnalysisTab):
- Replace period-rows-only layout with account-rows x period-columns grid
- Balance Sheet tab: accounts grouped by Assets/Liabilities/Equity with section subtotals and A = L + E validation per period
- Income Statement tab: Revenue/Expenses with Net Income row
- Sticky first column for account names during horizontal scroll
- Monthly/Quarterly/Yearly period selector still works
- Key metrics cards show latest period data and balance check

https://claude.ai/code/session_01CCk1pA3MvtFBBKegqHhhhs