### PR TITLE
fix: populate created_by on journal and ledger entries for SOC 2 auth…

### DIFF
--- a/src/app/api/investment-transactions/commit-to-ledger/route.ts
+++ b/src/app/api/investment-transactions/commit-to-ledger/route.ts
@@ -108,7 +108,8 @@ export async function POST(request: Request) {
           tradeNum,
           userId: user.id,
           entityId: resolvedEntityId,
-          tx
+          tx,
+          createdBy: userEmail,
         });
       },
       {

--- a/src/app/api/investments/assignment-exercise/route.ts
+++ b/src/app/api/investments/assignment-exercise/route.ts
@@ -61,7 +61,8 @@ export async function POST(request: Request) {
         strategy: strategy || 'ITM Spread Expiration',
         tradeNum: tradeNum || 'AUTO',
         userId: user.id,
-        entityId
+        entityId,
+        createdBy: userEmail,
       });
 
       results.push(result);

--- a/src/app/api/stock-lots/route.ts
+++ b/src/app/api/stock-lots/route.ts
@@ -170,7 +170,8 @@ export async function POST(request: Request) {
           tradeNum: actualTradeNum,
           userId: user.id,
           entityId,
-          tx
+          tx,
+          createdBy: userEmail,
         });
       },
       { maxWait: 30000, timeout: 120000 }

--- a/src/app/api/transactions/commit-to-ledger/route.ts
+++ b/src/app/api/transactions/commit-to-ledger/route.ts
@@ -98,6 +98,7 @@ export async function POST(request: NextRequest) {
           description: plaidTxn.name,
           merchantName: plaidTxn.merchantName || undefined,
           requestId,
+          createdBy: userEmail,
         });
 
         // Track whether the user overrode the auto-categorization prediction

--- a/src/app/api/transactions/uncommit/route.ts
+++ b/src/app/api/transactions/uncommit/route.ts
@@ -66,6 +66,7 @@ export async function POST(request: Request) {
           journalEntryId: originalEntry.id,
           transactionId: txn.transactionId,
           requestId,
+          createdBy: userEmail,
         });
 
         results.push({

--- a/src/lib/journal-entry-service.ts
+++ b/src/lib/journal-entry-service.ts
@@ -13,6 +13,7 @@ interface CommitPlaidTransactionParams {
   description: string;
   merchantName?: string;
   requestId?: string;
+  createdBy?: string;
 }
 
 interface ReversePlaidTransactionParams {
@@ -20,6 +21,7 @@ interface ReversePlaidTransactionParams {
   journalEntryId: string;
   transactionId: string;
   requestId?: string;
+  createdBy?: string;
 }
 
 function dollarsToCents(amount: number): bigint {
@@ -45,6 +47,7 @@ export async function commitPlaidTransaction(
     amount,
     description,
     requestId,
+    createdBy,
   } = params;
 
   return prisma.$transaction(async (tx: Tx) => {
@@ -93,6 +96,7 @@ export async function commitPlaidTransaction(
         source_id: transactionId,
         status: 'posted',
         request_id: requestId,
+        created_by: createdBy || null,
       },
     });
 
@@ -103,6 +107,7 @@ export async function commitPlaidTransaction(
         account_id: debitAccountId,
         entry_type: 'D',
         amount: amountCents,
+        created_by: createdBy || null,
       },
     });
 
@@ -113,6 +118,7 @@ export async function commitPlaidTransaction(
         account_id: creditAccountId,
         entry_type: 'C',
         amount: amountCents,
+        created_by: createdBy || null,
       },
     });
 
@@ -151,7 +157,7 @@ export async function reversePlaidTransaction(
   prisma: PrismaClient,
   params: ReversePlaidTransactionParams
 ) {
-  const { userId, journalEntryId, transactionId, requestId } = params;
+  const { userId, journalEntryId, transactionId, requestId, createdBy } = params;
 
   return prisma.$transaction(async (tx: Tx) => {
     // Look up original journal entry with its ledger entries and linked accounts
@@ -195,6 +201,7 @@ export async function reversePlaidTransaction(
         is_reversal: true,
         reverses_entry_id: original.id,
         request_id: requestId,
+        created_by: createdBy || null,
       },
     });
 
@@ -208,6 +215,7 @@ export async function reversePlaidTransaction(
           account_id: entry.account_id,
           entry_type: oppositeType,
           amount: entry.amount,
+          created_by: createdBy || null,
         },
       });
 

--- a/src/lib/position-tracker-service.ts
+++ b/src/lib/position-tracker-service.ts
@@ -30,8 +30,9 @@ export class PositionTrackerService {
     userId: string;
     entityId: string;
     tx?: TransactionContext;
+    createdBy?: string;
   }) {
-    const { legs, strategy, tradeNum, userId, entityId, tx } = params;
+    const { legs, strategy, tradeNum, userId, entityId, tx, createdBy } = params;
     const db = tx || prisma;
     const results = [];
     const skipped = [];
@@ -42,7 +43,7 @@ export class PositionTrackerService {
     for (const leg of legs) {
       if (leg.positionEffect === 'open') {
         console.log(`  [OPEN] ${leg.symbol} $${leg.strike} ${leg.contractType} ${leg.expiry?.toLocaleDateString()}`);
-        const result = await this.openPosition(leg, strategy, tradeNum, userId, entityId, db);
+        const result = await this.openPosition(leg, strategy, tradeNum, userId, entityId, db, createdBy);
         results.push(result);
       }
     }
@@ -61,7 +62,7 @@ export class PositionTrackerService {
       // This handles spread closes where multiple positions close together via stock
       // settlement, and expirations where positions expire worthless.
       console.log(`  [ATOMIC CLOSE] ${closeLegs.length} legs for Trade #${tradeNum}`);
-      const spreadResult = await this.closeSpreadAtomically(closeLegs, strategy, tradeNum, userId, entityId, db);
+      const spreadResult = await this.closeSpreadAtomically(closeLegs, strategy, tradeNum, userId, entityId, db, createdBy);
       results.push(...spreadResult.results);
       skipped.push(...spreadResult.skipped);
     } else {
@@ -98,7 +99,8 @@ export class PositionTrackerService {
             tradeNum,
             userId,
             entityId,
-            db
+            db,
+            createdBy
           );
           results.push(result);
         }
@@ -133,7 +135,8 @@ export class PositionTrackerService {
     tradeNum: string,
     userId: string,
     entityId: string,
-    db: TransactionContext
+    db: TransactionContext,
+    createdBy?: string
   ) {
     const TRADING_CASH = '1010';
     const multiplier = 100;
@@ -162,7 +165,7 @@ export class PositionTrackerService {
       date: leg.date,
       description: `OPEN ${positionType}: ${leg.symbol} ${leg.strike} ${leg.contractType?.toUpperCase()} ${leg.expiry?.toLocaleDateString()}`,
       lines, externalTransactionId: leg.id, strategy, tradeNum, amount: costBasis,
-      userId, entityId, db
+      userId, entityId, db, createdBy
     });
     await db.trading_positions.create({
       data: {
@@ -181,7 +184,8 @@ export class PositionTrackerService {
     tradeNum: string,
     userId: string,
     entityId: string,
-    db: TransactionContext
+    db: TransactionContext,
+    createdBy?: string
   ) {
     const TRADING_CASH = '1010';
 
@@ -296,7 +300,7 @@ export class PositionTrackerService {
       date: leg.date,
       description: `${isFullClose ? 'CLOSE' : 'PARTIAL CLOSE'} ${openPosition.position_type}: ${closeQty}x ${leg.symbol} ${leg.strike} ${leg.contractType?.toUpperCase()} - ${isGain ? 'GAIN' : 'LOSS'} $${(Math.abs(realizedPL) / 100).toFixed(2)}`,
       lines, externalTransactionId: leg.id, strategy, tradeNum, amount: proceeds,
-      userId, entityId, db
+      userId, entityId, db, createdBy
     });
 
     // Update position with new remaining quantity
@@ -357,7 +361,8 @@ export class PositionTrackerService {
     tradeNum: string,
     userId: string,
     entityId: string,
-    db: TransactionContext
+    db: TransactionContext,
+    createdBy?: string
   ): Promise<{ results: any[]; skipped: any[] }> {
     const TRADING_CASH = '1010';
     const results: any[] = [];
@@ -475,7 +480,8 @@ export class PositionTrackerService {
       amount: Math.abs(realizedPLCents),
       userId,
       entityId,
-      db
+      db,
+      createdBy
     });
 
     console.log(`  [ATOMIC] Journal entry ${journalEntry.id}: ${description}`);
@@ -576,9 +582,9 @@ export class PositionTrackerService {
     date: Date; description: string;
     lines: Array<{ accountCode: string; amount: number; entryType: 'D' | 'C' }>;
     externalTransactionId?: string; strategy?: string; tradeNum?: string; amount?: number;
-    userId: string; entityId: string; db: TransactionContext; requestId?: string;
+    userId: string; entityId: string; db: TransactionContext; requestId?: string; createdBy?: string;
   }) {
-    const { date, description, lines, externalTransactionId, strategy, tradeNum, userId, entityId, db, requestId } = params;
+    const { date, description, lines, externalTransactionId, strategy, tradeNum, userId, entityId, db, requestId, createdBy } = params;
     const debits = lines.filter(l => l.entryType === 'D').reduce((sum, l) => sum + l.amount, 0);
     const credits = lines.filter(l => l.entryType === 'C').reduce((sum, l) => sum + l.amount, 0);
     if (debits !== credits) throw new Error(`Unbalanced entry: debits=${debits} credits=${credits}`);
@@ -603,6 +609,7 @@ export class PositionTrackerService {
         status: 'posted',
         metadata: (strategy || tradeNum) ? { strategy, trade_num: tradeNum } : undefined,
         request_id: requestId || randomUUID(),
+        created_by: createdBy || null,
       }
     });
 
@@ -614,7 +621,8 @@ export class PositionTrackerService {
           journal_entry_id: journalEntry.id,
           account_id: account.id,
           amount: BigInt(line.amount),
-          entry_type: line.entryType
+          entry_type: line.entryType,
+          created_by: createdBy || null,
         }
       });
       const balanceChange = line.entryType === account.balance_type ? BigInt(line.amount) : BigInt(-line.amount);
@@ -631,9 +639,9 @@ export class PositionTrackerService {
   }
 
   async handleAssignmentExercise(params: {
-    exerciseTransfer: any; stockTransaction: any; strategy: string; tradeNum: string; userId: string; entityId: string;
+    exerciseTransfer: any; stockTransaction: any; strategy: string; tradeNum: string; userId: string; entityId: string; createdBy?: string;
   }) {
-    const { exerciseTransfer, stockTransaction, strategy, tradeNum, userId, entityId } = params;
+    const { exerciseTransfer, stockTransaction, strategy, tradeNum, userId, entityId, createdBy } = params;
     const nameMatch = exerciseTransfer.name.match(/(\d+\.?\d*)\s*call|put/i);
     const strike = nameMatch ? parseFloat(nameMatch[1]) : null;
     if (!strike) throw new Error(`Cannot extract strike from: ${exerciseTransfer.name}`);
@@ -663,7 +671,7 @@ export class PositionTrackerService {
       date: exerciseTransfer.date,
       description: `${isExercise ? 'EXERCISE' : 'ASSIGNMENT'}: ${symbol} $${strike} ${openPosition.option_type}`,
       lines, externalTransactionId: exerciseTransfer.id, strategy, tradeNum, amount: originalCost,
-      userId, entityId, db: prisma
+      userId, entityId, db: prisma, createdBy
     });
     await prisma.trading_positions.update({
       where: { id: openPosition.id },
@@ -696,8 +704,9 @@ export class PositionTrackerService {
     userId: string;
     entityId: string;
     tx?: TransactionContext;
+    createdBy?: string;
   }) {
-    const { legs, strategy, tradeNum, userId, entityId, tx } = params;
+    const { legs, strategy, tradeNum, userId, entityId, tx, createdBy } = params;
     const db = tx || prisma;
     const results = [];
     const TRADING_CASH = '1010';
@@ -736,7 +745,7 @@ export class PositionTrackerService {
           strategy,
           tradeNum,
           amount: costBasis,
-          userId, entityId, db
+          userId, entityId, db, createdBy
         });
 
         // Update investment transaction


### PR DESCRIPTION
…orization

Thread the authenticated user's email through all commit paths so that journal_entries.created_by and ledger_entries.created_by are populated instead of being left null.

Services changed:
- position-tracker-service: createJournalEntry, commitOptionsTrade, openPosition, closePosition, closeSpreadAtomically, handleAssignmentExercise, commitStockTrade all accept createdBy
- journal-entry-service: commitPlaidTransaction and reversePlaidTransaction accept createdBy and write it to both journal_entries and ledger_entries

Routes updated to pass userEmail:
- investment-transactions/commit-to-ledger
- transactions/commit-to-ledger
- transactions/uncommit
- investments/assignment-exercise
- stock-lots

https://claude.ai/code/session_01G3wmws3SMsURWZUXsqp27H