### PR TITLE
fix: make balance trigger DEFERRABLE INITIALLY DEFERRED so D+C insert…

### DIFF
--- a/prisma/migrations/20260226000500_fix_balance_trigger_deferred/migration.sql
+++ b/prisma/migrations/20260226000500_fix_balance_trigger_deferred/migration.sql
@@ -1,0 +1,17 @@
+-- Fix: make balance validation trigger DEFERRABLE INITIALLY DEFERRED
+-- so that both debit and credit ledger entries can be inserted within
+-- a transaction before the balance check fires.
+--
+-- Previously the trigger fired AFTER each row INSERT, meaning the first
+-- ledger entry (debit) was validated before the second (credit) existed,
+-- causing "Transaction must be balanced: debits=X credits=0" errors.
+
+-- Drop the existing non-deferred trigger
+DROP TRIGGER IF EXISTS check_transaction_balance ON ledger_entries;
+
+-- Recreate as a deferred constraint trigger
+CREATE CONSTRAINT TRIGGER check_transaction_balance
+  AFTER INSERT ON ledger_entries
+  DEFERRABLE INITIALLY DEFERRED
+  FOR EACH ROW
+  EXECUTE FUNCTION validate_transaction_balance();


### PR DESCRIPTION
…s can complete before validation

The check_transaction_balance trigger was firing AFTER each individual ledger_entry INSERT, causing "Transaction must be balanced: debits=X credits=0" errors when commitPlaidTransaction inserted the debit entry before the credit entry. By making it a CONSTRAINT TRIGGER with DEFERRABLE INITIALLY DEFERRED, the validation now runs at transaction commit time when both entries exist.

https://claude.ai/code/session_01MVDHUQHAXD2XkiKhVAmZvc