### PR TITLE
fix: proxy trip images server-side, add onError fallback, hide API key

### DIFF
--- a/src/app/api/places/photo/route.ts
+++ b/src/app/api/places/photo/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
+
+export async function GET(req: NextRequest) {
+  const userEmail = await getVerifiedEmail();
+  if (!userEmail) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const destination = req.nextUrl.searchParams.get('destination');
+  if (!destination) {
+    return NextResponse.json({ error: 'destination required' }, { status: 400 });
+  }
+
+  const apiKey = process.env.GOOGLE_PLACES_API_KEY;
+  if (!apiKey) {
+    return NextResponse.json({ error: 'Google API not configured' }, { status: 500 });
+  }
+
+  try {
+    // Step 1: Text Search to get a fresh photo_reference
+    const searchUrl = `https://maps.googleapis.com/maps/api/place/textsearch/json?query=${encodeURIComponent(destination)}&key=${apiKey}`;
+    const searchRes = await fetch(searchUrl);
+    const searchData = await searchRes.json();
+
+    const photoRef = searchData.results?.[0]?.photos?.[0]?.photo_reference;
+    if (!photoRef) {
+      return NextResponse.json({ error: 'No photo found' }, { status: 404 });
+    }
+
+    // Step 2: Fetch actual image bytes (API key stays server-side)
+    const photoUrl = `https://maps.googleapis.com/maps/api/place/photo?maxwidth=800&photo_reference=${photoRef}&key=${apiKey}`;
+    const photoRes = await fetch(photoUrl);
+
+    if (!photoRes.ok) {
+      return NextResponse.json({ error: 'Photo fetch failed' }, { status: 502 });
+    }
+
+    const imageBuffer = await photoRes.arrayBuffer();
+    const contentType = photoRes.headers.get('content-type') || 'image/jpeg';
+
+    return new NextResponse(imageBuffer, {
+      headers: {
+        'Content-Type': contentType,
+        'Cache-Control': 'public, max-age=604800, stale-while-revalidate=86400',
+      },
+    });
+  } catch (error) {
+    console.error('[places/photo] Error:', error);
+    return NextResponse.json({ error: 'Internal error' }, { status: 500 });
+  }
+}

--- a/src/app/hub/page.tsx
+++ b/src/app/hub/page.tsx
@@ -373,12 +373,18 @@ export default function HubPage() {
                     >
                       {/* Image */}
                       <div className="relative h-[120px] overflow-hidden">
-                        {trip.destinationPhoto ? (
-                          <img src={trip.destinationPhoto} alt={trip.destination || trip.name} className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300" />
-                        ) : (
-                          <div className="w-full h-full bg-gradient-to-br from-[#2d1b4e] to-[#4a3a6e] flex items-center justify-center">
-                            <span className="text-white/50 text-3xl font-mono">{(trip.destination || trip.name || '?').charAt(0)}</span>
-                          </div>
+                        {/* Gradient placeholder - always rendered, visible when image fails or no destination */}
+                        <div className="w-full h-full bg-gradient-to-br from-[#2d1b4e] to-[#4a3a6e] flex items-center justify-center">
+                          <span className="text-white/50 text-3xl font-mono">{(trip.destination || trip.name || '?').charAt(0)}</span>
+                        </div>
+                        {/* Photo from proxy - overlays placeholder, hides on error */}
+                        {trip.destination && (
+                          <img
+                            src={`/api/places/photo?destination=${encodeURIComponent(trip.destination)}`}
+                            alt={trip.destination || trip.name}
+                            className="absolute inset-0 w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
+                            onError={(e) => { e.currentTarget.style.display = 'none'; }}
+                          />
                         )}
                         {/* Overlay with destination name */}
                         <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-transparent to-transparent" />


### PR DESCRIPTION
- Add /api/places/photo proxy route that fetches fresh Google Places photos server-side, keeping the API key off the client
- Replace stored destinationPhoto URLs (with ephemeral photo_reference tokens) with live proxy calls using destination name
- Always render gradient placeholder behind the image; on load error the img hides itself revealing the fallback
- Proxy route requires auth (getVerifiedEmail) and returns 7-day Cache-Control headers to limit API calls

https://claude.ai/code/session_01EVTXPoi7KENn1PrBngxdji