### PR TITLE
fix: Closes tab shows transfer/expiration/assignment transactions

### DIFF
--- a/src/app/api/investment-transactions/opens/route.ts
+++ b/src/app/api/investment-transactions/opens/route.ts
@@ -62,16 +62,18 @@ export async function GET() {
         action = isSell ? 'sell' : 'buy';
       }
       
-      // Detect exercise/assignment (these CLOSE option positions)
+      // Detect exercise/assignment/expiration (these CLOSE option positions)
       const isExercise = nameLower.includes('exercise');
       const isAssignment = nameLower.includes('assignment');
+      const isExpiration = nameLower.includes('expiration');
       const isExerciseOrAssignment = isExercise || isAssignment;
-      
+      const isTransferClose = isExerciseOrAssignment || isExpiration || t.type === 'transfer';
+
       // Determine position type
       let positionType: 'open' | 'close' | 'unknown' = 'unknown';
-      
-      if (isExerciseOrAssignment) {
-        // ALL exercise/assignment transactions close option positions
+
+      if (isTransferClose) {
+        // ALL exercise/assignment/expiration/transfer transactions close option positions
         // Both the $0 transfers AND the stock buy/sell transactions
         // are closing legs for the original option trade
         positionType = 'close';
@@ -97,6 +99,8 @@ export async function GET() {
         expiration,
         action,
         positionType,
+        type: t.type,
+        subtype: t.subtype,
         quantity: t.quantity,
         price: t.price,
         amount: t.amount,


### PR DESCRIPTION
The opens route classified positionType based on exercise/assignment name patterns but missed expirations entirely — "Expiration SPY 540 Call" doesn't contain "exercise" or "assignment" so it fell through to the isOption check where it didn't match "to open"/"to close" either, landing in the unknown bucket.

Added isExpiration detection and a t.type === 'transfer' safety net so all transfer-type transactions (expirations, exercises, assignments) are classified as closes. Also added type/subtype to the API response for downstream commit processing.

https://claude.ai/code/session_01MVDHUQHAXD2XkiKhVAmZvc