### PR TITLE
fix: scope trading entity resolution to entity_type=trading in commit…

### DIFF
--- a/src/app/api/investment-transactions/commit-to-ledger/route.ts
+++ b/src/app/api/investment-transactions/commit-to-ledger/route.ts
@@ -30,7 +30,7 @@ export async function POST(request: Request) {
     let resolvedEntityId = entityId;
     if (!resolvedEntityId) {
       const tradingAccount = await prisma.chart_of_accounts.findFirst({
-        where: { userId: user.id, code: '1200' },
+        where: { userId: user.id, code: '1200', entity: { entity_type: 'trading' } },
         select: { entity_id: true },
       });
       if (!tradingAccount?.entity_id) {


### PR DESCRIPTION
…-to-ledger

The findFirst for COA code 1200 was unscoped by entity_type, so when a user had both a personal and trading entity with code 1200, it could resolve to the wrong entity. Subsequent lookups for put account codes (1210, 2110) then failed with "Account codes not found" because the personal entity doesn't have them.

Adds entity: { entity_type: 'trading' } filter to the findFirst query.

https://claude.ai/code/session_01G3wmws3SMsURWZUXsqp27H