### PR TITLE
feat: Schedule D and Form 8949 tax reporting with wash sale adjustmen…

### DIFF
--- a/src/app/api/tax/export/route.ts
+++ b/src/app/api/tax/export/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { generateForm8949, generateForm8949CSV } from '@/lib/tax-report-service';
+
+/**
+ * GET /api/tax/export?year=2025&format=8949
+ * Downloads a CSV file matching TurboTax Form 8949 import format.
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const user = await prisma.users.findFirst({
+      where: { email: { equals: userEmail, mode: 'insensitive' } }
+    });
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+
+    const yearParam = request.nextUrl.searchParams.get('year');
+    const taxYear = yearParam ? parseInt(yearParam, 10) : new Date().getFullYear();
+
+    if (isNaN(taxYear) || taxYear < 2000 || taxYear > 2100) {
+      return NextResponse.json({ error: 'Invalid year parameter' }, { status: 400 });
+    }
+
+    const entries = await generateForm8949(user.id, taxYear);
+    const csv = generateForm8949CSV(entries);
+
+    return new NextResponse(csv, {
+      status: 200,
+      headers: {
+        'Content-Type': 'text/csv',
+        'Content-Disposition': `attachment; filename="Form8949_${taxYear}.csv"`,
+      },
+    });
+  } catch (error) {
+    console.error('Tax export error:', error);
+    return NextResponse.json({ error: 'Failed to generate tax export' }, { status: 500 });
+  }
+}

--- a/src/app/api/tax/report/route.ts
+++ b/src/app/api/tax/report/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { generateTaxReport } from '@/lib/tax-report-service';
+
+/**
+ * GET /api/tax/report?year=2025
+ * Returns Form 8949 + Schedule D data for the given tax year.
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const user = await prisma.users.findFirst({
+      where: { email: { equals: userEmail, mode: 'insensitive' } }
+    });
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+
+    const yearParam = request.nextUrl.searchParams.get('year');
+    const taxYear = yearParam ? parseInt(yearParam, 10) : new Date().getFullYear();
+
+    if (isNaN(taxYear) || taxYear < 2000 || taxYear > 2100) {
+      return NextResponse.json({ error: 'Invalid year parameter' }, { status: 400 });
+    }
+
+    const report = await generateTaxReport(user.id, taxYear);
+
+    return NextResponse.json(report);
+  } catch (error) {
+    console.error('Tax report error:', error);
+    return NextResponse.json({ error: 'Failed to generate tax report' }, { status: 500 });
+  }
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -14,6 +14,7 @@ import PeriodClose from '@/components/dashboard/PeriodClose';
 import CPAExport from '@/components/dashboard/CPAExport';
 import PositionReportTab from '@/components/dashboard/PositionReportTab';
 import WashSaleReportTab from '@/components/dashboard/WashSaleReportTab';
+import TaxReportTab from '@/components/dashboard/TaxReportTab';
 
 interface Transaction {
   id: string;
@@ -331,6 +332,7 @@ export default function Dashboard() {
                 { key: 'close', label: 'Period Close' },
                 { key: 'positions', label: 'Positions' },
                 { key: 'wash-sales', label: 'Wash Sales' },
+                { key: 'tax', label: 'Tax Forms' },
                 { key: 'export', label: 'Export' },
               ].map(tab => (
                 <button key={tab.key} onClick={() => setActiveSection(tab.key)}
@@ -645,6 +647,11 @@ export default function Dashboard() {
               {/* Wash Sale Report */}
               {activeSection === 'wash-sales' && (
                 <WashSaleReportTab />
+              )}
+
+              {/* Tax Forms (Schedule D + Form 8949) */}
+              {activeSection === 'tax' && (
+                <TaxReportTab />
               )}
 
               {/* CPA Export */}

--- a/src/components/dashboard/TaxReportTab.tsx
+++ b/src/components/dashboard/TaxReportTab.tsx
@@ -1,0 +1,431 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+
+interface Form8949Entry {
+  description: string;
+  dateAcquired: string;
+  dateSold: string;
+  proceeds: number;
+  costBasis: number;
+  adjustmentCode: string;
+  adjustmentAmount: number;
+  gainOrLoss: number;
+  isLongTerm: boolean;
+  holdingDays: number;
+  symbol: string;
+  assetType: 'stock' | 'option';
+  box: string;
+}
+
+interface ScheduleDLine {
+  line: string;
+  description: string;
+  proceeds: number;
+  costBasis: number;
+  adjustments: number;
+  gainOrLoss: number;
+}
+
+interface ScheduleD {
+  partI: { line1a: ScheduleDLine; line1b: ScheduleDLine; line1c: ScheduleDLine; line7: ScheduleDLine };
+  partII: { line8a: ScheduleDLine; line8b: ScheduleDLine; line8c: ScheduleDLine; line15: ScheduleDLine };
+  line16: ScheduleDLine;
+}
+
+interface TaxReport {
+  taxYear: number;
+  form8949: { shortTerm: Form8949Entry[]; longTerm: Form8949Entry[] };
+  scheduleD: ScheduleD;
+  summary: {
+    totalDispositions: number;
+    shortTermCount: number;
+    longTermCount: number;
+    totalProceeds: number;
+    totalCostBasis: number;
+    totalAdjustments: number;
+    netGainOrLoss: number;
+    washSaleCount: number;
+    washSaleDisallowed: number;
+  };
+  availableYears: number[];
+}
+
+type ViewType = 'scheduleD' | 'form8949';
+
+export default function TaxReportTab() {
+  const [data, setData] = useState<TaxReport | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [year, setYear] = useState(new Date().getFullYear());
+  const [view, setView] = useState<ViewType>('scheduleD');
+  const [exporting, setExporting] = useState(false);
+
+  useEffect(() => {
+    loadData(year);
+  }, [year]);
+
+  const loadData = async (y: number) => {
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/tax/report?year=${y}`);
+      if (res.ok) {
+        const report = await res.json();
+        setData(report);
+        // Update year selector if we got available years
+        if (report.availableYears?.length > 0 && !report.availableYears.includes(y)) {
+          // Year is valid but has no data — keep it
+        }
+      }
+    } catch (error) {
+      console.error('Error loading tax report:', error);
+    }
+    setLoading(false);
+  };
+
+  const exportCSV = async () => {
+    setExporting(true);
+    try {
+      const res = await fetch(`/api/tax/export?year=${year}&format=8949`);
+      if (res.ok) {
+        const blob = await res.blob();
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = `Form8949_${year}.csv`;
+        a.click();
+        URL.revokeObjectURL(url);
+      }
+    } catch (error) {
+      console.error('Export error:', error);
+    }
+    setExporting(false);
+  };
+
+  const fmt = (val: number) => {
+    if (val === 0) return '-';
+    const abs = Math.abs(val);
+    const formatted = abs >= 1000
+      ? `$${abs.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
+      : `$${abs.toFixed(2)}`;
+    return val < 0 ? `(${formatted})` : formatted;
+  };
+
+  const plColor = (val: number) => val >= 0 ? 'text-green-700' : 'text-red-700';
+
+  const fmtDate = (d: string) => {
+    const dt = new Date(d + 'T00:00:00');
+    return dt.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: '2-digit' });
+  };
+
+  if (loading) {
+    return <div className="p-8 text-center text-sm text-gray-500">Generating tax report...</div>;
+  }
+
+  if (!data) {
+    return <div className="p-8 text-center text-sm text-red-600">Failed to load tax report</div>;
+  }
+
+  const { summary, scheduleD } = data;
+  const availableYears = data.availableYears.length > 0 ? data.availableYears : [year];
+
+  return (
+    <div>
+      {/* Header */}
+      <div className="bg-[#2d1b4e] text-white px-4 py-2 flex items-center justify-between">
+        <span className="text-sm font-semibold">Schedule D &amp; Form 8949</span>
+        <div className="flex items-center gap-2">
+          <select
+            value={year}
+            onChange={(e) => setYear(Number(e.target.value))}
+            className="bg-[#3d2b5e] text-white border-0 text-xs px-2 py-1 rounded"
+          >
+            {availableYears.map(y => <option key={y} value={y}>{y}</option>)}
+          </select>
+          <button
+            onClick={exportCSV}
+            disabled={exporting}
+            className="text-xs bg-emerald-600 px-3 py-1 rounded hover:bg-emerald-700 disabled:opacity-50"
+          >
+            {exporting ? 'Exporting...' : 'Export CSV'}
+          </button>
+        </div>
+      </div>
+
+      {/* Sub-tabs */}
+      <div className="flex border-b border-gray-200">
+        {[
+          { key: 'scheduleD', label: 'Schedule D' },
+          { key: 'form8949', label: `Form 8949 (${summary.totalDispositions})` },
+        ].map(tab => (
+          <button
+            key={tab.key}
+            onClick={() => setView(tab.key as ViewType)}
+            className={`px-4 py-2 text-xs font-medium ${
+              view === tab.key ? 'bg-[#2d1b4e] text-white' : 'bg-gray-50 text-gray-600'
+            }`}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Summary Cards */}
+      <div className="p-4 space-y-4">
+        <div className="grid grid-cols-5 gap-3">
+          <div className="border rounded-lg p-3">
+            <div className="text-[10px] text-gray-500 uppercase">Net Capital Gain/Loss</div>
+            <div className={`text-xl font-bold font-mono ${plColor(summary.netGainOrLoss)}`}>
+              {fmt(summary.netGainOrLoss)}
+            </div>
+          </div>
+          <div className="border rounded-lg p-3">
+            <div className="text-[10px] text-gray-500 uppercase">Short-Term</div>
+            <div className={`text-lg font-bold font-mono ${plColor(scheduleD.partI.line7.gainOrLoss)}`}>
+              {fmt(scheduleD.partI.line7.gainOrLoss)}
+            </div>
+            <div className="text-[10px] text-gray-400">{summary.shortTermCount} dispositions</div>
+          </div>
+          <div className="border rounded-lg p-3">
+            <div className="text-[10px] text-gray-500 uppercase">Long-Term</div>
+            <div className={`text-lg font-bold font-mono ${plColor(scheduleD.partII.line15.gainOrLoss)}`}>
+              {fmt(scheduleD.partII.line15.gainOrLoss)}
+            </div>
+            <div className="text-[10px] text-gray-400">{summary.longTermCount} dispositions</div>
+          </div>
+          <div className="border rounded-lg p-3">
+            <div className="text-[10px] text-gray-500 uppercase">Wash Sales</div>
+            <div className="text-lg font-bold font-mono text-amber-700">
+              {summary.washSaleCount}
+            </div>
+            <div className="text-[10px] text-gray-400">{fmt(summary.washSaleDisallowed)} disallowed</div>
+          </div>
+          <div className="border rounded-lg p-3">
+            <div className="text-[10px] text-gray-500 uppercase">Total Dispositions</div>
+            <div className="text-lg font-bold font-mono">{summary.totalDispositions}</div>
+          </div>
+        </div>
+
+        {/* Schedule D View */}
+        {view === 'scheduleD' && (
+          <div className="space-y-4">
+            {/* Part I: Short-Term */}
+            <div className="border rounded-lg overflow-hidden">
+              <div className="bg-yellow-50 px-4 py-2 text-sm font-semibold text-yellow-800">
+                Part I — Short-Term Capital Gains and Losses (held 1 year or less)
+              </div>
+              <table className="w-full text-xs">
+                <thead className="bg-gray-100">
+                  <tr>
+                    <th className="px-3 py-2 text-left w-[280px]">Line</th>
+                    <th className="px-3 py-2 text-right">(d) Proceeds</th>
+                    <th className="px-3 py-2 text-right">(e) Cost Basis</th>
+                    <th className="px-3 py-2 text-right">(g) Adjustments</th>
+                    <th className="px-3 py-2 text-right">(h) Gain or Loss</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {renderScheduleDLine(scheduleD.partI.line1a)}
+                  {renderScheduleDLine(scheduleD.partI.line1b)}
+                  {renderScheduleDLine(scheduleD.partI.line1c)}
+                  <tr className="bg-yellow-50 font-semibold border-t-2 border-yellow-300">
+                    <td className="px-3 py-2 text-yellow-800">Line {scheduleD.partI.line7.line}: {scheduleD.partI.line7.description}</td>
+                    <td className="px-3 py-2 text-right font-mono">{fmt(scheduleD.partI.line7.proceeds)}</td>
+                    <td className="px-3 py-2 text-right font-mono">{fmt(scheduleD.partI.line7.costBasis)}</td>
+                    <td className="px-3 py-2 text-right font-mono">{fmt(scheduleD.partI.line7.adjustments)}</td>
+                    <td className={`px-3 py-2 text-right font-mono ${plColor(scheduleD.partI.line7.gainOrLoss)}`}>
+                      {fmt(scheduleD.partI.line7.gainOrLoss)}
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+
+            {/* Part II: Long-Term */}
+            <div className="border rounded-lg overflow-hidden">
+              <div className="bg-blue-50 px-4 py-2 text-sm font-semibold text-blue-800">
+                Part II — Long-Term Capital Gains and Losses (held more than 1 year)
+              </div>
+              <table className="w-full text-xs">
+                <thead className="bg-gray-100">
+                  <tr>
+                    <th className="px-3 py-2 text-left w-[280px]">Line</th>
+                    <th className="px-3 py-2 text-right">(d) Proceeds</th>
+                    <th className="px-3 py-2 text-right">(e) Cost Basis</th>
+                    <th className="px-3 py-2 text-right">(g) Adjustments</th>
+                    <th className="px-3 py-2 text-right">(h) Gain or Loss</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {renderScheduleDLine(scheduleD.partII.line8a)}
+                  {renderScheduleDLine(scheduleD.partII.line8b)}
+                  {renderScheduleDLine(scheduleD.partII.line8c)}
+                  <tr className="bg-blue-50 font-semibold border-t-2 border-blue-300">
+                    <td className="px-3 py-2 text-blue-800">Line {scheduleD.partII.line15.line}: {scheduleD.partII.line15.description}</td>
+                    <td className="px-3 py-2 text-right font-mono">{fmt(scheduleD.partII.line15.proceeds)}</td>
+                    <td className="px-3 py-2 text-right font-mono">{fmt(scheduleD.partII.line15.costBasis)}</td>
+                    <td className="px-3 py-2 text-right font-mono">{fmt(scheduleD.partII.line15.adjustments)}</td>
+                    <td className={`px-3 py-2 text-right font-mono ${plColor(scheduleD.partII.line15.gainOrLoss)}`}>
+                      {fmt(scheduleD.partII.line15.gainOrLoss)}
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+
+            {/* Net Total */}
+            <div className="border-2 border-gray-800 rounded-lg overflow-hidden">
+              <table className="w-full text-xs">
+                <tbody>
+                  <tr className="bg-gray-100 font-bold">
+                    <td className="px-3 py-3 w-[280px]">Line {scheduleD.line16.line}: {scheduleD.line16.description}</td>
+                    <td className="px-3 py-3 text-right font-mono">{fmt(scheduleD.line16.proceeds)}</td>
+                    <td className="px-3 py-3 text-right font-mono">{fmt(scheduleD.line16.costBasis)}</td>
+                    <td className="px-3 py-3 text-right font-mono">{fmt(scheduleD.line16.adjustments)}</td>
+                    <td className={`px-3 py-3 text-right font-mono text-lg ${plColor(scheduleD.line16.gainOrLoss)}`}>
+                      {fmt(scheduleD.line16.gainOrLoss)}
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        )}
+
+        {/* Form 8949 View */}
+        {view === 'form8949' && (
+          <div className="space-y-4">
+            {/* Short-Term Section */}
+            {data.form8949.shortTerm.length > 0 && (
+              <div className="border rounded-lg overflow-hidden">
+                <div className="bg-yellow-50 px-4 py-2 text-sm font-semibold text-yellow-800">
+                  Short-Term — Held 1 Year or Less ({data.form8949.shortTerm.length} dispositions)
+                </div>
+                <div className="overflow-x-auto">
+                  <table className="w-full text-xs">
+                    <thead className="bg-gray-100">
+                      <tr>
+                        <th className="px-2 py-2 text-left">(a) Description</th>
+                        <th className="px-2 py-2 text-left">(b) Acquired</th>
+                        <th className="px-2 py-2 text-left">(c) Sold</th>
+                        <th className="px-2 py-2 text-right">(d) Proceeds</th>
+                        <th className="px-2 py-2 text-right">(e) Cost Basis</th>
+                        <th className="px-2 py-2 text-center">(f) Code</th>
+                        <th className="px-2 py-2 text-right">(g) Adjustment</th>
+                        <th className="px-2 py-2 text-right">(h) Gain/Loss</th>
+                        <th className="px-2 py-2 text-right">Days</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {data.form8949.shortTerm.map((e, i) => renderForm8949Row(e, i))}
+                      {renderForm8949Totals(data.form8949.shortTerm)}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            )}
+
+            {/* Long-Term Section */}
+            {data.form8949.longTerm.length > 0 && (
+              <div className="border rounded-lg overflow-hidden">
+                <div className="bg-blue-50 px-4 py-2 text-sm font-semibold text-blue-800">
+                  Long-Term — Held More Than 1 Year ({data.form8949.longTerm.length} dispositions)
+                </div>
+                <div className="overflow-x-auto">
+                  <table className="w-full text-xs">
+                    <thead className="bg-gray-100">
+                      <tr>
+                        <th className="px-2 py-2 text-left">(a) Description</th>
+                        <th className="px-2 py-2 text-left">(b) Acquired</th>
+                        <th className="px-2 py-2 text-left">(c) Sold</th>
+                        <th className="px-2 py-2 text-right">(d) Proceeds</th>
+                        <th className="px-2 py-2 text-right">(e) Cost Basis</th>
+                        <th className="px-2 py-2 text-center">(f) Code</th>
+                        <th className="px-2 py-2 text-right">(g) Adjustment</th>
+                        <th className="px-2 py-2 text-right">(h) Gain/Loss</th>
+                        <th className="px-2 py-2 text-right">Days</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {data.form8949.longTerm.map((e, i) => renderForm8949Row(e, i))}
+                      {renderForm8949Totals(data.form8949.longTerm)}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            )}
+
+            {summary.totalDispositions === 0 && (
+              <div className="text-center text-sm text-gray-500 py-8">
+                No dispositions found for tax year {year}
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+
+  function renderScheduleDLine(line: ScheduleDLine) {
+    const isEmpty = line.proceeds === 0 && line.costBasis === 0 && line.gainOrLoss === 0;
+    return (
+      <tr key={line.line} className={`border-b ${isEmpty ? 'text-gray-300' : ''}`}>
+        <td className="px-3 py-2">Line {line.line}: {line.description}</td>
+        <td className="px-3 py-2 text-right font-mono">{isEmpty ? '-' : fmt(line.proceeds)}</td>
+        <td className="px-3 py-2 text-right font-mono">{isEmpty ? '-' : fmt(line.costBasis)}</td>
+        <td className="px-3 py-2 text-right font-mono">{isEmpty ? '-' : fmt(line.adjustments)}</td>
+        <td className={`px-3 py-2 text-right font-mono ${isEmpty ? '' : plColor(line.gainOrLoss)}`}>
+          {isEmpty ? '-' : fmt(line.gainOrLoss)}
+        </td>
+      </tr>
+    );
+  }
+
+  function renderForm8949Row(e: Form8949Entry, i: number) {
+    return (
+      <tr key={`${e.dateSold}-${e.description}-${i}`} className={`border-b hover:bg-gray-50 ${e.adjustmentCode === 'W' ? 'bg-amber-50' : ''}`}>
+        <td className="px-2 py-1.5">
+          <span className="font-medium">{e.description}</span>
+          {e.assetType === 'option' && (
+            <span className="ml-1 text-[10px] px-1 py-0.5 bg-blue-100 text-blue-700 rounded">OPT</span>
+          )}
+        </td>
+        <td className="px-2 py-1.5 font-mono">{fmtDate(e.dateAcquired)}</td>
+        <td className="px-2 py-1.5 font-mono">{fmtDate(e.dateSold)}</td>
+        <td className="px-2 py-1.5 text-right font-mono">{fmt(e.proceeds)}</td>
+        <td className="px-2 py-1.5 text-right font-mono">{fmt(e.costBasis)}</td>
+        <td className="px-2 py-1.5 text-center">
+          {e.adjustmentCode && (
+            <span className="px-1.5 py-0.5 bg-amber-200 text-amber-900 text-[10px] font-bold rounded">
+              {e.adjustmentCode}
+            </span>
+          )}
+        </td>
+        <td className="px-2 py-1.5 text-right font-mono">
+          {e.adjustmentAmount !== 0 ? fmt(e.adjustmentAmount) : ''}
+        </td>
+        <td className={`px-2 py-1.5 text-right font-mono font-semibold ${plColor(e.gainOrLoss)}`}>
+          {fmt(e.gainOrLoss)}
+        </td>
+        <td className="px-2 py-1.5 text-right font-mono text-gray-400">{e.holdingDays}</td>
+      </tr>
+    );
+  }
+
+  function renderForm8949Totals(entries: Form8949Entry[]) {
+    const totProceeds = entries.reduce((s, e) => s + e.proceeds, 0);
+    const totCost = entries.reduce((s, e) => s + e.costBasis, 0);
+    const totAdj = entries.reduce((s, e) => s + e.adjustmentAmount, 0);
+    const totGL = entries.reduce((s, e) => s + e.gainOrLoss, 0);
+    return (
+      <tr className="bg-gray-100 font-semibold border-t-2">
+        <td className="px-2 py-2" colSpan={3}>Totals</td>
+        <td className="px-2 py-2 text-right font-mono">{fmt(totProceeds)}</td>
+        <td className="px-2 py-2 text-right font-mono">{fmt(totCost)}</td>
+        <td className="px-2 py-2"></td>
+        <td className="px-2 py-2 text-right font-mono">{fmt(totAdj)}</td>
+        <td className={`px-2 py-2 text-right font-mono ${plColor(totGL)}`}>{fmt(totGL)}</td>
+        <td className="px-2 py-2"></td>
+      </tr>
+    );
+  }
+}

--- a/src/lib/tax-report-service.ts
+++ b/src/lib/tax-report-service.ts
@@ -1,0 +1,409 @@
+import { prisma } from '@/lib/prisma';
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+// ============================================
+// Form 8949 — Sales and Other Dispositions of Capital Assets
+// ============================================
+
+/**
+ * Each row on Form 8949 represents one disposition.
+ * IRS columns: (a) Description, (b) Date acquired, (c) Date sold,
+ * (d) Proceeds, (e) Cost basis, (f) Adjustment code, (g) Adjustment amount,
+ * (h) Gain or loss = (d) - (e) + (g)
+ */
+export interface Form8949Entry {
+  description: string;        // (a) e.g. "100 sh AAPL" or "1 AAPL Jan 20 2025 $150 Call"
+  dateAcquired: string;       // (b) ISO date
+  dateSold: string;           // (c) ISO date
+  proceeds: number;           // (d)
+  costBasis: number;          // (e)
+  adjustmentCode: string;     // (f) "W" for wash sale, "" for none
+  adjustmentAmount: number;   // (g) wash sale disallowed loss (positive adds to basis)
+  gainOrLoss: number;         // (h) proceeds - costBasis + adjustmentAmount
+  isLongTerm: boolean;
+  holdingDays: number;
+  symbol: string;
+  assetType: 'stock' | 'option';
+  // Form 8949 Box classification:
+  // A = basis reported to IRS (1099-B with basis)
+  // B = basis NOT reported to IRS (1099-B without basis)
+  // C = no 1099-B received
+  box: 'A' | 'B' | 'C';
+}
+
+// ============================================
+// Schedule D — Capital Gains and Losses
+// ============================================
+
+export interface ScheduleDLine {
+  line: string;
+  description: string;
+  proceeds: number;
+  costBasis: number;
+  adjustments: number;
+  gainOrLoss: number;
+}
+
+export interface ScheduleD {
+  partI: {  // Short-term
+    line1a: ScheduleDLine;  // Box A (basis reported to IRS)
+    line1b: ScheduleDLine;  // Box B (basis NOT reported)
+    line1c: ScheduleDLine;  // Box C (no 1099-B)
+    line7: ScheduleDLine;   // Total short-term
+  };
+  partII: { // Long-term
+    line8a: ScheduleDLine;  // Box A
+    line8b: ScheduleDLine;  // Box B
+    line8c: ScheduleDLine;  // Box C
+    line15: ScheduleDLine;  // Total long-term
+  };
+  line16: ScheduleDLine;    // Net: line 7 + line 15
+}
+
+export interface TaxReport {
+  taxYear: number;
+  form8949: {
+    shortTerm: Form8949Entry[];
+    longTerm: Form8949Entry[];
+  };
+  scheduleD: ScheduleD;
+  summary: {
+    totalDispositions: number;
+    shortTermCount: number;
+    longTermCount: number;
+    totalProceeds: number;
+    totalCostBasis: number;
+    totalAdjustments: number;
+    netGainOrLoss: number;
+    washSaleCount: number;
+    washSaleDisallowed: number;
+  };
+  availableYears: number[];
+}
+
+/**
+ * Generate Form 8949 entries for a given user and tax year.
+ */
+export async function generateForm8949(
+  userId: string,
+  taxYear: number
+): Promise<Form8949Entry[]> {
+  const yearStart = new Date(`${taxYear}-01-01T00:00:00.000Z`);
+  const yearEnd = new Date(`${taxYear + 1}-01-01T00:00:00.000Z`);
+
+  const entries: Form8949Entry[] = [];
+
+  // ========== STOCK DISPOSITIONS ==========
+  const stockDispositions = await prisma.lot_dispositions.findMany({
+    where: {
+      disposed_date: { gte: yearStart, lt: yearEnd },
+      lot: { user_id: userId }
+    },
+    include: { lot: true },
+    orderBy: { disposed_date: 'asc' }
+  });
+
+  for (const disp of stockDispositions) {
+    const adjustmentAmount = disp.is_wash_sale ? disp.wash_sale_loss : 0;
+    // Form 8949 column (h): gain/loss = proceeds - cost + wash sale adjustment
+    // Wash sale adjustment is positive (adds to cost basis, reducing the loss reported)
+    const gainOrLoss = disp.total_proceeds - disp.cost_basis_disposed + adjustmentAmount;
+
+    entries.push({
+      description: `${disp.quantity_disposed} sh ${disp.lot.symbol}`,
+      dateAcquired: disp.lot.acquired_date.toISOString().split('T')[0],
+      dateSold: disp.disposed_date.toISOString().split('T')[0],
+      proceeds: round2(disp.total_proceeds),
+      costBasis: round2(disp.cost_basis_disposed),
+      adjustmentCode: disp.is_wash_sale ? 'W' : '',
+      adjustmentAmount: round2(adjustmentAmount),
+      gainOrLoss: round2(gainOrLoss),
+      isLongTerm: disp.is_long_term,
+      holdingDays: disp.holding_period_days,
+      symbol: disp.lot.symbol,
+      assetType: 'stock',
+      // Default to Box A (basis reported to IRS via 1099-B) for broker-imported transactions
+      box: 'A'
+    });
+  }
+
+  // ========== OPTION DISPOSITIONS ==========
+  // Get user's investment transaction IDs for scoping
+  const userAccounts = await prisma.accounts.findMany({
+    where: { userId },
+    select: { id: true }
+  });
+  const accountIds = userAccounts.map(a => a.id);
+
+  if (accountIds.length > 0) {
+    const userInvestmentTxnIds = (await prisma.investment_transactions.findMany({
+      where: { accountId: { in: accountIds } },
+      select: { id: true }
+    })).map(t => t.id);
+
+    if (userInvestmentTxnIds.length > 0) {
+      const closedOptions = await prisma.trading_positions.findMany({
+        where: {
+          open_investment_txn_id: { in: userInvestmentTxnIds },
+          status: 'CLOSED',
+          close_date: { gte: yearStart, lt: yearEnd }
+        },
+        orderBy: { close_date: 'asc' }
+      });
+
+      for (const pos of closedOptions) {
+        const closeDate = pos.close_date!;
+        const holdingDays = Math.floor(
+          (closeDate.getTime() - pos.open_date.getTime()) / MS_PER_DAY
+        );
+        const isLongTerm = holdingDays >= 365;
+        const proceeds = pos.proceeds || 0;
+        const costBasis = pos.cost_basis;
+        const gainOrLoss = proceeds - costBasis;
+
+        // Build option description: "1 AAPL Jan 20 2025 $150 Call"
+        const optDesc = buildOptionDescription(pos);
+
+        entries.push({
+          description: optDesc,
+          dateAcquired: pos.open_date.toISOString().split('T')[0],
+          dateSold: closeDate.toISOString().split('T')[0],
+          proceeds: round2(proceeds),
+          costBasis: round2(costBasis),
+          adjustmentCode: '',
+          adjustmentAmount: 0,
+          gainOrLoss: round2(gainOrLoss),
+          isLongTerm,
+          holdingDays,
+          symbol: extractUnderlying(pos.symbol),
+          assetType: 'option',
+          box: 'A'
+        });
+      }
+    }
+  }
+
+  // Sort by date sold
+  entries.sort((a, b) => a.dateSold.localeCompare(b.dateSold));
+
+  return entries;
+}
+
+/**
+ * Generate Schedule D from Form 8949 entries.
+ */
+export function generateScheduleD(entries: Form8949Entry[]): ScheduleD {
+  const shortTerm = entries.filter(e => !e.isLongTerm);
+  const longTerm = entries.filter(e => e.isLongTerm);
+
+  const stBoxA = shortTerm.filter(e => e.box === 'A');
+  const stBoxB = shortTerm.filter(e => e.box === 'B');
+  const stBoxC = shortTerm.filter(e => e.box === 'C');
+  const ltBoxA = longTerm.filter(e => e.box === 'A');
+  const ltBoxB = longTerm.filter(e => e.box === 'B');
+  const ltBoxC = longTerm.filter(e => e.box === 'C');
+
+  const sumLine = (items: Form8949Entry[], line: string, desc: string): ScheduleDLine => ({
+    line,
+    description: desc,
+    proceeds: round2(items.reduce((s, e) => s + e.proceeds, 0)),
+    costBasis: round2(items.reduce((s, e) => s + e.costBasis, 0)),
+    adjustments: round2(items.reduce((s, e) => s + e.adjustmentAmount, 0)),
+    gainOrLoss: round2(items.reduce((s, e) => s + e.gainOrLoss, 0)),
+  });
+
+  const line1a = sumLine(stBoxA, '1a', 'Short-term from Form 8949 Box A');
+  const line1b = sumLine(stBoxB, '1b', 'Short-term from Form 8949 Box B');
+  const line1c = sumLine(stBoxC, '1c', 'Short-term from Form 8949 Box C');
+  const line7: ScheduleDLine = {
+    line: '7',
+    description: 'Net short-term capital gain or (loss)',
+    proceeds: round2(line1a.proceeds + line1b.proceeds + line1c.proceeds),
+    costBasis: round2(line1a.costBasis + line1b.costBasis + line1c.costBasis),
+    adjustments: round2(line1a.adjustments + line1b.adjustments + line1c.adjustments),
+    gainOrLoss: round2(line1a.gainOrLoss + line1b.gainOrLoss + line1c.gainOrLoss),
+  };
+
+  const line8a = sumLine(ltBoxA, '8a', 'Long-term from Form 8949 Box A');
+  const line8b = sumLine(ltBoxB, '8b', 'Long-term from Form 8949 Box B');
+  const line8c = sumLine(ltBoxC, '8c', 'Long-term from Form 8949 Box C');
+  const line15: ScheduleDLine = {
+    line: '15',
+    description: 'Net long-term capital gain or (loss)',
+    proceeds: round2(line8a.proceeds + line8b.proceeds + line8c.proceeds),
+    costBasis: round2(line8a.costBasis + line8b.costBasis + line8c.costBasis),
+    adjustments: round2(line8a.adjustments + line8b.adjustments + line8c.adjustments),
+    gainOrLoss: round2(line8a.gainOrLoss + line8b.gainOrLoss + line8c.gainOrLoss),
+  };
+
+  const line16: ScheduleDLine = {
+    line: '16',
+    description: 'Net capital gain or (loss)',
+    proceeds: round2(line7.proceeds + line15.proceeds),
+    costBasis: round2(line7.costBasis + line15.costBasis),
+    adjustments: round2(line7.adjustments + line15.adjustments),
+    gainOrLoss: round2(line7.gainOrLoss + line15.gainOrLoss),
+  };
+
+  return {
+    partI: { line1a, line1b, line1c, line7 },
+    partII: { line8a, line8b, line8c, line15 },
+    line16
+  };
+}
+
+/**
+ * Generate the full tax report: Form 8949 + Schedule D + summary.
+ */
+export async function generateTaxReport(
+  userId: string,
+  taxYear: number
+): Promise<TaxReport> {
+  const entries = await generateForm8949(userId, taxYear);
+  const scheduleD = generateScheduleD(entries);
+
+  const shortTerm = entries.filter(e => !e.isLongTerm);
+  const longTerm = entries.filter(e => e.isLongTerm);
+  const washSales = entries.filter(e => e.adjustmentCode === 'W');
+
+  // Determine available years from all dispositions
+  const allDispYears = await prisma.lot_dispositions.findMany({
+    where: { lot: { user_id: userId } },
+    select: { disposed_date: true },
+    distinct: ['disposed_date']
+  });
+
+  const userAccounts = await prisma.accounts.findMany({
+    where: { userId },
+    select: { id: true }
+  });
+  const accountIds = userAccounts.map(a => a.id);
+
+  let optionCloseYears: number[] = [];
+  if (accountIds.length > 0) {
+    const txnIds = (await prisma.investment_transactions.findMany({
+      where: { accountId: { in: accountIds } },
+      select: { id: true }
+    })).map(t => t.id);
+
+    if (txnIds.length > 0) {
+      const closedOpts = await prisma.trading_positions.findMany({
+        where: {
+          open_investment_txn_id: { in: txnIds },
+          status: 'CLOSED',
+          close_date: { not: null }
+        },
+        select: { close_date: true }
+      });
+      optionCloseYears = closedOpts
+        .filter(p => p.close_date)
+        .map(p => p.close_date!.getFullYear());
+    }
+  }
+
+  const stockYears = allDispYears.map(d => d.disposed_date.getFullYear());
+  const allYears = [...new Set([...stockYears, ...optionCloseYears])].sort((a, b) => b - a);
+
+  // Ensure current year is always available
+  if (!allYears.includes(taxYear)) {
+    allYears.push(taxYear);
+    allYears.sort((a, b) => b - a);
+  }
+
+  return {
+    taxYear,
+    form8949: {
+      shortTerm,
+      longTerm
+    },
+    scheduleD,
+    summary: {
+      totalDispositions: entries.length,
+      shortTermCount: shortTerm.length,
+      longTermCount: longTerm.length,
+      totalProceeds: round2(entries.reduce((s, e) => s + e.proceeds, 0)),
+      totalCostBasis: round2(entries.reduce((s, e) => s + e.costBasis, 0)),
+      totalAdjustments: round2(entries.reduce((s, e) => s + e.adjustmentAmount, 0)),
+      netGainOrLoss: scheduleD.line16.gainOrLoss,
+      washSaleCount: washSales.length,
+      washSaleDisallowed: round2(washSales.reduce((s, e) => s + e.adjustmentAmount, 0)),
+    },
+    availableYears: allYears
+  };
+}
+
+/**
+ * Generate CSV content matching TurboTax Form 8949 import format.
+ */
+export function generateForm8949CSV(entries: Form8949Entry[]): string {
+  const headers = [
+    'Description of Property',
+    'Date Acquired',
+    'Date Sold',
+    'Proceeds',
+    'Cost or Other Basis',
+    'Adjustment Code',
+    'Adjustment Amount',
+    'Gain or Loss',
+    'Short/Long Term',
+    'Box'
+  ];
+
+  const rows = entries.map(e => [
+    csvEscape(e.description),
+    e.dateAcquired,
+    e.dateSold,
+    e.proceeds.toFixed(2),
+    e.costBasis.toFixed(2),
+    e.adjustmentCode,
+    e.adjustmentAmount !== 0 ? e.adjustmentAmount.toFixed(2) : '',
+    e.gainOrLoss.toFixed(2),
+    e.isLongTerm ? 'Long-term' : 'Short-term',
+    e.box
+  ]);
+
+  return [headers.join(','), ...rows.map(r => r.join(','))].join('\n');
+}
+
+// ============================================
+// Helpers
+// ============================================
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+function csvEscape(s: string): string {
+  if (s.includes(',') || s.includes('"') || s.includes('\n')) {
+    return `"${s.replace(/"/g, '""')}"`;
+  }
+  return s;
+}
+
+function extractUnderlying(symbol: string): string {
+  if (!symbol) return '';
+  const parts = symbol.trim().split(/[\s]/);
+  const first = parts[0];
+  if (/^[A-Z]{1,5}$/.test(first)) return first;
+  const match = first.match(/^([A-Z]{1,5})/);
+  return match ? match[1] : first.toUpperCase();
+}
+
+function buildOptionDescription(pos: {
+  symbol: string;
+  quantity: number;
+  option_type: string | null;
+  strike_price: number | null;
+  expiration_date: Date | null;
+}): string {
+  const underlying = extractUnderlying(pos.symbol);
+  const qty = Math.abs(pos.quantity);
+  const type = pos.option_type || 'Option';
+  const strike = pos.strike_price != null ? `$${pos.strike_price}` : '';
+  const exp = pos.expiration_date
+    ? pos.expiration_date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+    : '';
+
+  return `${qty} ${underlying} ${exp} ${strike} ${type}`.replace(/\s+/g, ' ').trim();
+}


### PR DESCRIPTION
…ts and CSV export

- tax-report-service.ts: generates Form 8949 entries from lot_dispositions (stocks) and closed trading_positions (options) for a given tax year. Classifies short-term vs long-term (<=365 days), incorporates wash sale adjustments with code W. Generates Schedule D from Form 8949 data with Part I (short-term lines 1a/1b/1c/7), Part II (long-term lines 8a/8b/8c/15), and net line 16. CSV export in TurboTax-compatible Form 8949 format.
- GET /api/tax/report?year=2025: returns full tax report (Form 8949 + Schedule D
  + summary stats + available years)
- GET /api/tax/export?year=2025: downloads CSV file matching TurboTax import format with all Form 8949 columns including wash sale adjustment codes
- TaxReportTab: dashboard UI with Schedule D view (IRS form layout with Part I/II totals) and Form 8949 view (full transaction list with wash sale highlighting, ST/LT sections, per-section totals). Year selector and CSV export button.
- Dashboard integration: added Tax Forms tab

https://claude.ai/code/session_01CCk1pA3MvtFBBKegqHhhhs