### PR TITLE
feat(ui): terminal density for SpendingTab and CommittedInvestmentsTable

### DIFF
--- a/src/components/dashboard/CommittedInvestmentsTable.tsx
+++ b/src/components/dashboard/CommittedInvestmentsTable.tsx
@@ -301,11 +301,11 @@ function InvColumnFilterDropdown({
     <div ref={panelRef} className="fixed bg-white border border-gray-200 rounded-lg shadow-xl z-[100] w-64" style={panelStyle}>
       <div className="border-b border-gray-100 p-2 space-y-1">
         <button onClick={() => { onSortWithDir(field, 'asc'); onCancel(); }}
-          className={`w-full text-left px-2 py-1.5 text-xs rounded hover:bg-gray-50 flex items-center gap-2 ${isSortedAsc ? 'text-[#2d1b4e] font-semibold bg-[#2d1b4e]/5' : 'text-gray-600'}`}>
+          className={`w-full text-left px-2 py-1.5 text-xs rounded hover:bg-gray-50 flex items-center gap-2 ${isSortedAsc ? 'text-brand-purple-deep font-semibold bg-brand-purple-deep/5' : 'text-gray-600'}`}>
           <span className="text-[10px]">{'\u25B2'}</span> {sortAscLabel}
         </button>
         <button onClick={() => { onSortWithDir(field, 'desc'); onCancel(); }}
-          className={`w-full text-left px-2 py-1.5 text-xs rounded hover:bg-gray-50 flex items-center gap-2 ${isSortedDesc ? 'text-[#2d1b4e] font-semibold bg-[#2d1b4e]/5' : 'text-gray-600'}`}>
+          className={`w-full text-left px-2 py-1.5 text-xs rounded hover:bg-gray-50 flex items-center gap-2 ${isSortedDesc ? 'text-brand-purple-deep font-semibold bg-brand-purple-deep/5' : 'text-gray-600'}`}>
           <span className="text-[10px]">{'\u25BC'}</span> {sortDescLabel}
         </button>
       </div>
@@ -316,10 +316,10 @@ function InvColumnFilterDropdown({
             {uniqueValues.length > 6 && (
               <input ref={searchRef} type="text" placeholder="Search..." value={localSearch}
                 onChange={e => setLocalSearch(e.target.value)}
-                className="w-full px-2 py-1.5 text-xs border rounded mb-2 outline-none focus:border-[#2d1b4e]" />
+                className="w-full px-2 py-1.5 text-xs border rounded mb-2 outline-none focus:border-brand-purple-deep" />
             )}
             <div className="flex items-center justify-between mb-1 px-1">
-              <button onClick={() => setLocalSelected(new Set(filteredValues.map(([v]) => v)))} className="text-[10px] text-[#2d1b4e] hover:underline">Select All</button>
+              <button onClick={() => setLocalSelected(new Set(filteredValues.map(([v]) => v)))} className="text-[10px] text-brand-purple-deep hover:underline">Select All</button>
               <button onClick={() => setLocalSelected(new Set())} className="text-[10px] text-red-500 hover:underline">Clear All</button>
             </div>
             <div className="max-h-[300px] overflow-auto border rounded">
@@ -340,25 +340,25 @@ function InvColumnFilterDropdown({
         {filterType === 'dateRange' && (
           <div className="space-y-2">
             <div><label className="block text-[10px] text-gray-500 mb-1">From</label>
-              <input ref={searchRef} type="date" value={localFrom} onChange={e => setLocalFrom(e.target.value)} className="w-full px-2 py-1.5 text-xs border rounded outline-none focus:border-[#2d1b4e]" /></div>
+              <input ref={searchRef} type="date" value={localFrom} onChange={e => setLocalFrom(e.target.value)} className="w-full px-2 py-1.5 text-xs border rounded outline-none focus:border-brand-purple-deep" /></div>
             <div><label className="block text-[10px] text-gray-500 mb-1">To</label>
-              <input type="date" value={localTo} onChange={e => setLocalTo(e.target.value)} className="w-full px-2 py-1.5 text-xs border rounded outline-none focus:border-[#2d1b4e]" /></div>
+              <input type="date" value={localTo} onChange={e => setLocalTo(e.target.value)} className="w-full px-2 py-1.5 text-xs border rounded outline-none focus:border-brand-purple-deep" /></div>
           </div>
         )}
 
         {filterType === 'amountRange' && (
           <div className="space-y-2">
             <div><label className="block text-[10px] text-gray-500 mb-1">Min</label>
-              <input ref={searchRef} type="number" placeholder="0" value={localMin} onChange={e => setLocalMin(e.target.value)} className="w-full px-2 py-1.5 text-xs border rounded outline-none focus:border-[#2d1b4e]" /></div>
+              <input ref={searchRef} type="number" placeholder="0" value={localMin} onChange={e => setLocalMin(e.target.value)} className="w-full px-2 py-1.5 text-xs border rounded outline-none focus:border-brand-purple-deep" /></div>
             <div><label className="block text-[10px] text-gray-500 mb-1">Max</label>
-              <input type="number" placeholder="999999" value={localMax} onChange={e => setLocalMax(e.target.value)} className="w-full px-2 py-1.5 text-xs border rounded outline-none focus:border-[#2d1b4e]" /></div>
+              <input type="number" placeholder="999999" value={localMax} onChange={e => setLocalMax(e.target.value)} className="w-full px-2 py-1.5 text-xs border rounded outline-none focus:border-brand-purple-deep" /></div>
           </div>
         )}
 
         {filterType === 'search' && (
           <input ref={searchRef} type="text" placeholder="Search..." value={localTerm}
             onChange={e => setLocalTerm(e.target.value)}
-            className="w-full px-2 py-1.5 text-xs border rounded outline-none focus:border-[#2d1b4e]" />
+            className="w-full px-2 py-1.5 text-xs border rounded outline-none focus:border-brand-purple-deep" />
         )}
       </div>
 
@@ -366,7 +366,7 @@ function InvColumnFilterDropdown({
         <button onClick={() => onApply(undefined)} className="text-[10px] text-red-500 hover:underline">Clear</button>
         <div className="flex gap-2">
           <button onClick={onCancel} className="px-3 py-1 text-xs border rounded hover:bg-gray-50">Cancel</button>
-          <button onClick={handleApply} className="px-3 py-1 text-xs bg-[#2d1b4e] text-white rounded hover:bg-[#3d2b5e]">Apply</button>
+          <button onClick={handleApply} className="px-3 py-1 text-xs bg-brand-purple-deep text-white rounded hover:bg-brand-purple-hover">Apply</button>
         </div>
       </div>
     </div>,
@@ -397,14 +397,14 @@ function InvFilterableHeader({
   const hasFilter = !!columnFilter;
 
   return (
-    <th className={`px-2 py-2.5 text-xs font-semibold select-none ${className || ''}`}>
+    <th className={`px-2 py-1 text-terminal-xs font-semibold font-mono uppercase tracking-widest select-none ${className || ''}`}>
       <span className="flex items-center gap-0.5">
         <span className="cursor-pointer hover:underline truncate" onClick={() => onSort(field)}>
           {label}
-          {isSortActive && <span className="text-[10px] ml-0.5">{sortDir === 'asc' ? '\u25B2' : '\u25BC'}</span>}
+          {isSortActive && <span className="text-[8px] ml-0.5">{sortDir === 'asc' ? '\u25B2' : '\u25BC'}</span>}
         </span>
         <button ref={btnRef} onClick={e => { e.stopPropagation(); setOpen(!open); }}
-          className={`ml-auto w-4 h-4 flex items-center justify-center rounded text-[9px] flex-shrink-0 ${
+          className={`ml-auto w-3.5 h-3.5 flex items-center justify-center rounded text-[8px] flex-shrink-0 ${
             hasFilter ? 'text-amber-400 bg-amber-400/20' : 'text-white/40 hover:text-white/80 hover:bg-white/10'
           }`}>
           {'\u25BC'}
@@ -441,7 +441,7 @@ export default function CommittedInvestmentsTable({
   massUncommitInvestments,
 }: CommittedInvestmentsTableProps) {
   const parentRef = useRef<HTMLDivElement>(null);
-  const ROW_HEIGHT = 44;
+  const ROW_HEIGHT = 30;
 
   // State
   const [search, setSearch] = useState('');
@@ -523,18 +523,18 @@ export default function CommittedInvestmentsTable({
   return (
     <div className="mt-6">
       {/* Header */}
-      <div className="bg-[#2d1b4e] text-white px-4 py-3 flex items-center justify-between">
+      <div className="bg-brand-purple-deep text-white px-3 py-1.5 flex items-center justify-between">
         <div>
-          <h3 className="text-sm font-semibold">Committed Investment Transactions</h3>
-          <p className="text-[10px] text-gray-300 font-mono">
-            {filtered.length === txns.length ? txns.length : `${filtered.length} of ${txns.length}`} transactions
-            {selectedCommittedInvestments.length > 0 && ` \u00B7 ${selectedCommittedInvestments.length} selected`}
+          <h3 className="text-terminal-base font-mono font-semibold">Committed Investment Transactions</h3>
+          <p className="text-terminal-xs text-white/50 font-mono">
+            {filtered.length === txns.length ? txns.length : `${filtered.length} of ${txns.length}`} txns
+            {selectedCommittedInvestments.length > 0 && ` \u00B7 ${selectedCommittedInvestments.length} sel`}
           </p>
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-1.5">
           {selectedCommittedInvestments.length > 0 && (
             <button onClick={massUncommitInvestments}
-              className="px-3 py-1.5 bg-red-500 hover:bg-red-600 text-white text-xs font-medium rounded transition-colors">
+              className="px-2 py-1 bg-brand-red hover:bg-red-600 text-white text-terminal-sm font-mono font-medium rounded transition-colors">
               Uncommit ({selectedCommittedInvestments.length})
             </button>
           )}
@@ -542,18 +542,18 @@ export default function CommittedInvestmentsTable({
       </div>
 
       {/* Search + filter pills */}
-      <div className="bg-gray-50 border-x border-gray-200 px-4 py-2 space-y-2">
-        <div className="flex items-center gap-2">
+      <div className="bg-bg-terminal border-x border-border px-3 py-1.5 space-y-1.5">
+        <div className="flex items-center gap-1.5">
           <input
             type="text"
             placeholder="Search symbol, name, strategy, COA, trade#..."
             value={search}
             onChange={e => setSearch(e.target.value)}
-            className="flex-1 px-3 py-1.5 text-xs border border-gray-200 rounded-lg outline-none focus:border-[#2d1b4e] focus:ring-1 focus:ring-[#2d1b4e]"
+            className="flex-1 px-2 py-1 text-terminal-base font-mono border border-border rounded outline-none focus:border-brand-purple-deep focus:ring-1 focus:ring-brand-purple-deep"
           />
           {(search || activeColFilterCount > 0) && (
             <button onClick={() => { setSearch(''); setColumnFilters({}); }}
-              className="px-2 py-1.5 text-[10px] text-red-500 hover:text-red-700">
+              className="px-2 py-1 text-terminal-xs text-brand-red hover:text-red-700">
               Clear All
             </button>
           )}
@@ -582,43 +582,43 @@ export default function CommittedInvestmentsTable({
       </div>
 
       {/* Virtualized Table */}
-      <div ref={parentRef} className="overflow-auto border border-gray-200 border-t-0" style={{ maxHeight: '600px' }}>
+      <div ref={parentRef} className="overflow-auto border border-border border-t-0" style={{ maxHeight: '600px' }}>
         <table className="w-full text-xs border-collapse min-w-[1800px]">
-          <thead className="bg-[#2d1b4e] text-white sticky top-0 z-10">
+          <thead className="bg-brand-purple text-white/70 sticky top-0 z-10">
             <tr>
-              <th className="px-2 py-2.5 w-10 sticky left-0 bg-[#2d1b4e] z-20">
-                <input type="checkbox" checked={allSelected} onChange={toggleAll} className="w-3.5 h-3.5 rounded" />
+              <th className="px-2 py-1 w-10 sticky left-0 bg-brand-purple z-20">
+                <input type="checkbox" checked={allSelected} onChange={toggleAll} className="w-3 h-3 rounded" />
               </th>
               <InvFilterableHeader label="Date" field="date" sortField={sortField} sortDir={sortDir} onSort={handleSort}
                 filterType="dateRange" allTransactions={txns} columnFilter={columnFilters.date} onApplyColumnFilter={handleApplyColumnFilter} className="w-24" />
-              <InvFilterableHeader label="Symbol" field="symbol" sortField={sortField} sortDir={sortDir} onSort={handleSort}
+              <InvFilterableHeader label="Sym" field="symbol" sortField={sortField} sortDir={sortDir} onSort={handleSort}
                 filterType="checkbox" allTransactions={txns} columnFilter={columnFilters.symbol} onApplyColumnFilter={handleApplyColumnFilter} className="w-20" />
-              <InvFilterableHeader label="Action" field="action" sortField={sortField} sortDir={sortDir} onSort={handleSort}
+              <InvFilterableHeader label="Act" field="action" sortField={sortField} sortDir={sortDir} onSort={handleSort}
                 filterType="checkbox" allTransactions={txns} columnFilter={columnFilters.action} onApplyColumnFilter={handleApplyColumnFilter} className="w-20" />
-              <InvFilterableHeader label="Description" field="name" sortField={sortField} sortDir={sortDir} onSort={handleSort}
+              <InvFilterableHeader label="Desc" field="name" sortField={sortField} sortDir={sortDir} onSort={handleSort}
                 filterType="search" allTransactions={txns} columnFilter={columnFilters.name} onApplyColumnFilter={handleApplyColumnFilter} className="min-w-[180px]" />
               <InvFilterableHeader label="Qty" field="quantity" sortField={sortField} sortDir={sortDir} onSort={handleSort}
                 filterType="amountRange" allTransactions={txns} columnFilter={columnFilters.quantity} onApplyColumnFilter={handleApplyColumnFilter} className="w-16 text-right" />
               <InvFilterableHeader label="Price" field="price" sortField={sortField} sortDir={sortDir} onSort={handleSort}
                 filterType="amountRange" allTransactions={txns} columnFilter={columnFilters.price} onApplyColumnFilter={handleApplyColumnFilter} className="w-20 text-right" />
-              <InvFilterableHeader label="Amount" field="amount" sortField={sortField} sortDir={sortDir} onSort={handleSort}
+              <InvFilterableHeader label="Amt" field="amount" sortField={sortField} sortDir={sortDir} onSort={handleSort}
                 filterType="amountRange" allTransactions={txns} columnFilter={columnFilters.amount} onApplyColumnFilter={handleApplyColumnFilter} className="w-24 text-right" />
               <InvFilterableHeader label="Fees" field="fees" sortField={sortField} sortDir={sortDir} onSort={handleSort}
                 filterType="amountRange" allTransactions={txns} columnFilter={columnFilters.fees} onApplyColumnFilter={handleApplyColumnFilter} className="w-16 text-right" />
-              <InvFilterableHeader label="Strategy" field="strategy" sortField={sortField} sortDir={sortDir} onSort={handleSort}
+              <InvFilterableHeader label="Strat" field="strategy" sortField={sortField} sortDir={sortDir} onSort={handleSort}
                 filterType="checkbox" allTransactions={txns} columnFilter={columnFilters.strategy} onApplyColumnFilter={handleApplyColumnFilter} className="w-28" />
               <InvFilterableHeader label="COA" field="accountCode" sortField={sortField} sortDir={sortDir} onSort={handleSort}
                 filterType="checkbox" allTransactions={txns} columnFilter={columnFilters.accountCode} onApplyColumnFilter={handleApplyColumnFilter} className="w-20" />
-              <InvFilterableHeader label="Trade #" field="tradeNum" sortField={sortField} sortDir={sortDir} onSort={handleSort}
+              <InvFilterableHeader label="Trd#" field="tradeNum" sortField={sortField} sortDir={sortDir} onSort={handleSort}
                 filterType="checkbox" allTransactions={txns} columnFilter={columnFilters.tradeNum} onApplyColumnFilter={handleApplyColumnFilter} className="w-16 text-center" />
-              <th className="px-2 py-2.5 text-xs font-semibold w-20">JE ID</th>
-              <th className="px-2 py-2.5 text-xs font-semibold w-28">DR Acct</th>
-              <th className="px-2 py-2.5 text-xs font-semibold w-28">CR Acct</th>
-              <th className="px-2 py-2.5 text-xs font-semibold w-10 text-center">D=C</th>
-              <th className="px-2 py-2.5 text-xs font-semibold w-20">Entity</th>
-              <th className="px-2 py-2.5 text-xs font-semibold w-24">By</th>
-              <th className="px-2 py-2.5 text-xs font-semibold w-20">At</th>
-              <th className="px-2 py-2.5 text-xs font-semibold w-8 text-center" title="Trigger-enforced immutability">{'\uD83D\uDD12'}</th>
+              <th className="px-2 py-1 text-terminal-xs font-semibold font-mono uppercase tracking-widest w-20">JE ID</th>
+              <th className="px-2 py-1 text-terminal-xs font-semibold font-mono uppercase tracking-widest w-28">DR Acct</th>
+              <th className="px-2 py-1 text-terminal-xs font-semibold font-mono uppercase tracking-widest w-28">CR Acct</th>
+              <th className="px-2 py-1 text-terminal-xs font-semibold font-mono uppercase tracking-widest w-10 text-center">D=C</th>
+              <th className="px-2 py-1 text-terminal-xs font-semibold font-mono uppercase tracking-widest w-20">Entity</th>
+              <th className="px-2 py-1 text-terminal-xs font-semibold font-mono uppercase tracking-widest w-24">By</th>
+              <th className="px-2 py-1 text-terminal-xs font-semibold font-mono uppercase tracking-widest w-20">At</th>
+              <th className="px-2 py-1 text-terminal-xs font-semibold font-mono uppercase tracking-widest w-8 text-center" title="Trigger-enforced immutability">{'\uD83D\uDD12'}</th>
             </tr>
           </thead>
           <tbody>
@@ -634,28 +634,28 @@ export default function CommittedInvestmentsTable({
               const symbol = getSymbol(txn);
               const action = getAction(txn);
               const isOption = !!(txn.security?.option_contract_type);
-              const rowBg = isSelected ? 'bg-[#2d1b4e]/5' : vRow.index % 2 === 0 ? 'bg-white' : 'bg-gray-50/50';
+              const rowBg = isSelected ? 'bg-brand-purple-deep/5' : vRow.index % 2 === 0 ? 'bg-white' : 'bg-bg-row';
 
               return (
                 <tr key={txn.id} data-index={vRow.index}
-                  className={`${rowBg} hover:bg-[#2d1b4e]/[.07] transition-colors`}
+                  className={`${rowBg} hover:bg-brand-purple-deep/[.07] border-b border-border-light transition-colors`}
                   style={{ height: ROW_HEIGHT }}>
-                  <td className="px-2 py-1 sticky left-0 z-[5]" style={{ background: 'inherit' }}>
-                    <input type="checkbox" checked={isSelected} onChange={() => toggleOne(txn.id)} className="w-3.5 h-3.5 rounded" />
+                  <td className="py-1 px-2 sticky left-0 z-[5]" style={{ background: 'inherit' }}>
+                    <input type="checkbox" checked={isSelected} onChange={() => toggleOne(txn.id)} className="w-3 h-3 rounded" />
                   </td>
-                  <td className="px-2 py-1 text-gray-600 whitespace-nowrap font-mono">{formatDate(txn.date)}</td>
-                  <td className="px-2 py-1 font-medium text-gray-900">
+                  <td className="py-1 px-2 text-text-muted whitespace-nowrap font-mono text-terminal-base">{formatDate(txn.date)}</td>
+                  <td className="py-1 px-2 font-medium text-terminal-base">
                     {symbol}
                     {isOption && (
-                      <span className={`ml-1 text-[9px] px-1 py-0.5 rounded ${
+                      <span className={`ml-1 text-[8px] px-0.5 py-0 rounded ${
                         txn.security?.option_contract_type === 'call' ? 'bg-blue-50 text-blue-600' : 'bg-purple-50 text-purple-600'
                       }`}>
                         {txn.security?.option_contract_type?.toUpperCase()}
                       </span>
                     )}
                   </td>
-                  <td className="px-2 py-1">
-                    <span className={`text-[10px] font-medium px-1.5 py-0.5 rounded ${
+                  <td className="py-1 px-2">
+                    <span className={`text-terminal-xs font-medium px-1 py-0 rounded ${
                       action === 'BUY' ? 'bg-blue-100 text-blue-700' :
                       action === 'SELL' ? 'bg-orange-100 text-orange-700' :
                       action === 'EXERCISE' || action === 'ASSIGN' ? 'bg-purple-100 text-purple-700' :
@@ -666,50 +666,50 @@ export default function CommittedInvestmentsTable({
                       {action}
                     </span>
                   </td>
-                  <td className="px-2 py-1 text-gray-800 truncate" title={txn.name}>
+                  <td className="py-1 px-2 text-text-secondary text-terminal-sm truncate" title={txn.name}>
                     {txn.name}
                     {isOption && txn.security?.option_strike_price && (
-                      <span className="text-gray-400 ml-1 text-[10px]">
+                      <span className="text-text-faint ml-1 text-terminal-xs">
                         ${txn.security.option_strike_price} {txn.security.option_expiration_date ? new Date(txn.security.option_expiration_date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' }) : ''}
                       </span>
                     )}
                   </td>
-                  <td className="px-2 py-1 text-right font-mono text-gray-700">{txn.quantity != null ? Math.abs(txn.quantity) : '\u2014'}</td>
-                  <td className="px-2 py-1 text-right font-mono text-gray-700">{txn.price != null ? `$${txn.price.toFixed(2)}` : '\u2014'}</td>
-                  <td className="px-2 py-1 text-right font-mono font-medium whitespace-nowrap">
-                    <span className={(txn.amount || 0) > 0 ? 'text-red-700' : 'text-green-700'}>
+                  <td className="py-1 px-2 text-right font-mono text-terminal-base text-text-secondary">{txn.quantity != null ? Math.abs(txn.quantity) : '\u2014'}</td>
+                  <td className="py-1 px-2 text-right font-mono text-terminal-base text-text-secondary">{txn.price != null ? `$${txn.price.toFixed(2)}` : '\u2014'}</td>
+                  <td className="py-1 px-2 text-right font-mono font-semibold whitespace-nowrap text-terminal-base">
+                    <span className={(txn.amount || 0) > 0 ? 'text-brand-red' : 'text-brand-green'}>
                       {(txn.amount || 0) > 0 ? '-' : '+'}{formatMoney(txn.amount || 0)}
                     </span>
                   </td>
-                  <td className="px-2 py-1 text-right font-mono text-gray-500">{txn.fees ? `$${txn.fees.toFixed(2)}` : '\u2014'}</td>
-                  <td className="px-2 py-1 text-gray-700 truncate">{txn.strategy || '\u2014'}</td>
-                  <td className="px-2 py-1 font-mono text-green-700 text-[11px]">{txn.accountCode || '\u2014'}</td>
-                  <td className="px-2 py-1 text-center font-mono">{txn.tradeNum || '\u2014'}</td>
+                  <td className="py-1 px-2 text-right font-mono text-terminal-sm text-text-faint">{txn.fees ? `$${txn.fees.toFixed(2)}` : '\u2014'}</td>
+                  <td className="py-1 px-2 text-text-secondary text-terminal-sm truncate">{txn.strategy || '\u2014'}</td>
+                  <td className="py-1 px-2 font-mono text-brand-green text-terminal-sm">{txn.accountCode || '\u2014'}</td>
+                  <td className="py-1 px-2 text-center font-mono text-terminal-sm">{txn.tradeNum || '\u2014'}</td>
                   {/* JE Proof columns */}
                   {(() => {
                     const jp = txn.journalProof;
                     const balanced = isProofBalanced(jp);
                     return (
                       <>
-                        <td className="px-2 py-1 font-mono text-[10px] whitespace-nowrap" style={{ color: '#3b2d6b' }} title={jp?.jeId || ''}>
+                        <td className="py-1 px-2 font-mono text-terminal-sm whitespace-nowrap text-brand-purple" title={jp?.jeId || ''}>
                           {jp?.jeId ? jp.jeId.slice(0, 8) : '\u2014'}
                         </td>
-                        <td className="px-2 py-1 text-[10px] text-gray-700 truncate" title={getProofDrAccounts(jp)}>
+                        <td className="py-1 px-2 text-terminal-sm text-text-secondary truncate" title={getProofDrAccounts(jp)}>
                           {getProofDrAccounts(jp)}
                         </td>
-                        <td className="px-2 py-1 text-[10px] text-gray-700 truncate" title={getProofCrAccounts(jp)}>
+                        <td className="py-1 px-2 text-terminal-sm text-text-secondary truncate" title={getProofCrAccounts(jp)}>
                           {getProofCrAccounts(jp)}
                         </td>
-                        <td className="px-2 py-1 text-center text-[11px]">
-                          {balanced === null ? '\u2014' : balanced ? <span className="text-green-600 font-bold">{'\u2713'}</span> : <span className="text-red-600 font-bold">{'\u2717'}</span>}
+                        <td className="py-1 px-2 text-center text-terminal-base">
+                          {balanced === null ? '\u2014' : balanced ? <span className="text-brand-green font-bold">{'\u2713'}</span> : <span className="text-brand-red font-bold">{'\u2717'}</span>}
                         </td>
-                        <td className="px-2 py-1 text-[10px] text-gray-600 truncate">{jp?.entityName || '\u2014'}</td>
-                        <td className="px-2 py-1 text-[10px] text-gray-600 truncate" title={jp?.createdBy || ''}>
+                        <td className="py-1 px-2 text-terminal-sm text-text-muted truncate">{jp?.entityName || '\u2014'}</td>
+                        <td className="py-1 px-2 text-terminal-sm text-text-muted truncate" title={jp?.createdBy || ''}>
                           {jp?.createdBy || '\u2014'}
                         </td>
-                        <td className="px-2 py-1 text-[10px] text-gray-500 font-mono whitespace-nowrap">{formatProofDate(jp?.createdAt)}</td>
-                        <td className="px-2 py-1 text-center" title="Immutable (trigger-enforced)">
-                          <span style={{ color: '#b8960f' }}>{'\uD83D\uDD12'}</span>
+                        <td className="py-1 px-2 text-terminal-sm text-text-faint font-mono whitespace-nowrap">{formatProofDate(jp?.createdAt)}</td>
+                        <td className="py-1 px-2 text-center" title="Immutable (trigger-enforced)">
+                          <span className="text-brand-gold">{'\uD83D\uDD12'}</span>
                         </td>
                       </>
                     );
@@ -728,16 +728,16 @@ export default function CommittedInvestmentsTable({
           </tbody>
         </table>
         {filtered.length === 0 && (
-          <div className="px-4 py-8 text-center text-gray-400 text-xs">
+          <div className="px-3 py-6 text-center text-text-faint text-terminal-sm">
             {search || activeColFilterCount > 0 ? 'No transactions match your filters.' : 'No committed investment transactions.'}
           </div>
         )}
       </div>
 
       {/* Footer summary */}
-      <div className="bg-gray-100 border border-gray-200 border-t-0 px-4 py-2 flex items-center justify-between text-xs">
-        <span className="text-gray-500">{filtered.length} row{filtered.length !== 1 ? 's' : ''}</span>
-        <span className="font-mono font-medium">
+      <div className="bg-bg-row border border-border border-t-0 px-3 py-1 flex items-center justify-between text-terminal-sm font-mono">
+        <span className="text-text-muted">{filtered.length} row{filtered.length !== 1 ? 's' : ''}</span>
+        <span className="font-semibold">
           Total: {formatMoney(filtered.reduce((s, t) => s + Math.abs(t.amount || 0), 0))}
         </span>
       </div>

--- a/src/components/dashboard/SpendingTab.tsx
+++ b/src/components/dashboard/SpendingTab.tsx
@@ -290,25 +290,25 @@ function MultiSelectFilter({ label, options, selected, onToggle }: {
     <div className="relative">
       <button
         onClick={() => setOpen(!open)}
-        className={`px-3 py-1.5 text-xs border rounded-lg flex items-center gap-1 transition-colors ${
-          selected.length > 0 ? 'bg-[#2d1b4e] text-white border-[#2d1b4e]' : 'bg-white hover:border-gray-400'
+        className={`px-2 py-1 text-terminal-sm font-mono border rounded flex items-center gap-1 transition-colors ${
+          selected.length > 0 ? 'bg-brand-purple-deep text-white border-brand-purple-deep' : 'bg-white hover:border-gray-400'
         }`}
       >
-        {label} {selected.length > 0 && <span className="px-1 py-0.5 bg-white/20 rounded text-[10px]">{selected.length}</span>}
-        <span className="text-[10px]">{open ? '▲' : '▼'}</span>
+        {label} {selected.length > 0 && <span className="px-1 py-0.5 bg-white/20 rounded text-[8px]">{selected.length}</span>}
+        <span className="text-[8px]">{open ? '▲' : '▼'}</span>
       </button>
       {open && (
-        <div className="absolute z-30 top-full mt-1 left-0 bg-white border border-gray-200 rounded-lg shadow-lg max-h-60 overflow-auto min-w-[200px]">
+        <div className="absolute z-30 top-full mt-1 left-0 bg-white border border-gray-200 rounded shadow-lg max-h-60 overflow-auto min-w-[200px]">
           {options.map(([val, count]) => (
-            <label key={val} className="flex items-center gap-2 px-3 py-1.5 hover:bg-gray-50 cursor-pointer text-xs">
+            <label key={val} className="flex items-center gap-2 px-2 py-1 hover:bg-gray-50 cursor-pointer text-terminal-sm">
               <input
                 type="checkbox"
                 checked={selected.includes(val)}
                 onChange={() => onToggle(val)}
-                className="w-3.5 h-3.5 rounded"
+                className="w-3 h-3 rounded"
               />
               <span className="truncate flex-1">{val}</span>
-              <span className="text-gray-400 text-[10px]">{count}</span>
+              <span className="text-text-faint text-terminal-xs">{count}</span>
             </label>
           ))}
         </div>
@@ -328,12 +328,12 @@ function SortHeader({ label, field, currentField, currentDir, onSort, className 
   const isActive = currentField === field;
   return (
     <th
-      className={`px-2 py-2.5 text-xs font-semibold cursor-pointer select-none hover:bg-[#3d2b5e] transition-colors ${className}`}
+      className={`px-2 py-1 text-terminal-xs font-semibold font-mono uppercase tracking-widest cursor-pointer select-none hover:bg-brand-purple-hover transition-colors ${className}`}
       onClick={() => onSort(field)}
     >
       <span className="flex items-center gap-1">
         {label}
-        {isActive && <span className="text-[10px]">{currentDir === 'asc' ? '▲' : '▼'}</span>}
+        {isActive && <span className="text-[8px]">{currentDir === 'asc' ? '▲' : '▼'}</span>}
       </span>
     </th>
   );
@@ -373,7 +373,7 @@ function CreateCoaModal({ onClose, onCreate }: {
   return (
     <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50 p-4" onClick={onClose}>
       <div className="bg-white rounded-lg shadow-xl w-full max-w-md" onClick={e => e.stopPropagation()}>
-        <div className="bg-[#2d1b4e] text-white px-4 py-3 rounded-t-lg flex items-center justify-between">
+        <div className="bg-brand-purple-deep text-white px-4 py-3 rounded-t-lg flex items-center justify-between">
           <span className="text-sm font-semibold">Create New COA Account</span>
           <button onClick={onClose} className="text-white/60 hover:text-white text-lg">×</button>
         </div>
@@ -551,13 +551,13 @@ function ColumnFilterDropdown({
       <div className="border-b border-gray-100 p-2 space-y-1">
         <button
           onClick={() => { onSortWithDir(field, 'asc'); onCancel(); }}
-          className={`w-full text-left px-2 py-1.5 text-xs rounded hover:bg-gray-50 flex items-center gap-2 ${isSortedAsc ? 'text-[#2d1b4e] font-semibold bg-[#2d1b4e]/5' : 'text-gray-600'}`}
+          className={`w-full text-left px-2 py-1.5 text-xs rounded hover:bg-gray-50 flex items-center gap-2 ${isSortedAsc ? 'text-brand-purple-deep font-semibold bg-brand-purple-deep/5' : 'text-gray-600'}`}
         >
           <span className="text-[10px]">{'\u25B2'}</span> {sortAscLabel}
         </button>
         <button
           onClick={() => { onSortWithDir(field, 'desc'); onCancel(); }}
-          className={`w-full text-left px-2 py-1.5 text-xs rounded hover:bg-gray-50 flex items-center gap-2 ${isSortedDesc ? 'text-[#2d1b4e] font-semibold bg-[#2d1b4e]/5' : 'text-gray-600'}`}
+          className={`w-full text-left px-2 py-1.5 text-xs rounded hover:bg-gray-50 flex items-center gap-2 ${isSortedDesc ? 'text-brand-purple-deep font-semibold bg-brand-purple-deep/5' : 'text-gray-600'}`}
         >
           <span className="text-[10px]">{'\u25BC'}</span> {sortDescLabel}
         </button>
@@ -574,11 +574,11 @@ function ColumnFilterDropdown({
                 placeholder="Search..."
                 value={localSearch}
                 onChange={e => setLocalSearch(e.target.value)}
-                className="w-full px-2 py-1.5 text-xs border rounded mb-2 outline-none focus:border-[#2d1b4e]"
+                className="w-full px-2 py-1.5 text-xs border rounded mb-2 outline-none focus:border-brand-purple-deep"
               />
             )}
             <div className="flex items-center justify-between mb-1 px-1">
-              <button onClick={() => setLocalSelected(new Set(filteredValues.map(([v]) => v)))} className="text-[10px] text-[#2d1b4e] hover:underline">Select All</button>
+              <button onClick={() => setLocalSelected(new Set(filteredValues.map(([v]) => v)))} className="text-[10px] text-brand-purple-deep hover:underline">Select All</button>
               <button onClick={() => setLocalSelected(new Set())} className="text-[10px] text-red-500 hover:underline">Clear All</button>
             </div>
             <div className="max-h-[300px] overflow-auto border rounded">
@@ -611,11 +611,11 @@ function ColumnFilterDropdown({
           <div className="space-y-2">
             <div>
               <label className="block text-[10px] text-gray-500 mb-1">From</label>
-              <input ref={searchRef} type="date" value={localFrom} onChange={e => setLocalFrom(e.target.value)} className="w-full px-2 py-1.5 text-xs border rounded outline-none focus:border-[#2d1b4e]" />
+              <input ref={searchRef} type="date" value={localFrom} onChange={e => setLocalFrom(e.target.value)} className="w-full px-2 py-1.5 text-xs border rounded outline-none focus:border-brand-purple-deep" />
             </div>
             <div>
               <label className="block text-[10px] text-gray-500 mb-1">To</label>
-              <input type="date" value={localTo} onChange={e => setLocalTo(e.target.value)} className="w-full px-2 py-1.5 text-xs border rounded outline-none focus:border-[#2d1b4e]" />
+              <input type="date" value={localTo} onChange={e => setLocalTo(e.target.value)} className="w-full px-2 py-1.5 text-xs border rounded outline-none focus:border-brand-purple-deep" />
             </div>
           </div>
         )}
@@ -624,17 +624,17 @@ function ColumnFilterDropdown({
           <div className="space-y-2">
             <div>
               <label className="block text-[10px] text-gray-500 mb-1">Min ($)</label>
-              <input ref={searchRef} type="number" placeholder="0.00" value={localMin} onChange={e => setLocalMin(e.target.value)} className="w-full px-2 py-1.5 text-xs border rounded outline-none focus:border-[#2d1b4e]" />
+              <input ref={searchRef} type="number" placeholder="0.00" value={localMin} onChange={e => setLocalMin(e.target.value)} className="w-full px-2 py-1.5 text-xs border rounded outline-none focus:border-brand-purple-deep" />
             </div>
             <div>
               <label className="block text-[10px] text-gray-500 mb-1">Max ($)</label>
-              <input type="number" placeholder="999999" value={localMax} onChange={e => setLocalMax(e.target.value)} className="w-full px-2 py-1.5 text-xs border rounded outline-none focus:border-[#2d1b4e]" />
+              <input type="number" placeholder="999999" value={localMax} onChange={e => setLocalMax(e.target.value)} className="w-full px-2 py-1.5 text-xs border rounded outline-none focus:border-brand-purple-deep" />
             </div>
           </div>
         )}
 
         {filterType === 'search' && (
-          <input ref={searchRef} type="text" placeholder="Search descriptions..." value={localTerm} onChange={e => setLocalTerm(e.target.value)} className="w-full px-2 py-1.5 text-xs border rounded outline-none focus:border-[#2d1b4e]" />
+          <input ref={searchRef} type="text" placeholder="Search descriptions..." value={localTerm} onChange={e => setLocalTerm(e.target.value)} className="w-full px-2 py-1.5 text-xs border rounded outline-none focus:border-brand-purple-deep" />
         )}
       </div>
 
@@ -643,7 +643,7 @@ function ColumnFilterDropdown({
         <button onClick={() => onApply(undefined)} className="text-[10px] text-red-500 hover:underline">Clear</button>
         <div className="flex gap-2">
           <button onClick={onCancel} className="px-3 py-1 text-xs border rounded hover:bg-gray-50">Cancel</button>
-          <button onClick={handleApply} className="px-3 py-1 text-xs bg-[#2d1b4e] text-white rounded hover:bg-[#3d2b5e]">Apply</button>
+          <button onClick={handleApply} className="px-3 py-1 text-xs bg-brand-purple-deep text-white rounded hover:bg-brand-purple-hover">Apply</button>
         </div>
       </div>
     </div>,
@@ -676,19 +676,19 @@ function FilterableHeader({
   const hasFilter = !!columnFilter;
 
   return (
-    <th className={`px-2 py-2.5 text-xs font-semibold select-none ${className || ''}`}>
+    <th className={`px-2 py-1 text-terminal-xs font-semibold font-mono uppercase tracking-widest select-none ${className || ''}`}>
       <span className="flex items-center gap-0.5">
         <span
           className="cursor-pointer hover:underline truncate"
           onClick={() => onSort(field)}
         >
           {label}
-          {isSortActive && <span className="text-[10px] ml-0.5">{sortDir === 'asc' ? '\u25B2' : '\u25BC'}</span>}
+          {isSortActive && <span className="text-[8px] ml-0.5">{sortDir === 'asc' ? '\u25B2' : '\u25BC'}</span>}
         </span>
         <button
           ref={btnRef}
           onClick={e => { e.stopPropagation(); setOpen(!open); }}
-          className={`ml-auto w-4 h-4 flex items-center justify-center rounded text-[9px] flex-shrink-0 ${
+          className={`ml-auto w-3.5 h-3.5 flex items-center justify-center rounded text-[8px] flex-shrink-0 ${
             hasFilter
               ? 'text-amber-400 bg-amber-400/20'
               : 'text-white/40 hover:text-white/80 hover:bg-white/10'
@@ -787,7 +787,7 @@ function VirtualTable({
   onApplyColumnFilter: (field: SortField, value: ColumnFilterValue | undefined) => void;
 }) {
   const parentRef = useRef<HTMLDivElement>(null);
-  const ROW_HEIGHT = 48;
+  const ROW_HEIGHT = 30;
 
   const virtualizer = useVirtualizer({
     count: rows.length,
@@ -825,28 +825,28 @@ function VirtualTable({
   return (
     <div ref={parentRef} className="overflow-auto" style={{ maxHeight: '600px' }}>
       <table className={`w-full text-xs border-collapse ${variant === 'committed' ? 'min-w-[1500px]' : 'min-w-[900px]'}`}>
-        <thead className="bg-[#2d1b4e] text-white sticky top-0 z-10">
+        <thead className="bg-brand-purple text-white/70 sticky top-0 z-10">
           <tr>
-            <th className="px-2 py-2.5 w-10 sticky left-0 bg-[#2d1b4e] z-20">
-              <input type="checkbox" checked={allSelected} onChange={toggleAll} className="w-3.5 h-3.5 rounded" />
+            <th className="px-2 py-1 w-10 sticky left-0 bg-brand-purple z-20">
+              <input type="checkbox" checked={allSelected} onChange={toggleAll} className="w-3 h-3 rounded" />
             </th>
             <FilterableHeader label="Date" field="date" sortField={sortField} sortDir={sortDir} onSort={onSort} filterType="dateRange" allTransactions={allTransactions} columnFilter={columnFilters.date} onApplyColumnFilter={onApplyColumnFilter} coaLookup={coaLookup} className="w-24" />
             <FilterableHeader label="Merchant" field="merchantName" sortField={sortField} sortDir={sortDir} onSort={onSort} filterType="checkbox" allTransactions={allTransactions} columnFilter={columnFilters.merchantName} onApplyColumnFilter={onApplyColumnFilter} coaLookup={coaLookup} className="min-w-[130px]" />
-            <FilterableHeader label="Description" field="name" sortField={sortField} sortDir={sortDir} onSort={onSort} filterType="search" allTransactions={allTransactions} columnFilter={columnFilters.name} onApplyColumnFilter={onApplyColumnFilter} coaLookup={coaLookup} className="min-w-[200px]" />
+            <FilterableHeader label="Desc" field="name" sortField={sortField} sortDir={sortDir} onSort={onSort} filterType="search" allTransactions={allTransactions} columnFilter={columnFilters.name} onApplyColumnFilter={onApplyColumnFilter} coaLookup={coaLookup} className="min-w-[200px]" />
             <FilterableHeader label="Amount" field="amount" sortField={sortField} sortDir={sortDir} onSort={onSort} filterType="amountRange" allTransactions={allTransactions} columnFilter={columnFilters.amount} onApplyColumnFilter={onApplyColumnFilter} coaLookup={coaLookup} className="w-24 text-right" />
             <FilterableHeader label="Account" field="accountName" sortField={sortField} sortDir={sortDir} onSort={onSort} filterType="checkbox" allTransactions={allTransactions} columnFilter={columnFilters.accountName} onApplyColumnFilter={onApplyColumnFilter} coaLookup={coaLookup} className="w-28" />
-            <FilterableHeader label="Institution" field="institutionName" sortField={sortField} sortDir={sortDir} onSort={onSort} filterType="checkbox" allTransactions={allTransactions} columnFilter={columnFilters.institutionName} onApplyColumnFilter={onApplyColumnFilter} coaLookup={coaLookup} className="w-28" />
-            <th className="px-2 py-2.5 text-xs font-semibold min-w-[180px]">COA</th>
+            <FilterableHeader label="Inst" field="institutionName" sortField={sortField} sortDir={sortDir} onSort={onSort} filterType="checkbox" allTransactions={allTransactions} columnFilter={columnFilters.institutionName} onApplyColumnFilter={onApplyColumnFilter} coaLookup={coaLookup} className="w-28" />
+            <th className="px-2 py-1 text-terminal-xs font-semibold font-mono uppercase tracking-widest min-w-[180px]">COA</th>
             {variant === 'committed' && (
               <>
-                <th className="px-2 py-2.5 text-xs font-semibold w-20">JE ID</th>
-                <th className="px-2 py-2.5 text-xs font-semibold w-28">DR Acct</th>
-                <th className="px-2 py-2.5 text-xs font-semibold w-28">CR Acct</th>
-                <th className="px-2 py-2.5 text-xs font-semibold w-10 text-center">D=C</th>
-                <th className="px-2 py-2.5 text-xs font-semibold w-20">Entity</th>
-                <th className="px-2 py-2.5 text-xs font-semibold w-24">By</th>
-                <th className="px-2 py-2.5 text-xs font-semibold w-20">At</th>
-                <th className="px-2 py-2.5 text-xs font-semibold w-8 text-center" title="Trigger-enforced immutability">{'\uD83D\uDD12'}</th>
+                <th className="px-2 py-1 text-terminal-xs font-semibold font-mono uppercase tracking-widest w-20">JE ID</th>
+                <th className="px-2 py-1 text-terminal-xs font-semibold font-mono uppercase tracking-widest w-28">DR Acct</th>
+                <th className="px-2 py-1 text-terminal-xs font-semibold font-mono uppercase tracking-widest w-28">CR Acct</th>
+                <th className="px-2 py-1 text-terminal-xs font-semibold font-mono uppercase tracking-widest w-10 text-center">D=C</th>
+                <th className="px-2 py-1 text-terminal-xs font-semibold font-mono uppercase tracking-widest w-20">Entity</th>
+                <th className="px-2 py-1 text-terminal-xs font-semibold font-mono uppercase tracking-widest w-24">By</th>
+                <th className="px-2 py-1 text-terminal-xs font-semibold font-mono uppercase tracking-widest w-20">At</th>
+                <th className="px-2 py-1 text-terminal-xs font-semibold font-mono uppercase tracking-widest w-8 text-center" title="Trigger-enforced immutability">{'\uD83D\uDD12'}</th>
               </>
             )}
           </tr>
@@ -862,50 +862,50 @@ function VirtualTable({
             const txn = rows[vRow.index];
             const isSelected = selected.has(txn.id);
             const rowBg = isSelected
-              ? 'bg-[#2d1b4e]/5'
+              ? 'bg-brand-purple-deep/5'
               : vRow.index % 2 === 0
                 ? 'bg-white'
-                : 'bg-gray-50/50';
+                : 'bg-bg-row';
 
             return (
               <tr
                 key={txn.id}
                 data-index={vRow.index}
-                className={`${rowBg} hover:bg-[#2d1b4e]/[.07] transition-colors`}
+                className={`${rowBg} hover:bg-brand-purple-deep/[.07] border-b border-border-light transition-colors`}
                 style={{ height: ROW_HEIGHT }}
               >
                 {/* Checkbox */}
-                <td className="px-2 py-1 sticky left-0 z-[5]" style={{ background: 'inherit' }}>
-                  <input type="checkbox" checked={isSelected} onChange={() => toggleOne(txn.id)} className="w-3.5 h-3.5 rounded" />
+                <td className="py-1 px-2 sticky left-0 z-[5]" style={{ background: 'inherit' }}>
+                  <input type="checkbox" checked={isSelected} onChange={() => toggleOne(txn.id)} className="w-3 h-3 rounded" />
                 </td>
                 {/* Date */}
-                <td className="px-2 py-1 text-gray-600 whitespace-nowrap font-mono">{formatDate(txn.date)}</td>
+                <td className="py-1 px-2 text-text-muted whitespace-nowrap font-mono text-terminal-base">{formatDate(txn.date)}</td>
                 {/* Merchant */}
-                <td className="px-2 py-1">
-                  <div className="flex items-center gap-1.5">
-                    {txn.logo_url && <img src={txn.logo_url} alt="" className="w-4 h-4 rounded-sm flex-shrink-0" />}
-                    <span className="truncate text-gray-900">{txn.merchantName || '\u2014'}</span>
+                <td className="py-1 px-2">
+                  <div className="flex items-center gap-1">
+                    {txn.logo_url && <img src={txn.logo_url} alt="" className="w-3.5 h-3.5 rounded-sm flex-shrink-0" />}
+                    <span className="truncate font-medium text-terminal-base">{txn.merchantName || '\u2014'}</span>
                   </div>
                 </td>
                 {/* Description */}
-                <td className="px-2 py-1 text-gray-800">{txn.name}</td>
+                <td className="py-1 px-2 text-text-secondary text-terminal-sm truncate">{txn.name}</td>
                 {/* Amount */}
-                <td className="px-2 py-1 text-right font-mono font-medium whitespace-nowrap">
-                  <span className={txn.amount > 0 ? 'text-red-700' : 'text-green-700'}>
+                <td className="py-1 px-2 text-right font-mono font-semibold whitespace-nowrap text-terminal-base">
+                  <span className={txn.amount > 0 ? 'text-brand-red' : 'text-brand-green'}>
                     {txn.amount > 0 ? '-' : '+'}{formatMoney(txn.amount)}
                   </span>
                 </td>
                 {/* Account */}
-                <td className="px-2 py-1 text-gray-600 truncate">{txn.accountName || '\u2014'}</td>
+                <td className="py-1 px-2 font-mono text-terminal-sm text-text-muted truncate">{txn.accountName || '\u2014'}</td>
                 {/* Institution */}
-                <td className="px-2 py-1 text-gray-600 truncate">{txn.institutionName || '\u2014'}</td>
+                <td className="py-1 px-2 font-mono text-terminal-sm text-text-muted truncate">{txn.institutionName || '\u2014'}</td>
                 {/* COA dropdown */}
-                <td className="px-2 py-1">
+                <td className="py-1 px-2">
                   {variant === 'pending' ? (
                     <select
                       value={rowChanges[txn.id]?.coa || ''}
                       onChange={e => setRowChanges(prev => ({ ...prev, [txn.id]: { ...(prev[txn.id] || { coa: '', sub: '' }), coa: e.target.value } }))}
-                      className="w-full text-[11px] border border-gray-200 rounded px-1.5 py-1 bg-white focus:border-[#2d1b4e] focus:ring-1 focus:ring-[#2d1b4e] outline-none"
+                      className="w-full text-terminal-sm font-mono border border-gray-200 rounded px-1 py-0.5 bg-white focus:border-brand-purple-deep focus:ring-1 focus:ring-brand-purple-deep outline-none"
                     >
                       <option value="">{txn.predicted_coa_code ? `${txn.predicted_coa_code} - ${coaLookup.get(txn.predicted_coa_code)?.name || 'Unknown'}` : 'Select...'}</option>
                       {Object.entries(coaGroupedByEntity).map(([entity, opts]) => (
@@ -916,10 +916,10 @@ function VirtualTable({
                       <option value="__NEW__">+ Add Category</option>
                     </select>
                   ) : (
-                    <span className="font-mono text-green-700 text-[11px]">
+                    <span className="font-mono text-brand-green text-terminal-sm">
                       {txn.accountCode}
                       {txn.accountCode && coaLookup.get(txn.accountCode) && (
-                        <span className="text-gray-400 ml-1">{coaLookup.get(txn.accountCode)!.name}</span>
+                        <span className="text-text-faint ml-1">{coaLookup.get(txn.accountCode)!.name}</span>
                       )}
                     </span>
                   )}
@@ -930,25 +930,25 @@ function VirtualTable({
                   const balanced = isProofBalanced(jp);
                   return (
                     <>
-                      <td className="px-2 py-1 font-mono text-[10px] whitespace-nowrap" style={{ color: '#3b2d6b' }} title={jp?.jeId || ''}>
+                      <td className="py-1 px-2 font-mono text-terminal-sm whitespace-nowrap text-brand-purple" title={jp?.jeId || ''}>
                         {jp?.jeId ? jp.jeId.slice(0, 8) : '\u2014'}
                       </td>
-                      <td className="px-2 py-1 text-[10px] text-gray-700 truncate" title={getProofDrAccounts(jp)}>
+                      <td className="py-1 px-2 text-terminal-sm text-text-secondary truncate" title={getProofDrAccounts(jp)}>
                         {getProofDrAccounts(jp)}
                       </td>
-                      <td className="px-2 py-1 text-[10px] text-gray-700 truncate" title={getProofCrAccounts(jp)}>
+                      <td className="py-1 px-2 text-terminal-sm text-text-secondary truncate" title={getProofCrAccounts(jp)}>
                         {getProofCrAccounts(jp)}
                       </td>
-                      <td className="px-2 py-1 text-center text-[11px]">
-                        {balanced === null ? '\u2014' : balanced ? <span className="text-green-600 font-bold">{'\u2713'}</span> : <span className="text-red-600 font-bold">{'\u2717'}</span>}
+                      <td className="py-1 px-2 text-center text-terminal-base">
+                        {balanced === null ? '\u2014' : balanced ? <span className="text-brand-green font-bold">{'\u2713'}</span> : <span className="text-brand-red font-bold">{'\u2717'}</span>}
                       </td>
-                      <td className="px-2 py-1 text-[10px] text-gray-600 truncate">{jp?.entityName || '\u2014'}</td>
-                      <td className="px-2 py-1 text-[10px] text-gray-600 truncate" title={jp?.createdBy || ''}>
+                      <td className="py-1 px-2 text-terminal-sm text-text-muted truncate">{jp?.entityName || '\u2014'}</td>
+                      <td className="py-1 px-2 text-terminal-sm text-text-muted truncate" title={jp?.createdBy || ''}>
                         {jp?.createdBy || '\u2014'}
                       </td>
-                      <td className="px-2 py-1 text-[10px] text-gray-500 font-mono whitespace-nowrap">{formatProofDate(jp?.createdAt)}</td>
-                      <td className="px-2 py-1 text-center" title="Immutable (trigger-enforced)">
-                        <span style={{ color: '#b8960f' }}>{'\uD83D\uDD12'}</span>
+                      <td className="py-1 px-2 text-terminal-sm text-text-faint font-mono whitespace-nowrap">{formatProofDate(jp?.createdAt)}</td>
+                      <td className="py-1 px-2 text-center" title="Immutable (trigger-enforced)">
+                        <span className="text-brand-gold">{'\uD83D\uDD12'}</span>
                       </td>
                     </>
                   );
@@ -1022,13 +1022,13 @@ function MerchantGroupTable({
   return (
     <div className="overflow-auto" style={{ maxHeight: '600px' }}>
       <table className="w-full text-xs border-collapse min-w-[1000px]">
-        <thead className="bg-[#2d1b4e] text-white sticky top-0 z-10">
+        <thead className="bg-brand-purple text-white/70 sticky top-0 z-10">
           <tr>
-            <th className="px-2 py-2.5 w-10"></th>
-            <th className="px-2 py-2.5 text-left font-semibold">Merchant</th>
-            <th className="px-2 py-2.5 text-right font-semibold w-16">Count</th>
-            <th className="px-2 py-2.5 text-right font-semibold w-28">Total</th>
-            <th className="px-2 py-2.5 text-left font-semibold min-w-[180px]">Batch COA</th>
+            <th className="px-2 py-1 w-10"></th>
+            <th className="px-2 py-1 text-left text-terminal-xs font-semibold font-mono uppercase tracking-widest">Merchant</th>
+            <th className="px-2 py-1 text-right text-terminal-xs font-semibold font-mono uppercase tracking-widest w-16">Count</th>
+            <th className="px-2 py-1 text-right text-terminal-xs font-semibold font-mono uppercase tracking-widest w-28">Total</th>
+            <th className="px-2 py-1 text-left text-terminal-xs font-semibold font-mono uppercase tracking-widest min-w-[180px]">Batch COA</th>
           </tr>
         </thead>
         <tbody>
@@ -1039,44 +1039,44 @@ function MerchantGroupTable({
 
             return (
               <Fragment key={merchant}>
-                <tr className="bg-gray-100 border-b border-gray-200 hover:bg-gray-200 cursor-pointer" onClick={() => toggleGroup(merchant)}>
-                  <td className="px-2 py-2" onClick={e => { e.stopPropagation(); selectGroup(txns, allSel); }}>
-                    <input type="checkbox" checked={allSel} onChange={() => selectGroup(txns, allSel)} className="w-3.5 h-3.5 rounded" />
+                <tr className="bg-bg-row border-b border-border-light hover:bg-gray-200 cursor-pointer" onClick={() => toggleGroup(merchant)}>
+                  <td className="px-2 py-1" onClick={e => { e.stopPropagation(); selectGroup(txns, allSel); }}>
+                    <input type="checkbox" checked={allSel} onChange={() => selectGroup(txns, allSel)} className="w-3 h-3 rounded" />
                   </td>
-                  <td className="px-2 py-2 font-medium text-gray-900">
-                    <span className="text-[10px] text-gray-400 mr-1.5">{isCollapsed ? '▶' : '▼'}</span>
+                  <td className="px-2 py-1 font-medium text-terminal-base">
+                    <span className="text-[8px] text-text-faint mr-1">{isCollapsed ? '▶' : '▼'}</span>
                     {merchant}
                   </td>
-                  <td className="px-2 py-2 text-right font-mono text-gray-600">{txns.length}</td>
-                  <td className="px-2 py-2 text-right font-mono font-medium">{formatMoney(total)}</td>
-                  <td className="px-2 py-2" onClick={e => e.stopPropagation()}>
+                  <td className="px-2 py-1 text-right font-mono text-text-muted text-terminal-base">{txns.length}</td>
+                  <td className="px-2 py-1 text-right font-mono font-semibold text-terminal-base">{formatMoney(total)}</td>
+                  <td className="px-2 py-1" onClick={e => e.stopPropagation()}>
                     {/* placeholder for group-level COA if needed */}
                   </td>
                 </tr>
                 {!isCollapsed && txns.map((txn, i) => (
-                  <tr key={txn.id} className={`${i % 2 === 0 ? 'bg-white' : 'bg-gray-50/50'} hover:bg-[#2d1b4e]/[.05]`}>
-                    <td className="px-2 py-1.5 pl-6">
+                  <tr key={txn.id} className={`${i % 2 === 0 ? 'bg-white' : 'bg-bg-row'} hover:bg-brand-purple-deep/[.05] border-b border-border-light`}>
+                    <td className="px-2 py-1 pl-6">
                       <input type="checkbox" checked={selected.has(txn.id)} onChange={() => setSelected(prev => {
                         const next = new Set(prev);
                         if (next.has(txn.id)) next.delete(txn.id); else next.add(txn.id);
                         return next;
-                      })} className="w-3.5 h-3.5 rounded" />
+                      })} className="w-3 h-3 rounded" />
                     </td>
-                    <td className="px-2 py-1.5 text-gray-600" colSpan={1}>
-                      <span className="font-mono text-gray-400 mr-2">{formatDate(txn.date)}</span>
+                    <td className="px-2 py-1 text-text-secondary text-terminal-sm" colSpan={1}>
+                      <span className="font-mono text-text-faint mr-2">{formatDate(txn.date)}</span>
                       {txn.name}
                     </td>
-                    <td className="px-2 py-1.5 text-right font-mono text-gray-500">{txn.personal_finance_category?.primary || ''}</td>
-                    <td className="px-2 py-1.5 text-right font-mono">
-                      <span className={txn.amount > 0 ? 'text-red-700' : 'text-green-700'}>
+                    <td className="px-2 py-1 text-right font-mono text-text-muted text-terminal-sm">{txn.personal_finance_category?.primary || ''}</td>
+                    <td className="px-2 py-1 text-right font-mono text-terminal-base">
+                      <span className={txn.amount > 0 ? 'text-brand-red' : 'text-brand-green'}>
                         {formatMoney(txn.amount)}
                       </span>
                     </td>
-                    <td className="px-2 py-1.5">
+                    <td className="px-2 py-1">
                       <select
                         value={rowChanges[txn.id]?.coa || ''}
                         onChange={e => setRowChanges(prev => ({ ...prev, [txn.id]: { ...(prev[txn.id] || { coa: '', sub: '' }), coa: e.target.value } }))}
-                        className="w-full text-[11px] border border-gray-200 rounded px-1.5 py-1 bg-white"
+                        className="w-full text-terminal-sm font-mono border border-gray-200 rounded px-1 py-0.5 bg-white"
                       >
                         <option value="">Select...</option>
                         {Object.entries(coaGroupedByEntity).map(([entity, opts]) => (
@@ -1341,10 +1341,10 @@ export default function SpendingTab({ transactions, committedTransactions, coaOp
   }
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-2">
       {/* Stats Row */}
-      <div className="flex items-center justify-between flex-wrap gap-2">
-        <div className="flex items-center gap-2">
+      <div className="flex items-center justify-between flex-wrap gap-1.5">
+        <div className="flex items-center gap-1.5">
           <Badge variant="warning">{transactions.length} pending</Badge>
           <Badge variant="success">{committedTransactions.length} committed</Badge>
           {(hasActiveFilters(pendingFilters) || hasPendingColFilters) && activeTable === 'pending' && (
@@ -1354,13 +1354,13 @@ export default function SpendingTab({ transactions, committedTransactions, coaOp
             <Badge variant="info">Showing {committedRows.length} of {committedTransactions.length}</Badge>
           )}
           {hasPendingColFilters && activeTable === 'pending' && (
-            <Badge variant="warning">{pendingColFilterCount} column filter{pendingColFilterCount !== 1 ? 's' : ''}</Badge>
+            <Badge variant="warning">{pendingColFilterCount} col filter{pendingColFilterCount !== 1 ? 's' : ''}</Badge>
           )}
           {hasCommittedColFilters && activeTable === 'committed' && (
-            <Badge variant="warning">{committedColFilterCount} column filter{committedColFilterCount !== 1 ? 's' : ''}</Badge>
+            <Badge variant="warning">{committedColFilterCount} col filter{committedColFilterCount !== 1 ? 's' : ''}</Badge>
           )}
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-1.5">
           {rowsWithCoa > 0 && (
             <Button size="sm" loading={committing} onClick={handleRowCommit}>
               Commit {rowsWithCoa} Row{rowsWithCoa !== 1 ? 's' : ''}
@@ -1368,13 +1368,13 @@ export default function SpendingTab({ transactions, committedTransactions, coaOp
           )}
           <button
             onClick={() => setViewMode(viewMode === 'flat' ? 'merchant' : 'flat')}
-            className={`px-3 py-1.5 text-xs border rounded-lg transition-colors ${viewMode === 'merchant' ? 'bg-[#2d1b4e] text-white border-[#2d1b4e]' : 'bg-white hover:border-gray-400'}`}
+            className={`px-2 py-1 text-terminal-sm font-mono border rounded transition-colors ${viewMode === 'merchant' ? 'bg-brand-purple-deep text-white border-brand-purple-deep' : 'bg-white hover:border-gray-400'}`}
           >
             {viewMode === 'flat' ? 'Group by Merchant' : 'Flat View'}
           </button>
           <button
             onClick={() => setShowFilters(!showFilters)}
-            className={`px-3 py-1.5 text-xs border rounded-lg transition-colors ${showFilters ? 'bg-[#2d1b4e] text-white border-[#2d1b4e]' : 'bg-white hover:border-gray-400'}`}
+            className={`px-2 py-1 text-terminal-sm font-mono border rounded transition-colors ${showFilters ? 'bg-brand-purple-deep text-white border-brand-purple-deep' : 'bg-white hover:border-gray-400'}`}
           >
             Filters
           </button>
@@ -1383,15 +1383,15 @@ export default function SpendingTab({ transactions, committedTransactions, coaOp
 
       {/* Filter Bar */}
       {showFilters && (
-        <div className="p-3 bg-gray-50 border rounded-lg space-y-3">
-          <div className="flex flex-wrap gap-2 items-center">
+        <div className="p-2 bg-bg-terminal border border-border rounded space-y-2">
+          <div className="flex flex-wrap gap-1.5 items-center">
             {/* Search */}
             <input
               type="text"
               placeholder="Search name, merchant, category..."
               value={pendingFilters.search}
               onChange={e => setPendingFilters(prev => ({ ...prev, search: e.target.value }))}
-              className="flex-1 min-w-[200px] px-3 py-1.5 text-xs border rounded-lg bg-white focus:border-[#2d1b4e] focus:ring-1 focus:ring-[#2d1b4e] outline-none"
+              className="flex-1 min-w-[200px] px-2 py-1 text-terminal-base font-mono border rounded bg-white focus:border-brand-purple-deep focus:ring-1 focus:ring-brand-purple-deep outline-none"
             />
             {/* Multi-selects */}
             <MultiSelectFilter
@@ -1452,7 +1452,7 @@ export default function SpendingTab({ transactions, committedTransactions, coaOp
           {(hasActiveFilters(pendingFilters) || hasPendingColFilters) && (
             <div className="flex flex-wrap gap-1.5">
               {pendingFilters.search && (
-                <span className="inline-flex items-center gap-1 px-2 py-0.5 bg-[#2d1b4e]/10 text-[#2d1b4e] rounded-full text-[10px]">
+                <span className="inline-flex items-center gap-1 px-2 py-0.5 bg-brand-purple-deep/10 text-brand-purple-deep rounded-full text-[10px]">
                   Search: &quot;{pendingFilters.search}&quot;
                   <button onClick={() => removeFilterPill('search')} className="hover:text-red-500">{'\u00D7'}</button>
                 </span>
@@ -1499,23 +1499,23 @@ export default function SpendingTab({ transactions, committedTransactions, coaOp
       )}
 
       {/* Table Tabs */}
-      <div className="flex border-b border-gray-200">
+      <div className="flex border-b border-border">
         <button
           onClick={() => setActiveTable('pending')}
-          className={`px-4 py-2 text-xs font-medium border-b-2 transition-colors ${
+          className={`px-3 py-1 text-terminal-base font-mono font-medium border-b-2 transition-colors ${
             activeTable === 'pending'
-              ? 'border-amber-500 text-amber-700 bg-amber-50'
-              : 'border-transparent text-gray-500 hover:text-gray-700'
+              ? 'border-brand-amber text-brand-amber'
+              : 'border-transparent text-text-muted hover:text-text-secondary'
           }`}
         >
           Pending ({pendingRows.length}{hasActiveFilters(pendingFilters) || hasPendingColFilters ? ` of ${transactions.length}` : ''})
         </button>
         <button
           onClick={() => setActiveTable('committed')}
-          className={`px-4 py-2 text-xs font-medium border-b-2 transition-colors ${
+          className={`px-3 py-1 text-terminal-base font-mono font-medium border-b-2 transition-colors ${
             activeTable === 'committed'
-              ? 'border-green-500 text-green-700 bg-green-50'
-              : 'border-transparent text-gray-500 hover:text-gray-700'
+              ? 'border-brand-green text-brand-green'
+              : 'border-transparent text-text-muted hover:text-text-secondary'
           }`}
         >
           Committed ({committedRows.length}{hasActiveFilters(committedFilters) || hasCommittedColFilters ? ` of ${committedTransactions.length}` : ''})
@@ -1535,7 +1535,7 @@ export default function SpendingTab({ transactions, committedTransactions, coaOp
               ) : (
                 <>
                   <p className="text-sm">No transactions match current filters</p>
-                  <button onClick={() => { setPendingFilters(EMPTY_FILTERS); setPendingColFilters(EMPTY_COL_FILTERS); }} className="text-xs text-[#2d1b4e] mt-2 underline">Clear filters</button>
+                  <button onClick={() => { setPendingFilters(EMPTY_FILTERS); setPendingColFilters(EMPTY_COL_FILTERS); }} className="text-xs text-brand-purple-deep mt-2 underline">Clear filters</button>
                 </>
               )}
             </div>
@@ -1576,19 +1576,19 @@ export default function SpendingTab({ transactions, committedTransactions, coaOp
       {activeTable === 'committed' && (
         <>
           {/* Committed filter bar */}
-          <div className="flex items-center gap-2 flex-wrap">
+          <div className="flex items-center gap-1.5 flex-wrap">
             <input
               type="text"
               placeholder="Search committed..."
               value={committedFilters.search}
               onChange={e => setCommittedFilters(prev => ({ ...prev, search: e.target.value }))}
-              className="flex-1 max-w-xs px-3 py-1.5 text-xs border rounded-lg bg-white focus:border-[#2d1b4e] outline-none"
+              className="flex-1 max-w-xs px-2 py-1 text-terminal-base font-mono border rounded bg-white focus:border-brand-purple-deep outline-none"
             />
             {hasActiveFilters(committedFilters) && (
-              <button onClick={() => setCommittedFilters(EMPTY_FILTERS)} className="text-xs text-red-500">Clear search</button>
+              <button onClick={() => setCommittedFilters(EMPTY_FILTERS)} className="text-terminal-sm text-brand-red">Clear search</button>
             )}
             {hasCommittedColFilters && (
-              <button onClick={() => setCommittedColFilters(EMPTY_COL_FILTERS)} className="text-xs text-amber-700 hover:text-red-500">Clear column filters</button>
+              <button onClick={() => setCommittedColFilters(EMPTY_COL_FILTERS)} className="text-terminal-sm text-brand-amber hover:text-brand-red">Clear column filters</button>
             )}
           </div>
           {/* Committed column filter pills */}
@@ -1630,10 +1630,10 @@ export default function SpendingTab({ transactions, committedTransactions, coaOp
 
       {/* Batch Commit Bar (sticky bottom when pending selected) */}
       {selectedPending.size > 0 && activeTable === 'pending' && (
-        <div className="sticky bottom-0 left-0 right-0 bg-[#2d1b4e] text-white p-3 rounded-lg shadow-lg z-20">
-          <div className="flex items-center gap-3 flex-wrap">
-            <span className="text-xs font-medium">
-              {selectedPending.size} transaction{selectedPending.size !== 1 ? 's' : ''} selected
+        <div className="sticky bottom-0 left-0 right-0 bg-brand-purple-deep text-white p-2 rounded shadow-lg z-20">
+          <div className="flex items-center gap-2 flex-wrap">
+            <span className="text-terminal-base font-mono font-medium">
+              {selectedPending.size} txn{selectedPending.size !== 1 ? 's' : ''}
               <span className="ml-1 text-white/60">({formatMoney(selectedPendingAmount)})</span>
             </span>
             <select
@@ -1642,7 +1642,7 @@ export default function SpendingTab({ transactions, committedTransactions, coaOp
                 if (e.target.value === '__NEW__') { setShowCreateCoa(true); return; }
                 setBatchCoa(e.target.value);
               }}
-              className="flex-1 min-w-[200px] bg-[#3d2b5e] text-white border-0 text-xs px-3 py-2 rounded"
+              className="flex-1 min-w-[200px] bg-brand-purple-hover text-white border-0 text-terminal-base font-mono px-2 py-1 rounded"
             >
               <option value="">Select COA...</option>
               {Object.entries(coaGroupedByEntity).map(([entity, opts]) => (
@@ -1654,10 +1654,10 @@ export default function SpendingTab({ transactions, committedTransactions, coaOp
             </select>
             <input
               type="text"
-              placeholder="Sub-account (optional)"
+              placeholder="Sub-account"
               value={batchSub}
               onChange={e => setBatchSub(e.target.value)}
-              className="w-40 bg-[#3d2b5e] text-white border-0 text-xs px-3 py-2 rounded placeholder-white/40"
+              className="w-32 bg-brand-purple-hover text-white border-0 text-terminal-base font-mono px-2 py-1 rounded placeholder-white/40"
             />
             <Button
               size="sm"
@@ -1666,11 +1666,11 @@ export default function SpendingTab({ transactions, committedTransactions, coaOp
               onClick={handleBatchCommit}
               className="!bg-green-500 hover:!bg-green-600 !text-white"
             >
-              Commit Selected
+              Commit
             </Button>
             <button
               onClick={() => setSelectedPending(new Set())}
-              className="text-white/60 hover:text-white text-xs underline"
+              className="text-white/60 hover:text-white text-terminal-sm underline"
             >
               Clear
             </button>
@@ -1680,10 +1680,10 @@ export default function SpendingTab({ transactions, committedTransactions, coaOp
 
       {/* Uncommit Bar (sticky bottom when committed selected) */}
       {selectedCommitted.size > 0 && activeTable === 'committed' && (
-        <div className="sticky bottom-0 left-0 right-0 bg-red-700 text-white p-3 rounded-lg shadow-lg z-20">
-          <div className="flex items-center gap-3">
-            <span className="text-xs font-medium">
-              {selectedCommitted.size} transaction{selectedCommitted.size !== 1 ? 's' : ''} selected for uncommit
+        <div className="sticky bottom-0 left-0 right-0 bg-brand-red text-white p-2 rounded shadow-lg z-20">
+          <div className="flex items-center gap-2">
+            <span className="text-terminal-base font-mono font-medium">
+              {selectedCommitted.size} txn{selectedCommitted.size !== 1 ? 's' : ''} to uncommit
             </span>
             <div className="flex-1" />
             <Button
@@ -1691,13 +1691,13 @@ export default function SpendingTab({ transactions, committedTransactions, coaOp
               variant="danger"
               loading={uncommitting}
               onClick={handleUncommit}
-              className="!bg-white !text-red-700 hover:!bg-red-50"
+              className="!bg-white !text-brand-red hover:!bg-red-50"
             >
-              Uncommit Selected
+              Uncommit
             </Button>
             <button
               onClick={() => setSelectedCommitted(new Set())}
-              className="text-white/60 hover:text-white text-xs underline"
+              className="text-white/60 hover:text-white text-terminal-sm underline"
             >
               Clear
             </button>


### PR DESCRIPTION
Replace all hardcoded hex colors with design tokens (bg-brand-purple, text-brand-purple-deep, text-brand-gold, etc.) — zero remaining hex literals in either component.

Table density changes:
- Row height: 48/44px → 30px
- Headers: text-terminal-xs, uppercase, tracking-widest, font-mono
- Data cells: text-terminal-base/sm with semantic text-text-muted/secondary/faint
- Amounts: font-mono font-semibold, text-brand-red/green
- Alternating rows: bg-bg-row instead of bg-gray-50
- Row borders: border-b border-border-light
- COA dropdowns: text-terminal-sm font-mono, tighter padding

Compact filter/toggle area:
- Buttons: px-2 py-1, text-terminal-sm font-mono
- Tabs: px-3 py-1, font-mono, brand token borders
- Search inputs: text-terminal-base font-mono
- Batch commit/uncommit bars: p-2, condensed labels

https://claude.ai/code/session_01L1KeynxpkMfJTynD9r8SKs