### PR TITLE
foundation: market-metrics pre-filter, top 9, unicode fix

### DIFF
--- a/src/app/api/ai/convergence-synthesis/route.ts
+++ b/src/app/api/ai/convergence-synthesis/route.ts
@@ -72,21 +72,21 @@ Composite = weighted average of all 4. Convergence gate requires 3/4 categories 
 
 You receive:
 - pipeline_summary: universe size, filter counts, timing
-- rankings.top_8: the final selected tickers with all scores, convergence rating, strategy suggestion, sector, IVP, IV-HV spread, HV trend, insider MSPR, beat streak, key signals
-- rankings.also_scored: runners-up that were scored but didn't make the final 8
+- rankings.top_9: the final selected tickers with all scores, convergence rating, strategy suggestion, sector, IVP, IV-HV spread, HV trend, insider MSPR, beat streak, key signals
+- rankings.also_scored: runners-up that were scored but didn't make the final 9
 - diversification.adjustments: any tickers excluded (convergence gate, quality floor, sector cap)
 - sector_stats: per-sector mean/std for key metrics
-- scoring_details: full scoring breakdown for each top-8 ticker (sub-scores, formulas, z-scores, regime classification)
+- scoring_details: full scoring breakdown for each top-9 ticker (sub-scores, formulas, z-scores, regime classification)
 - data_gaps and errors
 
 You perform FOUR analyses. Every claim must be directly computable from the data provided.
 
 1. PIPELINE SUMMARY
-Summarize the funnel: how many tickers entered, how many survived hard filters, how many were scored, and which 8 made it through. Note pipeline runtime. If there were Finnhub errors or data gaps, mention them.
+Summarize the funnel: how many tickers entered, how many survived hard filters, how many were scored, and which 9 made it through. Note pipeline runtime. If there were Finnhub errors or data gaps, mention them.
 Write 2-3 sentences. Every sentence must contain a number.
 
 2. CONVERGENCE ANALYSIS
-For each of the top 8 tickers:
+For each of the top 9 tickers:
 - State the composite score and convergence rating (e.g., "4/4 — all categories aligned")
 - Identify the STRONGEST category and the WEAKEST category with their scores
 - If vol_edge is the strongest, explain WHY (look at mispricing z-scores, term structure shape, IV-HV spread)
@@ -97,8 +97,8 @@ Write 2-3 sentences per ticker. Reference specific sub-scores and numbers.
 
 3. RISK FLAGS
 Scan the data for:
-a) Sector concentration: Are multiple top-8 tickers from the same sector? What's the sector distribution?
-b) Regime misalignment: Any top-8 ticker with regime < 45? What's dragging it down?
+a) Sector concentration: Are multiple top-9 tickers from the same sector? What's the sector distribution?
+b) Regime misalignment: Any top-9 ticker with regime < 45? What's dragging it down?
 c) Quality concerns: Any ticker with quality between 40-50 that barely passed the floor?
 d) Convergence weakness: Any ticker at exactly 3/4? Which category failed?
 e) Insider selling: Any ticker where MSPR is negative (insider selling)?
@@ -106,7 +106,7 @@ f) Exclusions: Summarize why tickers were excluded (convergence gate failures, q
 List each risk found. If none for a category, omit it.
 
 4. CROSS-TICKER INSIGHTS
-Look across all 8 tickers for patterns:
+Look across all 9 tickers for patterns:
 - Is there a dominant regime classification? What does it mean for premium selling?
 - What's the average composite score? Is the cohort strong or marginal?
 - Are the strategies all the same direction, or is there a mix of bullish/bearish/neutral?
@@ -143,7 +143,7 @@ function prepareSynthesisPayload(pipeline: PipelineResult): object {
     pipeline_summary: pipeline.pipeline_summary,
     rankings: {
       scored_count: pipeline.rankings.scored_count,
-      top_8: pipeline.rankings.top_8,
+      top_9: pipeline.rankings.top_9,
       // Include top 10 of also_scored for context
       also_scored_sample: pipeline.rankings.also_scored.slice(0, 10),
       sector_distribution: pipeline.rankings.sector_distribution,
@@ -156,6 +156,21 @@ function prepareSynthesisPayload(pipeline: PipelineResult): object {
       ]),
     ),
     scoring_details: pipeline.scoring_details,
+    pre_filter_summary: {
+      total: pipeline.pre_filter.length,
+      included: pipeline.pre_filter.filter(r => !r.excluded).length,
+      excluded: pipeline.pre_filter.filter(r => r.excluded).length,
+      earnings_warnings: pipeline.pre_filter.filter(r => r.earningsWarning != null).map(r => ({
+        symbol: r.symbol,
+        warning: r.earningsWarning,
+      })),
+      top_10_by_preScore: pipeline.pre_filter.filter(r => !r.excluded).slice(0, 10).map(r => ({
+        symbol: r.symbol,
+        preScore: r.preScore,
+        ivRank: r.ivRank,
+        liquidityRating: r.liquidityRating,
+      })),
+    },
     data_gaps: pipeline.data_gaps,
     errors: pipeline.errors,
   };
@@ -247,7 +262,8 @@ export async function GET(request: Request) {
     const result = {
       synthesis,
       pipeline_summary: pipeline.pipeline_summary,
-      top_8: pipeline.rankings.top_8,
+      top_9: pipeline.rankings.top_9,
+      pre_filter: pipeline.pre_filter,
       sector_distribution: pipeline.rankings.sector_distribution,
       timing: {
         pipeline_ms: pipelineMs,

--- a/src/components/convergence/ConvergenceIntelligence.tsx
+++ b/src/components/convergence/ConvergenceIntelligence.tsx
@@ -31,14 +31,14 @@ interface PipelineSummary {
   after_hard_filters: number;
   pre_scored: number;
   scored: number;
-  final_8: string[];
+  final_9: string[];
   pipeline_runtime_ms: number;
   timestamp: string;
 }
 
 interface BatchResponse {
   pipeline_summary: PipelineSummary;
-  top_8: RankedRow[];
+  top_9: RankedRow[];
   timing: { pipeline_ms: number; ai_ms: number; total_ms: number };
 }
 
@@ -162,17 +162,17 @@ function dirBadge(d: string) {
 }
 
 function fmtDollar(v: number | null): string {
-  if (v == null) return '\u2014';
+  if (v == null) return '—';
   return v >= 0 ? `$${v.toLocaleString()}` : `-$${Math.abs(v).toLocaleString()}`;
 }
 
 function fmtPct(v: number | null): string {
-  if (v == null) return '\u2014';
+  if (v == null) return '—';
   return `${(v * 100).toFixed(1)}%`;
 }
 
 function fmtMcap(v: number | null): string {
-  if (v == null) return '\u2014';
+  if (v == null) return '—';
   if (v >= 1e12) return `$${(v / 1e12).toFixed(1)}T`;
   if (v >= 1e9) return `$${(v / 1e9).toFixed(1)}B`;
   if (v >= 1e6) return `$${(v / 1e6).toFixed(0)}M`;
@@ -195,7 +195,7 @@ function statExplain(key: string, val: number | string | null): string {
     case 'beta': return n > 1.2 ? 'moves more than the market' : n > 0.8 ? 'moves roughly with the market' : 'less volatile than the market';
     case 'spy_correlation': return n > 0.7 ? 'strongly follows the S&P 500' : n > 0.4 ? 'somewhat follows the market' : 'marches to its own beat';
     case 'liquidity_rating': return n >= 4 ? 'easy to get in and out' : n >= 3 ? 'decent liquidity' : 'may be hard to fill';
-    case 'pe_ratio': return n > 40 ? 'high valuation \u2014 growth priced in' : n > 15 ? 'moderate valuation' : 'cheap on earnings';
+    case 'pe_ratio': return n > 40 ? 'high valuation — growth priced in' : n > 15 ? 'moderate valuation' : 'cheap on earnings';
     case 'buzz_ratio': return n > 2 ? 'much more coverage than normal' : n > 1 ? 'normal coverage' : 'below-average attention';
     case 'sentiment_momentum': return n > 20 ? 'sentiment improving recently' : n < -20 ? 'sentiment declining' : 'stable sentiment';
     default: return '';
@@ -319,7 +319,7 @@ function TickerCard({ detail, savedCards, savingCards, saveErrors, onSave, onRem
                   </div>
                   <div className="text-center">
                     <div className="text-[9px] text-slate-500 uppercase">Risk/Reward</div>
-                    <div className="text-sm font-mono font-black text-white">{card.setup.risk_reward_ratio != null ? card.setup.risk_reward_ratio.toFixed(2) : '\u2014'}</div>
+                    <div className="text-sm font-mono font-black text-white">{card.setup.risk_reward_ratio != null ? card.setup.risk_reward_ratio.toFixed(2) : '—'}</div>
                   </div>
                 </div>
 
@@ -387,7 +387,7 @@ function TickerCard({ detail, savedCards, savingCards, saveErrors, onSave, onRem
       ) : (
         <div className="px-5 py-4 text-center border-b" style={{ borderColor: '#334155' }}>
           <div className="text-slate-500 text-xs">
-            {detail._fetch_errors?.chain_fetch ? `No trade cards \u2014 ${detail._fetch_errors.chain_fetch}` : 'No strategies passed quality gates for this ticker'}
+            {detail._fetch_errors?.chain_fetch ? `No trade cards — ${detail._fetch_errors.chain_fetch}` : 'No strategies passed quality gates for this ticker'}
           </div>
         </div>
       )}
@@ -440,20 +440,20 @@ function TickerCard({ detail, savedCards, savingCards, saveErrors, onSave, onRem
             <div>
               <span className="text-slate-500 font-medium">Volatility: </span>
               <span className="text-slate-200 font-mono">
-                IV Rank {ks.iv_rank != null ? ks.iv_rank.toFixed(2) : '\u2014'}
-                {ks.iv_rank != null && <span className="text-slate-500"> \u2014 {statExplain('iv_rank', ks.iv_rank)}</span>}
-                {' | '}IV {ks.iv30 != null ? `${ks.iv30.toFixed(1)}%` : '\u2014'}
-                {' | '}HV {ks.hv30 != null ? `${ks.hv30.toFixed(1)}%` : '\u2014'}
+                IV Rank {ks.iv_rank != null ? ks.iv_rank.toFixed(2) : '—'}
+                {ks.iv_rank != null && <span className="text-slate-500"> — {statExplain('iv_rank', ks.iv_rank)}</span>}
+                {' | '}IV {ks.iv30 != null ? `${ks.iv30.toFixed(1)}%` : '—'}
+                {' | '}HV {ks.hv30 != null ? `${ks.hv30.toFixed(1)}%` : '—'}
               </span>
             </div>
             {/* Company row */}
             <div>
               <span className="text-slate-500 font-medium">Company: </span>
               <span className="text-slate-200 font-mono">
-                P/E {ks.pe_ratio != null ? ks.pe_ratio.toFixed(1) : '\u2014'}
-                {ks.pe_ratio != null && <span className="text-slate-500"> \u2014 {statExplain('pe_ratio', ks.pe_ratio)}</span>}
+                P/E {ks.pe_ratio != null ? ks.pe_ratio.toFixed(1) : '—'}
+                {ks.pe_ratio != null && <span className="text-slate-500"> — {statExplain('pe_ratio', ks.pe_ratio)}</span>}
                 {' | '}Cap {fmtMcap(ks.market_cap)}
-                {' | '}Earnings {ks.earnings_date ?? '\u2014'}
+                {' | '}Earnings {ks.earnings_date ?? '—'}
                 {ks.days_to_earnings != null && ks.days_to_earnings > 0 && <span className="text-amber-400"> ({ks.days_to_earnings}d away)</span>}
               </span>
             </div>
@@ -461,22 +461,22 @@ function TickerCard({ detail, savedCards, savingCards, saveErrors, onSave, onRem
             <div>
               <span className="text-slate-500 font-medium">Market: </span>
               <span className="text-slate-200 font-mono">
-                Beta {ks.beta != null ? ks.beta.toFixed(2) : '\u2014'}
-                {ks.beta != null && <span className="text-slate-500"> \u2014 {statExplain('beta', ks.beta)}</span>}
-                {' | '}SPY Corr {ks.spy_correlation != null ? ks.spy_correlation.toFixed(2) : '\u2014'}
-                {ks.spy_correlation != null && <span className="text-slate-500"> \u2014 {statExplain('spy_correlation', ks.spy_correlation)}</span>}
-                {' | '}Liquidity {ks.liquidity_rating != null ? `${ks.liquidity_rating}/5` : '\u2014'}
+                Beta {ks.beta != null ? ks.beta.toFixed(2) : '—'}
+                {ks.beta != null && <span className="text-slate-500"> — {statExplain('beta', ks.beta)}</span>}
+                {' | '}SPY Corr {ks.spy_correlation != null ? ks.spy_correlation.toFixed(2) : '—'}
+                {ks.spy_correlation != null && <span className="text-slate-500"> — {statExplain('spy_correlation', ks.spy_correlation)}</span>}
+                {' | '}Liquidity {ks.liquidity_rating != null ? `${ks.liquidity_rating}/5` : '—'}
               </span>
             </div>
             {/* Sentiment row */}
             <div>
               <span className="text-slate-500 font-medium">Sentiment: </span>
               <span className="text-slate-200 font-mono">
-                Analysts: {ks.analyst_consensus ?? '\u2014'}
-                {' | '}Buzz {ks.buzz_ratio != null ? `${ks.buzz_ratio.toFixed(1)}x` : '\u2014'}
-                {ks.buzz_ratio != null && <span className="text-slate-500"> \u2014 {statExplain('buzz_ratio', ks.buzz_ratio)}</span>}
-                {' | '}Trend {ks.sentiment_momentum != null ? ks.sentiment_momentum.toFixed(0) : '\u2014'}
-                {ks.sentiment_momentum != null && <span className="text-slate-500"> \u2014 {statExplain('sentiment_momentum', ks.sentiment_momentum)}</span>}
+                Analysts: {ks.analyst_consensus ?? '—'}
+                {' | '}Buzz {ks.buzz_ratio != null ? `${ks.buzz_ratio.toFixed(1)}x` : '—'}
+                {ks.buzz_ratio != null && <span className="text-slate-500"> — {statExplain('buzz_ratio', ks.buzz_ratio)}</span>}
+                {' | '}Trend {ks.sentiment_momentum != null ? ks.sentiment_momentum.toFixed(0) : '—'}
+                {ks.sentiment_momentum != null && <span className="text-slate-500"> — {statExplain('sentiment_momentum', ks.sentiment_momentum)}</span>}
               </span>
             </div>
           </div>
@@ -640,7 +640,7 @@ export default function ConvergenceIntelligence() {
     setEnriched([]);
     setEnriching(false);
     try {
-      const resp = await fetch(`/api/ai/convergence-synthesis?limit=8&universe=${universe}&refresh=true`);
+      const resp = await fetch(`/api/ai/convergence-synthesis?limit=9&universe=${universe}&refresh=true`);
       if (!resp.ok) {
         const body = await resp.json().catch(() => ({ error: `HTTP ${resp.status}` }));
         throw new Error(body.error || `HTTP ${resp.status}`);
@@ -650,7 +650,7 @@ export default function ConvergenceIntelligence() {
       setScanning(false);
 
       // Now enrich each top ticker sequentially
-      const symbols = json.top_8.map(r => r.symbol);
+      const symbols = json.top_9.map(r => r.symbol);
       if (symbols.length > 0) {
         setEnriching(true);
         setEnrichProgress({ done: 0, total: symbols.length, current: symbols[0] });
@@ -741,7 +741,7 @@ export default function ConvergenceIntelligence() {
             {batchData.pipeline_summary.total_universe} scanned
             {' \u2192 '}{batchData.pipeline_summary.after_hard_filters} filtered
             {' \u2192 '}{batchData.pipeline_summary.scored} scored
-            {' \u2192 '}{batchData.top_8.length} selected
+            {' \u2192 '}{batchData.top_9.length} selected
             {' ('}
             {(batchData.timing.total_ms / 1000).toFixed(1)}s)
           </div>
@@ -772,7 +772,7 @@ export default function ConvergenceIntelligence() {
             <div className="h-full rounded-full transition-all duration-300" style={{ width: `${(enrichProgress.done / enrichProgress.total) * 100}%`, background: '#4F46E5' }} />
           </div>
           <div className="text-[10px] text-slate-500 font-mono shrink-0">
-            {enrichProgress.done}/{enrichProgress.total} \u2014 loading {enrichProgress.current}
+            {enrichProgress.done}/{enrichProgress.total} — loading {enrichProgress.current}
           </div>
         </div>
       )}

--- a/src/components/convergence/ScannerResultsTable.tsx
+++ b/src/components/convergence/ScannerResultsTable.tsx
@@ -139,17 +139,17 @@ function dirBadge(d: string) {
 }
 
 function fmtDollar(v: number | null): string {
-  if (v == null) return '\u2014';
+  if (v == null) return '—';
   return v >= 0 ? `$${v.toLocaleString()}` : `-$${Math.abs(v).toLocaleString()}`;
 }
 
 function fmtPct(v: number | null): string {
-  if (v == null) return '\u2014';
+  if (v == null) return '—';
   return `${(v * 100).toFixed(1)}%`;
 }
 
 function fmtMcap(v: number | null): string {
-  if (v == null) return '\u2014';
+  if (v == null) return '—';
   if (v >= 1e12) return `$${(v / 1e12).toFixed(1)}T`;
   if (v >= 1e9) return `$${(v / 1e9).toFixed(1)}B`;
   if (v >= 1e6) return `$${(v / 1e6).toFixed(0)}M`;
@@ -242,27 +242,27 @@ function ExpandedDetail({ detail, card }: { detail: TickerDetail; card: TradeCar
           <div className="grid grid-cols-2 gap-x-6 gap-y-1 text-xs">
             <div>
               <span className="text-gray-500">IV Rank: </span>
-              <span className="text-gray-200 font-mono">{ks.iv_rank != null ? ks.iv_rank.toFixed(1) : '\u2014'}</span>
+              <span className="text-gray-200 font-mono">{ks.iv_rank != null ? ks.iv_rank.toFixed(1) : '—'}</span>
               {ks.iv_rank != null && <span className="text-gray-500 text-[10px]"> &mdash; {statExplain('iv_rank', ks.iv_rank)}</span>}
             </div>
             <div>
               <span className="text-gray-500">P/E: </span>
-              <span className="text-gray-200 font-mono">{ks.pe_ratio != null ? ks.pe_ratio.toFixed(1) : '\u2014'}</span>
+              <span className="text-gray-200 font-mono">{ks.pe_ratio != null ? ks.pe_ratio.toFixed(1) : '—'}</span>
               {ks.pe_ratio != null && <span className="text-gray-500 text-[10px]"> &mdash; {statExplain('pe_ratio', ks.pe_ratio)}</span>}
             </div>
             <div>
               <span className="text-gray-500">Beta: </span>
-              <span className="text-gray-200 font-mono">{ks.beta != null ? ks.beta.toFixed(2) : '\u2014'}</span>
+              <span className="text-gray-200 font-mono">{ks.beta != null ? ks.beta.toFixed(2) : '—'}</span>
               {ks.beta != null && <span className="text-gray-500 text-[10px]"> &mdash; {statExplain('beta', ks.beta)}</span>}
             </div>
             <div>
               <span className="text-gray-500">SPY Corr: </span>
-              <span className="text-gray-200 font-mono">{ks.spy_correlation != null ? ks.spy_correlation.toFixed(2) : '\u2014'}</span>
+              <span className="text-gray-200 font-mono">{ks.spy_correlation != null ? ks.spy_correlation.toFixed(2) : '—'}</span>
               {ks.spy_correlation != null && <span className="text-gray-500 text-[10px]"> &mdash; {statExplain('spy_correlation', ks.spy_correlation)}</span>}
             </div>
             <div>
               <span className="text-gray-500">Liquidity: </span>
-              <span className="text-gray-200 font-mono">{ks.liquidity_rating != null ? `${ks.liquidity_rating}/5` : '\u2014'}</span>
+              <span className="text-gray-200 font-mono">{ks.liquidity_rating != null ? `${ks.liquidity_rating}/5` : '—'}</span>
               {ks.liquidity_rating != null && <span className="text-gray-500 text-[10px]"> &mdash; {statExplain('liquidity_rating', ks.liquidity_rating)}</span>}
             </div>
             <div>
@@ -271,11 +271,11 @@ function ExpandedDetail({ detail, card }: { detail: TickerDetail; card: TradeCar
             </div>
             <div>
               <span className="text-gray-500">Sector: </span>
-              <span className="text-gray-200">{ks.sector ?? '\u2014'}</span>
+              <span className="text-gray-200">{ks.sector ?? '—'}</span>
             </div>
             <div>
               <span className="text-gray-500">Earnings: </span>
-              <span className="text-gray-200 font-mono">{ks.earnings_date ?? '\u2014'}</span>
+              <span className="text-gray-200 font-mono">{ks.earnings_date ?? '—'}</span>
               {ks.days_to_earnings != null && ks.days_to_earnings > 0 && (
                 <span className="text-amber-400 text-[10px]"> ({ks.days_to_earnings}d away)</span>
               )}
@@ -384,7 +384,7 @@ export default function ScannerResultsTable({
           const legsText = s.legs
             .map(l => `${l.side.toUpperCase()} ${l.strike}${l.type[0].toUpperCase()}`)
             .join(' / ');
-          let entryText = '\u2014';
+          let entryText = '—';
           if (s.net_credit != null && s.net_credit > 0) {
             entryText = `Collect $${(s.net_credit * 100).toFixed(0)}`;
           } else if (s.net_debit != null) {
@@ -595,7 +595,7 @@ export default function ScannerResultsTable({
                     </td>
                     {/* Legs */}
                     <td className="px-2 py-2 text-gray-300 font-mono text-[10px] max-w-[200px]" onClick={() => toggleRow(row.id)} style={{ whiteSpace: 'normal', wordBreak: 'break-word' }}>
-                      {row.legsText || '\u2014'}
+                      {row.legsText || '—'}
                     </td>
                     {/* Entry */}
                     <td className="px-2 py-2 text-right font-mono text-gray-200" onClick={() => toggleRow(row.id)}>
@@ -615,11 +615,11 @@ export default function ScannerResultsTable({
                     </td>
                     {/* R:R */}
                     <td className="px-2 py-2 text-right font-mono text-gray-200" onClick={() => toggleRow(row.id)}>
-                      {row.riskReward != null ? row.riskReward.toFixed(2) : '\u2014'}
+                      {row.riskReward != null ? row.riskReward.toFixed(2) : '—'}
                     </td>
                     {/* DTE */}
                     <td className="px-2 py-2 text-right font-mono text-gray-300" onClick={() => toggleRow(row.id)}>
-                      {row.dte ?? '\u2014'}
+                      {row.dte ?? '—'}
                     </td>
                   </tr>
 

--- a/src/lib/convergence/pipeline.ts
+++ b/src/lib/convergence/pipeline.ts
@@ -7,6 +7,8 @@ import { computeSectorStats } from './sector-stats';
 import type { SectorStatsMap } from './sector-stats';
 import { scoreAll } from './composite';
 import type { FullScoringResult } from './composite';
+import { computePreFilter } from './pre-filter';
+import type { PreFilterResult } from './pre-filter';
 import type {
   TTScannerData,
   ConvergenceInput,
@@ -72,7 +74,7 @@ export interface PipelineResult {
     pre_scored: number;
     finnhub_fetched: number;
     scored: number;
-    final_8: string[];
+    final_9: string[];
     pipeline_runtime_ms: number;
     finnhub_calls_made: number;
     finnhub_errors: number;
@@ -91,12 +93,13 @@ export interface PipelineResult {
   pre_scores: PreScoreRow[];
   rankings: {
     scored_count: number;
-    top_8: RankedRow[];
+    top_9: RankedRow[];
     also_scored: RankedRow[];
     sector_distribution: Record<string, number>;
   };
   diversification: DiversificationResult;
   scoring_details: Record<string, FullScoringResult>;
+  pre_filter: PreFilterResult[];
   data_gaps: string[];
   errors: string[];
 }
@@ -362,9 +365,25 @@ export async function runPipeline(limit: number = 20): Promise<PipelineResult> {
 
   const totalUniverse = allScannerData.length;
 
+  // ===== STEP A2: Pre-Filter (market-metrics-based ranking) =====
+  console.log('[Pipeline] Step A2: Running market-metrics pre-filter...');
+  const preFilterResults = computePreFilter(allScannerData);
+  const preFilterIncluded = preFilterResults.filter(r => !r.excluded);
+  const preFilterExcluded = preFilterResults.filter(r => r.excluded);
+  console.log(`[Pipeline] Step A2: ${preFilterIncluded.length} included, ${preFilterExcluded.length} excluded by pre-filter`);
+
+  // Use pre-filter to narrow the candidate set: take top (limit * 4) non-excluded
+  // tickers by preScore. This reduces the universe BEFORE hard filters + Finnhub.
+  const preFilterTopN = Math.min(limit * 4, preFilterIncluded.length);
+  const preFilterCandidates = new Set(
+    preFilterIncluded.slice(0, preFilterTopN).map(r => r.symbol)
+  );
+  const preFilteredScannerData = allScannerData.filter(t => preFilterCandidates.has(t.symbol));
+  console.log(`[Pipeline] Step A2: Narrowed ${allScannerData.length} → ${preFilteredScannerData.length} by preScore (top ${preFilterTopN})`);
+
   // ===== STEP B: Hard Filters =====
   console.log('[Pipeline] Step B: Applying hard filters...');
-  const hardFilters = applyHardFilters(allScannerData);
+  const hardFilters = applyHardFilters(preFilteredScannerData);
   console.log(`[Pipeline] Step B: ${hardFilters.input_count} → ${hardFilters.output_count} tickers`);
 
   // Build a map for quick lookup
@@ -383,7 +402,7 @@ export async function runPipeline(limit: number = 20): Promise<PipelineResult> {
   console.log('[Pipeline] Step D: Pre-scoring and limiting...');
   const preScores = computePreScores(survivors);
   // Overfetch: fetch 2x the desired final count so convergence gate + quality floor
-  // exclusions don't leave us short on tickers for the final 8
+  // exclusions don't leave us short on tickers for the final 9
   const fetchCount = Math.min(limit * 2, preScores.length);
   const topN = preScores.slice(0, fetchCount);
   const topSymbols = topN.map(r => r.symbol);
@@ -546,7 +565,7 @@ export async function runPipeline(limit: number = 20): Promise<PipelineResult> {
 
   // ===== STEP G: Rank and Diversify =====
   console.log('[Pipeline] Step G: Ranking and diversifying...');
-  const { top8, alsoScored, diversification, sectorDistribution } = rankAndDiversify(rankedRows);
+  const { top9, alsoScored, diversification, sectorDistribution } = rankAndDiversify(rankedRows);
 
   // ===== STEP G2: Fetch chain data and build trade cards =====
   console.log('[Pipeline] Step G2: Fetching option chains and building trade cards...');
@@ -567,8 +586,8 @@ export async function runPipeline(limit: number = 20): Promise<PipelineResult> {
     dataGaps.push('trade_cards: market closed. Rerun during market hours (Mon-Fri 9:30-16:00 ET).');
     console.log(`[Pipeline] Step G2: Market closed (${marketStatus.reason}), skipping chain fetch`);
   } else try {
-    // Build input for chain fetcher from top 8 tickers
-    const chainInputs = top8.map(row => {
+    // Build input for chain fetcher from top 9 tickers
+    const chainInputs = top9.map(row => {
       const ticker = scoredTickers.find(t => t.symbol === row.symbol);
       if (!ticker) return null;
 
@@ -645,9 +664,9 @@ export async function runPipeline(limit: number = 20): Promise<PipelineResult> {
   // ===== STEP H: Assemble Full Result =====
   console.log('[Pipeline] Step H: Assembling result...');
 
-  // Build scoring details for top 8 only
+  // Build scoring details for top 9 only
   const scoringDetails: Record<string, FullScoringResult> = {};
-  for (const row of top8) {
+  for (const row of top9) {
     const ticker = scoredTickers.find(t => t.symbol === row.symbol);
     if (ticker) {
       scoringDetails[row.symbol] = ticker.scoring;
@@ -667,7 +686,7 @@ export async function runPipeline(limit: number = 20): Promise<PipelineResult> {
 
   if (chainStats.chain_symbols_fetched > 0 && chainStats.total_trade_cards === 0) {
     dataGaps.push('trade_cards: option chains fetched but no strategies passed quality gates');
-  } else if (chainStats.chain_symbols_fetched === 0 && top8.length > 0) {
+  } else if (chainStats.chain_symbols_fetched === 0 && top9.length > 0) {
     dataGaps.push('trade_cards: chain fetch failed or no valid expirations found');
   }
 
@@ -680,7 +699,7 @@ export async function runPipeline(limit: number = 20): Promise<PipelineResult> {
       pre_scored: preScores.length,
       finnhub_fetched: topSymbols.length,
       scored: scoredTickers.length,
-      final_8: top8.map(r => r.symbol),
+      final_9: top9.map(r => r.symbol),
       pipeline_runtime_ms: pipelineMs,
       finnhub_calls_made: finnhubResult.stats.calls_made,
       finnhub_errors: finnhubResult.stats.errors,
@@ -699,17 +718,18 @@ export async function runPipeline(limit: number = 20): Promise<PipelineResult> {
     pre_scores: preScores,
     rankings: {
       scored_count: scoredTickers.length,
-      top_8: top8,
+      top_9: top9,
       also_scored: alsoScored,
       sector_distribution: sectorDistribution,
     },
     diversification,
     scoring_details: scoringDetails,
+    pre_filter: preFilterResults,
     data_gaps: dataGaps,
     errors,
   };
 
-  console.log(`[Pipeline] Complete in ${pipelineMs}ms. Final 8: ${top8.map(r => r.symbol).join(', ')}`);
+  console.log(`[Pipeline] Complete in ${pipelineMs}ms. Final 9: ${top9.map(r => r.symbol).join(', ')}`);
   return result;
 }
 
@@ -942,13 +962,13 @@ function buildRankedRows(
 // ===== STEP G: Rank and Diversify =====
 
 function rankAndDiversify(rankedRows: RankedRow[]): {
-  top8: RankedRow[];
+  top9: RankedRow[];
   alsoScored: RankedRow[];
   diversification: DiversificationResult;
   sectorDistribution: Record<string, number>;
 } {
   const MAX_PER_SECTOR = 2;
-  const TOP_N = 8;
+  const TOP_N = 9;
   const adjustments: string[] = [];
 
   // BUG 4 fix: Enforce convergence gate — exclude tickers with < 3/4 categories above 50
@@ -1049,7 +1069,7 @@ function rankAndDiversify(rankedRows: RankedRow[]): {
     .filter(r => !finalSymbols.has(r.symbol))
     .map((r, i) => ({ ...r, rank: TOP_N + 1 + i }));
 
-  // Sector distribution of final 8
+  // Sector distribution of final 9
   const sectorDistribution: Record<string, number> = {};
   for (const row of final) {
     const sector = row.sector || 'Unknown';
@@ -1057,7 +1077,7 @@ function rankAndDiversify(rankedRows: RankedRow[]): {
   }
 
   return {
-    top8: final,
+    top9: final,
     alsoScored,
     diversification: { adjustments },
     sectorDistribution,

--- a/src/lib/convergence/pre-filter.ts
+++ b/src/lib/convergence/pre-filter.ts
@@ -1,0 +1,85 @@
+import type { TTScannerData } from './types';
+
+// ===== PRE-FILTER RESULT =====
+
+export interface PreFilterResult {
+  symbol: string;
+  ivRank: number | null;           // 0-100, from implied-volatility-index-rank
+  ivPercentile: number | null;     // 0-100, from implied-volatility-percentile
+  liquidityRating: number | null;  // 1-5 stars
+  liquidityValue: number | null;   // raw liquidity value (same as rating for TT)
+  beta: number | null;
+  marketCap: number | null;
+  earningsDate: string | null;     // next earnings date
+  corrSpy3Month: number | null;    // SPY correlation
+  preScore: number;                // composite score for ranking
+  excluded: boolean;               // true if filtered out
+  exclusionReason: string | null;  // why excluded
+  earningsWarning: string | null;  // non-null if earnings within 3 calendar days
+}
+
+// ===== PRE-FILTER FUNCTION =====
+
+/**
+ * Score and rank all tickers from market-metrics data BEFORE
+ * any expensive chain/Finnhub fetches. One batch API call → smarter selection.
+ *
+ * preScore = (ivRank / 100) * 0.6 + (liquidityRating / 5) * 0.4
+ *   - If ivRank is null → use 0.5 (neutral)
+ *   - If liquidityRating is null → use 0.5 (neutral)
+ *   - If liquidityRating < 2 → excluded with reason
+ *   - If earningsDate within 3 calendar days → flagged (not excluded)
+ */
+export function computePreFilter(scannerData: TTScannerData[]): PreFilterResult[] {
+  const results: PreFilterResult[] = [];
+
+  for (const t of scannerData) {
+    const ivRank = t.ivRank > 0 ? t.ivRank : null;
+    const ivPercentile = t.ivPercentile > 0 ? t.ivPercentile : null;
+    const liquidityRating = t.liquidityRating;
+
+    // Compute earnings warning
+    let earningsWarning: string | null = null;
+    if (t.daysTillEarnings != null && t.daysTillEarnings >= 0 && t.daysTillEarnings <= 3) {
+      earningsWarning = `Earnings in ${t.daysTillEarnings} day${t.daysTillEarnings !== 1 ? 's' : ''} (${t.earningsDate})`;
+    }
+
+    // Check exclusion
+    let excluded = false;
+    let exclusionReason: string | null = null;
+
+    if (liquidityRating != null && liquidityRating < 2) {
+      excluded = true;
+      exclusionReason = `Low liquidity rating (${liquidityRating}/5)`;
+    }
+
+    // Compute preScore
+    const ivRankComponent = ivRank != null ? ivRank / 100 : 0.5;
+    const liqComponent = liquidityRating != null ? liquidityRating / 5 : 0.5;
+    const preScore = Math.round((ivRankComponent * 0.6 + liqComponent * 0.4) * 1000) / 1000;
+
+    results.push({
+      symbol: t.symbol,
+      ivRank,
+      ivPercentile,
+      liquidityRating,
+      liquidityValue: liquidityRating, // TT returns rating directly as the value
+      beta: t.beta,
+      marketCap: t.marketCap,
+      earningsDate: t.earningsDate,
+      corrSpy3Month: t.corrSpy,
+      preScore,
+      excluded,
+      exclusionReason,
+      earningsWarning,
+    });
+  }
+
+  // Sort by preScore descending (non-excluded first, then excluded)
+  results.sort((a, b) => {
+    if (a.excluded !== b.excluded) return a.excluded ? 1 : -1;
+    return b.preScore - a.preScore;
+  });
+
+  return results;
+}


### PR DESCRIPTION
- Replace all \u2014 Unicode escapes with literal em-dash character in ScannerResultsTable.tsx and ConvergenceIntelligence.tsx (14 + 26 instances)
- Change top 8 → top 9 across pipeline.ts, ConvergenceIntelligence.tsx, and convergence-synthesis/route.ts (types, variables, comments, API fields)
- Add market-metrics pre-filter (src/lib/convergence/pre-filter.ts): PreFilterResult interface with IVR, liquidity, beta, earnings warning; preScore = (ivRank/100)*0.6 + (liquidityRating/5)*0.4; excludes liquidity_rating < 2, flags earnings within 3 days
- Wire pre-filter into pipeline Step A2: runs on all market-metrics data BEFORE hard filters, narrows candidates by preScore for fewer API calls
- Expose pre_filter results in PipelineResult and synthesis API response

https://claude.ai/code/session_01DUiNKTEgGgPNqqy2GnXv5D