### PR TITLE
truth: Est. PoP rename + EV three-outcome model

### DIFF
--- a/src/components/BacktestPanel.tsx
+++ b/src/components/BacktestPanel.tsx
@@ -29,7 +29,7 @@ interface BacktestState {
 function HeroStats({ result }: { result: BacktestResult }) {
   const s = result.summary;
   const stats = [
-    { label: 'Win Rate', value: `${Math.round(s.winRate * 100)}%`, color: s.winRate >= 0.5 ? '#10B981' : '#EF4444' },
+    { label: 'Est. PoP', value: `${Math.round(s.winRate * 100)}%`, color: s.winRate >= 0.5 ? '#10B981' : '#EF4444' },
     { label: 'Total P&L', value: `$${s.totalPnl.toLocaleString()}`, color: s.totalPnl >= 0 ? '#10B981' : '#EF4444' },
     { label: 'Avg P&L', value: `$${s.avgPnl.toFixed(0)}`, color: s.avgPnl >= 0 ? '#10B981' : '#EF4444' },
     { label: 'Max Drawdown', value: `$${s.maxDrawdown.toFixed(0)}`, color: '#EF4444' },

--- a/src/components/convergence/ConvergenceIntelligence.tsx
+++ b/src/components/convergence/ConvergenceIntelligence.tsx
@@ -304,7 +304,7 @@ function TickerCard({ detail, savedCards, savingCards, saveErrors, onSave, onRem
                 </table>
 
                 {/* Key numbers row */}
-                <div className="grid grid-cols-4 gap-3 mb-2">
+                <div className="grid grid-cols-5 gap-3 mb-2">
                   <div className="text-center">
                     <div className="text-[9px] text-slate-500 uppercase">Max Profit</div>
                     <div className="text-sm font-mono font-black text-green-400">{fmtDollar(card.setup.max_profit)}</div>
@@ -314,14 +314,25 @@ function TickerCard({ detail, savedCards, savingCards, saveErrors, onSave, onRem
                     <div className="text-sm font-mono font-black text-red-400">{fmtDollar(card.setup.max_loss)}</div>
                   </div>
                   <div className="text-center">
-                    <div className="text-[9px] text-slate-500 uppercase">Win Rate</div>
+                    <div className="text-[9px] text-slate-500 uppercase" title="Estimated Probability of Profit based on delta approximation">Est. PoP</div>
                     <div className="text-sm font-mono font-black text-white">{fmtPct(card.setup.probability_of_profit)}</div>
+                  </div>
+                  <div className="text-center">
+                    <div className="text-[9px] text-slate-500 uppercase" title="Expected Value estimate using three-outcome model. Not a guarantee of returns.">Est. EV</div>
+                    <div className="text-sm font-mono font-black" style={{ color: card.setup.ev > 0 ? '#10B981' : card.setup.ev < 0 ? '#EF4444' : '#94A3B8' }}>
+                      {card.setup.ev !== 0 ? `${card.setup.ev >= 0 ? '+' : ''}$${Math.round(card.setup.ev)}` : '—'}
+                    </div>
                   </div>
                   <div className="text-center">
                     <div className="text-[9px] text-slate-500 uppercase">Risk/Reward</div>
                     <div className="text-sm font-mono font-black text-white">{card.setup.risk_reward_ratio != null ? card.setup.risk_reward_ratio.toFixed(2) : '—'}</div>
                   </div>
                 </div>
+                {card.setup.has_wide_spread && (
+                  <div className="text-[10px] text-amber-400 text-center mb-1" title="Bid/ask estimated from theoretical price — actual market spread may differ">
+                    &#x26A0; Wide bid-ask spread — prices estimated from theoretical model
+                  </div>
+                )}
 
                 {/* Premium line */}
                 <div className="text-center rounded py-1.5" style={{ background: '#0F172A' }}>

--- a/src/components/convergence/ScannerResultsTable.tsx
+++ b/src/components/convergence/ScannerResultsTable.tsx
@@ -184,11 +184,14 @@ interface TableRow {
   maxProfit: number | null;
   maxLoss: number | null;
   winPct: number | null;
+  ev: number | null;
+  evPerRisk: number | null;
   riskReward: number | null;
   dte: number | null;
+  hasWideSpread: boolean;
 }
 
-type SortKey = 'symbol' | 'score' | 'direction' | 'strategyName' | 'maxProfit' | 'maxLoss' | 'winPct' | 'riskReward' | 'dte';
+type SortKey = 'symbol' | 'score' | 'direction' | 'strategyName' | 'maxProfit' | 'maxLoss' | 'winPct' | 'ev' | 'evPerRisk' | 'riskReward' | 'dte';
 
 // ── Expanded Detail ──────────────────────────────────────────────────
 
@@ -375,8 +378,11 @@ export default function ScannerResultsTable({
           maxProfit: null,
           maxLoss: null,
           winPct: null,
+          ev: null,
+          evPerRisk: null,
           riskReward: null,
           dte: null,
+          hasWideSpread: false,
         });
       } else {
         for (const card of cards) {
@@ -404,8 +410,11 @@ export default function ScannerResultsTable({
             maxProfit: s.max_profit,
             maxLoss: s.max_loss,
             winPct: s.probability_of_profit,
+            ev: s.ev ?? null,
+            evPerRisk: s.ev_per_risk ?? null,
             riskReward: s.risk_reward_ratio,
             dte: s.dte,
+            hasWideSpread: s.has_wide_spread,
           });
         }
       }
@@ -427,6 +436,8 @@ export default function ScannerResultsTable({
         case 'maxProfit': aVal = a.maxProfit ?? -Infinity; bVal = b.maxProfit ?? -Infinity; break;
         case 'maxLoss': aVal = a.maxLoss ?? -Infinity; bVal = b.maxLoss ?? -Infinity; break;
         case 'winPct': aVal = a.winPct ?? -Infinity; bVal = b.winPct ?? -Infinity; break;
+        case 'ev': aVal = a.ev ?? -Infinity; bVal = b.ev ?? -Infinity; break;
+        case 'evPerRisk': aVal = a.evPerRisk ?? -Infinity; bVal = b.evPerRisk ?? -Infinity; break;
         case 'riskReward': aVal = a.riskReward ?? -Infinity; bVal = b.riskReward ?? -Infinity; break;
         case 'dte': aVal = a.dte ?? Infinity; bVal = b.dte ?? Infinity; break;
       }
@@ -532,7 +543,9 @@ export default function ScannerResultsTable({
               <th className={thBase + ' text-right'}>Entry</th>
               <th className={thBase + ' text-right'} onClick={() => toggleSort('maxProfit')}>Max P{sortIndicator('maxProfit')}</th>
               <th className={thBase + ' text-right'} onClick={() => toggleSort('maxLoss')}>Max L{sortIndicator('maxLoss')}</th>
-              <th className={thBase + ' text-right'} onClick={() => toggleSort('winPct')}>Win%{sortIndicator('winPct')}</th>
+              <th className={thBase + ' text-right'} onClick={() => toggleSort('winPct')} title="Estimated Probability of Profit based on option deltas. Actual results will vary.">Est. PoP{sortIndicator('winPct')}</th>
+              <th className={thBase + ' text-right'} onClick={() => toggleSort('ev')} title="Expected Value — estimated profit/loss per trade using three-outcome model">Est. EV{sortIndicator('ev')}</th>
+              <th className={thBase + ' text-right'} onClick={() => toggleSort('evPerRisk')} title="Expected Value per dollar risked — higher is better">EV/Risk{sortIndicator('evPerRisk')}</th>
               <th className={thBase + ' text-right'} onClick={() => toggleSort('riskReward')}>R:R{sortIndicator('riskReward')}</th>
               <th className={thBase + ' text-right'} onClick={() => toggleSort('dte')}>DTE{sortIndicator('dte')}</th>
             </tr>
@@ -587,7 +600,14 @@ export default function ScannerResultsTable({
                     </td>
                     {/* Strategy */}
                     <td className="px-2 py-2 text-gray-200" onClick={() => toggleRow(row.id)}>
-                      {row.card ? row.strategyName : (
+                      {row.card ? (
+                        <>
+                          {row.strategyName}
+                          {row.hasWideSpread && (
+                            <span className="ml-1 text-amber-400 cursor-help" title="Bid/ask estimated from theoretical price — actual market spread may differ">&#x26A0;</span>
+                          )}
+                        </>
+                      ) : (
                         <span className="text-gray-500 italic">
                           {row.detail._fetch_errors?.chain_fetch || 'No strategies available'}
                         </span>
@@ -609,9 +629,17 @@ export default function ScannerResultsTable({
                     <td className="px-2 py-2 text-right font-mono text-red-400" onClick={() => toggleRow(row.id)}>
                       {fmtDollar(row.maxLoss)}
                     </td>
-                    {/* Win% */}
+                    {/* Est. PoP */}
                     <td className="px-2 py-2 text-right font-mono text-gray-200" onClick={() => toggleRow(row.id)}>
                       {fmtPct(row.winPct)}
+                    </td>
+                    {/* Est. EV */}
+                    <td className="px-2 py-2 text-right font-mono" onClick={() => toggleRow(row.id)} style={{ color: row.ev == null ? '#6B7280' : row.ev > 0 ? '#10B981' : row.ev < 0 ? '#EF4444' : '#6B7280' }}>
+                      {row.ev != null ? `${row.ev >= 0 ? '+' : ''}$${Math.round(row.ev)}` : '—'}
+                    </td>
+                    {/* EV/Risk */}
+                    <td className="px-2 py-2 text-right font-mono" onClick={() => toggleRow(row.id)} style={{ color: row.evPerRisk == null ? '#6B7280' : row.evPerRisk > 0 ? '#10B981' : row.evPerRisk < 0 ? '#EF4444' : '#6B7280' }}>
+                      {row.evPerRisk != null ? row.evPerRisk.toFixed(3) : '—'}
                     </td>
                     {/* R:R */}
                     <td className="px-2 py-2 text-right font-mono text-gray-200" onClick={() => toggleRow(row.id)}>
@@ -626,7 +654,7 @@ export default function ScannerResultsTable({
                   {/* Error row */}
                   {error && (
                     <tr style={{ background: '#7F1D1D15' }}>
-                      <td colSpan={12} className="px-4 py-1 text-[10px] text-red-300">
+                      <td colSpan={14} className="px-4 py-1 text-[10px] text-red-300">
                         Failed to save: {error}
                       </td>
                     </tr>
@@ -635,7 +663,7 @@ export default function ScannerResultsTable({
                   {/* Expanded detail row */}
                   {isExpanded && (
                     <tr>
-                      <td colSpan={12} style={{ background: '#0F172A', padding: 0 }}>
+                      <td colSpan={14} style={{ background: '#0F172A', padding: 0 }}>
                         <ExpandedDetail detail={row.detail} card={row.card} />
                       </td>
                     </tr>

--- a/src/components/trading/TradeLabPanel.tsx
+++ b/src/components/trading/TradeLabPanel.tsx
@@ -340,7 +340,7 @@ export default function TradeLabPanel() {
                         <div className="font-mono font-bold text-green-700">{fmtDollar(card.max_profit)}</div>
                         <div className="text-gray-400">Max Loss</div>
                         <div className="font-mono font-bold text-red-700">{fmtDollar(card.max_loss)}</div>
-                        <div className="text-gray-400">Win Rate</div>
+                        <div className="text-gray-400" title="Estimated Probability of Profit based on delta approximation">Est. PoP</div>
                         <div className="font-mono font-bold">{card.win_rate != null ? `${Number(card.win_rate).toFixed(1)}%` : '\u2014'}</div>
                         <div className="text-gray-400">R:R</div>
                         <div className="font-mono font-bold">{card.risk_reward != null ? Number(card.risk_reward).toFixed(2) : '\u2014'}</div>
@@ -464,7 +464,7 @@ export default function TradeLabPanel() {
                             <span className="font-mono font-bold text-red-700">{fmtDollar(card.max_loss)}</span>
                           </div>
                           <div className="flex justify-between">
-                            <span className="text-gray-500">Win Rate</span>
+                            <span className="text-gray-500" title="Estimated Probability of Profit based on delta approximation">Est. PoP</span>
                             <span className="font-mono font-bold">{card.win_rate != null ? `${Number(card.win_rate).toFixed(1)}%` : '\u2014'}</span>
                           </div>
                           <div className="flex justify-between">

--- a/src/lib/strategy-builder.ts
+++ b/src/lib/strategy-builder.ts
@@ -132,6 +132,58 @@ export interface GenerateParams {
   hv30?: number;   // 30-day HV decimal (e.g. 0.25 for 25%)
 }
 
+// ─── Three-Outcome EV Model ─────────────────────────────────────────
+
+/**
+ * Three-outcome Expected Value model for spread strategies.
+ *
+ * Accounts for the partial P/L zone between short and long strikes
+ * that binary EV ignores.
+ *
+ * @param pop - Estimated probability of profit (0-1, from delta approximation)
+ * @param maxProfit - Maximum profit in dollars (positive number)
+ * @param maxLoss - Maximum loss in dollars (positive number, absolute value)
+ * @param shortDelta - Absolute delta of the short strike (e.g., 0.30)
+ * @param longDelta - Absolute delta of the long strike (e.g., 0.16)
+ * @returns { ev: number, evPerRisk: number }
+ */
+function calculateThreeOutcomeEV(
+  pop: number,
+  maxProfit: number,
+  maxLoss: number,
+  shortDelta: number | null,
+  longDelta: number | null,
+): { ev: number; evPerRisk: number } {
+  const absMaxLoss = Math.abs(maxLoss);
+
+  // If we don't have both deltas, fall back to binary model
+  if (shortDelta == null || longDelta == null || shortDelta <= longDelta) {
+    // Binary model: EV = PoP × MaxProfit - (1-PoP) × |MaxLoss|
+    const ev = pop * maxProfit - (1 - pop) * absMaxLoss;
+    const evPerRisk = absMaxLoss > 0 ? ev / absMaxLoss : 0;
+    return { ev: Math.round(ev * 100) / 100, evPerRisk: Math.round(evPerRisk * 1000) / 1000 };
+  }
+
+  // Three-outcome model
+  const pFullProfit = 1 - shortDelta;                    // probability price stays safe
+  const pPartial = Math.abs(shortDelta - longDelta);     // probability in partial zone
+  const pFullLoss = longDelta;                           // probability beyond long strike
+
+  // Partial P/L approximation: midpoint between max profit and max loss
+  const partialPL = (maxProfit - absMaxLoss) / 2;
+
+  const ev = pFullProfit * maxProfit
+           + pPartial * partialPL
+           + pFullLoss * (-absMaxLoss);
+
+  const evPerRisk = absMaxLoss > 0 ? ev / absMaxLoss : 0;
+
+  return {
+    ev: Math.round(ev * 100) / 100,
+    evPerRisk: Math.round(evPerRisk * 1000) / 1000
+  };
+}
+
 // ─── Tier 1: Strategy Labels ────────────────────────────────────────
 
 export interface StrategyLabel {
@@ -633,8 +685,24 @@ export function generateStrategies(params: GenerateParams): StrategyCard[] {
     const evPop = isCredit ? hvPop : card.pop;
 
     if (mp > 0 && effectiveML > 0) {
-      card.ev = Math.round((evPop * mp - (1 - evPop) * effectiveML) * 100) / 100;
-      card.evPerRisk = Math.round((card.ev / effectiveML) * 10000) / 10000;
+      // Extract short/long deltas for three-outcome model
+      const shortLegs = card.legs.filter(l => l.side === 'sell');
+      const longLegs = card.legs.filter(l => l.side === 'buy');
+
+      // For spreads: use absolute deltas of short and long strikes
+      const shortDelta = shortLegs.length > 0 ? Math.max(...shortLegs.map(l => Math.abs(l.delta))) : null;
+      const longDelta = longLegs.length > 0 ? Math.max(...longLegs.map(l => Math.abs(l.delta))) : null;
+
+      // Three-outcome EV for defined-risk spreads; binary for unlimited/single-leg
+      if (!card.isUnlimited && shortLegs.length > 0 && longLegs.length > 0) {
+        const result = calculateThreeOutcomeEV(evPop, mp, effectiveML, shortDelta, longDelta);
+        card.ev = result.ev;
+        card.evPerRisk = result.evPerRisk;
+      } else {
+        // Binary model for unlimited-risk or single-leg strategies
+        card.ev = Math.round((evPop * mp - (1 - evPop) * effectiveML) * 100) / 100;
+        card.evPerRisk = Math.round((card.ev / effectiveML) * 10000) / 10000;
+      }
     }
   }
 


### PR DESCRIPTION
- Rename "Win Rate" → "Est. PoP" in convergence scanner, strategy cards, backtest panel, and trade lab (estimation contexts only; actual historical win rates in trading journal/positions unchanged)
- Add three-outcome EV model (full profit / partial / full loss zones) for defined-risk spreads; binary fallback for unlimited-risk strategies
- Wire evPerRisk using calculated EV instead of hardcoded 0
- Add Est. EV and EV/Risk sortable columns to ScannerResultsTable
- Add Est. EV display to ConvergenceIntelligence strategy cards
- Add wide bid-ask spread warning indicators (⚠) on scanner table and strategy cards when has_wide_spread is true
- Add estimation disclaimers via tooltips on Est. PoP, Est. EV headers
- Zero new TypeScript errors in changed files

https://claude.ai/code/session_01DUiNKTEgGgPNqqy2GnXv5D