### PR TITLE
accuracy: upgrade PoP from delta approximation to N(d2) at breakeven …

### DIFF
--- a/src/components/convergence/ConvergenceIntelligence.tsx
+++ b/src/components/convergence/ConvergenceIntelligence.tsx
@@ -62,6 +62,7 @@ interface TradeCardSetup {
   max_loss: number | null;
   breakevens: number[];
   probability_of_profit: number | null;
+  pop_method: 'breakeven_d2' | 'delta_approx';
   hv_pop: number | null;
   risk_reward_ratio: number | null;
   greeks: { delta: number; gamma: number; theta: number; vega: number; theta_per_day: number };
@@ -319,7 +320,7 @@ function TickerCard({ detail, savedCards, savingCards, saveErrors, onSave, onRem
                     <div className="text-sm font-mono font-black text-red-400">{fmtDollar(card.setup.max_loss)}</div>
                   </div>
                   <div className="text-center">
-                    <div className="text-[9px] text-slate-500 uppercase" title="Estimated Probability of Profit based on delta approximation">Est. PoP</div>
+                    <div className="text-[9px] text-slate-500 uppercase" title={card.setup.pop_method === 'breakeven_d2' ? 'PoP via N(d2) at breakeven price' : 'PoP estimated from option deltas (approximate)'}>Est. PoP</div>
                     <div className="text-sm font-mono font-black text-white">{fmtPct(card.setup.probability_of_profit)}</div>
                   </div>
                   <div className="text-center">

--- a/src/components/convergence/ScannerResultsTable.tsx
+++ b/src/components/convergence/ScannerResultsTable.tsx
@@ -23,6 +23,7 @@ interface TradeCardSetup {
   max_loss: number | null;
   breakevens: number[];
   probability_of_profit: number | null;
+  pop_method: 'breakeven_d2' | 'delta_approx';
   hv_pop: number | null;
   risk_reward_ratio: number | null;
   greeks: { delta: number; gamma: number; theta: number; vega: number; theta_per_day: number };
@@ -184,6 +185,7 @@ interface TableRow {
   maxProfit: number | null;
   maxLoss: number | null;
   winPct: number | null;
+  popMethod: 'breakeven_d2' | 'delta_approx';
   ev: number | null;
   evPerRisk: number | null;
   riskReward: number | null;
@@ -378,6 +380,7 @@ export default function ScannerResultsTable({
           maxProfit: null,
           maxLoss: null,
           winPct: null,
+          popMethod: 'delta_approx' as const,
           ev: null,
           evPerRisk: null,
           riskReward: null,
@@ -410,6 +413,7 @@ export default function ScannerResultsTable({
             maxProfit: s.max_profit,
             maxLoss: s.max_loss,
             winPct: s.probability_of_profit,
+            popMethod: s.pop_method ?? 'delta_approx',
             ev: s.ev ?? null,
             evPerRisk: s.ev_per_risk ?? null,
             riskReward: s.risk_reward_ratio,
@@ -543,7 +547,7 @@ export default function ScannerResultsTable({
               <th className={thBase + ' text-right'}>Entry</th>
               <th className={thBase + ' text-right'} onClick={() => toggleSort('maxProfit')}>Max P{sortIndicator('maxProfit')}</th>
               <th className={thBase + ' text-right'} onClick={() => toggleSort('maxLoss')}>Max L{sortIndicator('maxLoss')}</th>
-              <th className={thBase + ' text-right'} onClick={() => toggleSort('winPct')} title="Estimated Probability of Profit based on option deltas. Actual results will vary.">Est. PoP{sortIndicator('winPct')}</th>
+              <th className={thBase + ' text-right'} onClick={() => toggleSort('winPct')} title="Estimated Probability of Profit — N(d2) at breakeven when available, delta approximation otherwise. Actual results will vary.">Est. PoP{sortIndicator('winPct')}</th>
               <th className={thBase + ' text-right'} onClick={() => toggleSort('ev')} title="Expected Value — estimated profit/loss per trade using three-outcome model">Est. EV{sortIndicator('ev')}</th>
               <th className={thBase + ' text-right'} onClick={() => toggleSort('evPerRisk')} title="Expected Value per dollar risked — higher is better">EV/Risk{sortIndicator('evPerRisk')}</th>
               <th className={thBase + ' text-right'} onClick={() => toggleSort('riskReward')}>R:R{sortIndicator('riskReward')}</th>
@@ -630,7 +634,13 @@ export default function ScannerResultsTable({
                       {fmtDollar(row.maxLoss)}
                     </td>
                     {/* Est. PoP */}
-                    <td className="px-2 py-2 text-right font-mono text-gray-200" onClick={() => toggleRow(row.id)}>
+                    <td
+                      className="px-2 py-2 text-right font-mono text-gray-200"
+                      onClick={() => toggleRow(row.id)}
+                      title={row.popMethod === 'breakeven_d2'
+                        ? 'PoP via N(d2) at breakeven price'
+                        : 'PoP estimated from option deltas (approximate)'}
+                    >
                       {fmtPct(row.winPct)}
                     </td>
                     {/* Est. EV */}

--- a/src/lib/convergence/filter-engine.ts
+++ b/src/lib/convergence/filter-engine.ts
@@ -30,6 +30,7 @@ interface TradeCardSetup {
   max_loss: number | null;
   breakevens: number[];
   probability_of_profit: number | null;
+  pop_method: 'breakeven_d2' | 'delta_approx';
   hv_pop: number | null;
   risk_reward_ratio: number | null;
   greeks: { delta: number; gamma: number; theta: number; vega: number; theta_per_day: number };

--- a/src/lib/convergence/probability.ts
+++ b/src/lib/convergence/probability.ts
@@ -1,0 +1,112 @@
+/**
+ * Probability utilities for options pricing.
+ * Implements the cumulative normal distribution N(x) needed for
+ * Black-Scholes probability calculations.
+ */
+
+/**
+ * Cumulative standard normal distribution function N(x).
+ * Uses the Abramowitz & Stegun rational approximation (error < 7.5e-8).
+ *
+ * This computes P(Z ≤ x) where Z ~ N(0,1).
+ */
+export function normalCDF(x: number): number {
+  if (x > 10) return 1;
+  if (x < -10) return 0;
+
+  const a1 = 0.254829592;
+  const a2 = -0.284496736;
+  const a3 = 1.421413741;
+  const a4 = -1.453152027;
+  const a5 = 1.061405429;
+  const p = 0.3275911;
+
+  const sign = x < 0 ? -1 : 1;
+  const absX = Math.abs(x);
+  const t = 1.0 / (1.0 + p * absX);
+  const y = 1.0 - (((((a5 * t + a4) * t) + a3) * t + a2) * t + a1) * t * Math.exp(-absX * absX / 2);
+
+  return 0.5 * (1.0 + sign * y);
+}
+
+/**
+ * Calculate d2 for Black-Scholes at a given target price.
+ *
+ * d2 = [ln(S/K) + (r - sigma^2/2)T] / (sigma * sqrt(T))
+ *
+ * Where:
+ *   S = current underlying price
+ *   K = target price (breakeven)
+ *   r = risk-free rate (default 0.045, ~current fed funds)
+ *   sigma = implied volatility (annualized, as decimal e.g. 0.25 for 25%)
+ *   T = time to expiration in years
+ *
+ * @returns d2 value, or null if inputs are invalid
+ */
+export function calcD2(
+  spotPrice: number,
+  targetPrice: number,
+  iv: number,
+  dteYears: number,
+  riskFreeRate: number = 0.045,
+): number | null {
+  if (spotPrice <= 0 || targetPrice <= 0 || iv <= 0 || dteYears <= 0) return null;
+
+  const sqrtT = Math.sqrt(dteYears);
+  const d2 = (Math.log(spotPrice / targetPrice) + (riskFreeRate - iv * iv / 2) * dteYears) / (iv * sqrtT);
+  return d2;
+}
+
+/**
+ * Probability that underlying price will be ABOVE targetPrice at expiration.
+ * P(S_T > K) = N(d2) where K = targetPrice
+ */
+export function probAbove(
+  spotPrice: number,
+  targetPrice: number,
+  iv: number,
+  dteYears: number,
+  riskFreeRate?: number,
+): number | null {
+  const d2 = calcD2(spotPrice, targetPrice, iv, dteYears, riskFreeRate);
+  if (d2 === null) return null;
+  return normalCDF(d2);
+}
+
+/**
+ * Probability that underlying price will be BELOW targetPrice at expiration.
+ * P(S_T < K) = N(-d2) = 1 - N(d2)
+ */
+export function probBelow(
+  spotPrice: number,
+  targetPrice: number,
+  iv: number,
+  dteYears: number,
+  riskFreeRate?: number,
+): number | null {
+  const above = probAbove(spotPrice, targetPrice, iv, dteYears, riskFreeRate);
+  if (above === null) return null;
+  return 1 - above;
+}
+
+/**
+ * Probability that underlying stays BETWEEN two prices at expiration.
+ * P(lower < S_T < upper) = N(d2_upper) - N(d2_lower)
+ *
+ * Where d2 is calculated at each boundary:
+ * N(d2_upper) = P(S_T > lower), i.e. prob above lower boundary
+ * minus P(S_T > upper) = prob above upper boundary
+ */
+export function probBetween(
+  spotPrice: number,
+  lowerPrice: number,
+  upperPrice: number,
+  iv: number,
+  dteYears: number,
+  riskFreeRate?: number,
+): number | null {
+  const aboveLower = probAbove(spotPrice, lowerPrice, iv, dteYears, riskFreeRate);
+  const aboveUpper = probAbove(spotPrice, upperPrice, iv, dteYears, riskFreeRate);
+  if (aboveLower === null || aboveUpper === null) return null;
+  return aboveLower - aboveUpper;
+}

--- a/src/lib/convergence/trade-cards.ts
+++ b/src/lib/convergence/trade-cards.ts
@@ -296,6 +296,7 @@ export function generateTradeCards(
       max_loss: card.maxLoss,
       breakevens: card.breakevens,
       probability_of_profit: card.pop,
+      pop_method: card.popMethod,
       hv_pop: card.hvPop,
       risk_reward_ratio: card.riskReward,
       greeks: {

--- a/src/lib/convergence/types.ts
+++ b/src/lib/convergence/types.ts
@@ -558,6 +558,7 @@ export interface TradeCardSetup {
   max_loss: number | null;
   breakevens: number[];
   probability_of_profit: number | null;
+  pop_method: 'breakeven_d2' | 'delta_approx';
   hv_pop: number | null;
   risk_reward_ratio: number | null;
   greeks: {

--- a/src/lib/strategy-builder.ts
+++ b/src/lib/strategy-builder.ts
@@ -1,6 +1,8 @@
 // Strategy Builder — client-side option strategy generation
 // No API calls; purely computes from chain + Greeks data
 
+import { probAbove, probBetween } from './convergence/probability';
+
 // ─── Math Utilities ─────────────────────────────────────────────────
 
 // Standard normal CDF — Abramowitz & Stegun approximation
@@ -52,6 +54,90 @@ function computeHvAdjustedPoP(
     return Math.max(0, Math.min(1, normalCDF(z)));
   }
   return card.pop ?? 0;
+}
+
+// ─── Breakeven-Based PoP (N(d2)) ────────────────────────────────────
+
+/**
+ * Calculate Probability of Profit using N(d2) at breakeven prices.
+ *
+ * More accurate than delta approximation because:
+ * 1. Uses N(d2) not N(d1) — true expiration probability, not hedge ratio
+ * 2. Evaluates at actual breakeven prices, not strike prices
+ * 3. For credit spreads, breakevens account for premium received
+ *
+ * IV source: params.iv30 — the underlying's 30-day implied volatility
+ * from TastyTrade market metrics (GenerateParams.iv30).
+ *
+ * @param breakevens - calculated breakeven price(s) from P&L curve
+ * @param spotPrice - current underlying price
+ * @param iv - implied volatility (annualized decimal, e.g. 0.25 for 25%)
+ * @param dte - days to expiration
+ * @param isCredit - true if strategy receives credit
+ * @returns { pop, method } or null if calculation not possible
+ */
+function calculateBreakevenPoP(
+  breakevens: number[],
+  spotPrice: number,
+  iv: number,
+  dte: number,
+  isCredit: boolean,
+): { pop: number; method: 'breakeven_d2' } | null {
+  if (breakevens.length === 0 || spotPrice <= 0 || iv <= 0 || dte <= 0) return null;
+
+  const dteYears = dte / 365;
+  const sorted = [...breakevens].sort((a, b) => a - b);
+
+  if (sorted.length === 1) {
+    // Single breakeven: credit spread or debit spread
+    const be = sorted[0];
+    if (isCredit) {
+      // Credit spread: profit if price stays on the "safe" side of breakeven
+      // Put credit spread: breakeven is below spot → profit if price ABOVE breakeven
+      // Call credit spread: breakeven is above spot → profit if price BELOW breakeven
+      if (be < spotPrice) {
+        const p = probAbove(spotPrice, be, iv, dteYears);
+        if (p === null) return null;
+        return { pop: Math.max(0, Math.min(1, p)), method: 'breakeven_d2' };
+      } else {
+        const p = probAbove(spotPrice, be, iv, dteYears);
+        if (p === null) return null;
+        // Price needs to stay below breakeven
+        return { pop: Math.max(0, Math.min(1, 1 - p)), method: 'breakeven_d2' };
+      }
+    } else {
+      // Debit spread: profit if price moves past breakeven
+      // Bull call spread: breakeven above spot → profit if price ABOVE breakeven
+      // Bear put spread: breakeven below spot → profit if price BELOW breakeven
+      if (be > spotPrice) {
+        const p = probAbove(spotPrice, be, iv, dteYears);
+        if (p === null) return null;
+        return { pop: Math.max(0, Math.min(1, p)), method: 'breakeven_d2' };
+      } else {
+        const p = probAbove(spotPrice, be, iv, dteYears);
+        if (p === null) return null;
+        return { pop: Math.max(0, Math.min(1, 1 - p)), method: 'breakeven_d2' };
+      }
+    }
+  }
+
+  if (sorted.length === 2) {
+    const [lowerBE, upperBE] = sorted;
+    if (isCredit) {
+      // Iron condor, short strangle, short straddle: profit if price stays BETWEEN breakevens
+      const p = probBetween(spotPrice, lowerBE, upperBE, iv, dteYears);
+      if (p === null) return null;
+      return { pop: Math.max(0, Math.min(1, p)), method: 'breakeven_d2' };
+    } else {
+      // Long straddle, long strangle: profit if price goes OUTSIDE breakevens
+      const p = probBetween(spotPrice, lowerBE, upperBE, iv, dteYears);
+      if (p === null) return null;
+      return { pop: Math.max(0, Math.min(1, 1 - p)), method: 'breakeven_d2' };
+    }
+  }
+
+  // 3+ breakevens: unusual strategy, skip
+  return null;
 }
 
 // ─── Types ──────────────────────────────────────────────────────────
@@ -107,6 +193,7 @@ export interface StrategyCard {
   maxLoss: number | null;    // dollars per contract (null = unlimited)
   breakevens: number[];
   pop: number | null;        // probability of profit 0-1
+  popMethod: 'breakeven_d2' | 'delta_approx'; // which calculation produced pop
   riskReward: number | null;
   netDelta: number;
   netGamma: number;
@@ -400,6 +487,7 @@ function buildCard(
     maxLoss,
     breakevens,
     pop: pop != null ? Math.round(pop * 100) / 100 : null,
+    popMethod: 'delta_approx',
     riskReward,
     netDelta: Math.round(netDelta * 1000) / 1000,
     netGamma: Math.round(netGamma * 10000) / 10000,
@@ -664,8 +752,22 @@ export function generateStrategies(params: GenerateParams): StrategyCard[] {
 
   console.log(`[StrategyBuilder] ${sym}: pre-filter cards=${cards.length} [${cards.map(c => c.name).join(', ')}]`);
 
-  // ─── Compute HV-Adjusted EV for each card ──────────────────────
+  // ─── Upgrade PoP: delta approximation → N(d2) at breakeven ────
   const iv = params.iv30 ?? 0.30;
+
+  for (const card of cards) {
+    if (card.breakevens.length === 0 || card.pop == null) continue;
+    const isCredit = CREDIT_STRATEGIES.includes(card.name) || (card.netCredit != null && card.netCredit > 0);
+    const bePoP = calculateBreakevenPoP(card.breakevens, currentPrice, iv, dte, isCredit);
+    if (bePoP) {
+      const deltaPop = card.pop;
+      card.pop = Math.round(bePoP.pop * 100) / 100;
+      card.popMethod = bePoP.method;
+      console.log(`[StrategyBuilder] ${sym}: PoP upgrade "${card.name}" — delta=${(deltaPop * 100).toFixed(1)}% → N(d2)=${(bePoP.pop * 100).toFixed(1)}% (IV=${(iv * 100).toFixed(1)}%, DTE=${dte}, BEs=[${card.breakevens.join(', ')}])`);
+    }
+  }
+
+  // ─── Compute HV-Adjusted EV for each card ──────────────────────
   const hv = params.hv30 ?? iv;
   // Safety cap: if IV/HV ratio > 4, cap at 4 to prevent unrealistic adjustments
   const cappedHv = iv > 0 && hv > 0 && iv / hv > 4 ? iv / 4 : hv;


### PR DESCRIPTION
…prices

- Add probability.ts with normalCDF (Abramowitz & Stegun), calcD2, probAbove/Below/Between
- Add calculateBreakevenPoP() handling 1-breakeven (spreads) and 2-breakeven (iron condors, strangles)
- Wire breakeven PoP upgrade into generateStrategies() — falls back to delta when N(d2) unavailable
- Add popMethod field ('breakeven_d2' | 'delta_approx') through full data pipeline: StrategyCard → trade-cards → types → filter-engine → ScannerResultsTable → ConvergenceIntelligence
- Update Est. PoP tooltips to reflect which calculation method was used

https://claude.ai/code/session_01DUiNKTEgGgPNqqy2GnXv5D