### PR TITLE
feat: xAI social sentiment via Grok x_search

### DIFF
--- a/src/app/api/ai/convergence-synthesis/route.ts
+++ b/src/app/api/ai/convergence-synthesis/route.ts
@@ -265,6 +265,7 @@ export async function GET(request: Request) {
       top_9: pipeline.rankings.top_9,
       pre_filter: pipeline.pre_filter,
       sector_distribution: pipeline.rankings.sector_distribution,
+      social_sentiment: pipeline.social_sentiment,
       timing: {
         pipeline_ms: pipelineMs,
         ai_ms: aiMs,

--- a/src/app/api/convergence/sentiment/route.ts
+++ b/src/app/api/convergence/sentiment/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from 'next/server';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { prisma } from '@/lib/prisma';
+import { requireTier } from '@/lib/auth-helpers';
+import { fetchSentimentBatch } from '@/lib/convergence/sentiment';
+
+export const maxDuration = 60;
+
+export async function POST(req: Request) {
+  // AUTH — required (paid xAI API)
+  const email = await getVerifiedEmail();
+  if (!email) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const user = await prisma.users.findFirst({
+    where: { email: { equals: email, mode: 'insensitive' } },
+  });
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const tierGate = requireTier(user.tier, 'ai');
+  if (tierGate) return tierGate;
+
+  let body: { symbols?: unknown };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const { symbols } = body;
+  if (!symbols || !Array.isArray(symbols) || symbols.length === 0) {
+    return NextResponse.json({ error: 'symbols array required' }, { status: 400 });
+  }
+
+  // Cap at 20 symbols per request to control costs
+  const capped = symbols.slice(0, 20).map(String);
+
+  const results = await fetchSentimentBatch(capped);
+
+  return NextResponse.json({
+    sentiment: Object.fromEntries(results),
+    symbols_requested: capped.length,
+    timestamp: new Date().toISOString(),
+  });
+}

--- a/src/components/convergence/ConvergenceIntelligence.tsx
+++ b/src/components/convergence/ConvergenceIntelligence.tsx
@@ -41,9 +41,24 @@ interface PipelineSummary {
   timestamp: string;
 }
 
+interface SocialSentimentData {
+  symbol: string;
+  score: number;
+  magnitude: number;
+  postCount: number;
+  bullishCount: number;
+  bearishCount: number;
+  neutralCount: number;
+  themes: string[];
+  samplePosts: { text: string; sentiment: 'bullish' | 'bearish' | 'neutral'; author: string }[];
+  dataAge: string;
+  error?: string;
+}
+
 interface BatchResponse {
   pipeline_summary: PipelineSummary;
   top_9: RankedRow[];
+  social_sentiment?: Record<string, SocialSentimentData>;
   timing: { pipeline_ms: number; ai_ms: number; total_ms: number };
 }
 
@@ -226,8 +241,9 @@ function ScoreBar({ label, score }: { label: string; score: number }) {
 
 // ── Ticker Card (the full card for one ticker) ─────────────────────
 
-function TickerCard({ detail, savedCards, savingCards, saveErrors, onSave, onRemove }: {
+function TickerCard({ detail, sentiment, savedCards, savingCards, saveErrors, onSave, onRemove }: {
   detail: TickerDetail;
+  sentiment?: SocialSentimentData;
   savedCards: Map<string, string>; // key: "SYMBOL|strategy_name" → saved card ID
   savingCards: Set<string>;
   saveErrors: Map<string, string>;
@@ -496,6 +512,31 @@ function TickerCard({ detail, savedCards, savingCards, saveErrors, onSave, onRem
                 {ks.sentiment_momentum != null && <span className="text-slate-500"> — {statExplain('sentiment_momentum', ks.sentiment_momentum)}</span>}
               </span>
             </div>
+            {/* Social Pulse row — from xAI x_search */}
+            {sentiment && !sentiment.error && sentiment.postCount > 0 && (
+              <div>
+                <span className="text-slate-500 font-medium">Social Pulse: </span>
+                <span
+                  className="font-mono font-bold"
+                  style={{ color: sentiment.score > 0.2 ? '#10B981' : sentiment.score < -0.2 ? '#EF4444' : '#94A3B8' }}
+                >
+                  {sentiment.score > 0 ? '+' : ''}{sentiment.score.toFixed(2)}
+                </span>
+                <span className="text-slate-400 font-mono">
+                  {' '}({sentiment.postCount} posts
+                  {' | '}{sentiment.bullishCount}B/{sentiment.bearishCount}b/{sentiment.neutralCount}N)
+                </span>
+                {sentiment.themes.length > 0 && (
+                  <span className="ml-2">
+                    {sentiment.themes.slice(0, 3).map((t, i) => (
+                      <span key={i} className="inline-block px-1.5 py-0.5 mr-1 rounded text-[9px] font-medium" style={{ background: '#334155', color: '#94A3B8' }}>
+                        {t}
+                      </span>
+                    ))}
+                  </span>
+                )}
+              </div>
+            )}
           </div>
         </div>
       )}
@@ -527,11 +568,12 @@ function TickerCard({ detail, savedCards, savingCards, saveErrors, onSave, onRem
 // ── Filtered Results Section ────────────────────────────────────────
 
 function FilteredResultsSection({
-  enriched, filters, onResetFilters,
+  enriched, filters, sentimentMap, onResetFilters,
   savedCards, savingCards, saveErrors, onSaveCard, onRemoveCard,
 }: {
   enriched: TickerDetail[];
   filters: ScannerFilters;
+  sentimentMap?: Record<string, SocialSentimentData>;
   onResetFilters: () => void;
   savedCards: Map<string, string>;
   savingCards: Set<string>;
@@ -540,8 +582,8 @@ function FilteredResultsSection({
   onRemoveCard: (cardKey: string, savedId: string) => Promise<void>;
 }) {
   const { passed, filtered, totalStrategies, passedStrategies } = useMemo(
-    () => applyFilters(enriched, filters),
-    [enriched, filters],
+    () => applyFilters(enriched, filters, sentimentMap),
+    [enriched, filters, sentimentMap],
   );
   const [showFiltered, setShowFiltered] = useState(false);
   const activeFilters = useMemo(() => describeActiveFilters(filters), [filters]);
@@ -593,6 +635,7 @@ function FilteredResultsSection({
 
       <ScannerResultsTable
         results={passed}
+        sentimentMap={sentimentMap}
         savedCards={savedCards}
         savingCards={savingCards}
         saveErrors={saveErrors}
@@ -897,6 +940,7 @@ export default function ConvergenceIntelligence() {
         <FilteredResultsSection
           enriched={enriched}
           filters={filters}
+          sentimentMap={batchData?.social_sentiment}
           onResetFilters={() => handleFiltersChange(DEFAULT_FILTERS)}
           savedCards={savedCards}
           savingCards={savingCards}
@@ -907,7 +951,7 @@ export default function ConvergenceIntelligence() {
       )}
       {enriched.length === 1 && (
         <div className="px-5 py-4 space-y-4">
-          <TickerCard detail={enriched[0]} savedCards={savedCards} savingCards={savingCards} saveErrors={saveErrors} onSave={saveCard} onRemove={removeCard} />
+          <TickerCard detail={enriched[0]} sentiment={batchData?.social_sentiment?.[enriched[0].symbol]} savedCards={savedCards} savingCards={savingCards} saveErrors={saveErrors} onSave={saveCard} onRemove={removeCard} />
         </div>
       )}
 

--- a/src/components/convergence/FilterPanel.tsx
+++ b/src/components/convergence/FilterPanel.tsx
@@ -42,6 +42,7 @@ function countActiveFilters(filters: ScannerFilters): number {
   if (filters.edge.minEvPerRisk !== d.edge.minEvPerRisk) count++;
   if (filters.edge.volEdge !== d.edge.volEdge) count++;
   if (filters.edge.minIvRank !== d.edge.minIvRank) count++;
+  if (filters.edge.minSentiment !== d.edge.minSentiment) count++;
   return count;
 }
 
@@ -359,6 +360,12 @@ export default function FilterPanel({ filters, onChange }: FilterPanelProps) {
                     min={0} max={100} step={1}
                     format={v => `${v}%`}
                     onChange={v => setEdge({ minIvRank: v })}
+                  />
+                  <SliderRow
+                    label="Min Sentiment" value={filters.edge.minSentiment}
+                    min={-100} max={100} step={10}
+                    format={v => (v / 100).toFixed(1)}
+                    onChange={v => setEdge({ minSentiment: v })}
                   />
                 </div>
               )}

--- a/src/components/convergence/ScannerResultsTable.tsx
+++ b/src/components/convergence/ScannerResultsTable.tsx
@@ -109,8 +109,23 @@ interface TickerDetail {
 
 // ── Props ────────────────────────────────────────────────────────────
 
+interface SocialSentimentData {
+  symbol: string;
+  score: number;
+  magnitude: number;
+  postCount: number;
+  bullishCount: number;
+  bearishCount: number;
+  neutralCount: number;
+  themes: string[];
+  samplePosts: { text: string; sentiment: 'bullish' | 'bearish' | 'neutral'; author: string }[];
+  dataAge: string;
+  error?: string;
+}
+
 interface ScannerResultsTableProps {
   results: TickerDetail[];
+  sentimentMap?: Record<string, SocialSentimentData>;
   savedCards: Map<string, string>;
   savingCards: Set<string>;
   saveErrors: Map<string, string>;
@@ -197,7 +212,7 @@ type SortKey = 'symbol' | 'score' | 'direction' | 'strategyName' | 'maxProfit' |
 
 // ── Expanded Detail ──────────────────────────────────────────────────
 
-function ExpandedDetail({ detail, card }: { detail: TickerDetail; card: TradeCardData | null }) {
+function ExpandedDetail({ detail, card, sentiment }: { detail: TickerDetail; card: TradeCardData | null; sentiment?: SocialSentimentData }) {
   const comp = detail.scores.composite;
   const why = card?.why;
   const ks = card?.key_stats;
@@ -337,6 +352,60 @@ function ExpandedDetail({ detail, card }: { detail: TickerDetail; card: TradeCar
           </div>
         </div>
       )}
+
+      {/* Social Pulse — from xAI x_search */}
+      {sentiment && !sentiment.error && sentiment.postCount > 0 && (
+        <div>
+          <div className="text-[10px] text-gray-500 uppercase tracking-wider font-bold mb-1.5">
+            Social Pulse
+            <span className="ml-2 text-[9px] text-gray-600 normal-case font-normal">
+              Based on {sentiment.postCount} X posts in last 24h
+            </span>
+          </div>
+          <div className="rounded px-3 py-2 text-xs space-y-2" style={{ background: '#1E293B' }}>
+            <div className="flex items-center gap-3">
+              <span className="text-gray-400">Score:</span>
+              <span
+                className="font-mono font-bold"
+                style={{ color: sentiment.score > 0.2 ? '#10B981' : sentiment.score < -0.2 ? '#EF4444' : '#94A3B8' }}
+              >
+                {sentiment.score > 0 ? '+' : ''}{sentiment.score.toFixed(2)}
+              </span>
+              <span className="text-gray-400">
+                ({sentiment.bullishCount} bullish / {sentiment.bearishCount} bearish / {sentiment.neutralCount} neutral)
+              </span>
+            </div>
+            {sentiment.themes.length > 0 && (
+              <div className="flex items-center gap-2">
+                <span className="text-gray-400 shrink-0">Themes:</span>
+                <div className="flex flex-wrap gap-1">
+                  {sentiment.themes.slice(0, 5).map((t, i) => (
+                    <span key={i} className="px-1.5 py-0.5 rounded text-[9px] font-medium" style={{ background: '#334155', color: '#94A3B8' }}>
+                      {t}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            )}
+            {sentiment.samplePosts.length > 0 && (
+              <div className="space-y-1 mt-1">
+                {sentiment.samplePosts.slice(0, 3).map((post, i) => {
+                  const sentColor = post.sentiment === 'bullish' ? '#34D399' : post.sentiment === 'bearish' ? '#F87171' : '#94A3B8';
+                  return (
+                    <div key={i} className="flex items-start gap-2">
+                      <span className="shrink-0 px-1 py-0.5 rounded text-[9px] font-bold" style={{ color: sentColor, background: sentColor + '15' }}>
+                        {post.sentiment.charAt(0).toUpperCase()}
+                      </span>
+                      <span className="text-gray-300 leading-relaxed flex-1">&ldquo;{post.text}&rdquo;</span>
+                      <span className="shrink-0 text-[9px] text-gray-500 font-mono">{post.author}</span>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        </div>
+      )}
     </div>
   );
 }
@@ -345,6 +414,7 @@ function ExpandedDetail({ detail, card }: { detail: TickerDetail; card: TradeCar
 
 export default function ScannerResultsTable({
   results,
+  sentimentMap,
   savedCards,
   savingCards,
   saveErrors,
@@ -540,6 +610,7 @@ export default function ScannerResultsTable({
             <tr style={{ background: '#1E293B' }}>
               <th className="px-2 py-2 w-8">{/* checkbox col */}</th>
               <th className={thBase + ' text-left'} onClick={() => toggleSort('symbol')}>Symbol{sortIndicator('symbol')}</th>
+              <th className={thBase + ' text-center w-6'} title="Social Sentiment from X/Twitter (via xAI Grok)">X</th>
               <th className={thBase + ' text-right'} onClick={() => toggleSort('score')}>Score{sortIndicator('score')}</th>
               <th className={thBase + ' text-left'} onClick={() => toggleSort('direction')}>Direction{sortIndicator('direction')}</th>
               <th className={thBase + ' text-left'} onClick={() => toggleSort('strategyName')}>Strategy{sortIndicator('strategyName')}</th>
@@ -591,6 +662,22 @@ export default function ScannerResultsTable({
                     {/* Symbol */}
                     <td className="px-2 py-2 font-mono font-bold text-white" onClick={() => toggleRow(row.id)}>
                       {row.symbol}
+                    </td>
+                    {/* Sentiment dot */}
+                    <td className="px-1 py-2 text-center" onClick={() => toggleRow(row.id)}>
+                      {(() => {
+                        const s = sentimentMap?.[row.symbol];
+                        if (!s || s.error || s.postCount === 0) return null;
+                        const color = s.score > 0.2 ? '#10B981' : s.score < -0.2 ? '#EF4444' : '#6B7280';
+                        const label = s.score > 0.2 ? 'bullish' : s.score < -0.2 ? 'bearish' : 'neutral';
+                        return (
+                          <span
+                            className="inline-block w-2 h-2 rounded-full"
+                            style={{ background: color }}
+                            title={`Social Sentiment: ${s.score > 0 ? '+' : ''}${s.score.toFixed(2)} (${label}) — ${s.postCount} posts. ${s.themes.length > 0 ? 'Themes: ' + s.themes.slice(0, 3).join(', ') : ''}`}
+                          />
+                        );
+                      })()}
                     </td>
                     {/* Score */}
                     <td className="px-2 py-2 text-right font-mono font-bold" onClick={() => toggleRow(row.id)} style={{ color: gradeColor(row.score) }}>
@@ -664,7 +751,7 @@ export default function ScannerResultsTable({
                   {/* Error row */}
                   {error && (
                     <tr style={{ background: '#7F1D1D15' }}>
-                      <td colSpan={14} className="px-4 py-1 text-[10px] text-red-300">
+                      <td colSpan={15} className="px-4 py-1 text-[10px] text-red-300">
                         Failed to save: {error}
                       </td>
                     </tr>
@@ -673,8 +760,8 @@ export default function ScannerResultsTable({
                   {/* Expanded detail row */}
                   {isExpanded && (
                     <tr>
-                      <td colSpan={14} style={{ background: '#0F172A', padding: 0 }}>
-                        <ExpandedDetail detail={row.detail} card={row.card} />
+                      <td colSpan={15} style={{ background: '#0F172A', padding: 0 }}>
+                        <ExpandedDetail detail={row.detail} card={row.card} sentiment={sentimentMap?.[row.symbol]} />
                       </td>
                     </tr>
                   )}

--- a/src/lib/convergence/filter-engine.ts
+++ b/src/lib/convergence/filter-engine.ts
@@ -123,9 +123,17 @@ export interface FilterOutput {
 
 // ── Main filter function ────────────────────────────────────────────
 
+interface SocialSentimentData {
+  score: number;
+  magnitude: number;
+  postCount: number;
+  error?: string;
+}
+
 export function applyFilters(
   results: TickerDetail[],
   filters: ScannerFilters,
+  sentimentMap?: Record<string, SocialSentimentData>,
 ): FilterOutput {
   const passed: TickerDetail[] = [];
   const filtered: FilteredResult[] = [];
@@ -138,6 +146,21 @@ export function applyFilters(
       // No strategies — pass through as-is (no cards to filter)
       passed.push(result);
       continue;
+    }
+
+    // Ticker-level: social sentiment filter
+    if (filters.edge.minSentiment > -100 && sentimentMap) {
+      const s = sentimentMap[result.symbol];
+      if (s && !s.error && s.postCount > 0) {
+        const minScore = filters.edge.minSentiment / 100;
+        if (s.score < minScore) {
+          filtered.push({
+            result,
+            reasons: [`Social sentiment ${s.score.toFixed(2)} below min ${minScore.toFixed(1)}`],
+          });
+          continue;
+        }
+      }
     }
 
     totalStrategies += cards.length;
@@ -313,6 +336,8 @@ export function describeActiveFilters(filters: ScannerFilters): string[] {
     parts.push(filters.edge.volEdge === 'IV_ABOVE_HV' ? 'IV > HV only' : 'IV < HV only');
   if (filters.edge.minIvRank !== d.edge.minIvRank)
     parts.push(`Min IVR \u2265 ${filters.edge.minIvRank}%`);
+  if (filters.edge.minSentiment !== d.edge.minSentiment)
+    parts.push(`Min Sentiment \u2265 ${(filters.edge.minSentiment / 100).toFixed(1)}`);
 
   return parts;
 }

--- a/src/lib/convergence/filter-types.ts
+++ b/src/lib/convergence/filter-types.ts
@@ -37,6 +37,7 @@ export interface EdgeMetrics {
   minEvPerRisk: number;         // ratio, default 0
   volEdge: VolEdge;
   minIvRank: number;            // 0-100, default 0
+  minSentiment: number;         // -100 to 100 (display as -1.0 to 1.0), default -100
 }
 
 // ── Combined Filter State ───────────────────────────────────────────
@@ -68,6 +69,7 @@ export const DEFAULT_FILTERS: ScannerFilters = {
     minEvPerRisk: 0,
     volEdge: 'ANY',
     minIvRank: 0,
+    minSentiment: -100,
   },
 };
 

--- a/src/lib/convergence/pipeline.ts
+++ b/src/lib/convergence/pipeline.ts
@@ -3,6 +3,8 @@ import { fetchFinnhubBatch, fetchFredMacro, fetchTTCandlesBatch, fetchAnnualFina
 import type { FinnhubData, CandleBatchStats } from './data-fetchers';
 import { fetchChainAndBuildCards, isMarketOpen } from './chain-fetcher';
 import type { ChainFetchStats, ChainFetchResult } from './chain-fetcher';
+import { fetchSentimentBatch } from './sentiment';
+import type { SentimentResult } from './sentiment';
 import { computeSectorStats } from './sector-stats';
 import type { SectorStatsMap } from './sector-stats';
 import { scoreAll } from './composite';
@@ -100,6 +102,7 @@ export interface PipelineResult {
   diversification: DiversificationResult;
   scoring_details: Record<string, FullScoringResult>;
   pre_filter: PreFilterResult[];
+  social_sentiment: Record<string, SentimentResult>;
   data_gaps: string[];
   errors: string[];
 }
@@ -567,6 +570,27 @@ export async function runPipeline(limit: number = 20): Promise<PipelineResult> {
   console.log('[Pipeline] Step G: Ranking and diversifying...');
   const { top9, alsoScored, diversification, sectorDistribution } = rankAndDiversify(rankedRows);
 
+  // ===== STEP G1.5: Fetch social sentiment (parallel with G2) =====
+  const top9Symbols = top9.map(r => r.symbol);
+  const sentimentPromise = (async (): Promise<Map<string, SentimentResult>> => {
+    if (!process.env.XAI_API_KEY) {
+      console.log('[Pipeline] Step G1.5: XAI_API_KEY not set — skipping social sentiment');
+      return new Map();
+    }
+    try {
+      console.log(`[Pipeline] Step G1.5: Fetching social sentiment for ${top9Symbols.length} symbols...`);
+      const startMs = Date.now();
+      const results = await fetchSentimentBatch(top9Symbols, 5);
+      console.log(`[Pipeline] Step G1.5: Sentiment fetched in ${Date.now() - startMs}ms`);
+      return results;
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : String(e);
+      errors.push(`Step G1.5 (sentiment): ${msg}`);
+      console.error('[Pipeline] Step G1.5 sentiment failed:', msg);
+      return new Map();
+    }
+  })();
+
   // ===== STEP G2: Fetch chain data and build trade cards =====
   console.log('[Pipeline] Step G2: Fetching option chains and building trade cards...');
   let chainStats: ChainFetchStats = {
@@ -661,6 +685,21 @@ export async function runPipeline(limit: number = 20): Promise<PipelineResult> {
     console.error('[Pipeline] Step G2 failed:', msg);
   }
 
+  // Await sentiment (launched in parallel with G2)
+  const sentimentMap = await sentimentPromise;
+  const socialSentiment: Record<string, SentimentResult> = Object.fromEntries(sentimentMap);
+  if (sentimentMap.size > 0) {
+    const withData = [...sentimentMap.values()].filter(s => !s.error).length;
+    console.log(`[Pipeline] Sentiment: ${withData}/${sentimentMap.size} symbols with data`);
+    if (withData === 0) {
+      dataGaps.push('social_sentiment: xAI returned no results (API may be unavailable or no posts found)');
+    }
+  } else if (process.env.XAI_API_KEY) {
+    dataGaps.push('social_sentiment: fetch failed or returned empty');
+  } else {
+    dataGaps.push('social_sentiment: XAI_API_KEY not configured — social sentiment disabled');
+  }
+
   // ===== STEP H: Assemble Full Result =====
   console.log('[Pipeline] Step H: Assembling result...');
 
@@ -725,6 +764,7 @@ export async function runPipeline(limit: number = 20): Promise<PipelineResult> {
     diversification,
     scoring_details: scoringDetails,
     pre_filter: preFilterResults,
+    social_sentiment: socialSentiment,
     data_gaps: dataGaps,
     errors,
   };

--- a/src/lib/convergence/sentiment.ts
+++ b/src/lib/convergence/sentiment.ts
@@ -1,0 +1,341 @@
+/**
+ * Social sentiment analysis via xAI Grok with native x_search.
+ *
+ * Two-stage pipeline:
+ * 1. Grok 4.1 Fast + x_search: Fetch recent X/Twitter posts about $TICKER
+ * 2. Grok 4.1 Fast (non-reasoning): Score sentiment with structured JSON output
+ *
+ * Returns a sentiment score (-1 to +1), post count, key themes, and sample posts.
+ * Designed to be OPTIONAL — scanner works without it.
+ */
+
+// ── Types ────────────────────────────────────────────────────────────
+
+export interface SentimentResult {
+  symbol: string;
+  score: number;            // -1 (very bearish) to +1 (very bullish)
+  magnitude: number;        // 0-1, how strong/confident the signal is
+  postCount: number;        // how many relevant posts were found
+  bullishCount: number;     // posts classified as bullish
+  bearishCount: number;     // posts classified as bearish
+  neutralCount: number;     // posts classified as neutral
+  themes: string[];         // top 3-5 themes
+  samplePosts: {
+    text: string;           // truncated to ~100 chars
+    sentiment: 'bullish' | 'bearish' | 'neutral';
+    author: string;         // @handle
+  }[];
+  dataAge: string;          // ISO timestamp of when this was fetched
+  error?: string;           // if sentiment fetch failed, why
+}
+
+interface XAIResponsesOutput {
+  id: string;
+  output: Array<{
+    type: string;
+    content?: Array<{
+      type: string;
+      text?: string;
+      annotations?: Array<{
+        type: string;
+        url: string;
+        title: string;
+      }>;
+    }>;
+  }>;
+  usage?: {
+    input_tokens: number;
+    output_tokens: number;
+  };
+}
+
+interface Stage1Post {
+  text: string;
+  sentiment: 'bullish' | 'bearish' | 'neutral';
+  author: string;
+  summary: string;
+}
+
+interface Stage1Result {
+  posts: Stage1Post[];
+  overall_sentiment: string;
+  key_themes: string[];
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+function emptyResult(symbol: string, error?: string): SentimentResult {
+  return {
+    symbol,
+    score: 0,
+    magnitude: 0,
+    postCount: 0,
+    bullishCount: 0,
+    bearishCount: 0,
+    neutralCount: 0,
+    themes: [],
+    samplePosts: [],
+    dataAge: new Date().toISOString(),
+    error,
+  };
+}
+
+function extractTextFromResponses(data: XAIResponsesOutput): string {
+  for (const output of data.output || []) {
+    if (output.content) {
+      for (const content of output.content) {
+        if (content.type === 'output_text' && content.text) {
+          return content.text;
+        }
+      }
+    }
+  }
+  return '';
+}
+
+function parseJSON<T>(text: string): T | null {
+  // Remove markdown code blocks if present
+  const codeBlockMatch = text.match(/```(?:json)?\n?([\s\S]*?)```/);
+  const jsonStr = codeBlockMatch ? codeBlockMatch[1] : text;
+
+  // Try to find a JSON object or array
+  const objMatch = jsonStr.match(/\{[\s\S]*\}/);
+  const arrMatch = jsonStr.match(/\[[\s\S]*\]/);
+  const candidate = objMatch?.[0] || arrMatch?.[0];
+  if (!candidate) return null;
+
+  try {
+    return JSON.parse(candidate) as T;
+  } catch {
+    return null;
+  }
+}
+
+// ── Stage 1: Fetch posts via x_search ────────────────────────────────
+
+async function fetchPostsViaXSearch(
+  symbol: string,
+  apiKey: string,
+): Promise<Stage1Result | null> {
+  const prompt = `Search X/Twitter for recent posts about $${symbol} stock in the last 24 hours.
+
+Find 10-20 relevant posts that discuss:
+- Price action, trading activity, or market sentiment
+- Earnings, revenue, or financial results
+- Product launches, partnerships, or business developments
+- Analyst upgrades/downgrades or price targets
+- Insider buying/selling
+
+IGNORE posts that are:
+- Spam, bots, or promotional content
+- Unrelated to the stock/company
+- Just sharing a stock price without commentary
+
+For each relevant post, extract:
+- The key sentiment (bullish, bearish, or neutral)
+- A brief summary of what they're saying (under 100 chars)
+- The author handle
+
+Respond with JSON only, no other text:
+{
+  "posts": [
+    { "text": "...", "sentiment": "bullish", "author": "@handle", "summary": "..." }
+  ],
+  "overall_sentiment": "bullish|bearish|neutral|mixed",
+  "key_themes": ["theme1", "theme2", "theme3"]
+}`;
+
+  const response = await fetch('https://api.x.ai/v1/responses', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model: 'grok-4-1-fast',
+      input: [{ role: 'user', content: prompt }],
+      tools: [
+        { type: 'x_search' },
+      ],
+    }),
+    signal: AbortSignal.timeout(60_000),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => '');
+    console.error(`[Sentiment] Stage 1 API error ${response.status} for ${symbol}:`, errorText.substring(0, 500));
+    return null;
+  }
+
+  const data: XAIResponsesOutput = await response.json();
+  const textContent = extractTextFromResponses(data);
+
+  if (!textContent) {
+    console.warn(`[Sentiment] Stage 1: No text content for ${symbol}`);
+    return null;
+  }
+
+  const parsed = parseJSON<Stage1Result>(textContent);
+  if (!parsed || !Array.isArray(parsed.posts)) {
+    console.warn(`[Sentiment] Stage 1: Could not parse JSON for ${symbol}`);
+    return null;
+  }
+
+  return parsed;
+}
+
+// ── Stage 2: Score sentiment ─────────────────────────────────────────
+
+async function scoreSentiment(
+  symbol: string,
+  stage1: Stage1Result,
+  apiKey: string,
+): Promise<{ score: number; magnitude: number } | null> {
+  const postsJson = JSON.stringify(stage1.posts.slice(0, 15));
+
+  const prompt = `Given these classified social media posts about $${symbol}:
+
+${postsJson}
+
+Overall sentiment from search: ${stage1.overall_sentiment}
+Key themes: ${stage1.key_themes.join(', ')}
+
+Compute a sentiment score:
+- Score: -1.0 (extremely bearish) to +1.0 (extremely bullish), 0 = neutral
+- Magnitude: 0.0 (no signal/low confidence) to 1.0 (very strong/high confidence signal)
+- Consider: post count, agreement between posts, credibility of sources, recency
+
+Respond with JSON only:
+{ "score": 0.35, "magnitude": 0.7 }`;
+
+  const response = await fetch('https://api.x.ai/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model: 'grok-4-1-fast-non-reasoning',
+      messages: [
+        { role: 'system', content: 'You are a financial sentiment analyst. Return only valid JSON, no markdown.' },
+        { role: 'user', content: prompt },
+      ],
+      temperature: 0.2,
+      max_tokens: 200,
+    }),
+    signal: AbortSignal.timeout(15_000),
+  });
+
+  if (!response.ok) {
+    console.error(`[Sentiment] Stage 2 API error ${response.status} for ${symbol}`);
+    return null;
+  }
+
+  const data = await response.json();
+  const content = data.choices?.[0]?.message?.content || '';
+  const parsed = parseJSON<{ score: number; magnitude: number }>(content);
+
+  if (!parsed || typeof parsed.score !== 'number' || typeof parsed.magnitude !== 'number') {
+    console.warn(`[Sentiment] Stage 2: Could not parse score for ${symbol}`);
+    return null;
+  }
+
+  // Clamp values
+  return {
+    score: Math.max(-1, Math.min(1, parsed.score)),
+    magnitude: Math.max(0, Math.min(1, parsed.magnitude)),
+  };
+}
+
+// ── Public API ───────────────────────────────────────────────────────
+
+/**
+ * Fetch social sentiment for a single ticker.
+ * Uses two-stage Grok pipeline: x_search -> sentiment scoring.
+ * Never throws — returns empty result with error field on failure.
+ */
+export async function fetchSentiment(symbol: string): Promise<SentimentResult> {
+  const apiKey = process.env.XAI_API_KEY;
+  if (!apiKey) {
+    console.warn('[Sentiment] XAI_API_KEY not configured — skipping sentiment');
+    return emptyResult(symbol, 'XAI_API_KEY not configured');
+  }
+
+  try {
+    const startTime = Date.now();
+    console.log(`[Sentiment] Fetching for ${symbol}...`);
+
+    // Stage 1: Fetch and classify posts via x_search
+    const stage1 = await fetchPostsViaXSearch(symbol, apiKey);
+    if (!stage1 || stage1.posts.length === 0) {
+      console.log(`[Sentiment] ${symbol}: No posts found`);
+      return emptyResult(symbol, 'No relevant posts found');
+    }
+
+    const posts = stage1.posts;
+    const bullishCount = posts.filter(p => p.sentiment === 'bullish').length;
+    const bearishCount = posts.filter(p => p.sentiment === 'bearish').length;
+    const neutralCount = posts.filter(p => p.sentiment === 'neutral').length;
+
+    // Stage 2: Compute numerical score
+    const scoreResult = await scoreSentiment(symbol, stage1, apiKey);
+
+    const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+    console.log(`[Sentiment] ${symbol}: ${posts.length} posts, score=${scoreResult?.score ?? 'N/A'} in ${elapsed}s`);
+
+    return {
+      symbol,
+      score: scoreResult?.score ?? 0,
+      magnitude: scoreResult?.magnitude ?? 0,
+      postCount: posts.length,
+      bullishCount,
+      bearishCount,
+      neutralCount,
+      themes: (stage1.key_themes || []).slice(0, 5),
+      samplePosts: posts.slice(0, 5).map(p => ({
+        text: (p.text || p.summary || '').substring(0, 100),
+        sentiment: p.sentiment || 'neutral',
+        author: p.author || '@unknown',
+      })),
+      dataAge: new Date().toISOString(),
+    };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`[Sentiment] ${symbol} failed:`, msg);
+    return emptyResult(symbol, msg);
+  }
+}
+
+/**
+ * Fetch social sentiment for multiple tickers in parallel.
+ * Uses semaphore to respect rate limits (480 RPM).
+ * Never throws — individual failures produce empty results.
+ */
+export async function fetchSentimentBatch(
+  symbols: string[],
+  concurrency: number = 10,
+): Promise<Map<string, SentimentResult>> {
+  const results = new Map<string, SentimentResult>();
+  let active = 0;
+  let index = 0;
+
+  return new Promise((resolve) => {
+    function next() {
+      while (active < concurrency && index < symbols.length) {
+        const sym = symbols[index++];
+        active++;
+        fetchSentiment(sym).then(result => {
+          results.set(sym, result);
+          active--;
+          if (results.size === symbols.length) {
+            resolve(results);
+          } else {
+            next();
+          }
+        });
+      }
+    }
+    if (symbols.length === 0) resolve(results);
+    else next();
+  });
+}

--- a/src/lib/convergence/types.ts
+++ b/src/lib/convergence/types.ts
@@ -590,6 +590,21 @@ export interface TradeCardWhy {
   risk_flags: string[];
 }
 
+export interface SocialSentiment {
+  score: number;          // -1 to +1
+  magnitude: number;      // 0 to 1
+  postCount: number;
+  themes: string[];
+  bullishPct: number;     // 0-100
+  bearishPct: number;     // 0-100
+  samplePosts?: {
+    text: string;
+    sentiment: 'bullish' | 'bearish' | 'neutral';
+    author: string;
+  }[];
+  dataAge: string;        // ISO timestamp
+}
+
 export interface TradeCardKeyStats {
   iv_rank: number | null;
   iv_percentile: number | null;
@@ -609,6 +624,7 @@ export interface TradeCardKeyStats {
   buzz_ratio: number | null;
   sentiment_momentum: number | null;
   analyst_consensus: string | null;
+  social_sentiment?: SocialSentiment;
 }
 
 export interface TradeCard {


### PR DESCRIPTION
Two-stage pipeline using xAI Responses API:
1. Grok 4.1 Fast + x_search: fetch/classify recent X posts about $TICKER
2. Grok 4.1 Fast (non-reasoning): score sentiment -1 to +1

New files:
- src/lib/convergence/sentiment.ts — fetchSentiment(), fetchSentimentBatch()
- src/app/api/convergence/sentiment/route.ts — authenticated POST endpoint

Pipeline integration:
- Sentiment fetched in parallel with chain data (Step G1.5) for top 9 symbols
- social_sentiment added to PipelineResult, flows through synthesis route
- SocialSentiment type added to types.ts TradeCardKeyStats

UI updates:
- ScannerResultsTable: sentiment dot indicator per row (green/red/gray)
- ScannerResultsTable expanded: Social Pulse section with score, themes, sample posts
- ConvergenceIntelligence TickerCard: Social Pulse row with score and theme tags
- FilterPanel: Min Sentiment slider (-1.0 to 1.0) in Edge Metrics tier
- filter-engine: ticker-level sentiment filter with sentimentMap passthrough

Design decisions:
- OPTIONAL enrichment — scanner works without XAI_API_KEY
- Never blocking — errors produce empty result, scan continues
- Capped at 20 symbols per API request to control costs
- Auth required (getVerifiedEmail + requireTier) on sentiment route

https://claude.ai/code/session_01DUiNKTEgGgPNqqy2GnXv5D