### PR TITLE
feat: uniform TICKER-XXXX trade ID format across all trade types

### DIFF
--- a/src/app/api/investment-transactions/max-trade-num/route.ts
+++ b/src/app/api/investment-transactions/max-trade-num/route.ts
@@ -2,6 +2,14 @@ import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 
+// Extract the numeric portion from both "42" (legacy) and "OKTA-0042" (TICKER-XXXX) formats
+function extractTradeNumber(tradeNum: string): number {
+  const match = tradeNum.match(/-(\d+)$/);
+  if (match) return parseInt(match[1], 10);
+  const num = parseInt(tradeNum, 10);
+  return isNaN(num) ? 0 : num;
+}
+
 export async function GET() {
   try {
     const userEmail = await getVerifiedEmail();
@@ -13,7 +21,7 @@ export async function GET() {
     if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
 
     // Get all trade numbers and find the max numerically
-    // (tradeNum is stored as string, so we can't use orderBy for numeric sorting)
+    // Supports both legacy "42" and new "OKTA-0042" (TICKER-XXXX) formats
     const results = await prisma.investment_transactions.findMany({
       where: {
         tradeNum: { not: null },
@@ -28,8 +36,8 @@ export async function GET() {
     let maxTradeNum = 0;
     for (const r of results) {
       if (r.tradeNum) {
-        const num = parseInt(r.tradeNum, 10);
-        if (!isNaN(num) && num > maxTradeNum) {
+        const num = extractTradeNumber(r.tradeNum);
+        if (num > maxTradeNum) {
           maxTradeNum = num;
         }
       }

--- a/src/app/api/stock-lots/commit/route.ts
+++ b/src/app/api/stock-lots/commit/route.ts
@@ -191,16 +191,18 @@ export async function POST(request: Request) {
         }
       });
 
-      // Get next trade number
+      // Get next trade number in TICKER-XXXX format
       const maxResult = await tx.investment_transactions.findMany({
         where: { tradeNum: { not: null }, accounts: { userId: user.id } },
         select: { tradeNum: true }
       });
       const maxNum = maxResult.reduce((max, t) => {
-        const num = parseInt(t.tradeNum || '0', 10);
-        return num > max ? num : max;
+        const raw = t.tradeNum || '0';
+        const match = raw.match(/-(\d+)$/);
+        const num = match ? parseInt(match[1], 10) : parseInt(raw, 10);
+        return (isNaN(num) ? 0 : num) > max ? (isNaN(num) ? 0 : num) : max;
       }, 0);
-      const tradeNum = String(maxNum + 1);
+      const tradeNum = `${symbol.toUpperCase()}-${String(maxNum + 1).padStart(4, '0')}`;
 
       // Create journal entry for the sale
       const TRADING_CASH = '1010';

--- a/src/app/api/stock-lots/route.ts
+++ b/src/app/api/stock-lots/route.ts
@@ -84,20 +84,6 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: 'Entity not found or not owned by user' }, { status: 404 });
     }
 
-    // Get next trade number if not provided
-    let actualTradeNum = tradeNum;
-    if (!actualTradeNum) {
-      const maxResult = await prisma.investment_transactions.findMany({
-        where: { tradeNum: { not: null }, accounts: { userId: user.id } },
-        select: { tradeNum: true }
-      });
-      const maxNum = maxResult.reduce((max, t) => {
-        const num = parseInt(t.tradeNum || '0', 10);
-        return num > max ? num : max;
-      }, 0);
-      actualTradeNum = String(maxNum + 1);
-    }
-
     // Fetch the investment transactions
     const transactions = await prisma.investment_transactions.findMany({
       where: { id: { in: transactionIds }, accounts: { userId: user.id } },
@@ -135,6 +121,27 @@ export async function POST(request: Request) {
         error: `${alreadyCommitted.length} transaction(s) already committed`,
         alreadyCommitted: alreadyCommitted.map(t => ({ id: t.id, tradeNum: t.tradeNum }))
       }, { status: 400 });
+    }
+
+    // Get next trade number if not provided (TICKER-XXXX format)
+    let actualTradeNum = tradeNum;
+    if (!actualTradeNum) {
+      const maxResult = await prisma.investment_transactions.findMany({
+        where: { tradeNum: { not: null }, accounts: { userId: user.id } },
+        select: { tradeNum: true }
+      });
+      const maxNum = maxResult.reduce((max, t) => {
+        const raw = t.tradeNum || '0';
+        const match = raw.match(/-(\d+)$/);
+        const num = match ? parseInt(match[1], 10) : parseInt(raw, 10);
+        return (isNaN(num) ? 0 : num) > max ? (isNaN(num) ? 0 : num) : max;
+      }, 0);
+      // Derive ticker from the first transaction's security
+      const firstTxn = transactions[0];
+      const ticker = (firstTxn.security?.ticker_symbol ||
+                     firstTxn.security?.option_underlying_ticker ||
+                     extractSymbol(firstTxn.name)).toUpperCase();
+      actualTradeNum = `${ticker}-${String(maxNum + 1).padStart(4, '0')}`;
     }
 
     // Transform to legs format

--- a/src/components/dashboard/OpensCommitPanel.tsx
+++ b/src/components/dashboard/OpensCommitPanel.tsx
@@ -184,6 +184,7 @@ export default function OpensCommitPanel({ onReload }: OpensCommitPanelProps) {
       const committedRes = await fetch('/api/investment-transactions/max-trade-num');
       const committedData = await committedRes.json();
       setNextTradeNum((committedData.maxTradeNum || 0) + 1);
+
       
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to fetch opens');
@@ -218,17 +219,20 @@ export default function OpensCommitPanel({ onReload }: OpensCommitPanelProps) {
 
     setCommitStatus({ loading: true, message: 'Starting commit...' });
     
-    let currentTradeNum = nextTradeNum;
+    let currentNum = nextTradeNum;
     let committed = 0;
     const errors: string[] = [];
+    const committedTradeNums: string[] = [];
 
     for (const group of confirmedGroups) {
+      const ticker = (group.underlying || 'UNKNOWN').toUpperCase();
+      const formattedTradeNum = `${ticker}-${String(currentNum).padStart(4, '0')}`;
       try {
         const transactionIds = group.legs.map(l => l.id);
-        
-        setCommitStatus({ 
-          loading: true, 
-          message: `Committing Trade #${currentTradeNum}: ${group.underlying} ${group.selectedStrategy}...` 
+
+        setCommitStatus({
+          loading: true,
+          message: `Committing ${formattedTradeNum}: ${group.underlying} ${group.selectedStrategy}...`
         });
 
         const res = await fetch('/api/investment-transactions/commit-to-ledger', {
@@ -238,27 +242,28 @@ export default function OpensCommitPanel({ onReload }: OpensCommitPanelProps) {
             transactionIds,
             accountCode: 'T-1210',
             strategy: group.selectedStrategy,
-            tradeNum: String(currentTradeNum),
+            tradeNum: formattedTradeNum,
           }),
         });
 
         const result = await res.json();
-        
+
         if (result.success) {
           committed++;
-          currentTradeNum++;
+          committedTradeNums.push(formattedTradeNum);
+          currentNum++;
         } else {
-          errors.push(`Trade #${currentTradeNum} (${group.underlying}): ${result.error}`);
+          errors.push(`${formattedTradeNum} (${group.underlying}): ${result.error}`);
         }
       } catch (err) {
-        errors.push(`Trade #${currentTradeNum} (${group.underlying}): ${err instanceof Error ? err.message : 'Unknown error'}`);
+        errors.push(`${formattedTradeNum} (${group.underlying}): ${err instanceof Error ? err.message : 'Unknown error'}`);
       }
     }
 
     setCommitStatus(null);
-    
+
     if (errors.length === 0) {
-      alert(`✅ Successfully committed ${committed} trades (Trade #${nextTradeNum} - #${currentTradeNum - 1})`);
+      alert(`✅ Successfully committed ${committed} trades (${committedTradeNums[0]} to ${committedTradeNums[committedTradeNums.length - 1]})`);
     } else {
       alert(`⚠️ Committed ${committed}/${confirmedGroups.length} trades.\n\nErrors:\n${errors.join('\n')}`);
     }

--- a/src/components/dashboard/TradeCommitQueue.tsx
+++ b/src/components/dashboard/TradeCommitQueue.tsx
@@ -99,7 +99,6 @@ export default function TradeCommitQueue({ onReload }: TradeCommitQueueProps) {
       
       setTransactions(all);
       setNextTradeNum((maxData.maxTradeNum || 0) + 1);
-      setTradeNum(String((maxData.maxTradeNum || 0) + 1));
       
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load');
@@ -158,6 +157,20 @@ export default function TradeCommitQueue({ onReload }: TradeCommitQueueProps) {
     return selectedTransactions.reduce((sum, t) => sum + (t.amount || 0), 0);
   }, [selectedTransactions]);
 
+  // Derive ticker from selected transactions for TICKER-XXXX format
+  const selectedTicker = useMemo(() => {
+    if (selectedTransactions.length === 0) return '';
+    const first = selectedTransactions[0];
+    return (first.underlying || first.ticker || 'UNKNOWN').toUpperCase();
+  }, [selectedTransactions]);
+
+  // Auto-populate tradeNum in TICKER-XXXX format when selection or number changes
+  useEffect(() => {
+    if (selectedTicker) {
+      setTradeNum(`${selectedTicker}-${String(nextTradeNum).padStart(4, '0')}`);
+    }
+  }, [selectedTicker, nextTradeNum]);
+
   const commitTrade = async () => {
     if (selectedIds.size === 0) {
       alert('Select transactions to commit');
@@ -188,10 +201,10 @@ export default function TradeCommitQueue({ onReload }: TradeCommitQueueProps) {
       const result = await res.json();
       
       if (result.success) {
-        alert(`✅ Committed Trade #${tradeNum} (${selectedIds.size} legs)`);
+        alert(`✅ Committed Trade ${tradeNum} (${selectedIds.size} legs)`);
         setSelectedIds(new Set());
         setStrategy('');
-        setTradeNum(String(Number(tradeNum) + 1));
+        setNextTradeNum(prev => prev + 1);
         await fetchData();
         await onReload();
       } else {
@@ -267,8 +280,8 @@ export default function TradeCommitQueue({ onReload }: TradeCommitQueueProps) {
                   type="text"
                   value={tradeNum}
                   onChange={e => setTradeNum(e.target.value)}
-                  placeholder="#"
-                  className="border rounded px-2 py-1 text-sm w-16 text-center"
+                  placeholder="TICK-0001"
+                  className="border rounded px-2 py-1 text-sm w-32 text-center font-mono"
                 />
                 
                 <button

--- a/src/components/dashboard/TradeCommitWorkflow.tsx
+++ b/src/components/dashboard/TradeCommitWorkflow.tsx
@@ -213,7 +213,6 @@ export default function TradeCommitWorkflow({ onReload }: TradeCommitWorkflowPro
       setCorporateActions(corpActionsData.actions || []);
       
       setNextTradeNum((maxData.maxTradeNum || 0) + 1);
-      setTradeNum(String((maxData.maxTradeNum || 0) + 1));
       
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load');
@@ -274,6 +273,20 @@ export default function TradeCommitWorkflow({ onReload }: TradeCommitWorkflowPro
     return selectedTransactions.reduce((sum, t) => sum + (t.amount || 0), 0);
   }, [selectedTransactions]);
 
+  // Derive ticker from selected transactions for TICKER-XXXX format
+  const selectedTicker = useMemo(() => {
+    if (selectedTransactions.length === 0) return '';
+    const first = selectedTransactions[0];
+    return (first.underlying || first.ticker || 'UNKNOWN').toUpperCase();
+  }, [selectedTransactions]);
+
+  // Auto-populate tradeNum in TICKER-XXXX format when selection or number changes
+  useEffect(() => {
+    if (selectedTicker) {
+      setTradeNum(`${selectedTicker}-${String(nextTradeNum).padStart(4, '0')}`);
+    }
+  }, [selectedTicker, nextTradeNum]);
+
   // Commit OPENS
   const commitOpens = async () => {
     if (selectedIds.size === 0) return alert('Select transactions to commit');
@@ -301,9 +314,9 @@ export default function TradeCommitWorkflow({ onReload }: TradeCommitWorkflowPro
       
       if (result.success) {
         const skippedCount = result.details?.skipped?.length || 0;
-        alert(`✅ Trade #${tradeNum} OPENED (${result.committed} legs)${skippedCount > 0 ? `\n⚠️ ${skippedCount} skipped` : ''}`);
+        alert(`✅ Trade ${tradeNum} OPENED (${result.committed} legs)${skippedCount > 0 ? `\n⚠️ ${skippedCount} skipped` : ''}`);
         clearSelection();
-        setTradeNum(String(Number(tradeNum) + 1));
+        setNextTradeNum(prev => prev + 1);
         await fetchData();
         await onReload();
       } else {
@@ -333,9 +346,12 @@ export default function TradeCommitWorkflow({ onReload }: TradeCommitWorkflowPro
       const result = await res.json();
       
       if (result.success) {
-        alert(`✅ Trade #${result.tradeNum}: Created ${result.committed} stock lot(s) with journal entries`);
+        alert(`✅ Trade ${result.tradeNum}: Created ${result.committed} stock lot(s) with journal entries`);
         clearSelection();
-        setTradeNum(String(Number(result.tradeNum) + 1));
+        // Extract number from returned TICKER-XXXX and increment
+        const match = (result.tradeNum || '').match(/-(\d+)$/);
+        const returnedNum = match ? parseInt(match[1], 10) : parseInt(result.tradeNum || '0', 10);
+        setNextTradeNum(returnedNum + 1);
         await fetchData();
         await onReload();
       } else {
@@ -607,8 +623,8 @@ export default function TradeCommitWorkflow({ onReload }: TradeCommitWorkflowPro
                     type="text"
                     value={tradeNum}
                     onChange={e => setTradeNum(e.target.value)}
-                    placeholder="Trade #"
-                    className="border rounded px-3 py-2 text-sm w-20 text-center"
+                    placeholder="TICK-0001"
+                    className="border rounded px-3 py-2 text-sm w-32 text-center font-mono"
                   />
                   <button
                     onClick={commitOpens}


### PR DESCRIPTION
Trade numbers now use format like SPY-0003, OKTA-0001 instead of plain sequential integers. Backward compatible with existing numeric trade IDs.

- max-trade-num API: parses both "42" and "OKTA-0042" formats
- stock-lots/commit: generates TICKER-XXXX from symbol
- stock-lots POST: generates TICKER-XXXX from transaction security
- TradeCommitWorkflow: auto-populates TICKER-XXXX from selected ticker
- OpensCommitPanel: constructs TICKER-XXXX per group underlying
- TradeCommitQueue: auto-populates TICKER-XXXX from selected ticker

https://claude.ai/code/session_01MVDHUQHAXD2XkiKhVAmZvc