### PR TITLE
feat(ui): restyle shared UI components — terminal density

### DIFF
--- a/src/components/ui/Badge.tsx
+++ b/src/components/ui/Badge.tsx
@@ -11,15 +11,15 @@ interface BadgeProps {
 
 export default function Badge({ children, variant = 'default', size = 'md', className = '' }: BadgeProps) {
   const variants = {
-    default: 'bg-gray-100 text-gray-700',
-    success: 'bg-green-100 text-green-700',
-    warning: 'bg-amber-100 text-amber-700',
-    danger: 'bg-red-100 text-red-700',
-    info: 'bg-blue-100 text-blue-700',
-    gold: 'bg-[#2d1b4e]/10 text-[#8f8c2a]',
-    purple: 'bg-purple-100 text-purple-700',
+    default: 'bg-bg-row text-text-secondary',
+    success: 'bg-green-50 text-brand-green',
+    warning: 'bg-amber-50 text-brand-amber',
+    danger: 'bg-red-50 text-brand-red',
+    info: 'bg-blue-50 text-blue-700',
+    gold: 'bg-brand-gold-wash text-brand-gold font-mono',
+    purple: 'bg-brand-purple-wash text-brand-purple font-mono',
   };
-  const sizes = { sm: 'px-2 py-0.5 text-xs', md: 'px-2.5 py-1 text-xs' };
+  const sizes = { sm: 'px-1.5 py-0.5 text-terminal-xs', md: 'px-2 py-0.5 text-terminal-sm' };
 
-  return <span className={`inline-flex items-center font-semibold rounded-full ${variants[variant]} ${sizes[size]} ${className}`}>{children}</span>;
+  return <span className={`inline-flex items-center font-semibold rounded ${variants[variant]} ${sizes[size]} ${className}`}>{children}</span>;
 }

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -11,18 +11,18 @@ interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
 }
 
 export default function Button({ children, variant = 'primary', size = 'md', loading = false, icon, className = '', disabled, ...props }: ButtonProps) {
-  const baseStyles = 'inline-flex items-center justify-center font-medium rounded-lg transition-all focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed';
+  const baseStyles = 'inline-flex items-center justify-center font-medium rounded transition-all focus:outline-none focus:ring-2 focus:ring-offset-1 disabled:opacity-50 disabled:cursor-not-allowed';
   const variants = {
-    primary: 'bg-gray-900 text-white hover:bg-[#2d1b4e] focus:ring-[#b4b237] shadow-sm',
-    secondary: 'bg-white text-gray-900 border-2 border-gray-900 hover:border-[#2d1b4e] hover:text-[#2d1b4e] focus:ring-[#b4b237]',
-    ghost: 'text-gray-600 hover:bg-gray-100 hover:text-gray-900 focus:ring-gray-300',
-    danger: 'bg-red-600 text-white hover:bg-red-700 focus:ring-red-500',
+    primary: 'bg-brand-purple text-white hover:bg-brand-purple-hover focus:ring-brand-purple shadow-sm',
+    secondary: 'bg-white text-text-primary border border-border hover:bg-bg-row focus:ring-brand-purple',
+    ghost: 'text-text-muted hover:text-text-primary hover:bg-bg-row focus:ring-brand-purple',
+    danger: 'bg-brand-red text-white hover:bg-red-700 focus:ring-brand-red',
   };
-  const sizes = { sm: 'px-3 py-1.5 text-sm gap-1.5', md: 'px-4 py-2 text-sm gap-2', lg: 'px-6 py-3 text-base gap-2' };
+  const sizes = { sm: 'h-6 px-2 text-terminal-sm gap-1', md: 'h-7 px-3 text-terminal-base gap-1.5', lg: 'h-8 px-4 text-terminal-lg gap-2' };
 
   return (
     <button className={`${baseStyles} ${variants[variant]} ${sizes[size]} ${className}`} disabled={disabled || loading} {...props}>
-      {loading ? <div className="w-4 h-4 border-2 border-current border-t-transparent rounded-full animate-spin" /> : icon ? <span className="flex-shrink-0">{icon}</span> : null}
+      {loading ? <div className="w-3.5 h-3.5 border-2 border-current border-t-transparent rounded-full animate-spin" /> : icon ? <span className="flex-shrink-0">{icon}</span> : null}
       {children}
     </button>
   );

--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -13,17 +13,17 @@ interface CardProps {
 
 export default function Card({ children, title, subtitle, action, noPadding = false, className = '' }: CardProps) {
   return (
-    <div className={`bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden ${className}`}>
+    <div className={`bg-white rounded border border-border shadow-sm overflow-hidden ${className}`}>
       {(title || action) && (
-        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-100">
+        <div className="flex items-center justify-between px-3 py-2 border-b border-border">
           <div>
-            {title && <h3 className="font-semibold text-gray-900">{title}</h3>}
-            {subtitle && <p className="text-sm text-gray-500 mt-0.5">{subtitle}</p>}
+            {title && <h3 className="text-terminal-lg font-semibold text-text-primary">{title}</h3>}
+            {subtitle && <p className="text-terminal-sm text-text-muted mt-0.5">{subtitle}</p>}
           </div>
           {action && <div>{action}</div>}
         </div>
       )}
-      <div className={noPadding ? '' : 'p-6'}>{children}</div>
+      <div className={noPadding ? '' : 'p-3'}>{children}</div>
     </div>
   );
 }

--- a/src/components/ui/PageHeader.tsx
+++ b/src/components/ui/PageHeader.tsx
@@ -15,25 +15,25 @@ export default function PageHeader({ title, subtitle, backHref, actions, badge }
   const router = useRouter();
 
   return (
-    <div className="bg-white border-b border-gray-200">
-      <div className="px-4 lg:px-8 py-6">
+    <div className="bg-white border-b border-border">
+      <div className="px-4 lg:px-6 py-2">
         {backHref && (
-          <button onClick={() => router.push(backHref)} className="flex items-center gap-1 text-sm text-gray-500 hover:text-gray-900 mb-3 group">
-            <svg className="w-4 h-4 group-hover:-translate-x-1 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <button onClick={() => router.push(backHref)} className="flex items-center gap-1 text-terminal-sm text-text-muted hover:text-text-primary mb-1.5 group">
+            <svg className="w-3.5 h-3.5 group-hover:-translate-x-0.5 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
             </svg>
             Back
           </button>
         )}
-        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
           <div>
-            <div className="flex items-center gap-3">
-              <h1 className="text-2xl sm:text-3xl font-bold text-gray-900">{title}</h1>
+            <div className="flex items-center gap-2">
+              <h1 className="text-sm font-semibold text-text-primary font-mono">{title}</h1>
               {badge}
             </div>
-            {subtitle && <p className="text-gray-500 mt-1">{subtitle}</p>}
+            {subtitle && <p className="text-terminal-sm text-text-muted mt-0.5">{subtitle}</p>}
           </div>
-          {actions && <div className="flex items-center gap-3 flex-shrink-0">{actions}</div>}
+          {actions && <div className="flex items-center gap-2 flex-shrink-0">{actions}</div>}
         </div>
       </div>
     </div>

--- a/src/components/ui/ResponsiveTable.tsx
+++ b/src/components/ui/ResponsiveTable.tsx
@@ -9,11 +9,11 @@ interface ResponsiveTableProps {
   showLandscapeHint?: boolean;
 }
 
-export default function ResponsiveTable({ 
-  children, 
+export default function ResponsiveTable({
+  children,
   minWidth = '900px',
   maxHeight,
-  showLandscapeHint = true 
+  showLandscapeHint = true
 }: ResponsiveTableProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const [canScrollLeft, setCanScrollLeft] = useState(false);
@@ -62,41 +62,41 @@ export default function ResponsiveTable({
     <div className="relative">
       {/* Landscape hint for mobile */}
       {showLandscapeHint && !isLandscape && (
-        <div className="sm:hidden bg-[#b4b237]/10 border border-[#b4b237]/30 rounded-lg px-3 py-2 mb-3 flex items-center gap-2 text-sm">
-          <span className="text-lg">📱↔️</span>
-          <span className="text-[#8f8c2a]">Rotate for better view</span>
+        <div className="sm:hidden bg-brand-gold-wash border border-brand-gold/30 rounded px-2 py-1.5 mb-2 flex items-center gap-2 text-terminal-xs">
+          <span className="text-sm">📱↔️</span>
+          <span className="text-text-faint font-mono">Rotate for better view</span>
         </div>
       )}
 
       {/* Scroll shadow left */}
-      <div className={`absolute left-0 top-0 bottom-0 w-8 bg-gradient-to-r from-white to-transparent z-10 pointer-events-none transition-opacity ${canScrollLeft ? 'opacity-100' : 'opacity-0'}`} />
-      
+      <div className={`absolute left-0 top-0 bottom-0 w-6 bg-gradient-to-r from-white to-transparent z-10 pointer-events-none transition-opacity ${canScrollLeft ? 'opacity-100' : 'opacity-0'}`} />
+
       {/* Scroll shadow right */}
-      <div className={`absolute right-0 top-0 bottom-0 w-8 bg-gradient-to-l from-white to-transparent z-10 pointer-events-none transition-opacity ${canScrollRight ? 'opacity-100' : 'opacity-0'}`} />
+      <div className={`absolute right-0 top-0 bottom-0 w-6 bg-gradient-to-l from-white to-transparent z-10 pointer-events-none transition-opacity ${canScrollRight ? 'opacity-100' : 'opacity-0'}`} />
 
       {/* Scroll buttons - visible on touch devices when scrollable */}
       {canScrollLeft && (
-        <button 
+        <button
           onClick={() => scrollTo('left')}
-          className="absolute left-1 top-1/2 -translate-y-1/2 z-20 w-8 h-8 bg-white/90 border border-gray-200 rounded-full shadow-md flex items-center justify-center text-gray-600 hover:bg-gray-50 sm:hidden"
+          className="absolute left-1 top-1/2 -translate-y-1/2 z-20 w-6 h-6 bg-white/90 border border-border rounded shadow-sm flex items-center justify-center text-brand-purple hover:bg-bg-row sm:hidden text-terminal-sm"
         >
           ‹
         </button>
       )}
       {canScrollRight && (
-        <button 
+        <button
           onClick={() => scrollTo('right')}
-          className="absolute right-1 top-1/2 -translate-y-1/2 z-20 w-8 h-8 bg-white/90 border border-gray-200 rounded-full shadow-md flex items-center justify-center text-gray-600 hover:bg-gray-50 sm:hidden"
+          className="absolute right-1 top-1/2 -translate-y-1/2 z-20 w-6 h-6 bg-white/90 border border-border rounded shadow-sm flex items-center justify-center text-brand-purple hover:bg-bg-row sm:hidden text-terminal-sm"
         >
           ›
         </button>
       )}
 
       {/* Scrollable container */}
-      <div 
+      <div
         ref={scrollRef}
-        className="overflow-x-auto overscroll-x-contain scrollbar-thin scrollbar-thumb-gray-300 scrollbar-track-transparent"
-        style={{ 
+        className="overflow-x-auto overscroll-x-contain scrollbar-thin scrollbar-thumb-brand-purple/20 scrollbar-track-transparent"
+        style={{
           WebkitOverflowScrolling: 'touch',
           maxHeight: maxHeight || 'none'
         }}
@@ -108,10 +108,10 @@ export default function ResponsiveTable({
 
       {/* Scroll indicator dots */}
       {(canScrollLeft || canScrollRight) && (
-        <div className="flex justify-center gap-1 mt-2 sm:hidden">
-          <div className={`w-1.5 h-1.5 rounded-full transition-colors ${!canScrollLeft ? 'bg-[#b4b237]' : 'bg-gray-300'}`} />
-          <div className={`w-1.5 h-1.5 rounded-full transition-colors ${canScrollLeft && canScrollRight ? 'bg-[#b4b237]' : 'bg-gray-300'}`} />
-          <div className={`w-1.5 h-1.5 rounded-full transition-colors ${!canScrollRight ? 'bg-[#b4b237]' : 'bg-gray-300'}`} />
+        <div className="flex justify-center gap-1 mt-1.5 sm:hidden">
+          <div className={`w-1.5 h-1.5 rounded-full transition-colors ${!canScrollLeft ? 'bg-brand-purple' : 'bg-border'}`} />
+          <div className={`w-1.5 h-1.5 rounded-full transition-colors ${canScrollLeft && canScrollRight ? 'bg-brand-purple' : 'bg-border'}`} />
+          <div className={`w-1.5 h-1.5 rounded-full transition-colors ${!canScrollRight ? 'bg-brand-purple' : 'bg-border'}`} />
         </div>
       )}
     </div>


### PR DESCRIPTION
- Button: 4 variants, 3 sizes, brand tokens, squared
- Badge: 7 variants incl gold/purple mono, 2 sizes
- Card: compact p-3, minimal shadow, terminal typography
- PageHeader: compact mono title, py-2
- ResponsiveTable: brand scroll indicators
- Zero hardcoded hex across all 5 components

https://claude.ai/code/session_01G3wmws3SMsURWZUXsqp27H