### PR TITLE
fix: remove unauthorized trial and pricing copy from home page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1092,7 +1092,7 @@ The AGPL + Commercial model ensures:
 
 <div align="center">
 
-**All plans include:** 14-day free trial • No credit card required • Your data, always exportable
+**All plans include:** Your data, always exportable
 
 </div>
 


### PR DESCRIPTION
Remove "14-day free trial" and "No credit card required" from the managed hosting section — this copy was never approved. Kept "Your data, always exportable" as it describes a real feature.

https://claude.ai/code/session_01MJg5YPdoS3guxn2fa1aL7R