### PR TITLE
feat: trade card persistence with queue system and Trade Lab tab

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -293,6 +293,7 @@ model trading_positions {
   realized_pl             Float?
   trade_num               String?   @db.VarChar(20)
   strategy                String?   @db.VarChar(50)
+  source                  String    @default("legacy") @db.VarChar(20)
   created_at              DateTime  @default(now())
   updated_at              DateTime  @updatedAt
 
@@ -368,6 +369,7 @@ model users {
   trade_journal_entries trade_journal_entries[]
   tastytrade_connections tastytrade_connections[]
   merchant_coa_mappings merchant_coa_mappings[]
+  trade_cards           trade_cards[]
 }
 
 model budgets {
@@ -1281,4 +1283,56 @@ model tastytrade_connections {
 
   @@unique([userId])
   @@index([status])
+}
+
+// ============================================
+// TRADE CARD PERSISTENCE & QUEUE
+// ============================================
+
+model trade_cards {
+  id                String    @id @default(uuid()) @db.Uuid
+  userId            String
+  symbol            String    @db.VarChar(20)
+  strategy_name     String    @db.VarChar(100)
+  direction         String    @db.VarChar(20)
+  legs              Json                           // [{action, type, strike, price}]
+  entry_price       Decimal?  @db.Decimal(12, 2)
+  max_profit        Decimal?  @db.Decimal(12, 2)
+  max_loss          Decimal?  @db.Decimal(12, 2)
+  win_rate          Decimal?  @db.Decimal(5, 2)
+  risk_reward       Decimal?  @db.Decimal(8, 4)
+  thesis_points     Json?                          // ["point 1", "point 2", ...]
+  key_stats         Json?                          // {iv_rank, hv, pe, beta, spy_corr, ...}
+  macro_regime      String?   @db.VarChar(100)
+  sentiment         String?   @db.VarChar(50)
+  insider_activity  String?   @db.Text
+  headlines         Json?                          // [{title, source, sentiment}]
+  dte               Int?
+  expiration_date   DateTime? @db.Date
+  generated_at      DateTime  @default(now())
+  status            String    @default("queued") @db.VarChar(20)
+
+  user              users     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  link              trade_card_links?
+
+  @@index([userId])
+  @@index([userId, status])
+  @@index([symbol])
+}
+
+model trade_card_links {
+  id                 String    @id @default(uuid()) @db.Uuid
+  trade_card_id      String    @unique @db.Uuid
+  trade_num          String    @db.VarChar(50)
+  linked_at          DateTime  @default(now())
+  actual_entry_price Decimal?  @db.Decimal(12, 2)
+  actual_exit_price  Decimal?  @db.Decimal(12, 2)
+  actual_pl          Decimal?  @db.Decimal(12, 2)
+  grade              String?   @db.VarChar(2)
+  thesis_results     Json?                         // [true, false, true, ...] per thesis point
+  notes              String?   @db.Text
+
+  trade_card         trade_cards @relation(fields: [trade_card_id], references: [id], onDelete: Cascade)
+
+  @@index([trade_num])
 }

--- a/src/app/api/trade-cards/route.ts
+++ b/src/app/api/trade-cards/route.ts
@@ -1,0 +1,198 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
+
+/**
+ * POST /api/trade-cards — Save a card to the queue
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const user = await prisma.users.findFirst({
+      where: { email: { equals: userEmail, mode: 'insensitive' } }
+    });
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+
+    const body = await request.json();
+    const {
+      symbol,
+      strategy_name,
+      direction,
+      legs,
+      entry_price,
+      max_profit,
+      max_loss,
+      win_rate,
+      risk_reward,
+      thesis_points,
+      key_stats,
+      macro_regime,
+      sentiment,
+      insider_activity,
+      headlines,
+      dte,
+      expiration_date,
+    } = body;
+
+    if (!symbol || !strategy_name || !direction || !legs) {
+      return NextResponse.json(
+        { error: 'Required: symbol, strategy_name, direction, legs' },
+        { status: 400 }
+      );
+    }
+
+    const card = await prisma.trade_cards.create({
+      data: {
+        userId: user.id,
+        symbol: symbol.toUpperCase(),
+        strategy_name,
+        direction,
+        legs,
+        entry_price: entry_price != null ? entry_price : null,
+        max_profit: max_profit != null ? max_profit : null,
+        max_loss: max_loss != null ? max_loss : null,
+        win_rate: win_rate != null ? win_rate : null,
+        risk_reward: risk_reward != null ? risk_reward : null,
+        thesis_points: thesis_points ?? null,
+        key_stats: key_stats ?? null,
+        macro_regime: macro_regime ?? null,
+        sentiment: sentiment ?? null,
+        insider_activity: insider_activity ?? null,
+        headlines: headlines ?? null,
+        dte: dte != null ? dte : null,
+        expiration_date: expiration_date ? new Date(expiration_date) : null,
+        status: 'queued',
+      },
+    });
+
+    return NextResponse.json({ success: true, card });
+  } catch (error) {
+    console.error('Trade card save error:', error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Failed to save trade card' },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * GET /api/trade-cards?status=queued — Get user's trade cards
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const user = await prisma.users.findFirst({
+      where: { email: { equals: userEmail, mode: 'insensitive' } }
+    });
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+
+    const statusFilter = request.nextUrl.searchParams.get('status');
+
+    const where: Record<string, unknown> = { userId: user.id };
+    if (statusFilter) {
+      where.status = statusFilter;
+    }
+
+    const cards = await prisma.trade_cards.findMany({
+      where,
+      include: { link: true },
+      orderBy: { generated_at: 'desc' },
+    });
+
+    return NextResponse.json({ cards });
+  } catch (error) {
+    console.error('Trade card list error:', error);
+    return NextResponse.json({ error: 'Failed to fetch trade cards' }, { status: 500 });
+  }
+}
+
+/**
+ * DELETE /api/trade-cards — Remove a card from queue (by id in body)
+ */
+export async function DELETE(request: NextRequest) {
+  try {
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const user = await prisma.users.findFirst({
+      where: { email: { equals: userEmail, mode: 'insensitive' } }
+    });
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+
+    const { id } = await request.json();
+    if (!id) return NextResponse.json({ error: 'Required: id' }, { status: 400 });
+
+    // Verify ownership and status
+    const card = await prisma.trade_cards.findFirst({
+      where: { id, userId: user.id },
+    });
+
+    if (!card) {
+      return NextResponse.json({ error: 'Card not found' }, { status: 404 });
+    }
+
+    if (card.status === 'linked' || card.status === 'graded') {
+      return NextResponse.json(
+        { error: `Cannot delete a ${card.status} card. Unlink it first.` },
+        { status: 400 }
+      );
+    }
+
+    await prisma.trade_cards.delete({ where: { id } });
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('Trade card delete error:', error);
+    return NextResponse.json({ error: 'Failed to delete trade card' }, { status: 500 });
+  }
+}
+
+/**
+ * PATCH /api/trade-cards — Update card status
+ */
+export async function PATCH(request: NextRequest) {
+  try {
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const user = await prisma.users.findFirst({
+      where: { email: { equals: userEmail, mode: 'insensitive' } }
+    });
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+
+    const { id, status } = await request.json();
+    if (!id || !status) {
+      return NextResponse.json({ error: 'Required: id, status' }, { status: 400 });
+    }
+
+    const validStatuses = ['queued', 'entered', 'linked', 'graded'];
+    if (!validStatuses.includes(status)) {
+      return NextResponse.json(
+        { error: `Invalid status. Must be one of: ${validStatuses.join(', ')}` },
+        { status: 400 }
+      );
+    }
+
+    // Verify ownership
+    const card = await prisma.trade_cards.findFirst({
+      where: { id, userId: user.id },
+    });
+    if (!card) {
+      return NextResponse.json({ error: 'Card not found' }, { status: 404 });
+    }
+
+    const updated = await prisma.trade_cards.update({
+      where: { id },
+      data: { status },
+    });
+
+    return NextResponse.json({ success: true, card: updated });
+  } catch (error) {
+    console.error('Trade card update error:', error);
+    return NextResponse.json({ error: 'Failed to update trade card' }, { status: 500 });
+  }
+}

--- a/src/app/trading/page.tsx
+++ b/src/app/trading/page.tsx
@@ -15,6 +15,7 @@ import {
   type CustomLeg,
 } from '@/lib/strategy-builder';
 import ConvergenceIntelligence from '@/components/convergence/ConvergenceIntelligence';
+import TradeLabPanel from '@/components/trading/TradeLabPanel';
 
 
 interface TradeSummary {
@@ -97,7 +98,7 @@ interface TradesData {
   byTicker: TickerBreakdown[];
 }
 
-type TabType = 'overview' | 'positions' | 'market-intelligence';
+type TabType = 'overview' | 'positions' | 'trade-lab' | 'market-intelligence';
 
 const EMOTIONS = ['confident', 'neutral', 'nervous', 'fomo', 'revenge', 'greedy', 'fearful'];
 const SETUPS = ['breakout', 'pullback', 'mean-reversion', 'momentum', 'earnings', 'theta-decay', 'volatility', 'other'];
@@ -1393,6 +1394,7 @@ export default function TradingPage() {
             {[
               { key: 'overview', label: 'Overview' },
               { key: 'positions', label: 'Open Positions' },
+              { key: 'trade-lab', label: 'Trade Lab' },
               { key: 'market-intelligence', label: 'Market Intelligence' },
             ].map(tab => (
               <button key={tab.key} onClick={() => setActiveTab(tab.key as TabType)}
@@ -1741,6 +1743,11 @@ export default function TradingPage() {
                   </table>
                 </div>
               </div>
+            )}
+
+            {/* Trade Lab Tab */}
+            {activeTab === 'trade-lab' && (
+              <TradeLabPanel />
             )}
 
             {/* Market Intelligence Tab */}

--- a/src/components/trading/TradeLabPanel.tsx
+++ b/src/components/trading/TradeLabPanel.tsx
@@ -1,0 +1,234 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+
+interface TradeCard {
+  id: string;
+  symbol: string;
+  strategy_name: string;
+  direction: string;
+  legs: { type: string; side: string; strike: number; price: number }[];
+  entry_price: number | null;
+  max_profit: number | null;
+  max_loss: number | null;
+  win_rate: number | null;
+  risk_reward: number | null;
+  thesis_points: string[] | null;
+  key_stats: Record<string, unknown> | null;
+  macro_regime: string | null;
+  sentiment: string | null;
+  headlines: { title: string; source: string; sentiment: string }[] | null;
+  dte: number | null;
+  expiration_date: string | null;
+  generated_at: string;
+  status: string;
+  link: {
+    trade_num: string;
+    grade: string | null;
+    actual_pl: number | null;
+  } | null;
+}
+
+const LEGACY_CUTOFF = '2026-02-23';
+
+export default function TradeLabPanel() {
+  const [cards, setCards] = useState<TradeCard[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [filter, setFilter] = useState<string>('all');
+
+  const loadCards = useCallback(async () => {
+    setLoading(true);
+    try {
+      const url = filter === 'all' ? '/api/trade-cards' : `/api/trade-cards?status=${filter}`;
+      const res = await fetch(url);
+      if (res.ok) {
+        const { cards: data } = await res.json();
+        setCards(data);
+      }
+    } catch (error) {
+      console.error('Failed to load trade cards:', error);
+    }
+    setLoading(false);
+  }, [filter]);
+
+  useEffect(() => {
+    loadCards();
+  }, [loadCards]);
+
+  const deleteCard = async (id: string) => {
+    try {
+      const res = await fetch('/api/trade-cards', {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id }),
+      });
+      if (res.ok) {
+        setCards(prev => prev.filter(c => c.id !== id));
+      }
+    } catch { /* ignore */ }
+  };
+
+  const fmtDollar = (v: number | null) => {
+    if (v == null) return '\u2014';
+    return v >= 0 ? `$${Math.abs(v).toLocaleString(undefined, { minimumFractionDigits: 0, maximumFractionDigits: 0 })}` : `-$${Math.abs(v).toLocaleString(undefined, { minimumFractionDigits: 0, maximumFractionDigits: 0 })}`;
+  };
+
+  const fmtDate = (d: string) => {
+    return new Date(d).toLocaleDateString('en-US', { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' });
+  };
+
+  const dirColor = (d: string) => {
+    const u = d.toUpperCase();
+    if (u === 'BULLISH') return { bg: '#065F46', text: '#34D399' };
+    if (u === 'BEARISH') return { bg: '#7F1D1D', text: '#FCA5A5' };
+    return { bg: '#334155', text: '#94A3B8' };
+  };
+
+  const statusBadge = (status: string) => {
+    switch (status) {
+      case 'queued': return { bg: '#4F46E5', text: 'Queued' };
+      case 'entered': return { bg: '#D97706', text: 'Entered' };
+      case 'linked': return { bg: '#059669', text: 'Linked' };
+      case 'graded': return { bg: '#7C3AED', text: 'Graded' };
+      default: return { bg: '#6B7280', text: status };
+    }
+  };
+
+  return (
+    <div>
+      {/* Header */}
+      <div className="bg-[#2d1b4e] text-white px-4 py-3 flex items-center justify-between">
+        <div>
+          <span className="text-sm font-semibold">Trade Lab</span>
+          <span className="text-[10px] text-purple-300 ml-2">{cards.length} card{cards.length !== 1 ? 's' : ''}</span>
+        </div>
+        <div className="flex items-center gap-2">
+          <select
+            value={filter}
+            onChange={e => setFilter(e.target.value)}
+            className="bg-[#3d2b5e] text-white border-0 text-xs px-2 py-1 rounded"
+          >
+            <option value="all">All</option>
+            <option value="queued">Queued</option>
+            <option value="entered">Entered</option>
+            <option value="linked">Linked</option>
+            <option value="graded">Graded</option>
+          </select>
+          <button onClick={loadCards} className="text-xs bg-[#3d2b5e] px-3 py-1 rounded hover:bg-[#4d3b6e]">
+            Refresh
+          </button>
+        </div>
+      </div>
+
+      {/* Legacy notice */}
+      <div className="bg-amber-50 border-b border-amber-200 px-4 py-2 text-xs text-amber-800">
+        Positions opened before Feb 23, 2026 are legacy trades without scanner data. Only new trades can be linked to trade cards.
+      </div>
+
+      {loading ? (
+        <div className="p-8 text-center text-sm text-gray-500">Loading trade cards...</div>
+      ) : cards.length === 0 ? (
+        <div className="p-12 text-center">
+          <div className="text-gray-400 text-sm mb-2">No trade cards {filter !== 'all' ? `with status "${filter}"` : 'yet'}</div>
+          <div className="text-gray-400 text-xs">
+            Use Market Intelligence to scan for opportunities, then click &ldquo;Enter Trade&rdquo; on any strategy card to save it here.
+          </div>
+        </div>
+      ) : (
+        <div className="divide-y divide-gray-100">
+          {cards.map(card => {
+            const dir = dirColor(card.direction);
+            const badge = statusBadge(card.status);
+            const legs = card.legs as { type: string; side: string; strike: number; price: number }[];
+
+            return (
+              <div key={card.id} className="px-4 py-3 hover:bg-gray-50 transition-colors">
+                <div className="flex items-start justify-between gap-4">
+                  {/* Left: symbol + strategy */}
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2 mb-1">
+                      <span className="text-base font-bold font-mono text-gray-900">{card.symbol}</span>
+                      <span className="text-xs font-medium text-gray-600">{card.strategy_name}</span>
+                      <span className="px-1.5 py-0.5 rounded text-[9px] font-bold" style={{ background: dir.bg, color: dir.text }}>
+                        {card.direction.toUpperCase()}
+                      </span>
+                      <span className="px-1.5 py-0.5 rounded text-[9px] font-bold text-white" style={{ background: badge.bg }}>
+                        {badge.text}
+                      </span>
+                    </div>
+
+                    {/* Legs */}
+                    <div className="flex gap-3 text-[11px] text-gray-500 mb-1">
+                      {legs.map((leg, i) => (
+                        <span key={i} className="font-mono">
+                          <span className={leg.side === 'sell' ? 'text-red-600' : 'text-green-600'}>{leg.side.toUpperCase()}</span>
+                          {' '}{leg.type.toUpperCase()}{' '}${leg.strike}{' '}@{' '}${leg.price.toFixed(2)}
+                        </span>
+                      ))}
+                    </div>
+
+                    {/* Meta row */}
+                    <div className="flex items-center gap-4 text-[10px] text-gray-400">
+                      <span>Queued {fmtDate(card.generated_at)}</span>
+                      {card.dte != null && <span>{card.dte} DTE</span>}
+                      {card.expiration_date && <span>Exp {new Date(card.expiration_date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}</span>}
+                    </div>
+
+                    {/* Thesis points */}
+                    {card.thesis_points && card.thesis_points.length > 0 && (
+                      <div className="mt-2 space-y-0.5">
+                        {(card.thesis_points as string[]).slice(0, 3).map((pt, i) => (
+                          <div key={i} className="text-[10px] text-gray-500 flex gap-1">
+                            <span className="text-gray-400 shrink-0">{i + 1}.</span>
+                            <span className="line-clamp-1">{pt}</span>
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+
+                  {/* Right: key numbers + actions */}
+                  <div className="shrink-0 text-right space-y-1">
+                    <div className="grid grid-cols-2 gap-x-4 gap-y-0.5 text-[11px]">
+                      <div className="text-gray-400">Max Profit</div>
+                      <div className="font-mono font-bold text-green-700">{fmtDollar(card.max_profit)}</div>
+                      <div className="text-gray-400">Max Loss</div>
+                      <div className="font-mono font-bold text-red-700">{fmtDollar(card.max_loss)}</div>
+                      <div className="text-gray-400">Win Rate</div>
+                      <div className="font-mono font-bold">{card.win_rate != null ? `${Number(card.win_rate).toFixed(1)}%` : '\u2014'}</div>
+                      <div className="text-gray-400">R:R</div>
+                      <div className="font-mono font-bold">{card.risk_reward != null ? Number(card.risk_reward).toFixed(2) : '\u2014'}</div>
+                    </div>
+
+                    {/* Delete button — only for queued/entered */}
+                    {(card.status === 'queued' || card.status === 'entered') && (
+                      <button
+                        onClick={() => deleteCard(card.id)}
+                        className="text-[10px] text-gray-400 hover:text-red-600 transition-colors mt-1"
+                      >
+                        Remove
+                      </button>
+                    )}
+
+                    {/* Linked info */}
+                    {card.link && (
+                      <div className="text-[10px] mt-1">
+                        <span className="text-gray-400">Trade #{card.link.trade_num}</span>
+                        {card.link.grade && <span className="ml-1 font-bold text-purple-600">{card.link.grade}</span>}
+                        {card.link.actual_pl != null && (
+                          <span className={`ml-1 font-mono font-bold ${Number(card.link.actual_pl) >= 0 ? 'text-green-700' : 'text-red-700'}`}>
+                            {fmtDollar(Number(card.link.actual_pl))}
+                          </span>
+                        )}
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Add trade_cards and trade_card_links schema models, POST/GET/DELETE/PATCH API endpoints, "Enter Trade" button on scanner strategy cards, and Trade Lab tab on the trading page for managing the trade card lifecycle.

https://claude.ai/code/session_01CCk1pA3MvtFBBKegqHhhhs