### PR TITLE
fix: remove Review tab, show COA names not codes, fix default table view

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -13,7 +13,7 @@ import CPAExport from '@/components/dashboard/CPAExport';
 import PositionReportTab from '@/components/dashboard/PositionReportTab';
 import WashSaleReportTab from '@/components/dashboard/WashSaleReportTab';
 import TaxReportTab from '@/components/dashboard/TaxReportTab';
-import ReviewQueueTab from '@/components/dashboard/ReviewQueueTab';
+
 
 interface Transaction {
   id: string;
@@ -137,7 +137,7 @@ export default function Dashboard() {
   const committedSpending = transactions.filter(t => t.accountCode);
   const uncommittedInvestments = investmentTransactions.filter((t: any) => !t.accountCode);
   const committedInvestments = investmentTransactions.filter((t: any) => t.accountCode);
-  const pendingReviewCount = transactions.filter(t => t.review_status === 'pending_review').length;
+
 
   const availableYears = useMemo(() => {
     const years = new Set<number>();
@@ -320,7 +320,7 @@ export default function Dashboard() {
               {[
                 { key: 'accounts', label: 'Accounts' },
                 { key: 'mapping', label: `Map COA${pendingCount > 0 ? ` (${pendingCount})` : ''}` },
-                { key: 'review', label: `Review${pendingReviewCount > 0 ? ` (${pendingReviewCount})` : ''}` },
+
                 { key: 'statements', label: 'Statements' },
                 { key: 'ledger', label: 'Ledger' },
                 { key: 'journal', label: 'Journal' },
@@ -405,18 +405,6 @@ export default function Dashboard() {
                 </div>
               )}
 
-              {/* Review Queue */}
-              {activeSection === 'review' && (
-                <div>
-                  <div className="bg-[#2d1b4e] text-white px-4 py-2 flex items-center justify-between">
-                    <span className="text-sm font-semibold">Review Queue</span>
-                    {pendingReviewCount > 0 && <span className="px-2 py-0.5 bg-amber-500 text-white text-[10px] font-medium">{pendingReviewCount} pending</span>}
-                  </div>
-                  <div className="p-4">
-                    <ReviewQueueTab coaOptions={coaOptions} />
-                  </div>
-                </div>
-              )}
 
               {/* Financial Statements */}
               {activeSection === 'statements' && (

--- a/src/components/dashboard/SpendingTab.tsx
+++ b/src/components/dashboard/SpendingTab.tsx
@@ -862,7 +862,7 @@ function VirtualTable({
                       onChange={e => setRowChanges(prev => ({ ...prev, [txn.id]: { ...(prev[txn.id] || { coa: '', sub: '' }), coa: e.target.value } }))}
                       className="w-full text-[11px] border border-gray-200 rounded px-1.5 py-1 bg-white focus:border-[#2d1b4e] focus:ring-1 focus:ring-[#2d1b4e] outline-none"
                     >
-                      <option value="">{txn.predicted_coa_code ? `AI: ${txn.predicted_coa_code}` : 'Select...'}</option>
+                      <option value="">{txn.predicted_coa_code ? `${txn.predicted_coa_code} - ${coaLookup.get(txn.predicted_coa_code)?.name || 'Unknown'}` : 'Select...'}</option>
                       {Object.entries(coaGroupedByEntity).map(([entity, opts]) => (
                         <optgroup key={entity} label={entity || 'General'}>
                           {opts.map(o => <option key={o.id} value={o.code}>{o.code} - {o.name}</option>)}


### PR DESCRIPTION
- Remove redundant Review tab (ReviewQueueTab) from dashboard navigation since Map COA provides the same functionality
- Fix COA dropdown placeholder to show "6100 - Groceries & Food" instead of "AI: 6100" by resolving codes via coaLookup
- Confirmed default view mode is already 'flat' (no change needed)
- Note: SpendingTab uses @tanstack/react-virtual for row virtualization, so all 4k+ transactions load but only visible rows render

https://claude.ai/code/session_01MVDHUQHAXD2XkiKhVAmZvc