### PR TITLE
feat(ui): terminal density restyle — Group A+B bookkeeping tables

### DIFF
--- a/src/components/dashboard/GeneralLedger.tsx
+++ b/src/components/dashboard/GeneralLedger.tsx
@@ -54,7 +54,7 @@ type SortDir = 'asc' | 'desc';
 /*  Helpers                                                            */
 /* ------------------------------------------------------------------ */
 
-const ROW_HEIGHT = 40;
+const ROW_HEIGHT = 30;
 
 const fmtMoney = (n: number): string =>
   '$' +
@@ -318,14 +318,14 @@ export default function GeneralLedger({ coaOptions, onReload }: GeneralLedgerPro
   /* ================================================================ */
 
   return (
-    <div className="bg-white rounded-xl border border-gray-200 overflow-hidden">
+    <div className="bg-white rounded border border-border overflow-hidden">
       {/* ---- Header ---- */}
-      <div className="bg-[#2d1b4e] text-white px-4 py-3 flex items-center justify-between">
-        <h2 className="text-sm font-semibold tracking-wide">General Ledger</h2>
+      <div className="bg-brand-purple text-white px-3 py-1.5 flex items-center justify-between">
+        <h2 className="text-terminal-lg font-semibold tracking-wide">General Ledger</h2>
         {selectedCode && (
           <button
             onClick={handleExportCSV}
-            className="px-3 py-1 text-xs border border-white/30 rounded hover:bg-white/10 transition"
+            className="px-2 py-0.5 text-terminal-sm border border-white/30 rounded hover:bg-white/10 transition"
           >
             Export CSV
           </button>
@@ -333,7 +333,7 @@ export default function GeneralLedger({ coaOptions, onReload }: GeneralLedgerPro
       </div>
 
       {/* ---- Controls bar ---- */}
-      <div className="p-3 border-b bg-gray-50 flex flex-wrap gap-2 items-center">
+      <div className="p-2 border-b bg-bg-row flex flex-wrap gap-2 items-center">
         {/* Account selector */}
         <div className="relative min-w-[260px]" ref={dropdownRef}>
           <input
@@ -354,7 +354,7 @@ export default function GeneralLedger({ coaOptions, onReload }: GeneralLedgerPro
               setAccountSearch('');
             }}
             placeholder="Search accounts..."
-            className="w-full px-3 py-2 border rounded-lg text-xs pr-8"
+            className="w-full h-7 px-2 border border-border rounded text-terminal-base font-mono pr-8"
           />
           {selectedCode && (
             <button
@@ -363,20 +363,20 @@ export default function GeneralLedger({ coaOptions, onReload }: GeneralLedgerPro
                 setAccountSearch('');
                 setAccountDropdownOpen(false);
               }}
-              className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-700 text-sm"
+              className="absolute right-2 top-1/2 -translate-y-1/2 text-text-faint hover:text-text-primary text-sm"
               title="Clear selection"
             >
               x
             </button>
           )}
           {accountDropdownOpen && (
-            <div className="absolute z-30 top-full left-0 right-0 mt-1 bg-white border border-gray-200 rounded-lg shadow-lg max-h-72 overflow-y-auto">
+            <div className="absolute z-30 top-full left-0 right-0 mt-1 bg-white border border-border rounded shadow-lg max-h-72 overflow-y-auto">
               {Object.entries(groupedAccounts).length === 0 && (
-                <div className="px-3 py-2 text-xs text-gray-400">No accounts found</div>
+                <div className="px-3 py-2 text-terminal-base text-text-faint">No accounts found</div>
               )}
               {Object.entries(groupedAccounts).map(([group, accounts]) => (
                 <div key={group}>
-                  <div className="px-3 py-1.5 text-[10px] font-semibold text-gray-500 bg-gray-50 uppercase tracking-wider">
+                  <div className="px-3 py-1.5 text-terminal-xs font-semibold text-text-muted bg-bg-row uppercase tracking-wider">
                     {group}
                   </div>
                   {accounts.map((a) => (
@@ -387,13 +387,13 @@ export default function GeneralLedger({ coaOptions, onReload }: GeneralLedgerPro
                         setAccountSearch('');
                         setAccountDropdownOpen(false);
                       }}
-                      className="w-full text-left px-3 py-1.5 text-xs hover:bg-[#2d1b4e]/[.07] flex justify-between items-center"
+                      className="w-full text-left px-3 py-1.5 text-terminal-base hover:bg-brand-purple/[.07] flex justify-between items-center"
                     >
                       <span>
                         <span className="font-medium">{a.code}</span>{' '}
-                        <span className="text-gray-600">- {a.name}</span>
+                        <span className="text-text-secondary">- {a.name}</span>
                       </span>
-                      <span className="text-gray-500 ml-2 tabular-nums">{fmtMoney(a.balance)}</span>
+                      <span className="text-text-muted ml-2 tabular-nums">{fmtMoney(a.balance)}</span>
                     </button>
                   ))}
                 </div>
@@ -407,14 +407,14 @@ export default function GeneralLedger({ coaOptions, onReload }: GeneralLedgerPro
           type="date"
           value={dateFrom}
           onChange={(e) => setDateFrom(e.target.value)}
-          className="px-3 py-2 border rounded-lg text-xs"
+          className="h-7 px-2 border border-border rounded text-terminal-base font-mono"
           placeholder="From"
         />
         <input
           type="date"
           value={dateTo}
           onChange={(e) => setDateTo(e.target.value)}
-          className="px-3 py-2 border rounded-lg text-xs"
+          className="h-7 px-2 border border-border rounded text-terminal-base font-mono"
           placeholder="To"
         />
 
@@ -424,7 +424,7 @@ export default function GeneralLedger({ coaOptions, onReload }: GeneralLedgerPro
           value={keyword}
           onChange={(e) => setKeyword(e.target.value)}
           placeholder="Search descriptions..."
-          className="flex-1 min-w-[150px] px-3 py-2 border rounded-lg text-xs"
+          className="flex-1 min-w-[150px] h-7 px-2 border border-border rounded text-terminal-base font-mono"
         />
 
         {/* Reload */}
@@ -433,7 +433,7 @@ export default function GeneralLedger({ coaOptions, onReload }: GeneralLedgerPro
             onReload();
             fetchLedger(selectedCode);
           }}
-          className="px-3 py-2 text-xs border rounded-lg hover:bg-gray-100"
+          className="h-7 px-2 text-terminal-base font-mono border border-border rounded hover:bg-bg-row"
         >
           Reload
         </button>
@@ -441,10 +441,10 @@ export default function GeneralLedger({ coaOptions, onReload }: GeneralLedgerPro
 
       {/* ---- Loading / Error ---- */}
       {loading && (
-        <div className="p-8 text-center text-xs text-gray-500">Loading ledger data...</div>
+        <div className="p-8 text-center text-terminal-sm text-text-muted">Loading ledger data...</div>
       )}
       {error && (
-        <div className="p-4 text-center text-xs text-red-600 bg-red-50">
+        <div className="p-4 text-center text-terminal-sm text-red-600 bg-red-50">
           Error: {error}
           <button onClick={() => fetchLedger(selectedCode)} className="ml-2 underline">
             Retry
@@ -455,13 +455,13 @@ export default function GeneralLedger({ coaOptions, onReload }: GeneralLedgerPro
       {/* ---- No account selected: show summary grid ---- */}
       {!loading && !error && !selectedCode && (
         <div className="overflow-x-auto">
-          <table className="w-full text-xs min-w-[700px]">
+          <table className="w-full text-terminal-base min-w-[700px]">
             <thead>
-              <tr className="bg-[#2d1b4e] text-white">
-                <th className="px-3 py-2 text-left font-semibold">Account Code</th>
-                <th className="px-3 py-2 text-left font-semibold">Account Name</th>
-                <th className="px-3 py-2 text-left font-semibold">Type</th>
-                <th className="px-3 py-2 text-right font-semibold">Balance</th>
+              <tr className="bg-brand-purple text-white">
+                <th className="text-terminal-xs uppercase tracking-widest font-mono py-1 px-2 text-left">Account Code</th>
+                <th className="text-terminal-xs uppercase tracking-widest font-mono py-1 px-2 text-left">Account Name</th>
+                <th className="text-terminal-xs uppercase tracking-widest font-mono py-1 px-2 text-left">Type</th>
+                <th className="text-terminal-xs uppercase tracking-widest font-mono py-1 px-2 text-right">Balance</th>
               </tr>
             </thead>
             <tbody>
@@ -470,7 +470,7 @@ export default function GeneralLedger({ coaOptions, onReload }: GeneralLedgerPro
                   <tr>
                     <td
                       colSpan={4}
-                      className="px-3 py-2 text-[10px] font-bold text-gray-500 bg-gray-100 uppercase tracking-wider"
+                      className="py-1 px-2 text-terminal-xs font-bold text-text-muted bg-bg-row uppercase tracking-wider"
                     >
                       {type}
                     </td>
@@ -479,14 +479,14 @@ export default function GeneralLedger({ coaOptions, onReload }: GeneralLedgerPro
                     <tr
                       key={acct.accountCode}
                       onClick={() => setSelectedCode(acct.accountCode)}
-                      className={`cursor-pointer hover:bg-[#2d1b4e]/[.07] ${
-                        idx % 2 === 0 ? 'bg-white' : 'bg-gray-50/50'
+                      className={`cursor-pointer hover:bg-brand-purple/[.07] ${
+                        idx % 2 === 0 ? 'bg-white' : 'bg-bg-row'
                       }`}
                     >
-                      <td className="px-3 py-2 font-medium">{acct.accountCode}</td>
-                      <td className="px-3 py-2 text-gray-700">{acct.accountName}</td>
-                      <td className="px-3 py-2 text-gray-500">{acct.accountType}</td>
-                      <td className="px-3 py-2 text-right font-mono tabular-nums">
+                      <td className="py-1 px-2 font-medium">{acct.accountCode}</td>
+                      <td className="py-1 px-2 text-text-secondary">{acct.accountName}</td>
+                      <td className="py-1 px-2 text-text-muted">{acct.accountType}</td>
+                      <td className="py-1 px-2 text-right font-mono tabular-nums">
                         {fmtMoney(acct.closingBalance)}
                       </td>
                     </tr>
@@ -495,7 +495,7 @@ export default function GeneralLedger({ coaOptions, onReload }: GeneralLedgerPro
               ))}
               {accountsByType.length === 0 && (
                 <tr>
-                  <td colSpan={4} className="px-3 py-8 text-center text-gray-400">
+                  <td colSpan={4} className="px-3 py-8 text-center text-text-faint">
                     No ledger entries found. Post journal entries first.
                   </td>
                 </tr>
@@ -509,15 +509,15 @@ export default function GeneralLedger({ coaOptions, onReload }: GeneralLedgerPro
       {!loading && !error && selectedCode && selectedAccount && (
         <>
           {/* Account summary row */}
-          <div className="px-4 py-3 bg-gray-50 border-b flex flex-wrap gap-6 text-xs">
+          <div className="px-3 py-1.5 bg-bg-row border-b flex flex-wrap gap-6 text-terminal-sm">
             <div>
-              <span className="text-gray-500">Opening Balance</span>
+              <span className="text-text-muted">Opening Balance</span>
               <div className="font-semibold tabular-nums mt-0.5">
                 {fmtMoney(selectedAccount.openingBalance)}
               </div>
             </div>
             <div>
-              <span className="text-gray-500">Total Debits</span>
+              <span className="text-text-muted">Total Debits</span>
               <div className="font-semibold text-red-600 tabular-nums mt-0.5">
                 {fmtMoney(
                   selectedAccount.entries
@@ -527,7 +527,7 @@ export default function GeneralLedger({ coaOptions, onReload }: GeneralLedgerPro
               </div>
             </div>
             <div>
-              <span className="text-gray-500">Total Credits</span>
+              <span className="text-text-muted">Total Credits</span>
               <div className="font-semibold text-green-600 tabular-nums mt-0.5">
                 {fmtMoney(
                   selectedAccount.entries
@@ -537,48 +537,48 @@ export default function GeneralLedger({ coaOptions, onReload }: GeneralLedgerPro
               </div>
             </div>
             <div>
-              <span className="text-gray-500">Closing Balance</span>
+              <span className="text-text-muted">Closing Balance</span>
               <div className="font-semibold tabular-nums mt-0.5">
                 {fmtMoney(selectedAccount.closingBalance)}
               </div>
             </div>
-            <div className="ml-auto self-center text-gray-500">
+            <div className="ml-auto self-center text-text-muted">
               {selectedAccount.accountCode} - {selectedAccount.accountName} ({selectedAccount.accountType})
             </div>
           </div>
 
           {/* Virtualized table */}
-          <div className="overflow-x-auto border border-gray-200">
+          <div className="overflow-x-auto border border-border">
             {/* Column headers */}
             <div className="min-w-[900px]">
-              <div className="bg-[#2d1b4e] text-white flex text-xs font-semibold sticky top-0 z-10">
+              <div className="bg-brand-purple text-white flex text-terminal-xs uppercase tracking-widest font-mono sticky top-0 z-10">
                 <button
                   onClick={() => handleSort('date')}
-                  className="px-3 py-2 text-left w-[100px] hover:bg-white/10 shrink-0"
+                  className="py-1 px-2 text-left w-[100px] hover:bg-white/10 shrink-0"
                 >
                   Date{sortArrow('date')}
                 </button>
-                <div className="px-3 py-2 text-left w-[90px] shrink-0">Entry #</div>
+                <div className="py-1 px-2 text-left w-[90px] shrink-0">Entry #</div>
                 <button
                   onClick={() => handleSort('description')}
-                  className="px-3 py-2 text-left flex-1 hover:bg-white/10"
+                  className="py-1 px-2 text-left flex-1 hover:bg-white/10"
                 >
                   Description{sortArrow('description')}
                 </button>
                 <button
                   onClick={() => handleSort('amount')}
-                  className="px-3 py-2 text-right w-[100px] hover:bg-white/10 shrink-0"
+                  className="py-1 px-2 text-right w-[100px] hover:bg-white/10 shrink-0"
                 >
                   Debit{sortArrow('amount')}
                 </button>
-                <div className="px-3 py-2 text-right w-[100px] shrink-0">Credit</div>
+                <div className="py-1 px-2 text-right w-[100px] shrink-0">Credit</div>
                 <button
                   onClick={() => handleSort('balance')}
-                  className="px-3 py-2 text-right w-[110px] hover:bg-white/10 shrink-0"
+                  className="py-1 px-2 text-right w-[110px] hover:bg-white/10 shrink-0"
                 >
                   Balance{sortArrow('balance')}
                 </button>
-                <div className="px-3 py-2 text-center w-[90px] shrink-0">Status</div>
+                <div className="py-1 px-2 text-center w-[90px] shrink-0">Status</div>
               </div>
 
               {/* Scroll container */}
@@ -605,55 +605,55 @@ export default function GeneralLedger({ coaOptions, onReload }: GeneralLedgerPro
                           transform: `translateY(${vRow.start}px)`,
                         }}
                         className={[
-                          'flex items-center text-xs',
-                          rowIdx % 2 === 0 ? 'bg-white' : 'bg-gray-50/50',
-                          'hover:bg-[#2d1b4e]/[.07]',
-                          isReversed ? 'text-gray-400' : '',
+                          'flex items-center text-terminal-base',
+                          rowIdx % 2 === 0 ? 'bg-white' : 'bg-bg-row',
+                          'hover:bg-brand-purple/[.07]',
+                          isReversed ? 'text-text-faint' : '',
                           isReversal ? 'border-l-[3px] border-amber-400' : '',
                         ].join(' ')}
                       >
                         {/* Date */}
-                        <div className="px-3 py-2 w-[100px] shrink-0 whitespace-nowrap">
+                        <div className="py-1 px-2 w-[100px] shrink-0 whitespace-nowrap font-mono text-text-muted">
                           {fmtDate(entry.date)}
                         </div>
 
                         {/* Entry # */}
-                        <div className="px-3 py-2 w-[90px] shrink-0 font-mono text-[11px] truncate">
+                        <div className="py-1 px-2 w-[90px] shrink-0 font-mono text-terminal-sm truncate">
                           {entry.journal_id.substring(0, 8)}
                         </div>
 
                         {/* Description */}
                         <div
-                          className={`px-3 py-2 flex-1 truncate ${isReversed ? 'line-through' : ''}`}
+                          className={`py-1 px-2 flex-1 truncate ${isReversed ? 'line-through' : ''}`}
                           title={entry.description}
                         >
                           {entry.description}
                         </div>
 
                         {/* Debit */}
-                        <div className="px-3 py-2 w-[100px] shrink-0 text-right font-mono tabular-nums">
+                        <div className="py-1 px-2 w-[100px] shrink-0 text-right font-mono tabular-nums">
                           {entry.entryType === 'D' ? fmtMoney(entry.amount) : ''}
                         </div>
 
                         {/* Credit */}
-                        <div className="px-3 py-2 w-[100px] shrink-0 text-right font-mono tabular-nums">
+                        <div className="py-1 px-2 w-[100px] shrink-0 text-right font-mono tabular-nums">
                           {entry.entryType === 'C' ? fmtMoney(entry.amount) : ''}
                         </div>
 
                         {/* Balance */}
-                        <div className="px-3 py-2 w-[110px] shrink-0 text-right font-mono tabular-nums">
+                        <div className="py-1 px-2 w-[110px] shrink-0 text-right font-mono tabular-nums">
                           {fmtMoney(entry.runningBalance)}
                         </div>
 
                         {/* Status */}
-                        <div className="px-3 py-2 w-[90px] shrink-0 text-center">
+                        <div className="py-1 px-2 w-[90px] shrink-0 text-center">
                           {status === 'Active' && (
                             <span className="inline-block px-1.5 py-0.5 rounded text-[10px] bg-green-100 text-green-700">
                               Active
                             </span>
                           )}
                           {status === 'Reversed' && (
-                            <span className="inline-block px-1.5 py-0.5 rounded text-[10px] bg-gray-200 text-gray-500">
+                            <span className="inline-block px-1.5 py-0.5 rounded text-[10px] bg-bg-row text-text-muted">
                               Reversed
                             </span>
                           )}
@@ -672,15 +672,15 @@ export default function GeneralLedger({ coaOptions, onReload }: GeneralLedgerPro
           </div>
 
           {/* Footer summary */}
-          <div className="px-4 py-3 bg-gray-50 border-t flex justify-between text-xs">
-            <span className="text-gray-600">
+          <div className="px-3 py-1.5 bg-bg-row border-t flex justify-between text-terminal-sm">
+            <span className="text-text-secondary">
               {filteredEntries.length} {filteredEntries.length === 1 ? 'entry' : 'entries'}
             </span>
-            <span className="text-gray-600">
+            <span className="text-text-secondary">
               Total Debits:{' '}
               <span className="font-semibold text-red-600">{fmtMoney(totalDebits)}</span>
             </span>
-            <span className="text-gray-600">
+            <span className="text-text-secondary">
               Total Credits:{' '}
               <span className="font-semibold text-green-600">{fmtMoney(totalCredits)}</span>
             </span>
@@ -690,7 +690,7 @@ export default function GeneralLedger({ coaOptions, onReload }: GeneralLedgerPro
 
       {/* Account selected but not found in data */}
       {!loading && !error && selectedCode && !selectedAccount && (
-        <div className="p-8 text-center text-xs text-gray-400">
+        <div className="p-8 text-center text-terminal-sm text-text-muted">
           No ledger entries for account {selectedCode}.
         </div>
       )}

--- a/src/components/dashboard/JournalEntryEngine.tsx
+++ b/src/components/dashboard/JournalEntryEngine.tsx
@@ -89,7 +89,7 @@ const ENTRY_TYPES = [
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
-const ROW_HEIGHT = 44;
+const ROW_HEIGHT = 30;
 
 function formatDate(d: string | null | undefined): string {
   if (!d) return '\u2014';
@@ -307,14 +307,14 @@ function JournalColumnFilterDropdown({
   };
 
   return createPortal(
-    <div ref={panelRef} className="fixed bg-white border border-gray-200 rounded-lg shadow-xl z-[100] w-64" style={panelStyle}>
-      <div className="border-b border-gray-100 p-2 space-y-1">
+    <div ref={panelRef} className="fixed bg-white border border-border rounded shadow-xl z-[100] w-64" style={panelStyle}>
+      <div className="border-b border-border-light p-2 space-y-1">
         <button onClick={() => { onSortWithDir(field, 'asc'); onCancel(); }}
-          className={`w-full text-left px-2 py-1.5 text-xs rounded hover:bg-gray-50 flex items-center gap-2 ${isSortedAsc ? 'text-[#2d1b4e] font-semibold bg-[#2d1b4e]/5' : 'text-gray-600'}`}>
+          className={`w-full text-left px-2 py-1.5 text-terminal-sm rounded hover:bg-bg-row flex items-center gap-2 ${isSortedAsc ? 'text-brand-purple font-semibold bg-brand-purple/5' : 'text-text-secondary'}`}>
           <span className="text-[10px]">{'\u25B2'}</span> {sortAscLabel}
         </button>
         <button onClick={() => { onSortWithDir(field, 'desc'); onCancel(); }}
-          className={`w-full text-left px-2 py-1.5 text-xs rounded hover:bg-gray-50 flex items-center gap-2 ${isSortedDesc ? 'text-[#2d1b4e] font-semibold bg-[#2d1b4e]/5' : 'text-gray-600'}`}>
+          className={`w-full text-left px-2 py-1.5 text-terminal-sm rounded hover:bg-bg-row flex items-center gap-2 ${isSortedDesc ? 'text-brand-purple font-semibold bg-brand-purple/5' : 'text-text-secondary'}`}>
           <span className="text-[10px]">{'\u25BC'}</span> {sortDescLabel}
         </button>
       </div>
@@ -325,57 +325,57 @@ function JournalColumnFilterDropdown({
             {uniqueValues.length > 6 && (
               <input ref={searchRef} type="text" placeholder="Search..." value={localSearch}
                 onChange={e => setLocalSearch(e.target.value)}
-                className="w-full px-2 py-1.5 text-xs border rounded mb-2 outline-none focus:border-[#2d1b4e]" />
+                className="w-full px-2 h-7 text-terminal-base font-mono border border-border rounded mb-2 outline-none focus:border-brand-purple" />
             )}
             <div className="flex items-center justify-between mb-1 px-1">
-              <button onClick={() => setLocalSelected(new Set(filteredValues.map(([v]) => v)))} className="text-[10px] text-[#2d1b4e] hover:underline">Select All</button>
+              <button onClick={() => setLocalSelected(new Set(filteredValues.map(([v]) => v)))} className="text-[10px] text-brand-purple hover:underline">Select All</button>
               <button onClick={() => setLocalSelected(new Set())} className="text-[10px] text-red-500 hover:underline">Clear All</button>
             </div>
             <div className="max-h-[300px] overflow-auto border rounded">
               {filteredValues.map(([val, count]) => (
-                <label key={val} className="flex items-center gap-2 px-2 py-1.5 hover:bg-gray-50 cursor-pointer text-xs">
+                <label key={val} className="flex items-center gap-2 px-2 py-1.5 hover:bg-bg-row cursor-pointer text-terminal-sm">
                   <input type="checkbox" checked={localSelected.has(val)}
                     onChange={() => setLocalSelected(prev => { const next = new Set(prev); if (next.has(val)) next.delete(val); else next.add(val); return next; })}
                     className="w-3.5 h-3.5 rounded flex-shrink-0" />
                   <span className="truncate flex-1">{val}</span>
-                  <span className="text-gray-400 text-[10px] flex-shrink-0">({count})</span>
+                  <span className="text-text-faint text-[10px] flex-shrink-0">({count})</span>
                 </label>
               ))}
-              {filteredValues.length === 0 && <div className="px-2 py-3 text-center text-gray-400 text-xs">No values found</div>}
+              {filteredValues.length === 0 && <div className="px-2 py-3 text-center text-text-faint text-terminal-sm">No values found</div>}
             </div>
           </>
         )}
 
         {filterType === 'dateRange' && (
           <div className="space-y-2">
-            <div><label className="block text-[10px] text-gray-500 mb-1">From</label>
-              <input ref={searchRef} type="date" value={localFrom} onChange={e => setLocalFrom(e.target.value)} className="w-full px-2 py-1.5 text-xs border rounded outline-none focus:border-[#2d1b4e]" /></div>
-            <div><label className="block text-[10px] text-gray-500 mb-1">To</label>
-              <input type="date" value={localTo} onChange={e => setLocalTo(e.target.value)} className="w-full px-2 py-1.5 text-xs border rounded outline-none focus:border-[#2d1b4e]" /></div>
+            <div><label className="block text-[10px] text-text-muted mb-1">From</label>
+              <input ref={searchRef} type="date" value={localFrom} onChange={e => setLocalFrom(e.target.value)} className="w-full px-2 h-7 text-terminal-base font-mono border border-border rounded outline-none focus:border-brand-purple" /></div>
+            <div><label className="block text-[10px] text-text-muted mb-1">To</label>
+              <input type="date" value={localTo} onChange={e => setLocalTo(e.target.value)} className="w-full px-2 h-7 text-terminal-base font-mono border border-border rounded outline-none focus:border-brand-purple" /></div>
           </div>
         )}
 
         {filterType === 'amountRange' && (
           <div className="space-y-2">
-            <div><label className="block text-[10px] text-gray-500 mb-1">Min</label>
-              <input ref={searchRef} type="number" placeholder="0" value={localMin} onChange={e => setLocalMin(e.target.value)} className="w-full px-2 py-1.5 text-xs border rounded outline-none focus:border-[#2d1b4e]" /></div>
-            <div><label className="block text-[10px] text-gray-500 mb-1">Max</label>
-              <input type="number" placeholder="999999" value={localMax} onChange={e => setLocalMax(e.target.value)} className="w-full px-2 py-1.5 text-xs border rounded outline-none focus:border-[#2d1b4e]" /></div>
+            <div><label className="block text-[10px] text-text-muted mb-1">Min</label>
+              <input ref={searchRef} type="number" placeholder="0" value={localMin} onChange={e => setLocalMin(e.target.value)} className="w-full px-2 h-7 text-terminal-base font-mono border border-border rounded outline-none focus:border-brand-purple" /></div>
+            <div><label className="block text-[10px] text-text-muted mb-1">Max</label>
+              <input type="number" placeholder="999999" value={localMax} onChange={e => setLocalMax(e.target.value)} className="w-full px-2 h-7 text-terminal-base font-mono border border-border rounded outline-none focus:border-brand-purple" /></div>
           </div>
         )}
 
         {filterType === 'search' && (
           <input ref={searchRef} type="text" placeholder="Search..." value={localTerm}
             onChange={e => setLocalTerm(e.target.value)}
-            className="w-full px-2 py-1.5 text-xs border rounded outline-none focus:border-[#2d1b4e]" />
+            className="w-full px-2 h-7 text-terminal-base font-mono border border-border rounded outline-none focus:border-brand-purple" />
         )}
       </div>
 
-      <div className="border-t border-gray-100 p-2 flex justify-between gap-2">
+      <div className="border-t border-border-light p-2 flex justify-between gap-2">
         <button onClick={() => onApply(undefined)} className="text-[10px] text-red-500 hover:underline">Clear</button>
         <div className="flex gap-2">
-          <button onClick={onCancel} className="px-3 py-1 text-xs border rounded hover:bg-gray-50">Cancel</button>
-          <button onClick={handleApply} className="px-3 py-1 text-xs bg-[#2d1b4e] text-white rounded hover:bg-[#3d2b5e]">Apply</button>
+          <button onClick={onCancel} className="px-3 py-1 text-terminal-sm border rounded hover:bg-bg-row">Cancel</button>
+          <button onClick={handleApply} className="px-3 py-1 text-terminal-sm bg-brand-purple text-white rounded hover:bg-brand-purple-hover">Apply</button>
         </div>
       </div>
     </div>,
@@ -406,7 +406,7 @@ function JournalFilterableHeader({
   const hasFilter = !!columnFilter;
 
   return (
-    <th className={`px-2 py-2.5 text-xs font-semibold select-none ${className || ''}`}>
+    <th className={`py-1 px-2 text-terminal-xs uppercase tracking-widest font-mono font-semibold select-none ${className || ''}`}>
       <span className="flex items-center gap-0.5">
         <span className="cursor-pointer hover:underline truncate" onClick={() => onSort(field)}>
           {label}
@@ -561,18 +561,18 @@ export default function JournalEntryEngine({ journalTransactions, coaOptions, on
   // ─── Render ──────────────────────────────────────────────────────────────
 
   return (
-    <div className="bg-white rounded-xl border overflow-hidden">
+    <div className="bg-white rounded border border-border overflow-hidden">
       {/* Header */}
-      <div className="bg-[#2d1b4e] text-white px-4 py-3 flex items-center justify-between">
+      <div className="bg-brand-purple text-white px-3 py-1.5 flex items-center justify-between">
         <div>
-          <h3 className="text-sm font-semibold">Journal Entries</h3>
-          <p className="text-[10px] text-gray-300 font-mono">
+          <h3 className="text-terminal-lg font-semibold">Journal Entries</h3>
+          <p className="text-terminal-xs text-text-faint font-mono">
             {txns.length} journal entries ({reversalCount} reversals)
           </p>
         </div>
         <button
           onClick={() => setShowForm(!showForm)}
-          className="px-4 py-1.5 bg-white/10 hover:bg-white/20 text-white rounded-lg text-xs font-medium transition-colors"
+          className="px-4 py-1.5 bg-white/10 hover:bg-white/20 text-white rounded text-terminal-sm font-medium transition-colors"
         >
           {showForm ? '\u2715 Cancel' : '+ New Entry'}
         </button>
@@ -586,50 +586,50 @@ export default function JournalEntryEngine({ journalTransactions, coaOptions, on
           {/* Entry Header */}
           <div className="flex flex-wrap gap-3 mb-4">
             <div>
-              <label className="block text-xs text-gray-500 mb-1">Date</label>
+              <label className="block text-terminal-sm text-text-muted mb-1">Date</label>
               <input
                 type="date"
                 value={newDate}
                 onChange={(e) => setNewDate(e.target.value)}
-                className="px-3 py-2 border rounded-lg text-sm"
+                className="px-2 h-7 border border-border rounded text-terminal-base font-mono"
               />
             </div>
             <div>
-              <label className="block text-xs text-gray-500 mb-1">Type</label>
+              <label className="block text-terminal-sm text-text-muted mb-1">Type</label>
               <select
                 value={newType}
                 onChange={(e) => setNewType(e.target.value)}
-                className="px-3 py-2 border rounded-lg text-sm"
+                className="px-2 h-7 border border-border rounded text-terminal-base font-mono"
               >
                 {ENTRY_TYPES.map(t => <option key={t.value} value={t.value}>{t.label}</option>)}
               </select>
             </div>
             <div className="flex-1 min-w-[200px]">
-              <label className="block text-xs text-gray-500 mb-1">Memo</label>
+              <label className="block text-terminal-sm text-text-muted mb-1">Memo</label>
               <input
                 type="text"
                 value={newMemo}
                 onChange={(e) => setNewMemo(e.target.value)}
                 placeholder="Description of this entry..."
-                className="w-full px-3 py-2 border rounded-lg text-sm"
+                className="w-full px-2 h-7 border border-border rounded text-terminal-base font-mono"
               />
             </div>
           </div>
 
           {/* Entry Lines */}
           <table className="w-full text-sm mb-3">
-            <thead className="bg-gray-100">
+            <thead className="bg-brand-purple text-white/70">
               <tr>
-                <th className="px-2 py-2 text-left font-medium">Account</th>
-                <th className="px-2 py-2 text-left font-medium">Description</th>
-                <th className="px-2 py-2 text-right font-medium w-28">Debit</th>
-                <th className="px-2 py-2 text-right font-medium w-28">Credit</th>
+                <th className="py-1 px-2 text-left text-terminal-xs uppercase tracking-widest font-mono font-medium">Account</th>
+                <th className="py-1 px-2 text-left text-terminal-xs uppercase tracking-widest font-mono font-medium">Description</th>
+                <th className="py-1 px-2 text-right text-terminal-xs uppercase tracking-widest font-mono font-medium w-28">Debit</th>
+                <th className="py-1 px-2 text-right text-terminal-xs uppercase tracking-widest font-mono font-medium w-28">Credit</th>
                 <th className="w-8"></th>
               </tr>
             </thead>
             <tbody>
               {newLines.map((line, idx) => (
-                <tr key={idx} className="border-b">
+                <tr key={idx} className="border-b border-border-light">
                   <td className="px-2 py-2">
                     <select
                       value={line.accountCode}
@@ -683,10 +683,10 @@ export default function JournalEntryEngine({ journalTransactions, coaOptions, on
                 </tr>
               ))}
             </tbody>
-            <tfoot className="bg-gray-50 font-semibold">
+            <tfoot className="bg-bg-row font-semibold">
               <tr>
                 <td className="px-2 py-2" colSpan={2}>
-                  <button onClick={addLine} className="text-[#2d1b4e] text-sm hover:underline">+ Add Line</button>
+                  <button onClick={addLine} className="text-brand-purple text-sm hover:underline">+ Add Line</button>
                 </td>
                 <td className="px-2 py-2 text-right">${totalDebits.toFixed(2)}</td>
                 <td className="px-2 py-2 text-right">${totalCredits.toFixed(2)}</td>
@@ -714,14 +714,14 @@ export default function JournalEntryEngine({ journalTransactions, coaOptions, on
               <button
                 onClick={() => handleSave('draft')}
                 disabled={!isBalanced || saving}
-                className="px-4 py-2 border rounded-lg text-sm disabled:opacity-50"
+                className="px-4 py-2 border border-border rounded text-sm disabled:opacity-50"
               >
                 Save as Draft
               </button>
               <button
                 onClick={() => handleSave('posted')}
                 disabled={!isBalanced || saving}
-                className="px-4 py-2 bg-[#2d1b4e] text-white rounded-lg text-sm font-medium disabled:opacity-50"
+                className="px-4 py-2 bg-brand-purple text-white rounded text-sm font-medium disabled:opacity-50"
               >
                 {saving ? 'Saving...' : 'Post Entry'}
               </button>
@@ -731,14 +731,14 @@ export default function JournalEntryEngine({ journalTransactions, coaOptions, on
       )}
 
       {/* Search + filter pills */}
-      <div className="bg-gray-50 border-x border-gray-200 px-4 py-2 space-y-2">
+      <div className="bg-bg-row border-x border-border px-4 py-2 space-y-2">
         <div className="flex items-center gap-2">
           <input
             type="text"
             placeholder="Search descriptions..."
             value={search}
             onChange={e => setSearch(e.target.value)}
-            className="flex-1 px-3 py-1.5 text-xs border border-gray-200 rounded-lg outline-none focus:border-[#2d1b4e] focus:ring-1 focus:ring-[#2d1b4e]"
+            className="flex-1 px-2 h-7 text-terminal-base font-mono border border-border rounded outline-none focus:border-brand-purple focus:ring-1 focus:ring-brand-purple"
           />
           {(search || activeColFilterCount > 0) && (
             <button onClick={() => { setSearch(''); setColumnFilters({}); }}
@@ -771,9 +771,9 @@ export default function JournalEntryEngine({ journalTransactions, coaOptions, on
       </div>
 
       {/* Virtualized Table */}
-      <div ref={parentRef} className="overflow-auto border border-gray-200 border-t-0" style={{ maxHeight: '600px' }}>
-        <table className="w-full text-xs border-collapse min-w-[1000px]">
-          <thead className="bg-[#2d1b4e] text-white sticky top-0 z-10">
+      <div ref={parentRef} className="overflow-auto border border-border border-t-0" style={{ maxHeight: '600px' }}>
+        <table className="w-full text-terminal-base border-collapse min-w-[1000px]">
+          <thead className="bg-brand-purple text-white sticky top-0 z-10">
             <tr>
               <JournalFilterableHeader label="Date" field="date" sortField={sortField} sortDir={sortDir} onSort={handleSort}
                 filterType="dateRange" allTransactions={txns} columnFilter={columnFilters.date} onApplyColumnFilter={handleApplyColumnFilter} className="w-24" />
@@ -787,8 +787,8 @@ export default function JournalEntryEngine({ journalTransactions, coaOptions, on
                 filterType="amountRange" allTransactions={txns} columnFilter={columnFilters.debits} onApplyColumnFilter={handleApplyColumnFilter} className="w-24 text-right" />
               <JournalFilterableHeader label="Credits" field="credits" sortField={sortField} sortDir={sortDir} onSort={handleSort}
                 filterType="amountRange" allTransactions={txns} columnFilter={columnFilters.credits} onApplyColumnFilter={handleApplyColumnFilter} className="w-24 text-right" />
-              <th className="px-2 py-2.5 text-xs font-semibold w-16 text-center">Balanced</th>
-              <th className="px-2 py-2.5 text-xs font-semibold w-36">Related</th>
+              <th className="py-1 px-2 text-terminal-xs uppercase tracking-widest font-mono font-semibold w-16 text-center">Balanced</th>
+              <th className="py-1 px-2 text-terminal-xs uppercase tracking-widest font-mono font-semibold w-36">Related</th>
             </tr>
           </thead>
           <tbody>
@@ -809,8 +809,8 @@ export default function JournalEntryEngine({ journalTransactions, coaOptions, on
               const isReversal = txn.is_reversal;
               const isExpanded = expandedId === txn.id;
 
-              const rowBg = vRow.index % 2 === 0 ? 'bg-white' : 'bg-gray-50/50';
-              const textClass = isReversed ? 'text-gray-400' : '';
+              const rowBg = vRow.index % 2 === 0 ? 'bg-white' : 'bg-bg-row';
+              const textClass = isReversed ? 'text-text-faint' : '';
               const borderClass = isReversal ? 'border-l-[3px] border-amber-400' : '';
 
               return (
@@ -818,12 +818,12 @@ export default function JournalEntryEngine({ journalTransactions, coaOptions, on
                   {/* Main row */}
                   <td colSpan={8} className="p-0">
                     <div
-                      className={`${rowBg} ${borderClass} hover:bg-[#2d1b4e]/[.07] transition-colors cursor-pointer flex items-center ${textClass}`}
+                      className={`${rowBg} ${borderClass} hover:bg-brand-purple/[.07] transition-colors cursor-pointer flex items-center ${textClass}`}
                       style={{ height: ROW_HEIGHT }}
                       onClick={() => setExpandedId(isExpanded ? null : txn.id)}
                     >
                       {/* Date */}
-                      <div className="px-2 py-1 w-24 flex-shrink-0 whitespace-nowrap font-mono">
+                      <div className="px-2 py-1 w-24 flex-shrink-0 whitespace-nowrap font-mono text-text-muted">
                         {formatDate(txn.date)}
                       </div>
                       {/* Description */}
@@ -835,7 +835,7 @@ export default function JournalEntryEngine({ journalTransactions, coaOptions, on
                       {/* Type */}
                       <div className="px-2 py-1 w-24 flex-shrink-0">
                         <span className={`text-[10px] font-medium px-1.5 py-0.5 rounded ${
-                          derivedType === 'Reversal' ? 'bg-amber-100 text-amber-700' : 'bg-gray-100 text-gray-600'
+                          derivedType === 'Reversal' ? 'bg-amber-100 text-amber-700' : 'bg-bg-row text-text-secondary'
                         }`}>
                           {derivedType}
                         </span>
@@ -851,11 +851,11 @@ export default function JournalEntryEngine({ journalTransactions, coaOptions, on
                         </span>
                       </div>
                       {/* Debits */}
-                      <div className="px-2 py-1 w-24 flex-shrink-0 text-right font-mono">
+                      <div className="px-2 py-1 w-24 flex-shrink-0 text-right font-mono font-semibold">
                         {debits > 0 ? formatMoneyDollars(debits) : '\u2014'}
                       </div>
                       {/* Credits */}
-                      <div className="px-2 py-1 w-24 flex-shrink-0 text-right font-mono">
+                      <div className="px-2 py-1 w-24 flex-shrink-0 text-right font-mono font-semibold">
                         {credits > 0 ? formatMoneyDollars(credits) : '\u2014'}
                       </div>
                       {/* Balanced */}
@@ -871,7 +871,7 @@ export default function JournalEntryEngine({ journalTransactions, coaOptions, on
                         {isReversal && txn.reverses_journal_id && (
                           <button
                             onClick={(e) => { e.stopPropagation(); setExpandedId(txn.reverses_journal_id); }}
-                            className="text-[10px] text-[#2d1b4e] hover:underline truncate block"
+                            className="text-[10px] text-brand-purple hover:underline truncate block"
                           >
                             Reversal of {truncateId(txn.reverses_journal_id)}
                           </button>
@@ -879,7 +879,7 @@ export default function JournalEntryEngine({ journalTransactions, coaOptions, on
                         {isReversed && txn.reversed_by_transaction_id && (
                           <button
                             onClick={(e) => { e.stopPropagation(); setExpandedId(txn.reversed_by_transaction_id); }}
-                            className="text-[10px] text-[#2d1b4e] hover:underline truncate block"
+                            className="text-[10px] text-brand-purple hover:underline truncate block"
                           >
                             Reversed by {truncateId(txn.reversed_by_transaction_id)}
                           </button>
@@ -889,14 +889,14 @@ export default function JournalEntryEngine({ journalTransactions, coaOptions, on
 
                     {/* Expanded detail */}
                     {isExpanded && (
-                      <div className="bg-gray-50 px-6 py-3 border-t border-gray-200">
-                        <table className="w-full text-xs">
-                          <thead className="bg-gray-100">
+                      <div className="bg-bg-row px-6 py-3 border-t border-border-light">
+                        <table className="w-full text-terminal-base">
+                          <thead className="bg-brand-purple text-white/70">
                             <tr>
-                              <th className="px-3 py-2 text-left font-medium">COA Code</th>
-                              <th className="px-3 py-2 text-left font-medium">COA Name</th>
-                              <th className="px-3 py-2 text-right font-medium">Debit</th>
-                              <th className="px-3 py-2 text-right font-medium">Credit</th>
+                              <th className="py-1 px-2 text-left text-terminal-xs uppercase tracking-widest font-mono font-medium">COA Code</th>
+                              <th className="py-1 px-2 text-left text-terminal-xs uppercase tracking-widest font-mono font-medium">COA Name</th>
+                              <th className="py-1 px-2 text-right text-terminal-xs uppercase tracking-widest font-mono font-medium">Debit</th>
+                              <th className="py-1 px-2 text-right text-terminal-xs uppercase tracking-widest font-mono font-medium">Credit</th>
                             </tr>
                           </thead>
                           <tbody>
@@ -904,35 +904,35 @@ export default function JournalEntryEngine({ journalTransactions, coaOptions, on
                               const legDebit = leg.entry_type === 'D' ? leg.amount : 0;
                               const legCredit = leg.entry_type === 'C' ? leg.amount : 0;
                               return (
-                                <tr key={leg.id} className={`border-b border-gray-200 ${isReversed ? 'text-gray-400' : ''}`}>
-                                  <td className={`px-3 py-2 font-mono ${isReversed ? 'line-through' : ''}`}>
+                                <tr key={leg.id} className={`border-b border-border-light ${isReversed ? 'text-text-faint' : ''}`}>
+                                  <td className={`py-1 px-2 font-mono ${isReversed ? 'line-through' : ''}`}>
                                     {leg.account.code}
                                   </td>
-                                  <td className={`px-3 py-2 ${isReversed ? 'line-through' : ''}`}>
+                                  <td className={`py-1 px-2 ${isReversed ? 'line-through' : ''}`}>
                                     {leg.account.name}
                                   </td>
-                                  <td className={`px-3 py-2 text-right font-mono ${isReversed ? 'line-through' : ''}`}>
+                                  <td className={`py-1 px-2 text-right font-mono font-semibold ${isReversed ? 'line-through' : ''}`}>
                                     {legDebit > 0 ? formatMoney(legDebit) : '\u2014'}
                                   </td>
-                                  <td className={`px-3 py-2 text-right font-mono ${isReversed ? 'line-through' : ''}`}>
+                                  <td className={`py-1 px-2 text-right font-mono font-semibold ${isReversed ? 'line-through' : ''}`}>
                                     {legCredit > 0 ? formatMoney(legCredit) : '\u2014'}
                                   </td>
                                 </tr>
                               );
                             })}
                           </tbody>
-                          <tfoot className="bg-gray-100 font-semibold">
+                          <tfoot className="bg-bg-row font-semibold">
                             <tr>
-                              <td colSpan={2} className="px-3 py-2">Total</td>
-                              <td className="px-3 py-2 text-right font-mono">{formatMoneyDollars(debits)}</td>
-                              <td className="px-3 py-2 text-right font-mono">{formatMoneyDollars(credits)}</td>
+                              <td colSpan={2} className="py-1 px-2">Total</td>
+                              <td className="py-1 px-2 text-right font-mono font-semibold">{formatMoneyDollars(debits)}</td>
+                              <td className="py-1 px-2 text-right font-mono font-semibold">{formatMoneyDollars(credits)}</td>
                             </tr>
                           </tfoot>
                         </table>
                         {txn.strategy && (
-                          <div className="mt-2 text-[10px] text-gray-500">
-                            Strategy: <span className="font-medium text-gray-700">{txn.strategy}</span>
-                            {txn.trade_num && <> | Trade #: <span className="font-medium text-gray-700">{txn.trade_num}</span></>}
+                          <div className="mt-2 text-[10px] text-text-muted">
+                            Strategy: <span className="font-medium text-text-primary">{txn.strategy}</span>
+                            {txn.trade_num && <> | Trade #: <span className="font-medium text-text-primary">{txn.trade_num}</span></>}
                           </div>
                         )}
                       </div>
@@ -952,15 +952,15 @@ export default function JournalEntryEngine({ journalTransactions, coaOptions, on
           </tbody>
         </table>
         {filtered.length === 0 && (
-          <div className="px-4 py-8 text-center text-gray-400 text-xs">
+          <div className="px-4 py-8 text-center text-text-faint text-terminal-sm">
             {search || activeColFilterCount > 0 ? 'No journal entries match your filters.' : 'No journal entries yet. Click "+ New Entry" to create one.'}
           </div>
         )}
       </div>
 
       {/* Footer summary */}
-      <div className="bg-gray-100 border border-gray-200 border-t-0 px-4 py-2 flex items-center justify-between text-xs">
-        <span className="text-gray-500">
+      <div className="bg-bg-row border border-border border-t-0 px-3 py-1.5 flex items-center justify-between text-terminal-sm">
+        <span className="text-text-muted">
           {filtered.length === txns.length ? txns.length : `${filtered.length} of ${txns.length}`} entries
         </span>
         <span className="font-mono font-medium">

--- a/src/components/dashboard/PositionReportTab.tsx
+++ b/src/components/dashboard/PositionReportTab.tsx
@@ -138,11 +138,11 @@ export default function PositionReportTab() {
   };
 
   if (loading) {
-    return <div className="p-8 text-center text-sm text-gray-500">Loading position report...</div>;
+    return <div className="p-8 text-center text-terminal-sm text-text-muted">Loading position report...</div>;
   }
 
   if (!data) {
-    return <div className="p-8 text-center text-sm text-red-600">Failed to load position data</div>;
+    return <div className="p-8 text-center text-terminal-sm text-brand-red">Failed to load position data</div>;
   }
 
   const { summary } = data;
@@ -150,15 +150,15 @@ export default function PositionReportTab() {
   return (
     <div>
       {/* Header */}
-      <div className="bg-[#2d1b4e] text-white px-4 py-2 flex items-center justify-between">
-        <span className="text-sm font-semibold">Position &amp; P&amp;L Report</span>
-        <button onClick={loadData} className="text-xs bg-[#3d2b5e] px-3 py-1 rounded hover:bg-[#4d3b6e]">
+      <div className="bg-brand-purple text-white px-3 py-1.5 flex items-center justify-between">
+        <span className="text-terminal-lg font-semibold">Position &amp; P&amp;L Report</span>
+        <button onClick={loadData} className="text-terminal-sm bg-brand-purple-hover px-2 py-0.5 rounded hover:bg-brand-purple-hover">
           Refresh
         </button>
       </div>
 
       {/* Sub-tabs */}
-      <div className="flex border-b border-gray-200">
+      <div className="flex border-b border-border">
         {[
           { key: 'summary', label: 'P&L Summary' },
           { key: 'open', label: `Open (${summary.openPositions})` },
@@ -167,8 +167,8 @@ export default function PositionReportTab() {
           <button
             key={tab.key}
             onClick={() => setActiveView(tab.key as any)}
-            className={`px-4 py-2 text-xs font-medium ${
-              activeView === tab.key ? 'bg-[#2d1b4e] text-white' : 'bg-gray-50 text-gray-600'
+            className={`px-3 py-1 text-terminal-sm font-medium ${
+              activeView === tab.key ? 'bg-brand-purple text-white' : 'bg-bg-row text-text-muted'
             }`}
           >
             {tab.label}
@@ -178,53 +178,53 @@ export default function PositionReportTab() {
 
       {/* P&L Summary View */}
       {activeView === 'summary' && (
-        <div className="p-4 space-y-4">
+        <div className="p-3 space-y-3">
           {/* Top metrics */}
-          <div className="grid grid-cols-5 gap-3">
-            <div className="border rounded-lg p-3">
-              <div className="text-[10px] text-gray-500 uppercase">Total Realized P&L</div>
-              <div className={`text-xl font-bold font-mono ${plColor(summary.totalRealizedPL)}`}>
+          <div className="grid grid-cols-5 gap-2">
+            <div className="border border-border rounded p-2">
+              <div className="text-terminal-xs text-text-muted uppercase tracking-widest">Total Realized P&L</div>
+              <div className={`text-lg font-bold font-mono ${plColor(summary.totalRealizedPL)}`}>
                 {fmt(summary.totalRealizedPL)}
               </div>
             </div>
-            <div className="border rounded-lg p-3">
-              <div className="text-[10px] text-gray-500 uppercase">Short-Term P&L</div>
-              <div className={`text-xl font-bold font-mono ${plColor(summary.shortTermPL)}`}>
+            <div className="border border-border rounded p-2">
+              <div className="text-terminal-xs text-text-muted uppercase tracking-widest">Short-Term P&L</div>
+              <div className={`text-lg font-bold font-mono ${plColor(summary.shortTermPL)}`}>
                 {fmt(summary.shortTermPL)}
               </div>
             </div>
-            <div className="border rounded-lg p-3">
-              <div className="text-[10px] text-gray-500 uppercase">Long-Term P&L</div>
-              <div className={`text-xl font-bold font-mono ${plColor(summary.longTermPL)}`}>
+            <div className="border border-border rounded p-2">
+              <div className="text-terminal-xs text-text-muted uppercase tracking-widest">Long-Term P&L</div>
+              <div className={`text-lg font-bold font-mono ${plColor(summary.longTermPL)}`}>
                 {fmt(summary.longTermPL)}
               </div>
             </div>
-            <div className="border rounded-lg p-3">
-              <div className="text-[10px] text-gray-500 uppercase">Win Rate</div>
-              <div className="text-xl font-bold font-mono">{summary.winRate}%</div>
+            <div className="border border-border rounded p-2">
+              <div className="text-terminal-xs text-text-muted uppercase tracking-widest">Win Rate</div>
+              <div className="text-lg font-bold font-mono">{summary.winRate}%</div>
             </div>
-            <div className="border rounded-lg p-3">
-              <div className="text-[10px] text-gray-500 uppercase">Profit Factor</div>
-              <div className="text-xl font-bold font-mono">
+            <div className="border border-border rounded p-2">
+              <div className="text-terminal-xs text-text-muted uppercase tracking-widest">Profit Factor</div>
+              <div className="text-lg font-bold font-mono">
                 {summary.profitFactor >= 999 ? 'N/A' : summary.profitFactor.toFixed(2)}
               </div>
             </div>
           </div>
 
           {/* Options vs Stocks breakdown */}
-          <div className="grid grid-cols-2 gap-4">
-            <div className="border rounded-lg p-4">
-              <h4 className="text-sm font-semibold mb-3">Options P&L</h4>
-              <div className={`text-2xl font-bold font-mono ${plColor(summary.optionRealizedPL)}`}>
+          <div className="grid grid-cols-2 gap-3">
+            <div className="border border-border rounded p-3">
+              <h4 className="text-terminal-lg font-semibold mb-2">Options P&L</h4>
+              <div className={`text-xl font-bold font-mono ${plColor(summary.optionRealizedPL)}`}>
                 {fmt(summary.optionRealizedPL)}
               </div>
             </div>
-            <div className="border rounded-lg p-4">
-              <h4 className="text-sm font-semibold mb-3">Stocks P&L</h4>
-              <div className={`text-2xl font-bold font-mono ${plColor(summary.stockRealizedPL)}`}>
+            <div className="border border-border rounded p-3">
+              <h4 className="text-terminal-lg font-semibold mb-2">Stocks P&L</h4>
+              <div className={`text-xl font-bold font-mono ${plColor(summary.stockRealizedPL)}`}>
                 {fmt(summary.stockRealizedPL)}
               </div>
-              <div className="flex gap-4 mt-2 text-xs text-gray-500">
+              <div className="flex gap-4 mt-2 text-terminal-sm text-text-muted">
                 <span>ST: <span className={`font-mono ${plColor(summary.shortTermPL - (summary.shortTermPL - (data.closedPositions.stocks.reduce((s, p) => s + p.shortTermPL, 0))))}`}>{fmt(data.closedPositions.stocks.reduce((s, p) => s + p.shortTermPL, 0))}</span></span>
                 <span>LT: <span className={`font-mono ${plColor(data.closedPositions.stocks.reduce((s, p) => s + p.longTermPL, 0))}`}>{fmt(data.closedPositions.stocks.reduce((s, p) => s + p.longTermPL, 0))}</span></span>
               </div>
@@ -233,30 +233,30 @@ export default function PositionReportTab() {
 
           {/* Strategy breakdown */}
           {data.byStrategy.length > 0 && (
-            <div className="border rounded-lg overflow-hidden">
-              <div className="bg-gray-50 px-4 py-2 text-sm font-semibold">By Strategy</div>
-              <table className="w-full text-xs">
-                <thead className="bg-gray-100">
+            <div className="border border-border rounded overflow-hidden">
+              <div className="bg-bg-row px-3 py-1.5 text-terminal-lg font-semibold">By Strategy</div>
+              <table className="w-full text-terminal-base">
+                <thead className="bg-brand-purple text-white/70">
                   <tr>
-                    <th className="px-3 py-2 text-left">Strategy</th>
-                    <th className="px-3 py-2 text-right">Trades</th>
-                    <th className="px-3 py-2 text-right">Wins</th>
-                    <th className="px-3 py-2 text-right">Losses</th>
-                    <th className="px-3 py-2 text-right">Win Rate</th>
-                    <th className="px-3 py-2 text-right">P&L</th>
+                    <th className="py-1 px-2 text-left text-terminal-xs uppercase tracking-widest font-mono">Strategy</th>
+                    <th className="py-1 px-2 text-right text-terminal-xs uppercase tracking-widest font-mono">Trades</th>
+                    <th className="py-1 px-2 text-right text-terminal-xs uppercase tracking-widest font-mono">Wins</th>
+                    <th className="py-1 px-2 text-right text-terminal-xs uppercase tracking-widest font-mono">Losses</th>
+                    <th className="py-1 px-2 text-right text-terminal-xs uppercase tracking-widest font-mono">Win Rate</th>
+                    <th className="py-1 px-2 text-right text-terminal-xs uppercase tracking-widest font-mono">P&L</th>
                   </tr>
                 </thead>
                 <tbody>
-                  {data.byStrategy.map(s => (
-                    <tr key={s.strategy} className="border-b hover:bg-gray-50">
-                      <td className="px-3 py-2 font-medium">{s.strategy}</td>
-                      <td className="px-3 py-2 text-right font-mono">{s.count}</td>
-                      <td className="px-3 py-2 text-right font-mono text-green-700">{s.wins}</td>
-                      <td className="px-3 py-2 text-right font-mono text-red-700">{s.losses}</td>
-                      <td className="px-3 py-2 text-right font-mono">
+                  {data.byStrategy.map((s, idx) => (
+                    <tr key={s.strategy} className={`border-b border-border-light hover:bg-bg-row ${idx % 2 === 0 ? 'bg-white' : 'bg-bg-row'}`}>
+                      <td className="py-1 px-2 font-medium">{s.strategy}</td>
+                      <td className="py-1 px-2 text-right font-mono">{s.count}</td>
+                      <td className="py-1 px-2 text-right font-mono text-brand-green">{s.wins}</td>
+                      <td className="py-1 px-2 text-right font-mono text-brand-red">{s.losses}</td>
+                      <td className="py-1 px-2 text-right font-mono">
                         {s.count > 0 ? Math.round((s.wins / s.count) * 100) : 0}%
                       </td>
-                      <td className={`px-3 py-2 text-right font-mono font-semibold ${plColor(s.pl)}`}>
+                      <td className={`py-1 px-2 text-right font-mono font-semibold ${plColor(s.pl)}`}>
                         {fmt(s.pl)}
                       </td>
                     </tr>
@@ -267,14 +267,14 @@ export default function PositionReportTab() {
           )}
 
           {/* Avg win/loss */}
-          <div className="grid grid-cols-2 gap-4">
-            <div className="border rounded-lg p-3">
-              <div className="text-[10px] text-gray-500 uppercase">Avg Win</div>
-              <div className="text-lg font-bold font-mono text-green-700">{fmt(summary.avgWin)}</div>
+          <div className="grid grid-cols-2 gap-3">
+            <div className="border border-border rounded p-2">
+              <div className="text-terminal-xs text-text-muted uppercase tracking-widest">Avg Win</div>
+              <div className="text-base font-bold font-mono text-brand-green">{fmt(summary.avgWin)}</div>
             </div>
-            <div className="border rounded-lg p-3">
-              <div className="text-[10px] text-gray-500 uppercase">Avg Loss</div>
-              <div className="text-lg font-bold font-mono text-red-700">{fmt(summary.avgLoss)}</div>
+            <div className="border border-border rounded p-2">
+              <div className="text-terminal-xs text-text-muted uppercase tracking-widest">Avg Loss</div>
+              <div className="text-base font-bold font-mono text-brand-red">{fmt(summary.avgLoss)}</div>
             </div>
           </div>
         </div>
@@ -282,46 +282,46 @@ export default function PositionReportTab() {
 
       {/* Open Positions View */}
       {activeView === 'open' && (
-        <div className="p-4 space-y-4">
+        <div className="p-3 space-y-3">
           {/* Open Options */}
           {data.openPositions.options.length > 0 && (
-            <div className="border rounded-lg overflow-hidden">
-              <div className="bg-blue-50 px-4 py-2 text-sm font-semibold text-blue-800">
+            <div className="border border-border rounded overflow-hidden">
+              <div className="bg-bg-row px-3 py-1.5 text-terminal-lg font-semibold text-text-primary">
                 Open Options ({data.openPositions.options.length})
               </div>
               <div className="overflow-x-auto">
-                <table className="w-full text-xs">
-                  <thead className="bg-gray-100">
+                <table className="w-full text-terminal-base">
+                  <thead className="bg-brand-purple text-white/70">
                     <tr>
-                      <th className="px-3 py-2 text-left">Symbol</th>
-                      <th className="px-3 py-2 text-left">Type</th>
-                      <th className="px-3 py-2 text-right">Strike</th>
-                      <th className="px-3 py-2 text-left">Exp</th>
-                      <th className="px-3 py-2 text-right">Qty</th>
-                      <th className="px-3 py-2 text-right">Cost Basis</th>
-                      <th className="px-3 py-2 text-left">Opened</th>
-                      <th className="px-3 py-2 text-left">Strategy</th>
-                      <th className="px-3 py-2 text-right">Trade #</th>
+                      <th className="py-1 px-2 text-left text-terminal-xs uppercase tracking-widest font-mono">Symbol</th>
+                      <th className="py-1 px-2 text-left text-terminal-xs uppercase tracking-widest font-mono">Type</th>
+                      <th className="py-1 px-2 text-right text-terminal-xs uppercase tracking-widest font-mono">Strike</th>
+                      <th className="py-1 px-2 text-left text-terminal-xs uppercase tracking-widest font-mono">Exp</th>
+                      <th className="py-1 px-2 text-right text-terminal-xs uppercase tracking-widest font-mono">Qty</th>
+                      <th className="py-1 px-2 text-right text-terminal-xs uppercase tracking-widest font-mono">Cost Basis</th>
+                      <th className="py-1 px-2 text-left text-terminal-xs uppercase tracking-widest font-mono">Opened</th>
+                      <th className="py-1 px-2 text-left text-terminal-xs uppercase tracking-widest font-mono">Strategy</th>
+                      <th className="py-1 px-2 text-right text-terminal-xs uppercase tracking-widest font-mono">Trade #</th>
                     </tr>
                   </thead>
                   <tbody>
-                    {data.openPositions.options.map(p => (
-                      <tr key={p.id} className="border-b hover:bg-gray-50">
-                        <td className="px-3 py-2 font-medium">{p.symbol}</td>
-                        <td className="px-3 py-2">
+                    {data.openPositions.options.map((p, idx) => (
+                      <tr key={p.id} className={`border-b border-border-light hover:bg-bg-row ${idx % 2 === 0 ? 'bg-white' : 'bg-bg-row'}`}>
+                        <td className="py-1 px-2 font-medium">{p.symbol}</td>
+                        <td className="py-1 px-2">
                           <span className={`px-1.5 py-0.5 rounded text-[10px] font-medium ${
                             p.optionType === 'CALL' ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800'
                           }`}>
                             {p.positionType} {p.optionType}
                           </span>
                         </td>
-                        <td className="px-3 py-2 text-right font-mono">${p.strike?.toFixed(2) ?? '-'}</td>
-                        <td className="px-3 py-2">{fmtDate(p.expiration)}</td>
-                        <td className="px-3 py-2 text-right font-mono">{p.remainingQuantity}</td>
-                        <td className="px-3 py-2 text-right font-mono">{fmt(p.costBasis)}</td>
-                        <td className="px-3 py-2">{fmtDate(p.openDate)}</td>
-                        <td className="px-3 py-2">{p.strategy}</td>
-                        <td className="px-3 py-2 text-right font-mono text-gray-400">#{p.tradeNum}</td>
+                        <td className="py-1 px-2 text-right font-mono font-semibold">${p.strike?.toFixed(2) ?? '-'}</td>
+                        <td className="py-1 px-2 font-mono text-text-muted">{fmtDate(p.expiration)}</td>
+                        <td className="py-1 px-2 text-right font-mono">{p.remainingQuantity}</td>
+                        <td className="py-1 px-2 text-right font-mono font-semibold">{fmt(p.costBasis)}</td>
+                        <td className="py-1 px-2 font-mono text-text-muted">{fmtDate(p.openDate)}</td>
+                        <td className="py-1 px-2">{p.strategy}</td>
+                        <td className="py-1 px-2 text-right font-mono text-text-faint">#{p.tradeNum}</td>
                       </tr>
                     ))}
                   </tbody>
@@ -332,35 +332,35 @@ export default function PositionReportTab() {
 
           {/* Open Stocks */}
           {data.openPositions.stocks.length > 0 && (
-            <div className="border rounded-lg overflow-hidden">
-              <div className="bg-purple-50 px-4 py-2 text-sm font-semibold text-purple-800">
+            <div className="border border-border rounded overflow-hidden">
+              <div className="bg-bg-row px-3 py-1.5 text-terminal-lg font-semibold text-text-primary">
                 Open Stock Positions ({data.openPositions.stocks.length})
               </div>
               <div className="overflow-x-auto">
-                <table className="w-full text-xs">
-                  <thead className="bg-gray-100">
+                <table className="w-full text-terminal-base">
+                  <thead className="bg-brand-purple text-white/70">
                     <tr>
-                      <th className="px-3 py-2 text-left">Symbol</th>
-                      <th className="px-3 py-2 text-right">Shares</th>
-                      <th className="px-3 py-2 text-right">Avg Cost</th>
-                      <th className="px-3 py-2 text-right">Cost Basis</th>
-                      <th className="px-3 py-2 text-right">Realized P&L</th>
-                      <th className="px-3 py-2 text-left">Opened</th>
-                      <th className="px-3 py-2 text-right">Lots</th>
+                      <th className="py-1 px-2 text-left text-terminal-xs uppercase tracking-widest font-mono">Symbol</th>
+                      <th className="py-1 px-2 text-right text-terminal-xs uppercase tracking-widest font-mono">Shares</th>
+                      <th className="py-1 px-2 text-right text-terminal-xs uppercase tracking-widest font-mono">Avg Cost</th>
+                      <th className="py-1 px-2 text-right text-terminal-xs uppercase tracking-widest font-mono">Cost Basis</th>
+                      <th className="py-1 px-2 text-right text-terminal-xs uppercase tracking-widest font-mono">Realized P&L</th>
+                      <th className="py-1 px-2 text-left text-terminal-xs uppercase tracking-widest font-mono">Opened</th>
+                      <th className="py-1 px-2 text-right text-terminal-xs uppercase tracking-widest font-mono">Lots</th>
                     </tr>
                   </thead>
                   <tbody>
-                    {data.openPositions.stocks.map(p => (
-                      <tr key={p.symbol} className="border-b hover:bg-gray-50">
-                        <td className="px-3 py-2 font-medium">{p.symbol}</td>
-                        <td className="px-3 py-2 text-right font-mono">{p.shares.remaining}</td>
-                        <td className="px-3 py-2 text-right font-mono">${p.avgCostPerShare.toFixed(2)}</td>
-                        <td className="px-3 py-2 text-right font-mono">{fmt(p.remainingCostBasis)}</td>
-                        <td className={`px-3 py-2 text-right font-mono font-semibold ${plColor(p.realizedPL)}`}>
+                    {data.openPositions.stocks.map((p, idx) => (
+                      <tr key={p.symbol} className={`border-b border-border-light hover:bg-bg-row ${idx % 2 === 0 ? 'bg-white' : 'bg-bg-row'}`}>
+                        <td className="py-1 px-2 font-medium">{p.symbol}</td>
+                        <td className="py-1 px-2 text-right font-mono">{p.shares.remaining}</td>
+                        <td className="py-1 px-2 text-right font-mono font-semibold">${p.avgCostPerShare.toFixed(2)}</td>
+                        <td className="py-1 px-2 text-right font-mono font-semibold">{fmt(p.remainingCostBasis)}</td>
+                        <td className={`py-1 px-2 text-right font-mono font-semibold ${plColor(p.realizedPL)}`}>
                           {fmt(p.realizedPL)}
                         </td>
-                        <td className="px-3 py-2">{fmtDate(p.openDate)}</td>
-                        <td className="px-3 py-2 text-right font-mono text-gray-400">{p.lotCount}</td>
+                        <td className="py-1 px-2 font-mono text-text-muted">{fmtDate(p.openDate)}</td>
+                        <td className="py-1 px-2 text-right font-mono text-text-faint">{p.lotCount}</td>
                       </tr>
                     ))}
                   </tbody>
@@ -370,65 +370,65 @@ export default function PositionReportTab() {
           )}
 
           {data.openPositions.options.length === 0 && data.openPositions.stocks.length === 0 && (
-            <div className="text-center text-sm text-gray-500 py-8">No open positions</div>
+            <div className="text-center text-terminal-sm text-text-muted py-8">No open positions</div>
           )}
         </div>
       )}
 
       {/* Closed Positions View */}
       {activeView === 'closed' && (
-        <div className="p-4 space-y-4">
+        <div className="p-3 space-y-3">
           {/* Closed Options */}
           {data.closedPositions.options.length > 0 && (
-            <div className="border rounded-lg overflow-hidden">
-              <div className="bg-blue-50 px-4 py-2 text-sm font-semibold text-blue-800">
+            <div className="border border-border rounded overflow-hidden">
+              <div className="bg-bg-row px-3 py-1.5 text-terminal-lg font-semibold text-text-primary">
                 Closed Options ({data.closedPositions.options.length})
               </div>
               <div className="overflow-x-auto">
-                <table className="w-full text-xs">
-                  <thead className="bg-gray-100">
+                <table className="w-full text-terminal-base">
+                  <thead className="bg-brand-purple text-white/70">
                     <tr>
-                      <th className="px-3 py-2 text-left">Symbol</th>
-                      <th className="px-3 py-2 text-left">Type</th>
-                      <th className="px-3 py-2 text-right">Strike</th>
-                      <th className="px-3 py-2 text-right">Qty</th>
-                      <th className="px-3 py-2 text-right">Cost Basis</th>
-                      <th className="px-3 py-2 text-right">Proceeds</th>
-                      <th className="px-3 py-2 text-right">P&L</th>
-                      <th className="px-3 py-2 text-right">Days</th>
-                      <th className="px-3 py-2 text-left">Term</th>
-                      <th className="px-3 py-2 text-left">Closed</th>
-                      <th className="px-3 py-2 text-right">Trade #</th>
+                      <th className="py-1 px-2 text-left text-terminal-xs uppercase tracking-widest font-mono">Symbol</th>
+                      <th className="py-1 px-2 text-left text-terminal-xs uppercase tracking-widest font-mono">Type</th>
+                      <th className="py-1 px-2 text-right text-terminal-xs uppercase tracking-widest font-mono">Strike</th>
+                      <th className="py-1 px-2 text-right text-terminal-xs uppercase tracking-widest font-mono">Qty</th>
+                      <th className="py-1 px-2 text-right text-terminal-xs uppercase tracking-widest font-mono">Cost Basis</th>
+                      <th className="py-1 px-2 text-right text-terminal-xs uppercase tracking-widest font-mono">Proceeds</th>
+                      <th className="py-1 px-2 text-right text-terminal-xs uppercase tracking-widest font-mono">P&L</th>
+                      <th className="py-1 px-2 text-right text-terminal-xs uppercase tracking-widest font-mono">Days</th>
+                      <th className="py-1 px-2 text-left text-terminal-xs uppercase tracking-widest font-mono">Term</th>
+                      <th className="py-1 px-2 text-left text-terminal-xs uppercase tracking-widest font-mono">Closed</th>
+                      <th className="py-1 px-2 text-right text-terminal-xs uppercase tracking-widest font-mono">Trade #</th>
                     </tr>
                   </thead>
                   <tbody>
-                    {data.closedPositions.options.map(p => (
-                      <tr key={p.id} className="border-b hover:bg-gray-50">
-                        <td className="px-3 py-2 font-medium">{p.symbol}</td>
-                        <td className="px-3 py-2">
+                    {data.closedPositions.options.map((p, idx) => (
+                      <tr key={p.id} className={`border-b border-border-light hover:bg-bg-row ${idx % 2 === 0 ? 'bg-white' : 'bg-bg-row'}`}>
+                        <td className="py-1 px-2 font-medium">{p.symbol}</td>
+                        <td className="py-1 px-2">
                           <span className={`px-1.5 py-0.5 rounded text-[10px] font-medium ${
                             p.optionType === 'CALL' ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800'
                           }`}>
                             {p.positionType} {p.optionType}
                           </span>
                         </td>
-                        <td className="px-3 py-2 text-right font-mono">${p.strike?.toFixed(2) ?? '-'}</td>
-                        <td className="px-3 py-2 text-right font-mono">{p.quantity}</td>
-                        <td className="px-3 py-2 text-right font-mono">{fmt(p.costBasis)}</td>
-                        <td className="px-3 py-2 text-right font-mono">{fmt(p.proceeds)}</td>
-                        <td className={`px-3 py-2 text-right font-mono font-semibold ${plColor(p.realizedPL)}`}>
+                        <td className="py-1 px-2 text-right font-mono font-semibold">${p.strike?.toFixed(2) ?? '-'}</td>
+                        <td className="py-1 px-2 text-right font-mono">{p.quantity}</td>
+                        <td className="py-1 px-2 text-right font-mono font-semibold">{fmt(p.costBasis)}</td>
+                        <td className="py-1 px-2 text-right font-mono font-semibold">{fmt(p.proceeds)}</td>
+                        <td className={`py-1 px-2 text-right font-mono font-semibold ${plColor(p.realizedPL)}`}>
                           {fmt(p.realizedPL)}
                         </td>
-                        <td className="px-3 py-2 text-right font-mono text-gray-500">{p.holdingDays ?? '-'}</td>
-                        <td className="px-3 py-2">
+                        <td className="py-1 px-2 text-right font-mono text-text-muted">{p.holdingDays ?? '-'}</td>
+                        <td className="py-1 px-2">
                           <span className={`px-1.5 py-0.5 rounded text-[10px] font-medium ${
                             p.isLongTerm ? 'bg-blue-100 text-blue-800' : 'bg-yellow-100 text-yellow-800'
                           }`}>
                             {p.isLongTerm ? 'LT' : 'ST'}
                           </span>
                         </td>
-                        <td className="px-3 py-2">{fmtDate(p.closeDate)}</td>
-                        <td className="px-3 py-2 text-right font-mono text-gray-400">#{p.tradeNum}</td>
+                        <td className="py-1 px-2 font-mono text-text-muted">{fmtDate(p.closeDate)}</td>
+                        <td className="py-1 px-2 text-right font-mono text-text-faint">#{p.tradeNum}</td>
                       </tr>
                     ))}
                   </tbody>
@@ -439,41 +439,41 @@ export default function PositionReportTab() {
 
           {/* Closed Stocks */}
           {data.closedPositions.stocks.length > 0 && (
-            <div className="border rounded-lg overflow-hidden">
-              <div className="bg-purple-50 px-4 py-2 text-sm font-semibold text-purple-800">
+            <div className="border border-border rounded overflow-hidden">
+              <div className="bg-bg-row px-3 py-1.5 text-terminal-lg font-semibold text-text-primary">
                 Closed Stock Positions ({data.closedPositions.stocks.length})
               </div>
               <div className="overflow-x-auto">
-                <table className="w-full text-xs">
-                  <thead className="bg-gray-100">
+                <table className="w-full text-terminal-base">
+                  <thead className="bg-brand-purple text-white/70">
                     <tr>
-                      <th className="px-3 py-2 text-left">Symbol</th>
-                      <th className="px-3 py-2 text-right">Shares</th>
-                      <th className="px-3 py-2 text-right">Cost Basis</th>
-                      <th className="px-3 py-2 text-right">Proceeds</th>
-                      <th className="px-3 py-2 text-right">P&L</th>
-                      <th className="px-3 py-2 text-right">ST P&L</th>
-                      <th className="px-3 py-2 text-right">LT P&L</th>
-                      <th className="px-3 py-2 text-left">Closed</th>
+                      <th className="py-1 px-2 text-left text-terminal-xs uppercase tracking-widest font-mono">Symbol</th>
+                      <th className="py-1 px-2 text-right text-terminal-xs uppercase tracking-widest font-mono">Shares</th>
+                      <th className="py-1 px-2 text-right text-terminal-xs uppercase tracking-widest font-mono">Cost Basis</th>
+                      <th className="py-1 px-2 text-right text-terminal-xs uppercase tracking-widest font-mono">Proceeds</th>
+                      <th className="py-1 px-2 text-right text-terminal-xs uppercase tracking-widest font-mono">P&L</th>
+                      <th className="py-1 px-2 text-right text-terminal-xs uppercase tracking-widest font-mono">ST P&L</th>
+                      <th className="py-1 px-2 text-right text-terminal-xs uppercase tracking-widest font-mono">LT P&L</th>
+                      <th className="py-1 px-2 text-left text-terminal-xs uppercase tracking-widest font-mono">Closed</th>
                     </tr>
                   </thead>
                   <tbody>
-                    {data.closedPositions.stocks.map(p => (
-                      <tr key={p.symbol} className="border-b hover:bg-gray-50">
-                        <td className="px-3 py-2 font-medium">{p.symbol}</td>
-                        <td className="px-3 py-2 text-right font-mono">{p.shares.original}</td>
-                        <td className="px-3 py-2 text-right font-mono">{fmt(p.costBasis)}</td>
-                        <td className="px-3 py-2 text-right font-mono">{fmt(p.proceeds)}</td>
-                        <td className={`px-3 py-2 text-right font-mono font-semibold ${plColor(p.realizedPL)}`}>
+                    {data.closedPositions.stocks.map((p, idx) => (
+                      <tr key={p.symbol} className={`border-b border-border-light hover:bg-bg-row ${idx % 2 === 0 ? 'bg-white' : 'bg-bg-row'}`}>
+                        <td className="py-1 px-2 font-medium">{p.symbol}</td>
+                        <td className="py-1 px-2 text-right font-mono">{p.shares.original}</td>
+                        <td className="py-1 px-2 text-right font-mono font-semibold">{fmt(p.costBasis)}</td>
+                        <td className="py-1 px-2 text-right font-mono font-semibold">{fmt(p.proceeds)}</td>
+                        <td className={`py-1 px-2 text-right font-mono font-semibold ${plColor(p.realizedPL)}`}>
                           {fmt(p.realizedPL)}
                         </td>
-                        <td className={`px-3 py-2 text-right font-mono ${plColor(p.shortTermPL)}`}>
+                        <td className={`py-1 px-2 text-right font-mono ${plColor(p.shortTermPL)}`}>
                           {fmt(p.shortTermPL)}
                         </td>
-                        <td className={`px-3 py-2 text-right font-mono ${plColor(p.longTermPL)}`}>
+                        <td className={`py-1 px-2 text-right font-mono ${plColor(p.longTermPL)}`}>
                           {fmt(p.longTermPL)}
                         </td>
-                        <td className="px-3 py-2">{fmtDate(p.closeDate)}</td>
+                        <td className="py-1 px-2 font-mono text-text-muted">{fmtDate(p.closeDate)}</td>
                       </tr>
                     ))}
                   </tbody>
@@ -483,7 +483,7 @@ export default function PositionReportTab() {
           )}
 
           {data.closedPositions.options.length === 0 && data.closedPositions.stocks.length === 0 && (
-            <div className="text-center text-sm text-gray-500 py-8">No closed positions</div>
+            <div className="text-center text-terminal-sm text-text-muted py-8">No closed positions</div>
           )}
         </div>
       )}

--- a/src/components/dashboard/TaxReportTab.tsx
+++ b/src/components/dashboard/TaxReportTab.tsx
@@ -284,7 +284,7 @@ export default function TaxReportTab() {
     return val < 0 ? `(${formatted})` : formatted;
   };
 
-  const plColor = (val: number) => val >= 0 ? 'text-green-700' : 'text-red-700';
+  const plColor = (val: number) => val >= 0 ? 'text-brand-green' : 'text-brand-red';
 
   const fmtDate = (d: string) => {
     const dt = new Date(d + 'T00:00:00');
@@ -296,11 +296,11 @@ export default function TaxReportTab() {
   // ── Loading / error states ──
 
   if (loading) {
-    return <div className="p-8 text-center text-sm text-gray-500">Generating tax report...</div>;
+    return <div className="p-8 text-center text-terminal-sm text-text-muted">Generating tax report...</div>;
   }
 
   if (!data) {
-    return <div className="p-8 text-center text-sm text-red-600">Failed to load tax report</div>;
+    return <div className="p-8 text-center text-terminal-sm text-red-600">Failed to load tax report</div>;
   }
 
   const { summary, scheduleD } = data;
@@ -322,13 +322,13 @@ export default function TaxReportTab() {
   return (
     <div>
       {/* Header */}
-      <div className="bg-[#2d1b4e] text-white px-4 py-2 flex items-center justify-between">
-        <span className="text-sm font-semibold">Tax Reports</span>
+      <div className="bg-brand-purple text-white px-3 py-1.5 flex items-center justify-between">
+        <span className="text-terminal-lg font-semibold">Tax Reports</span>
         <div className="flex items-center gap-2">
           <select
             value={year}
             onChange={(e: React.ChangeEvent<HTMLSelectElement>) => setYear(Number(e.target.value))}
-            className="bg-[#3d2b5e] text-white border-0 text-xs px-2 py-1 rounded"
+            className="bg-brand-purple-hover text-white border-0 text-terminal-sm px-2 py-1 rounded"
           >
             {availableYears.map((y: number) => <option key={y} value={y}>{y}</option>)}
           </select>
@@ -336,7 +336,7 @@ export default function TaxReportTab() {
             <button
               onClick={exportCSV}
               disabled={exporting}
-              className="text-xs bg-emerald-600 px-3 py-1 rounded hover:bg-emerald-700 disabled:opacity-50"
+              className="text-terminal-sm bg-emerald-600 px-3 py-1 rounded hover:bg-emerald-700 disabled:opacity-50"
             >
               {exporting ? 'Exporting...' : 'Export CSV'}
             </button>
@@ -345,7 +345,7 @@ export default function TaxReportTab() {
       </div>
 
       {/* ─── DISCLAIMER BANNER ─── */}
-      <div className="bg-amber-50 border-b-2 border-amber-300 px-4 py-3 text-xs text-amber-900">
+      <div className="bg-amber-50 border-b-2 border-amber-300 px-3 py-1.5 text-terminal-base text-amber-900">
         <span className="font-bold">TAX ESTIMATE ONLY</span> — This report organizes your ledger
         data into IRS form structure for review purposes. It is NOT a tax filing. All figures must
         be verified by a licensed CPA or tax professional before filing. Temple Stuart is not a tax
@@ -353,13 +353,13 @@ export default function TaxReportTab() {
       </div>
 
       {/* Sub-tabs */}
-      <div className="flex border-b border-gray-200">
+      <div className="flex border-b border-border">
         {tabs.map(tab => (
           <button
             key={tab.key}
             onClick={() => setView(tab.key)}
-            className={`px-4 py-2 text-xs font-medium ${
-              view === tab.key ? 'bg-[#2d1b4e] text-white' : 'bg-gray-50 text-gray-600'
+            className={`px-3 py-1 text-terminal-sm font-medium ${
+              view === tab.key ? 'bg-brand-purple text-white' : 'bg-bg-row text-text-muted'
             }`}
           >
             {tab.label}
@@ -374,52 +374,52 @@ export default function TaxReportTab() {
         <div className="p-4 space-y-4">
           {/* Summary Cards */}
           <div className="grid grid-cols-5 gap-3">
-            <div className="border rounded-lg p-3">
-              <div className="text-[10px] text-gray-500 uppercase">Net Capital Gain/Loss</div>
-              <div className={`text-xl font-bold font-mono ${plColor(summary.netGainOrLoss)}`}>
+            <div className="border border-border rounded p-2">
+              <div className="text-terminal-xs text-text-muted uppercase tracking-widest">Net Capital Gain/Loss</div>
+              <div className={`text-lg font-bold font-mono ${plColor(summary.netGainOrLoss)}`}>
                 {fmt(summary.netGainOrLoss)}
               </div>
             </div>
-            <div className="border rounded-lg p-3">
-              <div className="text-[10px] text-gray-500 uppercase">Short-Term</div>
+            <div className="border border-border rounded p-2">
+              <div className="text-terminal-xs text-text-muted uppercase tracking-widest">Short-Term</div>
               <div className={`text-lg font-bold font-mono ${plColor(scheduleD.partI.line7.gainOrLoss)}`}>
                 {fmt(scheduleD.partI.line7.gainOrLoss)}
               </div>
-              <div className="text-[10px] text-gray-400">{summary.shortTermCount} dispositions</div>
+              <div className="text-terminal-xs text-text-faint">{summary.shortTermCount} dispositions</div>
             </div>
-            <div className="border rounded-lg p-3">
-              <div className="text-[10px] text-gray-500 uppercase">Long-Term</div>
+            <div className="border border-border rounded p-2">
+              <div className="text-terminal-xs text-text-muted uppercase tracking-widest">Long-Term</div>
               <div className={`text-lg font-bold font-mono ${plColor(scheduleD.partII.line15.gainOrLoss)}`}>
                 {fmt(scheduleD.partII.line15.gainOrLoss)}
               </div>
-              <div className="text-[10px] text-gray-400">{summary.longTermCount} dispositions</div>
+              <div className="text-terminal-xs text-text-faint">{summary.longTermCount} dispositions</div>
             </div>
-            <div className="border rounded-lg p-3">
-              <div className="text-[10px] text-gray-500 uppercase">Wash Sales</div>
-              <div className="text-lg font-bold font-mono text-amber-700">
+            <div className="border border-border rounded p-2">
+              <div className="text-terminal-xs text-text-muted uppercase tracking-widest">Wash Sales</div>
+              <div className="text-lg font-bold font-mono text-brand-amber">
                 {summary.washSaleCount}
               </div>
-              <div className="text-[10px] text-gray-400">{fmt(summary.washSaleDisallowed)} disallowed</div>
+              <div className="text-terminal-xs text-text-faint">{fmt(summary.washSaleDisallowed)} disallowed</div>
             </div>
-            <div className="border rounded-lg p-3">
-              <div className="text-[10px] text-gray-500 uppercase">Total Dispositions</div>
+            <div className="border border-border rounded p-2">
+              <div className="text-terminal-xs text-text-muted uppercase tracking-widest">Total Dispositions</div>
               <div className="text-lg font-bold font-mono">{summary.totalDispositions}</div>
             </div>
           </div>
 
           {/* Part I: Short-Term */}
-          <div className="border rounded-lg overflow-hidden">
-            <div className="bg-yellow-50 px-4 py-2 text-sm font-semibold text-yellow-800">
+          <div className="border border-border rounded overflow-hidden">
+            <div className="bg-yellow-50 px-3 py-1.5 text-terminal-lg font-semibold text-yellow-800">
               Part I — Short-Term Capital Gains and Losses (held 1 year or less)
             </div>
-            <table className="w-full text-xs">
-              <thead className="bg-gray-100">
+            <table className="w-full text-terminal-base">
+              <thead className="bg-brand-purple text-white/70">
                 <tr>
-                  <th className="px-3 py-2 text-left w-[280px]">Line</th>
-                  <th className="px-3 py-2 text-right">(d) Proceeds</th>
-                  <th className="px-3 py-2 text-right">(e) Cost Basis</th>
-                  <th className="px-3 py-2 text-right">(g) Adjustments</th>
-                  <th className="px-3 py-2 text-right">(h) Gain or Loss</th>
+                  <th className="py-1 px-2 text-left w-[280px] text-terminal-xs uppercase tracking-widest font-mono">Line</th>
+                  <th className="py-1 px-2 text-right text-terminal-xs uppercase tracking-widest font-mono">(d) Proceeds</th>
+                  <th className="py-1 px-2 text-right text-terminal-xs uppercase tracking-widest font-mono">(e) Cost Basis</th>
+                  <th className="py-1 px-2 text-right text-terminal-xs uppercase tracking-widest font-mono">(g) Adjustments</th>
+                  <th className="py-1 px-2 text-right text-terminal-xs uppercase tracking-widest font-mono">(h) Gain or Loss</th>
                 </tr>
               </thead>
               <tbody>
@@ -427,11 +427,11 @@ export default function TaxReportTab() {
                 {renderScheduleDLine(scheduleD.partI.line1b)}
                 {renderScheduleDLine(scheduleD.partI.line1c)}
                 <tr className="bg-yellow-50 font-semibold border-t-2 border-yellow-300">
-                  <td className="px-3 py-2 text-yellow-800">Line {scheduleD.partI.line7.line}: {scheduleD.partI.line7.description}</td>
-                  <td className="px-3 py-2 text-right font-mono">{fmt(scheduleD.partI.line7.proceeds)}</td>
-                  <td className="px-3 py-2 text-right font-mono">{fmt(scheduleD.partI.line7.costBasis)}</td>
-                  <td className="px-3 py-2 text-right font-mono">{fmt(scheduleD.partI.line7.adjustments)}</td>
-                  <td className={`px-3 py-2 text-right font-mono ${plColor(scheduleD.partI.line7.gainOrLoss)}`}>
+                  <td className="py-1 px-2 text-yellow-800">Line {scheduleD.partI.line7.line}: {scheduleD.partI.line7.description}</td>
+                  <td className="py-1 px-2 text-right font-mono">{fmt(scheduleD.partI.line7.proceeds)}</td>
+                  <td className="py-1 px-2 text-right font-mono">{fmt(scheduleD.partI.line7.costBasis)}</td>
+                  <td className="py-1 px-2 text-right font-mono">{fmt(scheduleD.partI.line7.adjustments)}</td>
+                  <td className={`py-1 px-2 text-right font-mono ${plColor(scheduleD.partI.line7.gainOrLoss)}`}>
                     {fmt(scheduleD.partI.line7.gainOrLoss)}
                   </td>
                 </tr>
@@ -440,18 +440,18 @@ export default function TaxReportTab() {
           </div>
 
           {/* Part II: Long-Term */}
-          <div className="border rounded-lg overflow-hidden">
-            <div className="bg-blue-50 px-4 py-2 text-sm font-semibold text-blue-800">
+          <div className="border border-border rounded overflow-hidden">
+            <div className="bg-blue-50 px-3 py-1.5 text-terminal-lg font-semibold text-blue-800">
               Part II — Long-Term Capital Gains and Losses (held more than 1 year)
             </div>
-            <table className="w-full text-xs">
-              <thead className="bg-gray-100">
+            <table className="w-full text-terminal-base">
+              <thead className="bg-brand-purple text-white/70">
                 <tr>
-                  <th className="px-3 py-2 text-left w-[280px]">Line</th>
-                  <th className="px-3 py-2 text-right">(d) Proceeds</th>
-                  <th className="px-3 py-2 text-right">(e) Cost Basis</th>
-                  <th className="px-3 py-2 text-right">(g) Adjustments</th>
-                  <th className="px-3 py-2 text-right">(h) Gain or Loss</th>
+                  <th className="py-1 px-2 text-left w-[280px] text-terminal-xs uppercase tracking-widest font-mono">Line</th>
+                  <th className="py-1 px-2 text-right text-terminal-xs uppercase tracking-widest font-mono">(d) Proceeds</th>
+                  <th className="py-1 px-2 text-right text-terminal-xs uppercase tracking-widest font-mono">(e) Cost Basis</th>
+                  <th className="py-1 px-2 text-right text-terminal-xs uppercase tracking-widest font-mono">(g) Adjustments</th>
+                  <th className="py-1 px-2 text-right text-terminal-xs uppercase tracking-widest font-mono">(h) Gain or Loss</th>
                 </tr>
               </thead>
               <tbody>
@@ -459,11 +459,11 @@ export default function TaxReportTab() {
                 {renderScheduleDLine(scheduleD.partII.line8b)}
                 {renderScheduleDLine(scheduleD.partII.line8c)}
                 <tr className="bg-blue-50 font-semibold border-t-2 border-blue-300">
-                  <td className="px-3 py-2 text-blue-800">Line {scheduleD.partII.line15.line}: {scheduleD.partII.line15.description}</td>
-                  <td className="px-3 py-2 text-right font-mono">{fmt(scheduleD.partII.line15.proceeds)}</td>
-                  <td className="px-3 py-2 text-right font-mono">{fmt(scheduleD.partII.line15.costBasis)}</td>
-                  <td className="px-3 py-2 text-right font-mono">{fmt(scheduleD.partII.line15.adjustments)}</td>
-                  <td className={`px-3 py-2 text-right font-mono ${plColor(scheduleD.partII.line15.gainOrLoss)}`}>
+                  <td className="py-1 px-2 text-blue-800">Line {scheduleD.partII.line15.line}: {scheduleD.partII.line15.description}</td>
+                  <td className="py-1 px-2 text-right font-mono">{fmt(scheduleD.partII.line15.proceeds)}</td>
+                  <td className="py-1 px-2 text-right font-mono">{fmt(scheduleD.partII.line15.costBasis)}</td>
+                  <td className="py-1 px-2 text-right font-mono">{fmt(scheduleD.partII.line15.adjustments)}</td>
+                  <td className={`py-1 px-2 text-right font-mono ${plColor(scheduleD.partII.line15.gainOrLoss)}`}>
                     {fmt(scheduleD.partII.line15.gainOrLoss)}
                   </td>
                 </tr>
@@ -472,10 +472,10 @@ export default function TaxReportTab() {
           </div>
 
           {/* Net Total */}
-          <div className="border-2 border-gray-800 rounded-lg overflow-hidden">
-            <table className="w-full text-xs">
+          <div className="border-2 border-text-primary rounded overflow-hidden">
+            <table className="w-full text-terminal-base">
               <tbody>
-                <tr className="bg-gray-100 font-bold">
+                <tr className="bg-bg-row font-bold">
                   <td className="px-3 py-3 w-[280px]">Line {scheduleD.line16.line}: {scheduleD.line16.description}</td>
                   <td className="px-3 py-3 text-right font-mono">{fmt(scheduleD.line16.proceeds)}</td>
                   <td className="px-3 py-3 text-right font-mono">{fmt(scheduleD.line16.costBasis)}</td>
@@ -496,23 +496,23 @@ export default function TaxReportTab() {
       {view === 'form8949' && (
         <div className="p-4 space-y-4">
           {data.form8949.shortTerm.length > 0 && (
-            <div className="border rounded-lg overflow-hidden">
-              <div className="bg-yellow-50 px-4 py-2 text-sm font-semibold text-yellow-800">
+            <div className="border border-border rounded overflow-hidden">
+              <div className="bg-yellow-50 px-3 py-1.5 text-terminal-lg font-semibold text-yellow-800">
                 Short-Term — Held 1 Year or Less ({data.form8949.shortTerm.length} dispositions)
               </div>
               <div className="overflow-x-auto">
-                <table className="w-full text-xs">
-                  <thead className="bg-gray-100">
+                <table className="w-full text-terminal-base">
+                  <thead className="bg-brand-purple text-white/70">
                     <tr>
-                      <th className="px-2 py-2 text-left">(a) Description</th>
-                      <th className="px-2 py-2 text-left">(b) Acquired</th>
-                      <th className="px-2 py-2 text-left">(c) Sold</th>
-                      <th className="px-2 py-2 text-right">(d) Proceeds</th>
-                      <th className="px-2 py-2 text-right">(e) Cost Basis</th>
-                      <th className="px-2 py-2 text-center">(f) Code</th>
-                      <th className="px-2 py-2 text-right">(g) Adjustment</th>
-                      <th className="px-2 py-2 text-right">(h) Gain/Loss</th>
-                      <th className="px-2 py-2 text-right">Days</th>
+                      <th className="py-1 px-2 text-left text-terminal-xs uppercase tracking-widest font-mono">(a) Description</th>
+                      <th className="py-1 px-2 text-left text-terminal-xs uppercase tracking-widest font-mono">(b) Acquired</th>
+                      <th className="py-1 px-2 text-left text-terminal-xs uppercase tracking-widest font-mono">(c) Sold</th>
+                      <th className="py-1 px-2 text-right text-terminal-xs uppercase tracking-widest font-mono">(d) Proceeds</th>
+                      <th className="py-1 px-2 text-right text-terminal-xs uppercase tracking-widest font-mono">(e) Cost Basis</th>
+                      <th className="py-1 px-2 text-center text-terminal-xs uppercase tracking-widest font-mono">(f) Code</th>
+                      <th className="py-1 px-2 text-right text-terminal-xs uppercase tracking-widest font-mono">(g) Adjustment</th>
+                      <th className="py-1 px-2 text-right text-terminal-xs uppercase tracking-widest font-mono">(h) Gain/Loss</th>
+                      <th className="py-1 px-2 text-right text-terminal-xs uppercase tracking-widest font-mono">Days</th>
                     </tr>
                   </thead>
                   <tbody>
@@ -525,23 +525,23 @@ export default function TaxReportTab() {
           )}
 
           {data.form8949.longTerm.length > 0 && (
-            <div className="border rounded-lg overflow-hidden">
-              <div className="bg-blue-50 px-4 py-2 text-sm font-semibold text-blue-800">
+            <div className="border border-border rounded overflow-hidden">
+              <div className="bg-blue-50 px-3 py-1.5 text-terminal-lg font-semibold text-blue-800">
                 Long-Term — Held More Than 1 Year ({data.form8949.longTerm.length} dispositions)
               </div>
               <div className="overflow-x-auto">
-                <table className="w-full text-xs">
-                  <thead className="bg-gray-100">
+                <table className="w-full text-terminal-base">
+                  <thead className="bg-brand-purple text-white/70">
                     <tr>
-                      <th className="px-2 py-2 text-left">(a) Description</th>
-                      <th className="px-2 py-2 text-left">(b) Acquired</th>
-                      <th className="px-2 py-2 text-left">(c) Sold</th>
-                      <th className="px-2 py-2 text-right">(d) Proceeds</th>
-                      <th className="px-2 py-2 text-right">(e) Cost Basis</th>
-                      <th className="px-2 py-2 text-center">(f) Code</th>
-                      <th className="px-2 py-2 text-right">(g) Adjustment</th>
-                      <th className="px-2 py-2 text-right">(h) Gain/Loss</th>
-                      <th className="px-2 py-2 text-right">Days</th>
+                      <th className="py-1 px-2 text-left text-terminal-xs uppercase tracking-widest font-mono">(a) Description</th>
+                      <th className="py-1 px-2 text-left text-terminal-xs uppercase tracking-widest font-mono">(b) Acquired</th>
+                      <th className="py-1 px-2 text-left text-terminal-xs uppercase tracking-widest font-mono">(c) Sold</th>
+                      <th className="py-1 px-2 text-right text-terminal-xs uppercase tracking-widest font-mono">(d) Proceeds</th>
+                      <th className="py-1 px-2 text-right text-terminal-xs uppercase tracking-widest font-mono">(e) Cost Basis</th>
+                      <th className="py-1 px-2 text-center text-terminal-xs uppercase tracking-widest font-mono">(f) Code</th>
+                      <th className="py-1 px-2 text-right text-terminal-xs uppercase tracking-widest font-mono">(g) Adjustment</th>
+                      <th className="py-1 px-2 text-right text-terminal-xs uppercase tracking-widest font-mono">(h) Gain/Loss</th>
+                      <th className="py-1 px-2 text-right text-terminal-xs uppercase tracking-widest font-mono">Days</th>
                     </tr>
                   </thead>
                   <tbody>
@@ -554,7 +554,7 @@ export default function TaxReportTab() {
           )}
 
           {summary.totalDispositions === 0 && (
-            <div className="text-center text-sm text-gray-500 py-8">
+            <div className="text-center text-terminal-sm text-text-muted py-8">
               No dispositions found for tax year {year}
             </div>
           )}
@@ -567,111 +567,111 @@ export default function TaxReportTab() {
       {view === 'scheduleC' && (
         <div className="p-4 space-y-4">
           {scheduleCLoading ? (
-            <div className="p-8 text-center text-sm text-gray-500">Loading Schedule C...</div>
+            <div className="p-8 text-center text-terminal-sm text-text-muted">Loading Schedule C...</div>
           ) : !scheduleCData ? (
-            <div className="p-8 text-center text-sm text-red-600">Failed to load Schedule C</div>
+            <div className="p-8 text-center text-terminal-sm text-red-600">Failed to load Schedule C</div>
           ) : (
             <>
               {/* Business name */}
-              <div className="text-xs text-gray-500">
-                Schedule C — Profit or Loss From Business: <span className="font-semibold text-gray-700">{scheduleCData.scheduleC.businessName}</span>
+              <div className="text-terminal-base text-text-muted">
+                Schedule C — Profit or Loss From Business: <span className="font-semibold text-text-secondary">{scheduleCData.scheduleC.businessName}</span>
               </div>
 
               {/* Part I: Income */}
-              <div className="border rounded-lg overflow-hidden">
-                <div className="bg-green-50 px-4 py-2 text-sm font-semibold text-green-800">
+              <div className="border border-border rounded overflow-hidden">
+                <div className="bg-green-50 px-3 py-1.5 text-terminal-lg font-semibold text-green-800">
                   Part I — Income
                 </div>
-                <table className="w-full text-xs">
+                <table className="w-full text-terminal-base">
                   <tbody>
                     <tr className="border-b">
-                      <td className="px-4 py-2 w-2/3">Line 1: Gross receipts or sales</td>
-                      <td className="px-4 py-2 text-right font-mono font-semibold">{fmt(scheduleCData.scheduleC.line1)}</td>
+                      <td className="py-1 px-2 w-2/3">Line 1: Gross receipts or sales</td>
+                      <td className="py-1 px-2 text-right font-mono font-semibold">{fmt(scheduleCData.scheduleC.line1)}</td>
                     </tr>
                     {scheduleCData.scheduleC.revenueAccounts.map(ra => (
-                      <tr key={ra.code} className="border-b text-gray-500">
-                        <td className="px-4 py-1 pl-8 text-[11px]">{ra.code} — {ra.name}</td>
-                        <td className="px-4 py-1 text-right font-mono text-[11px]">{fmt(ra.amount)}</td>
+                      <tr key={ra.code} className="border-b text-text-muted">
+                        <td className="py-1 px-2 pl-8 text-terminal-sm">{ra.code} — {ra.name}</td>
+                        <td className="py-1 px-2 text-right font-mono text-terminal-sm">{fmt(ra.amount)}</td>
                       </tr>
                     ))}
                     {scheduleCData.scheduleC.line2 !== 0 && (
                       <tr className="border-b">
-                        <td className="px-4 py-2">Line 2: Returns and allowances</td>
-                        <td className="px-4 py-2 text-right font-mono">{fmt(scheduleCData.scheduleC.line2)}</td>
+                        <td className="py-1 px-2">Line 2: Returns and allowances</td>
+                        <td className="py-1 px-2 text-right font-mono">{fmt(scheduleCData.scheduleC.line2)}</td>
                       </tr>
                     )}
                     <tr className="bg-green-50 font-semibold border-t-2 border-green-300">
-                      <td className="px-4 py-2 text-green-800">Line 7: Gross income</td>
-                      <td className="px-4 py-2 text-right font-mono text-green-800">{fmt(scheduleCData.scheduleC.line7)}</td>
+                      <td className="py-1 px-2 text-green-800">Line 7: Gross income</td>
+                      <td className="py-1 px-2 text-right font-mono text-green-800">{fmt(scheduleCData.scheduleC.line7)}</td>
                     </tr>
                   </tbody>
                 </table>
               </div>
 
               {/* Part II: Expenses */}
-              <div className="border rounded-lg overflow-hidden">
-                <div className="bg-red-50 px-4 py-2 text-sm font-semibold text-red-800">
+              <div className="border border-border rounded overflow-hidden">
+                <div className="bg-red-50 px-3 py-1.5 text-terminal-lg font-semibold text-red-800">
                   Part II — Expenses
                 </div>
-                <table className="w-full text-xs">
+                <table className="w-full text-terminal-base">
                   <tbody>
                     {scheduleCData.scheduleC.expenses.map(exp => (
                       <tr key={exp.line} className="border-b">
-                        <td className="px-4 py-2 w-2/3">
+                        <td className="py-1 px-2 w-2/3">
                           <span className="font-medium">Line {exp.line}: {exp.label}</span>
                           {exp.accounts.length > 1 && (
-                            <span className="text-gray-400 text-[10px] ml-2">({exp.accounts.length} accounts)</span>
+                            <span className="text-text-faint text-terminal-xs ml-2">({exp.accounts.length} accounts)</span>
                           )}
                           {exp.accounts.map(a => (
-                            <div key={a.code} className="text-[10px] text-gray-400 pl-4">{a.code} — {a.name}: {fmt(a.amount)}</div>
+                            <div key={a.code} className="text-terminal-xs text-text-faint pl-4">{a.code} — {a.name}: {fmt(a.amount)}</div>
                           ))}
                         </td>
-                        <td className="px-4 py-2 text-right font-mono align-top">{fmt(exp.amount)}</td>
+                        <td className="py-1 px-2 text-right font-mono align-top">{fmt(exp.amount)}</td>
                       </tr>
                     ))}
                     {scheduleCData.scheduleC.expenses.length === 0 && (
                       <tr className="border-b">
-                        <td className="px-4 py-4 text-gray-400 text-center" colSpan={2}>No business expenses recorded</td>
+                        <td className="py-1 px-2 text-text-faint text-center" colSpan={2}>No business expenses recorded</td>
                       </tr>
                     )}
                     <tr className="bg-red-50 font-semibold border-t-2 border-red-300">
-                      <td className="px-4 py-2 text-red-800">Line 28: Total expenses</td>
-                      <td className="px-4 py-2 text-right font-mono text-red-800">{fmt(scheduleCData.scheduleC.line28)}</td>
+                      <td className="py-1 px-2 text-red-800">Line 28: Total expenses</td>
+                      <td className="py-1 px-2 text-right font-mono text-red-800">{fmt(scheduleCData.scheduleC.line28)}</td>
                     </tr>
                   </tbody>
                 </table>
               </div>
 
               {/* Line 31: Net profit */}
-              <div className={`border-2 rounded-lg p-4 text-center ${scheduleCData.scheduleC.line31 >= 0 ? 'border-green-600 bg-green-50' : 'border-red-600 bg-red-50'}`}>
-                <div className="text-xs text-gray-600 mb-1">Line 31: Net profit or (loss)</div>
+              <div className={`border-2 rounded p-2 text-center ${scheduleCData.scheduleC.line31 >= 0 ? 'border-green-600 bg-green-50' : 'border-red-600 bg-red-50'}`}>
+                <div className="text-terminal-base text-text-secondary mb-1">Line 31: Net profit or (loss)</div>
                 <div className={`text-2xl font-bold font-mono ${plColor(scheduleCData.scheduleC.line31)}`}>
                   {fmt(scheduleCData.scheduleC.line31)}
                 </div>
               </div>
 
               {/* Schedule SE summary */}
-              <div className="border rounded-lg overflow-hidden">
-                <div className="bg-purple-50 px-4 py-2 text-sm font-semibold text-purple-800">
+              <div className="border border-border rounded overflow-hidden">
+                <div className="bg-purple-50 px-3 py-1.5 text-terminal-lg font-semibold text-purple-800">
                   Schedule SE — Self-Employment Tax
                 </div>
-                <table className="w-full text-xs">
+                <table className="w-full text-terminal-base">
                   <tbody>
                     <tr className="border-b">
-                      <td className="px-4 py-2">Line 2: Net earnings from self-employment</td>
-                      <td className="px-4 py-2 text-right font-mono">{fmt(scheduleCData.scheduleSE.line2)}</td>
+                      <td className="py-1 px-2">Line 2: Net earnings from self-employment</td>
+                      <td className="py-1 px-2 text-right font-mono">{fmt(scheduleCData.scheduleSE.line2)}</td>
                     </tr>
                     <tr className="border-b">
-                      <td className="px-4 py-2">Line 3: 92.35% of Line 2</td>
-                      <td className="px-4 py-2 text-right font-mono">{fmt(scheduleCData.scheduleSE.line3)}</td>
+                      <td className="py-1 px-2">Line 3: 92.35% of Line 2</td>
+                      <td className="py-1 px-2 text-right font-mono">{fmt(scheduleCData.scheduleSE.line3)}</td>
                     </tr>
                     <tr className="border-b font-semibold">
-                      <td className="px-4 py-2">Line 12: Self-employment tax (15.3%)</td>
-                      <td className="px-4 py-2 text-right font-mono text-red-700">{fmt(scheduleCData.scheduleSE.line12)}</td>
+                      <td className="py-1 px-2">Line 12: Self-employment tax (15.3%)</td>
+                      <td className="py-1 px-2 text-right font-mono text-brand-red">{fmt(scheduleCData.scheduleSE.line12)}</td>
                     </tr>
                     <tr className="bg-purple-50 font-semibold">
-                      <td className="px-4 py-2 text-purple-800">Line 13: Deductible half of SE tax</td>
-                      <td className="px-4 py-2 text-right font-mono text-purple-800">{fmt(scheduleCData.scheduleSE.line13)}</td>
+                      <td className="py-1 px-2 text-purple-800">Line 13: Deductible half of SE tax</td>
+                      <td className="py-1 px-2 text-right font-mono text-purple-800">{fmt(scheduleCData.scheduleSE.line13)}</td>
                     </tr>
                   </tbody>
                 </table>
@@ -679,7 +679,7 @@ export default function TaxReportTab() {
 
               {/* Unmapped accounts warning */}
               {scheduleCData.scheduleC.unmappedAccounts.length > 0 && (
-                <div className="bg-amber-50 border border-amber-200 rounded-lg p-3 text-xs text-amber-800">
+                <div className="bg-amber-50 border border-amber-200 rounded p-2 text-terminal-base text-amber-800">
                   <span className="font-semibold">Note:</span> {scheduleCData.scheduleC.unmappedAccounts.length} account(s) could not be
                   auto-mapped and were placed in Line 27a (Other):
                   {scheduleCData.scheduleC.unmappedAccounts.map(a => (
@@ -698,46 +698,46 @@ export default function TaxReportTab() {
       {view === 'form1040' && (
         <div className="p-4 space-y-4">
           {form1040Loading ? (
-            <div className="p-8 text-center text-sm text-gray-500">Loading Form 1040...</div>
+            <div className="p-8 text-center text-terminal-sm text-text-muted">Loading Form 1040...</div>
           ) : !form1040Data ? (
-            <div className="p-8 text-center text-sm text-red-600">Failed to load Form 1040</div>
+            <div className="p-8 text-center text-terminal-sm text-red-600">Failed to load Form 1040</div>
           ) : (
             <>
               {/* INCOME */}
-              <div className="border rounded-lg overflow-hidden">
-                <div className="bg-green-50 px-4 py-2 text-sm font-semibold text-green-800">
+              <div className="border border-border rounded overflow-hidden">
+                <div className="bg-green-50 px-3 py-1.5 text-terminal-lg font-semibold text-green-800">
                   Income
                 </div>
-                <table className="w-full text-xs">
+                <table className="w-full text-terminal-base">
                   <tbody>
                     <tr className="border-b">
-                      <td className="px-4 py-2">Line 1: Wages, salaries, tips (W-2)</td>
-                      <td className="px-4 py-2 text-right font-mono">{fmt(form1040Data.line1)}</td>
-                      <td className="px-4 py-1 text-right text-[10px] text-gray-400 w-28">{form1040Data.line1Source}</td>
+                      <td className="py-1 px-2">Line 1: Wages, salaries, tips (W-2)</td>
+                      <td className="py-1 px-2 text-right font-mono">{fmt(form1040Data.line1)}</td>
+                      <td className="py-1 px-2 text-right text-terminal-xs text-text-faint w-28">{form1040Data.line1Source}</td>
                     </tr>
                     <tr className="border-b">
-                      <td className="px-4 py-2">Line 5a: Pensions and annuities (gross)</td>
-                      <td className="px-4 py-2 text-right font-mono">{fmt(form1040Data.line5a)}</td>
-                      <td className="px-4 py-1 text-right text-[10px] text-gray-400">403(b)/DCP</td>
+                      <td className="py-1 px-2">Line 5a: Pensions and annuities (gross)</td>
+                      <td className="py-1 px-2 text-right font-mono">{fmt(form1040Data.line5a)}</td>
+                      <td className="py-1 px-2 text-right text-terminal-xs text-text-faint">403(b)/DCP</td>
                     </tr>
                     <tr className="border-b">
-                      <td className="px-4 py-2">Line 5b: Taxable amount</td>
-                      <td className="px-4 py-2 text-right font-mono">{fmt(form1040Data.line5b)}</td>
+                      <td className="py-1 px-2">Line 5b: Taxable amount</td>
+                      <td className="py-1 px-2 text-right font-mono">{fmt(form1040Data.line5b)}</td>
                       <td></td>
                     </tr>
                     <tr className="border-b">
-                      <td className="px-4 py-2">Line 7: Capital gain or (loss) — Schedule D</td>
-                      <td className={`px-4 py-2 text-right font-mono ${plColor(form1040Data.line7)}`}>{fmt(form1040Data.line7)}</td>
+                      <td className="py-1 px-2">Line 7: Capital gain or (loss) — Schedule D</td>
+                      <td className={`py-1 px-2 text-right font-mono ${plColor(form1040Data.line7)}`}>{fmt(form1040Data.line7)}</td>
                       <td></td>
                     </tr>
                     <tr className="border-b">
-                      <td className="px-4 py-2">Line 8: Other income — Schedule C net profit</td>
-                      <td className={`px-4 py-2 text-right font-mono ${plColor(form1040Data.line8)}`}>{fmt(form1040Data.line8)}</td>
+                      <td className="py-1 px-2">Line 8: Other income — Schedule C net profit</td>
+                      <td className={`py-1 px-2 text-right font-mono ${plColor(form1040Data.line8)}`}>{fmt(form1040Data.line8)}</td>
                       <td></td>
                     </tr>
                     <tr className="bg-green-50 font-semibold border-t-2 border-green-300">
-                      <td className="px-4 py-2 text-green-800">Line 9: Total income</td>
-                      <td className="px-4 py-2 text-right font-mono text-green-800">{fmt(form1040Data.line9)}</td>
+                      <td className="py-1 px-2 text-green-800">Line 9: Total income</td>
+                      <td className="py-1 px-2 text-right font-mono text-green-800">{fmt(form1040Data.line9)}</td>
                       <td></td>
                     </tr>
                   </tbody>
@@ -745,155 +745,155 @@ export default function TaxReportTab() {
               </div>
 
               {/* ADJUSTMENTS */}
-              <div className="border rounded-lg overflow-hidden">
-                <div className="bg-blue-50 px-4 py-2 text-sm font-semibold text-blue-800">
+              <div className="border border-border rounded overflow-hidden">
+                <div className="bg-blue-50 px-3 py-1.5 text-terminal-lg font-semibold text-blue-800">
                   Adjustments to Income
                 </div>
-                <table className="w-full text-xs">
+                <table className="w-full text-terminal-base">
                   <tbody>
                     <tr className="border-b">
-                      <td className="px-4 py-2">Deductible half of self-employment tax</td>
-                      <td className="px-4 py-2 text-right font-mono">{fmt(form1040Data.seTaxDeduction)}</td>
+                      <td className="py-1 px-2">Deductible half of self-employment tax</td>
+                      <td className="py-1 px-2 text-right font-mono">{fmt(form1040Data.seTaxDeduction)}</td>
                     </tr>
                     <tr className="bg-blue-50 font-semibold border-t-2 border-blue-300">
-                      <td className="px-4 py-2 text-blue-800">Line 11: Adjusted gross income (AGI)</td>
-                      <td className="px-4 py-2 text-right font-mono text-blue-800">{fmt(form1040Data.line11)}</td>
+                      <td className="py-1 px-2 text-blue-800">Line 11: Adjusted gross income (AGI)</td>
+                      <td className="py-1 px-2 text-right font-mono text-blue-800">{fmt(form1040Data.line11)}</td>
                     </tr>
                   </tbody>
                 </table>
               </div>
 
               {/* DEDUCTIONS */}
-              <div className="border rounded-lg overflow-hidden">
-                <div className="bg-indigo-50 px-4 py-2 text-sm font-semibold text-indigo-800 flex items-center justify-between">
+              <div className="border border-border rounded overflow-hidden">
+                <div className="bg-indigo-50 px-3 py-1.5 text-terminal-lg font-semibold text-indigo-800 flex items-center justify-between">
                   <span>Deductions</span>
                   <select
                     value={overrides['filing_status'] || form1040Data.filingStatus}
                     onChange={(e) => saveOverride('filing_status', e.target.value)}
-                    className="text-xs border border-indigo-300 rounded px-2 py-1 bg-white text-indigo-800"
+                    className="text-terminal-base font-mono border border-indigo-300 rounded h-7 px-2 bg-white text-indigo-800"
                   >
                     {FILING_STATUSES.map(fs => (
                       <option key={fs.value} value={fs.value}>{fs.label}</option>
                     ))}
                   </select>
                 </div>
-                <table className="w-full text-xs">
+                <table className="w-full text-terminal-base">
                   <tbody>
                     <tr className="border-b">
-                      <td className="px-4 py-2">Standard deduction ({FILING_STATUSES.find(f => f.value === form1040Data.filingStatus)?.label || 'Single'})</td>
-                      <td className="px-4 py-2 text-right font-mono">{fmt(form1040Data.standardDeduction)}</td>
+                      <td className="py-1 px-2">Standard deduction ({FILING_STATUSES.find(f => f.value === form1040Data.filingStatus)?.label || 'Single'})</td>
+                      <td className="py-1 px-2 text-right font-mono">{fmt(form1040Data.standardDeduction)}</td>
                     </tr>
                     <tr className="bg-indigo-50 font-semibold border-t-2 border-indigo-300">
-                      <td className="px-4 py-2 text-indigo-800">Line 15: Taxable income</td>
-                      <td className="px-4 py-2 text-right font-mono text-indigo-800">{fmt(form1040Data.line15)}</td>
+                      <td className="py-1 px-2 text-indigo-800">Line 15: Taxable income</td>
+                      <td className="py-1 px-2 text-right font-mono text-indigo-800">{fmt(form1040Data.line15)}</td>
                     </tr>
                   </tbody>
                 </table>
               </div>
 
               {/* TAX COMPUTATION — Bracket Breakdown */}
-              <div className="border rounded-lg overflow-hidden">
-                <div className="bg-orange-50 px-4 py-2 text-sm font-semibold text-orange-800">
+              <div className="border border-border rounded overflow-hidden">
+                <div className="bg-orange-50 px-3 py-1.5 text-terminal-lg font-semibold text-orange-800">
                   Tax Computation — {year} Brackets
                 </div>
-                <table className="w-full text-xs">
-                  <thead className="bg-gray-100">
+                <table className="w-full text-terminal-base">
+                  <thead className="bg-brand-purple text-white/70">
                     <tr>
-                      <th className="px-4 py-2 text-left">Bracket</th>
-                      <th className="px-4 py-2 text-right">Rate</th>
-                      <th className="px-4 py-2 text-right">Taxable in Bracket</th>
-                      <th className="px-4 py-2 text-right">Tax</th>
+                      <th className="py-1 px-2 text-left text-terminal-xs uppercase tracking-widest font-mono">Bracket</th>
+                      <th className="py-1 px-2 text-right text-terminal-xs uppercase tracking-widest font-mono">Rate</th>
+                      <th className="py-1 px-2 text-right text-terminal-xs uppercase tracking-widest font-mono">Taxable in Bracket</th>
+                      <th className="py-1 px-2 text-right text-terminal-xs uppercase tracking-widest font-mono">Tax</th>
                     </tr>
                   </thead>
                   <tbody>
                     {form1040Data.bracketBreakdown.map(b => (
                       <tr key={b.bracket} className="border-b">
-                        <td className="px-4 py-1.5 font-mono">{b.bracket}</td>
-                        <td className="px-4 py-1.5 text-right">{fmtPct(b.rate)}</td>
-                        <td className="px-4 py-1.5 text-right font-mono">{fmt(b.taxableInBracket)}</td>
-                        <td className="px-4 py-1.5 text-right font-mono">{fmt(b.taxForBracket)}</td>
+                        <td className="py-1 px-2 font-mono">{b.bracket}</td>
+                        <td className="py-1 px-2 text-right">{fmtPct(b.rate)}</td>
+                        <td className="py-1 px-2 text-right font-mono">{fmt(b.taxableInBracket)}</td>
+                        <td className="py-1 px-2 text-right font-mono">{fmt(b.taxForBracket)}</td>
                       </tr>
                     ))}
                     <tr className="bg-orange-50 font-semibold border-t-2 border-orange-300">
-                      <td className="px-4 py-2 text-orange-800" colSpan={3}>Line 16: Income tax</td>
-                      <td className="px-4 py-2 text-right font-mono text-orange-800">{fmt(form1040Data.incomeTax)}</td>
+                      <td className="py-1 px-2 text-orange-800" colSpan={3}>Line 16: Income tax</td>
+                      <td className="py-1 px-2 text-right font-mono text-orange-800">{fmt(form1040Data.incomeTax)}</td>
                     </tr>
                   </tbody>
                 </table>
               </div>
 
               {/* ADDITIONAL TAXES */}
-              <div className="border rounded-lg overflow-hidden">
-                <div className="bg-red-50 px-4 py-2 text-sm font-semibold text-red-800">
+              <div className="border border-border rounded overflow-hidden">
+                <div className="bg-red-50 px-3 py-1.5 text-terminal-lg font-semibold text-red-800">
                   Additional Taxes
                 </div>
-                <table className="w-full text-xs">
+                <table className="w-full text-terminal-base">
                   <tbody>
                     <tr className="border-b">
-                      <td className="px-4 py-2">Self-employment tax (Schedule SE)</td>
-                      <td className="px-4 py-2 text-right font-mono">{fmt(form1040Data.selfEmploymentTax)}</td>
+                      <td className="py-1 px-2">Self-employment tax (Schedule SE)</td>
+                      <td className="py-1 px-2 text-right font-mono">{fmt(form1040Data.selfEmploymentTax)}</td>
                     </tr>
                     {form1040Data.earlyWithdrawalPenalty > 0 && (
                       <tr className="border-b">
-                        <td className="px-4 py-2">Early withdrawal penalty (10% of 403(b) — Schedule 2 Line 8)</td>
-                        <td className="px-4 py-2 text-right font-mono text-red-700">{fmt(form1040Data.earlyWithdrawalPenalty)}</td>
+                        <td className="py-1 px-2">Early withdrawal penalty (10% of 403(b) — Schedule 2 Line 8)</td>
+                        <td className="py-1 px-2 text-right font-mono text-brand-red">{fmt(form1040Data.earlyWithdrawalPenalty)}</td>
                       </tr>
                     )}
                     <tr className="bg-red-50 font-semibold border-t-2 border-red-300">
-                      <td className="px-4 py-2 text-red-800">Line 23: Total tax</td>
-                      <td className="px-4 py-2 text-right font-mono text-red-800">{fmt(form1040Data.totalTax)}</td>
+                      <td className="py-1 px-2 text-red-800">Line 23: Total tax</td>
+                      <td className="py-1 px-2 text-right font-mono text-red-800">{fmt(form1040Data.totalTax)}</td>
                     </tr>
                   </tbody>
                 </table>
               </div>
 
               {/* PAYMENTS & CREDITS */}
-              <div className="border rounded-lg overflow-hidden">
-                <div className="bg-teal-50 px-4 py-2 text-sm font-semibold text-teal-800">
+              <div className="border border-border rounded overflow-hidden">
+                <div className="bg-teal-50 px-3 py-1.5 text-terminal-lg font-semibold text-teal-800">
                   Payments &amp; Credits
                 </div>
-                <table className="w-full text-xs">
+                <table className="w-full text-terminal-base">
                   <tbody>
                     <tr className="border-b">
-                      <td className="px-4 py-2">W-2 federal tax withheld</td>
-                      <td className="px-4 py-2 text-right font-mono">{fmt(form1040Data.w2Withheld)}</td>
+                      <td className="py-1 px-2">W-2 federal tax withheld</td>
+                      <td className="py-1 px-2 text-right font-mono">{fmt(form1040Data.w2Withheld)}</td>
                     </tr>
                     <tr className="border-b">
-                      <td className="px-4 py-2">1099-R tax withheld</td>
-                      <td className="px-4 py-2 text-right font-mono">{fmt(form1040Data.retirementWithheld)}</td>
+                      <td className="py-1 px-2">1099-R tax withheld</td>
+                      <td className="py-1 px-2 text-right font-mono">{fmt(form1040Data.retirementWithheld)}</td>
                     </tr>
                     <tr className="border-b">
-                      <td className="px-4 py-2">Estimated tax payments made</td>
-                      <td className="px-4 py-2 text-right font-mono">{fmt(form1040Data.estimatedPayments)}</td>
+                      <td className="py-1 px-2">Estimated tax payments made</td>
+                      <td className="py-1 px-2 text-right font-mono">{fmt(form1040Data.estimatedPayments)}</td>
                     </tr>
                     <tr className="bg-teal-50 font-semibold border-t-2 border-teal-300">
-                      <td className="px-4 py-2 text-teal-800">Line 24: Total payments</td>
-                      <td className="px-4 py-2 text-right font-mono text-teal-800">{fmt(form1040Data.totalPayments)}</td>
+                      <td className="py-1 px-2 text-teal-800">Line 24: Total payments</td>
+                      <td className="py-1 px-2 text-right font-mono text-teal-800">{fmt(form1040Data.totalPayments)}</td>
                     </tr>
                   </tbody>
                 </table>
               </div>
 
               {/* BOTTOM LINE */}
-              <div className={`border-2 rounded-lg p-6 text-center ${form1040Data.isRefund ? 'border-green-600 bg-green-50' : 'border-red-600 bg-red-50'}`}>
-                <div className="text-xs text-gray-600 mb-1">
+              <div className={`border-2 rounded p-2 text-center ${form1040Data.isRefund ? 'border-green-600 bg-green-50' : 'border-red-600 bg-red-50'}`}>
+                <div className="text-terminal-base text-text-secondary mb-1">
                   {form1040Data.isRefund ? 'Estimated Refund' : 'Estimated Amount Owed'}
                 </div>
-                <div className={`text-3xl font-bold font-mono ${form1040Data.isRefund ? 'text-green-700' : 'text-red-700'}`}>
+                <div className={`text-3xl font-bold font-mono ${form1040Data.isRefund ? 'text-brand-green' : 'text-brand-red'}`}>
                   {fmt(Math.abs(form1040Data.amountOwed))}
                 </div>
-                <div className="text-[10px] text-gray-400 mt-2">ESTIMATE ONLY — verify with CPA before filing</div>
+                <div className="text-terminal-xs text-text-faint mt-2">ESTIMATE ONLY — verify with CPA before filing</div>
               </div>
 
               {/* ── MANUAL TAX DATA ENTRY ── */}
-              <div className="border rounded-lg overflow-hidden">
-                <div className="bg-gray-100 px-4 py-2 text-sm font-semibold text-gray-700 flex items-center justify-between">
+              <div className="border border-border rounded overflow-hidden">
+                <div className="bg-bg-row px-3 py-1.5 text-terminal-lg font-semibold text-text-secondary flex items-center justify-between">
                   <span>Manual Tax Data Entry</span>
-                  {savingOverride && <span className="text-[10px] text-blue-500 animate-pulse">Saving {savingOverride}...</span>}
+                  {savingOverride && <span className="text-terminal-xs text-blue-500 animate-pulse">Saving {savingOverride}...</span>}
                 </div>
                 <div className="p-4 space-y-3">
                   {/* W-2 fields */}
-                  <div className="text-xs font-semibold text-gray-600 border-b pb-1">W-2 Information</div>
+                  <div className="text-terminal-base font-semibold text-text-secondary border-b pb-1">W-2 Information</div>
                   <div className="grid grid-cols-2 gap-3">
                     {renderOverrideField('w2_gross_wages', 'Gross wages')}
                     {renderOverrideField('w2_federal_withheld', 'Federal tax withheld')}
@@ -901,17 +901,17 @@ export default function TaxReportTab() {
                   </div>
 
                   {/* 1099-R fields */}
-                  <div className="text-xs font-semibold text-gray-600 border-b pb-1 pt-2">1099-R Information (403(b)/DCP)</div>
+                  <div className="text-terminal-base font-semibold text-text-secondary border-b pb-1 pt-2">1099-R Information (403(b)/DCP)</div>
                   <div className="grid grid-cols-2 gap-3">
                     {renderOverrideField('retirement_distribution_gross', 'Gross distribution')}
                     {renderOverrideField('retirement_distribution_taxable', 'Taxable amount')}
                     {renderOverrideField('retirement_distribution_withheld', 'Federal tax withheld')}
                     <div>
-                      <label className="text-[10px] text-gray-500 block mb-0.5">Distribution code</label>
+                      <label className="text-terminal-xs text-text-muted block mb-0.5">Distribution code</label>
                       <select
                         value={overrides['retirement_distribution_code'] || '1'}
                         onChange={(e) => saveOverride('retirement_distribution_code', e.target.value)}
-                        className="w-full text-xs border rounded px-2 py-1.5"
+                        className="w-full text-terminal-base font-mono border border-border rounded h-7 px-2"
                       >
                         <option value="1">1 — Early distribution (10% penalty)</option>
                         <option value="2">2 — Early exception applies</option>
@@ -921,7 +921,7 @@ export default function TaxReportTab() {
                   </div>
 
                   {/* Estimated payments */}
-                  <div className="text-xs font-semibold text-gray-600 border-b pb-1 pt-2">Estimated Tax Payments</div>
+                  <div className="text-terminal-base font-semibold text-text-secondary border-b pb-1 pt-2">Estimated Tax Payments</div>
                   <div className="grid grid-cols-2 gap-3">
                     {renderOverrideField('estimated_payments_made', 'Total estimated payments made')}
                   </div>
@@ -941,12 +941,12 @@ export default function TaxReportTab() {
   function renderScheduleDLine(line: ScheduleDLine) {
     const isEmpty = line.proceeds === 0 && line.costBasis === 0 && line.gainOrLoss === 0;
     return (
-      <tr key={line.line} className={`border-b ${isEmpty ? 'text-gray-300' : ''}`}>
-        <td className="px-3 py-2">Line {line.line}: {line.description}</td>
-        <td className="px-3 py-2 text-right font-mono">{isEmpty ? '-' : fmt(line.proceeds)}</td>
-        <td className="px-3 py-2 text-right font-mono">{isEmpty ? '-' : fmt(line.costBasis)}</td>
-        <td className="px-3 py-2 text-right font-mono">{isEmpty ? '-' : fmt(line.adjustments)}</td>
-        <td className={`px-3 py-2 text-right font-mono ${isEmpty ? '' : plColor(line.gainOrLoss)}`}>
+      <tr key={line.line} className={`border-b ${isEmpty ? 'text-text-faint' : ''}`}>
+        <td className="py-1 px-2">Line {line.line}: {line.description}</td>
+        <td className="py-1 px-2 text-right font-mono">{isEmpty ? '-' : fmt(line.proceeds)}</td>
+        <td className="py-1 px-2 text-right font-mono">{isEmpty ? '-' : fmt(line.costBasis)}</td>
+        <td className="py-1 px-2 text-right font-mono">{isEmpty ? '-' : fmt(line.adjustments)}</td>
+        <td className={`py-1 px-2 text-right font-mono ${isEmpty ? '' : plColor(line.gainOrLoss)}`}>
           {isEmpty ? '-' : fmt(line.gainOrLoss)}
         </td>
       </tr>
@@ -955,11 +955,11 @@ export default function TaxReportTab() {
 
   function renderForm8949Row(e: Form8949Entry, i: number) {
     return (
-      <tr key={`${e.dateSold}-${e.description}-${i}`} className={`border-b hover:bg-gray-50 ${e.adjustmentCode === 'W' ? 'bg-amber-50' : ''}`}>
+      <tr key={`${e.dateSold}-${e.description}-${i}`} className={`border-b hover:bg-bg-row ${e.adjustmentCode === 'W' ? 'bg-amber-50' : ''}`}>
         <td className="px-2 py-1.5">
           <span className="font-medium">{e.description}</span>
           {e.assetType === 'option' && (
-            <span className="ml-1 text-[10px] px-1 py-0.5 bg-blue-100 text-blue-700 rounded">OPT</span>
+            <span className="ml-1 text-terminal-xs px-1 py-0.5 bg-blue-100 text-blue-700 rounded">OPT</span>
           )}
         </td>
         <td className="px-2 py-1.5 font-mono">{fmtDate(e.dateAcquired)}</td>
@@ -968,7 +968,7 @@ export default function TaxReportTab() {
         <td className="px-2 py-1.5 text-right font-mono">{fmt(e.costBasis)}</td>
         <td className="px-2 py-1.5 text-center">
           {e.adjustmentCode && (
-            <span className="px-1.5 py-0.5 bg-amber-200 text-amber-900 text-[10px] font-bold rounded">
+            <span className="px-1.5 py-0.5 bg-amber-200 text-amber-900 text-terminal-xs font-bold rounded">
               {e.adjustmentCode}
             </span>
           )}
@@ -979,7 +979,7 @@ export default function TaxReportTab() {
         <td className={`px-2 py-1.5 text-right font-mono font-semibold ${plColor(e.gainOrLoss)}`}>
           {fmt(e.gainOrLoss)}
         </td>
-        <td className="px-2 py-1.5 text-right font-mono text-gray-400">{e.holdingDays}</td>
+        <td className="px-2 py-1.5 text-right font-mono text-text-faint">{e.holdingDays}</td>
       </tr>
     );
   }
@@ -990,14 +990,14 @@ export default function TaxReportTab() {
     const totAdj = entries.reduce((s, e) => s + e.adjustmentAmount, 0);
     const totGL = entries.reduce((s, e) => s + e.gainOrLoss, 0);
     return (
-      <tr className="bg-gray-100 font-semibold border-t-2">
-        <td className="px-2 py-2" colSpan={3}>Totals</td>
-        <td className="px-2 py-2 text-right font-mono">{fmt(totProceeds)}</td>
-        <td className="px-2 py-2 text-right font-mono">{fmt(totCost)}</td>
-        <td className="px-2 py-2"></td>
-        <td className="px-2 py-2 text-right font-mono">{fmt(totAdj)}</td>
-        <td className={`px-2 py-2 text-right font-mono ${plColor(totGL)}`}>{fmt(totGL)}</td>
-        <td className="px-2 py-2"></td>
+      <tr className="bg-bg-row font-semibold border-t-2">
+        <td className="px-2 py-1.5" colSpan={3}>Totals</td>
+        <td className="px-2 py-1.5 text-right font-mono">{fmt(totProceeds)}</td>
+        <td className="px-2 py-1.5 text-right font-mono">{fmt(totCost)}</td>
+        <td className="px-2 py-1.5"></td>
+        <td className="px-2 py-1.5 text-right font-mono">{fmt(totAdj)}</td>
+        <td className={`px-2 py-1.5 text-right font-mono ${plColor(totGL)}`}>{fmt(totGL)}</td>
+        <td className="px-2 py-1.5"></td>
       </tr>
     );
   }
@@ -1007,19 +1007,19 @@ export default function TaxReportTab() {
   function renderOverrideField(key: string, label: string) {
     return (
       <div>
-        <label className="text-[10px] text-gray-500 block mb-0.5">{label}</label>
+        <label className="text-terminal-xs text-text-muted block mb-0.5">{label}</label>
         <div className="relative">
-          <span className="absolute left-2 top-1.5 text-xs text-gray-400">$</span>
+          <span className="absolute left-2 top-1.5 text-terminal-base text-text-faint">$</span>
           <input
             type="number"
             step="0.01"
             value={overrides[key] || ''}
             onChange={(e) => saveOverride(key, e.target.value)}
             placeholder="0.00"
-            className="w-full text-xs border rounded px-2 py-1.5 pl-5 font-mono"
+            className="w-full text-terminal-base font-mono border border-border rounded h-7 px-2 pl-5"
           />
           {savingOverride === key && (
-            <span className="absolute right-2 top-1.5 text-[10px] text-blue-500">saving...</span>
+            <span className="absolute right-2 top-1.5 text-terminal-xs text-blue-500">saving...</span>
           )}
         </div>
       </div>

--- a/src/components/dashboard/TradeCommitWorkflow.tsx
+++ b/src/components/dashboard/TradeCommitWorkflow.tsx
@@ -531,23 +531,23 @@ export default function TradeCommitWorkflow({ onReload }: TradeCommitWorkflowPro
   const TxnSortHeader = ({ label, field, className = '' }: { label: string; field: TxnSortField; className?: string }) => {
     const isActive = txnSortField === field;
     return (
-      <th className={`px-2 py-2 text-xs font-semibold cursor-pointer select-none hover:bg-[#3d2b5e] transition-colors ${className}`}
+      <th className={`py-1 px-2 text-terminal-xs uppercase tracking-widest font-mono font-semibold cursor-pointer select-none hover:bg-brand-purple-hover transition-colors ${className}`}
         onClick={() => handleTxnSort(field)}>
         <span className="flex items-center gap-1">
           {label}
-          {isActive && <span className="text-[10px]">{txnSortDir === 'asc' ? '\u25B2' : '\u25BC'}</span>}
+          {isActive && <span className="text-terminal-xs">{txnSortDir === 'asc' ? '\u25B2' : '\u25BC'}</span>}
         </span>
       </th>
     );
   };
 
   if (loading) {
-    return <div className="p-6 bg-white border rounded-lg"><div className="animate-pulse">Loading...</div></div>;
+    return <div className="p-3 bg-white border border-border rounded"><div className="animate-pulse text-terminal-sm text-text-muted">Loading...</div></div>;
   }
 
   if (error) {
     return (
-      <div className="p-6 bg-red-50 border border-red-200 rounded-lg">
+      <div className="p-3 bg-red-50 border border-red-200 rounded">
         <div className="text-red-600">Error: {error}</div>
         <button onClick={fetchData} className="mt-2 text-blue-600 underline">Retry</button>
       </div>
@@ -557,43 +557,43 @@ export default function TradeCommitWorkflow({ onReload }: TradeCommitWorkflowPro
   return (
     <div className="space-y-4">
       {/* Header with Tabs */}
-      <div className="flex items-center justify-between p-4 bg-gradient-to-r from-indigo-50 to-purple-50 border-2 border-indigo-200 rounded-lg">
+      <div className="flex items-center justify-between px-3 py-1.5 bg-gradient-to-r from-indigo-50 to-purple-50 border-2 border-indigo-200 rounded">
         <div>
-          <h3 className="font-bold text-lg">📊 Trade Commit Workflow</h3>
-          <p className="text-sm text-gray-600">
+          <h3 className="font-semibold text-terminal-lg">Trade Commit Workflow</h3>
+          <p className="text-terminal-sm text-text-muted">
             {opens.length} opens • {closes.length} closes • {openTrades.length} open trades • Next #: {nextTradeNum}
           </p>
         </div>
         
-        <div className="flex gap-1 bg-white rounded-lg p-1 border">
+        <div className="flex gap-1 bg-white rounded p-1 border border-border">
           <button
             onClick={() => { setActiveTab('opens'); clearSelection(); setTxnSearch(''); }}
-            className={`px-4 py-2 rounded-md text-sm font-medium transition-colors ${
-              activeTab === 'opens' ? 'bg-green-100 text-green-700' : 'text-gray-600 hover:bg-gray-100'
+            className={`px-4 py-2 rounded text-terminal-sm font-medium transition-colors ${
+              activeTab === 'opens' ? 'bg-green-100 text-green-700' : 'bg-bg-row text-text-muted'
             }`}
           >
             1. Opens ({opens.length})
           </button>
           <button
             onClick={() => { setActiveTab('closes'); clearSelection(); setTxnSearch(''); }}
-            className={`px-4 py-2 rounded-md text-sm font-medium transition-colors ${
-              activeTab === 'closes' ? 'bg-red-100 text-red-700' : 'text-gray-600 hover:bg-gray-100'
+            className={`px-4 py-2 rounded text-terminal-sm font-medium transition-colors ${
+              activeTab === 'closes' ? 'bg-red-100 text-red-700' : 'bg-bg-row text-text-muted'
             }`}
           >
             2. Closes ({closes.length})
           </button>
           <button
             onClick={() => { setActiveTab('trades'); clearSelection(); setTxnSearch(''); }}
-            className={`px-4 py-2 rounded-md text-sm font-medium transition-colors ${
-              activeTab === 'trades' ? 'bg-blue-100 text-blue-700' : 'text-gray-600 hover:bg-gray-100'
+            className={`px-4 py-2 rounded text-terminal-sm font-medium transition-colors ${
+              activeTab === 'trades' ? 'bg-blue-100 text-blue-700' : 'bg-bg-row text-text-muted'
             }`}
           >
             3. Trades ({openTrades.length})
           </button>
           <button
             onClick={() => { setActiveTab('corporate-actions'); clearSelection(); setTxnSearch(''); }}
-            className={`px-4 py-2 rounded-md text-sm font-medium transition-colors ${
-              activeTab === 'corporate-actions' ? 'bg-purple-100 text-purple-700' : 'text-gray-600 hover:bg-gray-100'
+            className={`px-4 py-2 rounded text-terminal-sm font-medium transition-colors ${
+              activeTab === 'corporate-actions' ? 'bg-purple-100 text-purple-700' : 'bg-bg-row text-text-muted'
             }`}
           >
             4. Corp Actions ({corporateActions.length})
@@ -606,16 +606,16 @@ export default function TradeCommitWorkflow({ onReload }: TradeCommitWorkflowPro
         <>
           {/* Commit Controls */}
           {selectedIds.size > 0 && (
-            <div className="p-4 bg-green-50 border border-green-200 rounded-lg sticky top-0 z-10">
+            <div className="p-3 bg-green-50 border border-green-200 rounded sticky top-0 z-10">
               <div className="flex items-center justify-between">
                 <div>
-                  <span className="font-medium">{selectedIds.size} legs selected</span>
-                  <span className={`ml-3 ${selectedTotal < 0 ? 'text-green-600' : 'text-red-600'}`}>
+                  <span className="font-medium text-terminal-sm">{selectedIds.size} legs selected</span>
+                  <span className={`ml-3 font-mono font-semibold ${selectedTotal < 0 ? 'text-green-600' : 'text-red-600'}`}>
                     Net: ${Math.abs(selectedTotal).toFixed(2)} {selectedTotal < 0 ? 'CR' : 'DR'}
                   </span>
                 </div>
                 <div className="flex gap-2 items-center">
-                  <select value={strategy} onChange={e => setStrategy(e.target.value)} className="border rounded px-3 py-2 text-sm">
+                  <select value={strategy} onChange={e => setStrategy(e.target.value)} className="border border-border rounded h-7 px-2 text-terminal-base font-mono">
                     <option value="">Strategy...</option>
                     {STRATEGY_OPTIONS.map(s => <option key={s.value} value={s.value}>{s.label}</option>)}
                   </select>
@@ -624,16 +624,16 @@ export default function TradeCommitWorkflow({ onReload }: TradeCommitWorkflowPro
                     value={tradeNum}
                     onChange={e => setTradeNum(e.target.value)}
                     placeholder="TICK-0001"
-                    className="border rounded px-3 py-2 text-sm w-32 text-center font-mono"
+                    className="border border-border rounded h-7 px-2 text-terminal-base font-mono w-32 text-center"
                   />
                   <button
                     onClick={commitOpens}
                     disabled={committing || !strategy || !tradeNum}
-                    className="px-4 py-2 bg-green-600 text-white rounded text-sm font-medium hover:bg-green-700 disabled:bg-gray-400"
+                    className="px-4 py-2 bg-green-600 text-white rounded text-terminal-sm font-medium hover:bg-green-700 disabled:bg-text-faint"
                   >
                     {committing ? 'Committing...' : 'Open Position'}
                   </button>
-                  <button onClick={clearSelection} className="px-3 py-2 text-gray-500 hover:text-gray-700 text-sm">Clear</button>
+                  <button onClick={clearSelection} className="px-3 py-2 text-text-muted hover:text-text-primary text-terminal-sm">Clear</button>
                 </div>
               </div>
             </div>
@@ -643,19 +643,19 @@ export default function TradeCommitWorkflow({ onReload }: TradeCommitWorkflowPro
           <div className="mb-2">
             <input type="text" placeholder="Search by symbol, name, action..."
               value={txnSearch} onChange={e => setTxnSearch(e.target.value)}
-              className="w-full px-3 py-1.5 text-xs border border-gray-200 rounded-lg outline-none focus:border-[#2d1b4e] focus:ring-1 focus:ring-[#2d1b4e]" />
+              className="w-full h-7 px-2 text-terminal-base font-mono border border-border rounded outline-none focus:border-brand-purple focus:ring-1 focus:ring-brand-purple" />
           </div>
 
           {/* Opens Table */}
-          <div ref={opensScrollRef} className="overflow-auto border border-gray-200 rounded-lg" style={{ maxHeight: '500px' }}>
-            <table className="w-full text-xs border-collapse min-w-[800px]">
-              <thead className="bg-[#2d1b4e] text-white sticky top-0 z-10">
+          <div ref={opensScrollRef} className="overflow-auto border border-border rounded" style={{ maxHeight: '500px' }}>
+            <table className="w-full text-terminal-base border-collapse min-w-[800px]">
+              <thead className="bg-brand-purple text-white/70 sticky top-0 z-10">
                 <tr>
-                  <th className="px-2 py-2 w-10"></th>
+                  <th className="py-1 px-2 w-10"></th>
                   <TxnSortHeader label="Date" field="date" className="w-24" />
                   <TxnSortHeader label="Symbol" field="ticker" className="w-20" />
                   <TxnSortHeader label="Action" field="action" className="w-20" />
-                  <th className="px-2 py-2 text-xs font-semibold text-left">Details</th>
+                  <th className="py-1 px-2 text-terminal-xs uppercase tracking-widest font-mono font-semibold text-left">Details</th>
                   <TxnSortHeader label="Qty" field="quantity" className="w-16 text-right" />
                   <TxnSortHeader label="Price" field="price" className="w-20 text-right" />
                   <TxnSortHeader label="Amount" field="amount" className="w-24 text-right" />
@@ -665,44 +665,44 @@ export default function TradeCommitWorkflow({ onReload }: TradeCommitWorkflowPro
                 {filteredOpens.map((t, i) => {
                   const isSelected = selectedIds.has(t.id);
                   const ticker = t.underlying || t.ticker || 'UNKNOWN';
-                  const rowBg = isSelected ? 'bg-[#2d1b4e]/5' : i % 2 === 0 ? 'bg-white' : 'bg-gray-50/50';
+                  const rowBg = isSelected ? 'bg-brand-purple-wash' : i % 2 === 0 ? 'bg-white' : 'bg-bg-row';
                   return (
-                    <tr key={t.id} className={`${rowBg} hover:bg-[#2d1b4e]/[.07] cursor-pointer transition-colors`}
+                    <tr key={t.id} className={`${rowBg} hover:bg-bg-row cursor-pointer transition-colors border-b border-border-light`}
                       style={{ height: 40 }}
                       onClick={() => toggleSelect(t.id)}>
-                      <td className="px-2 py-1">
+                      <td className="py-1 px-2">
                         <input type="checkbox" checked={isSelected} onChange={() => toggleSelect(t.id)} className="w-3.5 h-3.5 rounded" />
                       </td>
-                      <td className="px-2 py-1 font-mono text-gray-600 whitespace-nowrap">
+                      <td className="py-1 px-2 font-mono text-text-muted whitespace-nowrap">
                         {new Date(t.date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}
                       </td>
-                      <td className="px-2 py-1 font-medium text-gray-900">{ticker}</td>
-                      <td className="px-2 py-1">
-                        <span className={`text-[10px] font-medium px-1.5 py-0.5 rounded ${
+                      <td className="py-1 px-2 font-medium text-terminal-base text-text-primary">{ticker}</td>
+                      <td className="py-1 px-2">
+                        <span className={`text-terminal-xs font-medium px-1.5 py-0.5 rounded ${
                           t.action.includes('sell') ? 'bg-orange-100 text-orange-700' : 'bg-blue-100 text-blue-700'
                         }`}>
                           {t.action.includes('sell') ? 'SELL' : 'BUY'}
                         </span>
                       </td>
-                      <td className="px-2 py-1 text-gray-700">
+                      <td className="py-1 px-2 text-terminal-base text-text-primary">
                         {t.isOption ? (
                           <span className="flex items-center gap-1">
                             <span className="font-mono">${t.strike}</span>
                             <span className={`text-[9px] px-1 rounded ${
                               t.optionType === 'call' ? 'bg-blue-50 text-blue-600' : 'bg-purple-50 text-purple-600'
                             }`}>{t.optionType?.toUpperCase()}</span>
-                            <span className="text-gray-400 text-[10px]">{t.expiration}</span>
+                            <span className="text-text-muted text-terminal-xs">{t.expiration}</span>
                           </span>
                         ) : (
-                          <span className="text-gray-500 truncate text-[11px]">{t.name}</span>
+                          <span className="text-text-muted truncate text-terminal-base">{t.name}</span>
                         )}
                       </td>
-                      <td className="px-2 py-1 text-right font-mono text-gray-700">{t.quantity}</td>
-                      <td className="px-2 py-1 text-right font-mono text-gray-700">${t.price?.toFixed(2)}</td>
-                      <td className="px-2 py-1 text-right font-mono font-medium whitespace-nowrap">
+                      <td className="py-1 px-2 text-right font-mono text-terminal-base text-text-primary">{t.quantity}</td>
+                      <td className="py-1 px-2 text-right font-mono text-terminal-base text-text-primary">${t.price?.toFixed(2)}</td>
+                      <td className="py-1 px-2 text-right font-mono font-semibold whitespace-nowrap">
                         <span className={t.amount < 0 ? 'text-green-600' : 'text-red-600'}>
                           ${Math.abs(t.amount).toFixed(2)}
-                          <span className="text-[10px] text-gray-400 ml-1">{t.amount < 0 ? 'CR' : 'DR'}</span>
+                          <span className="text-terminal-xs text-text-muted ml-1">{t.amount < 0 ? 'CR' : 'DR'}</span>
                         </span>
                       </td>
                     </tr>
@@ -711,13 +711,13 @@ export default function TradeCommitWorkflow({ onReload }: TradeCommitWorkflowPro
               </tbody>
             </table>
             {filteredOpens.length === 0 && (
-              <div className="p-8 text-center text-gray-400 text-xs">
+              <div className="p-8 text-center text-text-muted text-terminal-sm">
                 {txnSearch ? 'No opens match your search.' : 'No uncommitted opening transactions.'}
               </div>
             )}
           </div>
           {filteredOpens.length > 0 && (
-            <div className="text-[10px] text-gray-500 mt-1 px-1">
+            <div className="text-terminal-xs text-text-muted mt-1 px-1">
               {filteredOpens.length}{filteredOpens.length !== opens.length ? ` of ${opens.length}` : ''} transactions
               {' \u00B7 '}
               {sortedOpenTickers.length} symbols
@@ -731,16 +731,16 @@ export default function TradeCommitWorkflow({ onReload }: TradeCommitWorkflowPro
         <>
           {/* Commit Controls */}
           {selectedIds.size > 0 && (
-            <div className="p-4 bg-red-50 border border-red-200 rounded-lg sticky top-0 z-10">
+            <div className="p-3 bg-red-50 border border-red-200 rounded sticky top-0 z-10">
               <div className="flex items-center justify-between">
                 <div>
-                  <span className="font-medium">{selectedIds.size} closing legs selected</span>
-                  <span className={`ml-3 ${selectedTotal < 0 ? 'text-green-600' : 'text-red-600'}`}>
+                  <span className="font-medium text-terminal-sm">{selectedIds.size} closing legs selected</span>
+                  <span className={`ml-3 font-mono font-semibold ${selectedTotal < 0 ? 'text-green-600' : 'text-red-600'}`}>
                     Net: ${Math.abs(selectedTotal).toFixed(2)} {selectedTotal < 0 ? 'CR' : 'DR'}
                   </span>
                 </div>
                 <div className="flex gap-2 items-center">
-                  <select value={linkedTradeId} onChange={e => setLinkedTradeId(e.target.value)} className="border rounded px-3 py-2 text-sm min-w-[250px]">
+                  <select value={linkedTradeId} onChange={e => setLinkedTradeId(e.target.value)} className="border border-border rounded h-7 px-2 text-terminal-base font-mono min-w-[250px]">
                     <option value="">Link to open position...</option>
                     {openTrades.length > 0 && (
                       <optgroup label="Option Trades">
@@ -764,11 +764,11 @@ export default function TradeCommitWorkflow({ onReload }: TradeCommitWorkflowPro
                   <button
                     onClick={commitCloses}
                     disabled={committing || !linkedTradeId}
-                    className="px-4 py-2 bg-red-600 text-white rounded text-sm font-medium hover:bg-red-700 disabled:bg-gray-400"
+                    className="px-4 py-2 bg-red-600 text-white rounded text-terminal-sm font-medium hover:bg-red-700 disabled:bg-text-faint"
                   >
                     {committing ? 'Closing...' : 'Close Position'}
                   </button>
-                  <button onClick={clearSelection} className="px-3 py-2 text-gray-500 hover:text-gray-700 text-sm">Clear</button>
+                  <button onClick={clearSelection} className="px-3 py-2 text-text-muted hover:text-text-primary text-terminal-sm">Clear</button>
                 </div>
               </div>
             </div>
@@ -778,19 +778,19 @@ export default function TradeCommitWorkflow({ onReload }: TradeCommitWorkflowPro
           <div className="mb-2">
             <input type="text" placeholder="Search by symbol, name, action..."
               value={txnSearch} onChange={e => setTxnSearch(e.target.value)}
-              className="w-full px-3 py-1.5 text-xs border border-gray-200 rounded-lg outline-none focus:border-[#2d1b4e] focus:ring-1 focus:ring-[#2d1b4e]" />
+              className="w-full h-7 px-2 text-terminal-base font-mono border border-border rounded outline-none focus:border-brand-purple focus:ring-1 focus:ring-brand-purple" />
           </div>
 
           {/* Closes Table */}
-          <div ref={closesScrollRef} className="overflow-auto border border-gray-200 rounded-lg" style={{ maxHeight: '500px' }}>
-            <table className="w-full text-xs border-collapse min-w-[800px]">
-              <thead className="bg-[#2d1b4e] text-white sticky top-0 z-10">
+          <div ref={closesScrollRef} className="overflow-auto border border-border rounded" style={{ maxHeight: '500px' }}>
+            <table className="w-full text-terminal-base border-collapse min-w-[800px]">
+              <thead className="bg-brand-purple text-white/70 sticky top-0 z-10">
                 <tr>
-                  <th className="px-2 py-2 w-10"></th>
+                  <th className="py-1 px-2 w-10"></th>
                   <TxnSortHeader label="Date" field="date" className="w-24" />
                   <TxnSortHeader label="Symbol" field="ticker" className="w-20" />
                   <TxnSortHeader label="Action" field="action" className="w-20" />
-                  <th className="px-2 py-2 text-xs font-semibold text-left">Details</th>
+                  <th className="py-1 px-2 text-terminal-xs uppercase tracking-widest font-mono font-semibold text-left">Details</th>
                   <TxnSortHeader label="Qty" field="quantity" className="w-16 text-right" />
                   <TxnSortHeader label="Price" field="price" className="w-20 text-right" />
                   <TxnSortHeader label="Amount" field="amount" className="w-24 text-right" />
@@ -800,20 +800,20 @@ export default function TradeCommitWorkflow({ onReload }: TradeCommitWorkflowPro
                 {filteredCloses.map((t, i) => {
                   const isSelected = selectedIds.has(t.id);
                   const ticker = t.underlying || t.ticker || 'UNKNOWN';
-                  const rowBg = isSelected ? 'bg-[#2d1b4e]/5' : i % 2 === 0 ? 'bg-white' : 'bg-gray-50/50';
+                  const rowBg = isSelected ? 'bg-brand-purple-wash' : i % 2 === 0 ? 'bg-white' : 'bg-bg-row';
                   return (
-                    <tr key={t.id} className={`${rowBg} hover:bg-[#2d1b4e]/[.07] cursor-pointer transition-colors`}
+                    <tr key={t.id} className={`${rowBg} hover:bg-bg-row cursor-pointer transition-colors border-b border-border-light`}
                       style={{ height: 40 }}
                       onClick={() => toggleSelect(t.id)}>
-                      <td className="px-2 py-1">
+                      <td className="py-1 px-2">
                         <input type="checkbox" checked={isSelected} onChange={() => toggleSelect(t.id)} className="w-3.5 h-3.5 rounded" />
                       </td>
-                      <td className="px-2 py-1 font-mono text-gray-600 whitespace-nowrap">
+                      <td className="py-1 px-2 font-mono text-text-muted whitespace-nowrap">
                         {new Date(t.date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}
                       </td>
-                      <td className="px-2 py-1 font-medium text-gray-900">{ticker}</td>
-                      <td className="px-2 py-1">
-                        <span className={`text-[10px] font-medium px-1.5 py-0.5 rounded ${
+                      <td className="py-1 px-2 font-medium text-terminal-base text-text-primary">{ticker}</td>
+                      <td className="py-1 px-2">
+                        <span className={`text-terminal-xs font-medium px-1.5 py-0.5 rounded ${
                           t.action.includes('sell') ? 'bg-orange-100 text-orange-700' :
                           t.action.includes('exercise') || t.action.includes('assignment') ? 'bg-purple-100 text-purple-700' :
                           'bg-blue-100 text-blue-700'
@@ -823,25 +823,25 @@ export default function TradeCommitWorkflow({ onReload }: TradeCommitWorkflowPro
                            t.action.includes('assignment') ? 'ASSIGN' : 'BUY'}
                         </span>
                       </td>
-                      <td className="px-2 py-1 text-gray-700">
+                      <td className="py-1 px-2 text-terminal-base text-text-primary">
                         {t.isOption ? (
                           <span className="flex items-center gap-1">
                             <span className="font-mono">${t.strike}</span>
                             <span className={`text-[9px] px-1 rounded ${
                               t.optionType === 'call' ? 'bg-blue-50 text-blue-600' : 'bg-purple-50 text-purple-600'
                             }`}>{t.optionType?.toUpperCase()}</span>
-                            <span className="text-gray-400 text-[10px]">{t.expiration}</span>
+                            <span className="text-text-muted text-terminal-xs">{t.expiration}</span>
                           </span>
                         ) : (
-                          <span className="text-gray-500 truncate text-[11px]">{t.name}</span>
+                          <span className="text-text-muted truncate text-terminal-base">{t.name}</span>
                         )}
                       </td>
-                      <td className="px-2 py-1 text-right font-mono text-gray-700">{t.quantity}</td>
-                      <td className="px-2 py-1 text-right font-mono text-gray-700">${t.price?.toFixed(2)}</td>
-                      <td className="px-2 py-1 text-right font-mono font-medium whitespace-nowrap">
+                      <td className="py-1 px-2 text-right font-mono text-terminal-base text-text-primary">{t.quantity}</td>
+                      <td className="py-1 px-2 text-right font-mono text-terminal-base text-text-primary">${t.price?.toFixed(2)}</td>
+                      <td className="py-1 px-2 text-right font-mono font-semibold whitespace-nowrap">
                         <span className={t.amount < 0 ? 'text-green-600' : 'text-red-600'}>
                           ${Math.abs(t.amount).toFixed(2)}
-                          <span className="text-[10px] text-gray-400 ml-1">{t.amount < 0 ? 'CR' : 'DR'}</span>
+                          <span className="text-terminal-xs text-text-muted ml-1">{t.amount < 0 ? 'CR' : 'DR'}</span>
                         </span>
                       </td>
                     </tr>
@@ -850,13 +850,13 @@ export default function TradeCommitWorkflow({ onReload }: TradeCommitWorkflowPro
               </tbody>
             </table>
             {filteredCloses.length === 0 && (
-              <div className="p-8 text-center text-gray-400 text-xs">
+              <div className="p-8 text-center text-text-muted text-terminal-sm">
                 {txnSearch ? 'No closes match your search.' : 'No uncommitted closing transactions.'}
               </div>
             )}
           </div>
           {filteredCloses.length > 0 && (
-            <div className="text-[10px] text-gray-500 mt-1 px-1">
+            <div className="text-terminal-xs text-text-muted mt-1 px-1">
               {filteredCloses.length}{filteredCloses.length !== closes.length ? ` of ${closes.length}` : ''} transactions
               {' \u00B7 '}
               {sortedCloseTickers.length} symbols
@@ -869,49 +869,49 @@ export default function TradeCommitWorkflow({ onReload }: TradeCommitWorkflowPro
       {activeTab === 'trades' && (
         <div>
           {openTrades.length === 0 ? (
-            <div className="p-8 text-center text-gray-500 bg-gray-50 rounded-lg">
+            <div className="p-8 text-center text-text-muted bg-bg-row rounded text-terminal-sm">
               No open trades. Commit some opening positions first.
             </div>
           ) : (
-            <div className="overflow-auto border border-gray-200 rounded-lg">
-              <table className="w-full text-xs border-collapse min-w-[700px]">
-                <thead className="bg-[#2d1b4e] text-white sticky top-0 z-10">
+            <div className="overflow-auto border border-border rounded">
+              <table className="w-full text-terminal-base border-collapse min-w-[700px]">
+                <thead className="bg-brand-purple text-white/70 sticky top-0 z-10">
                   <tr>
-                    <th className="px-3 py-2.5 text-left font-semibold">Trade #</th>
-                    <th className="px-3 py-2.5 text-left font-semibold">Symbol</th>
-                    <th className="px-3 py-2.5 text-left font-semibold">Strategy</th>
-                    <th className="px-3 py-2.5 text-left font-semibold">Status</th>
-                    <th className="px-3 py-2.5 text-left font-semibold">Opened</th>
-                    <th className="px-3 py-2.5 text-right font-semibold">Cost Basis</th>
-                    <th className="px-3 py-2.5 text-center font-semibold">Legs</th>
-                    <th className="px-3 py-2.5 text-left font-semibold">Leg Details</th>
+                    <th className="py-1 px-2 text-terminal-xs uppercase tracking-widest font-mono text-left font-semibold">Trade #</th>
+                    <th className="py-1 px-2 text-terminal-xs uppercase tracking-widest font-mono text-left font-semibold">Symbol</th>
+                    <th className="py-1 px-2 text-terminal-xs uppercase tracking-widest font-mono text-left font-semibold">Strategy</th>
+                    <th className="py-1 px-2 text-terminal-xs uppercase tracking-widest font-mono text-left font-semibold">Status</th>
+                    <th className="py-1 px-2 text-terminal-xs uppercase tracking-widest font-mono text-left font-semibold">Opened</th>
+                    <th className="py-1 px-2 text-terminal-xs uppercase tracking-widest font-mono text-right font-semibold">Cost Basis</th>
+                    <th className="py-1 px-2 text-terminal-xs uppercase tracking-widest font-mono text-center font-semibold">Legs</th>
+                    <th className="py-1 px-2 text-terminal-xs uppercase tracking-widest font-mono text-left font-semibold">Leg Details</th>
                   </tr>
                 </thead>
                 <tbody>
                   {openTrades.map((trade, i) => (
-                    <tr key={trade.id} className={`${i % 2 === 0 ? 'bg-white' : 'bg-gray-50/50'} hover:bg-[#2d1b4e]/[.07] transition-colors`}>
-                      <td className="px-3 py-2 font-mono font-bold text-[#2d1b4e]">#{trade.trade_num}</td>
-                      <td className="px-3 py-2 font-medium text-gray-900">{trade.symbol}</td>
-                      <td className="px-3 py-2">
-                        <span className="text-[10px] font-medium px-1.5 py-0.5 rounded bg-blue-100 text-blue-700">
+                    <tr key={trade.id} className={`${i % 2 === 0 ? 'bg-white' : 'bg-bg-row'} hover:bg-bg-row transition-colors border-b border-border-light`}>
+                      <td className="py-1 px-2 font-mono font-bold text-brand-purple">#{trade.trade_num}</td>
+                      <td className="py-1 px-2 font-medium text-terminal-base text-text-primary">{trade.symbol}</td>
+                      <td className="py-1 px-2">
+                        <span className="text-terminal-xs font-medium px-1.5 py-0.5 rounded bg-blue-100 text-blue-700">
                           {trade.strategy}
                         </span>
                       </td>
-                      <td className="px-3 py-2">
-                        <span className={`text-[10px] font-medium px-1.5 py-0.5 rounded ${
-                          trade.status === 'OPEN' ? 'bg-green-100 text-green-700' : 'bg-gray-100 text-gray-600'
+                      <td className="py-1 px-2">
+                        <span className={`text-terminal-xs font-medium px-1.5 py-0.5 rounded ${
+                          trade.status === 'OPEN' ? 'bg-green-100 text-green-700' : 'bg-bg-row text-text-muted'
                         }`}>{trade.status}</span>
                       </td>
-                      <td className="px-3 py-2 font-mono text-gray-600">
+                      <td className="py-1 px-2 font-mono text-text-muted">
                         {new Date(trade.open_date).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: '2-digit' })}
                       </td>
-                      <td className="px-3 py-2 text-right font-mono font-medium">
+                      <td className="py-1 px-2 text-right font-mono font-semibold">
                         ${trade.cost_basis.toFixed(2)}
                       </td>
-                      <td className="px-3 py-2 text-center font-mono text-gray-600">
+                      <td className="py-1 px-2 text-center font-mono text-text-muted">
                         {trade.legs?.length || 0}
                       </td>
-                      <td className="px-3 py-2 text-gray-600">
+                      <td className="py-1 px-2 text-text-muted">
                         {trade.legs && trade.legs.length > 0 ? (
                           <div className="flex flex-wrap gap-1">
                             {trade.legs.map((leg, li) => (
@@ -923,7 +923,7 @@ export default function TradeCommitWorkflow({ onReload }: TradeCommitWorkflowPro
                             ))}
                           </div>
                         ) : (
-                          <span className="text-gray-400">{'\u2014'}</span>
+                          <span className="text-text-muted">{'\u2014'}</span>
                         )}
                       </td>
                     </tr>
@@ -941,54 +941,54 @@ export default function TradeCommitWorkflow({ onReload }: TradeCommitWorkflowPro
           <div className="mb-4">
             <button
               onClick={() => setShowCorpActionModal(true)}
-              className="px-4 py-2 bg-purple-600 text-white rounded-lg text-sm font-medium hover:bg-purple-700"
+              className="px-4 py-2 bg-purple-600 text-white rounded text-terminal-sm font-medium hover:bg-purple-700"
             >
               + Record Corporate Action
             </button>
           </div>
 
           <div className="space-y-3">
-            <h3 className="font-semibold text-gray-700">Corporate Actions History</h3>
+            <h3 className="font-semibold text-text-primary">Corporate Actions History</h3>
             {corporateActions.length === 0 ? (
-              <div className="p-8 text-center text-gray-500 bg-gray-50 rounded-lg">
+              <div className="p-8 text-center text-text-muted bg-bg-row rounded text-terminal-sm">
                 <p>No corporate actions recorded.</p>
-                <p className="text-sm mt-2">Stock splits, dividends, mergers, and spinoffs will appear here.</p>
+                <p className="text-terminal-sm mt-2">Stock splits, dividends, mergers, and spinoffs will appear here.</p>
               </div>
             ) : (
               corporateActions.map((action: any) => (
-                <div key={action.id} className="border rounded-lg p-4 bg-white">
+                <div key={action.id} className="border border-border rounded p-3 bg-white">
                   <div className="flex justify-between items-start">
                     <div>
                       <span className="font-bold text-lg">{action.symbol}</span>
-                      <span className={`ml-2 text-xs px-2 py-0.5 rounded ${
+                      <span className={`ml-2 text-terminal-xs px-2 py-0.5 rounded ${
                         action.action_type === 'REVERSE_SPLIT' ? 'bg-orange-100 text-orange-700' :
                         action.action_type === 'SPLIT' ? 'bg-green-100 text-green-700' :
-                        'bg-gray-100 text-gray-700'
+                        'bg-bg-row text-text-muted'
                       }`}>
                         {action.action_type.replace('_', ' ')}
                       </span>
                     </div>
-                    <div className="text-right text-sm text-gray-500">
+                    <div className="text-right text-terminal-sm text-text-muted">
                       {new Date(action.effective_date).toLocaleDateString()}
                     </div>
                   </div>
-                  <div className="mt-2 grid grid-cols-2 gap-4 text-sm">
+                  <div className="mt-2 grid grid-cols-2 gap-4 text-terminal-sm">
                     <div>
-                      <span className="text-gray-500">Ratio:</span>
+                      <span className="text-text-muted">Ratio:</span>
                       <span className="ml-2 font-medium">{action.ratio_from}:{action.ratio_to}</span>
                     </div>
                     {action.pre_split_shares && (
                       <div>
-                        <span className="text-gray-500">Shares:</span>
+                        <span className="text-text-muted">Shares:</span>
                         <span className="ml-2 font-medium">{action.pre_split_shares} → {action.post_split_shares}</span>
                       </div>
                     )}
                   </div>
                   {action.notes && (
-                    <div className="mt-2 text-sm text-gray-600 italic">&quot;{action.notes}&quot;</div>
+                    <div className="mt-2 text-terminal-sm text-text-muted italic">&quot;{action.notes}&quot;</div>
                   )}
                   {action.source && (
-                    <div className="mt-1 text-xs text-gray-400">Source: {action.source}</div>
+                    <div className="mt-1 text-terminal-xs text-text-muted">Source: {action.source}</div>
                   )}
                 </div>
               ))
@@ -997,27 +997,27 @@ export default function TradeCommitWorkflow({ onReload }: TradeCommitWorkflowPro
 
           {showCorpActionModal && (
             <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-              <div className="bg-white rounded-lg p-6 w-full max-w-lg max-h-[90vh] overflow-y-auto">
+              <div className="bg-white rounded p-3 w-full max-w-lg max-h-[90vh] overflow-y-auto">
                 <h2 className="text-xl font-bold mb-4">Record Corporate Action</h2>
                 
                 <div className="space-y-4">
                   <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-1">Symbol *</label>
+                    <label className="block text-terminal-sm font-medium text-text-primary mb-1">Symbol *</label>
                     <input
                       type="text"
                       value={corpActionForm.symbol}
                       onChange={e => setCorpActionForm({...corpActionForm, symbol: e.target.value.toUpperCase()})}
-                      className="w-full border rounded-lg px-3 py-2"
+                      className="w-full border border-border rounded h-7 px-2 text-terminal-base font-mono"
                       placeholder="e.g., UAVS"
                     />
                   </div>
 
                   <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-1">Action Type *</label>
+                    <label className="block text-terminal-sm font-medium text-text-primary mb-1">Action Type *</label>
                     <select
                       value={corpActionForm.action_type}
                       onChange={e => setCorpActionForm({...corpActionForm, action_type: e.target.value})}
-                      className="w-full border rounded-lg px-3 py-2"
+                      className="w-full border border-border rounded h-7 px-2 text-terminal-base font-mono"
                     >
                       <option value="REVERSE_SPLIT">Reverse Split (fewer shares)</option>
                       <option value="SPLIT">Forward Split (more shares)</option>
@@ -1028,60 +1028,60 @@ export default function TradeCommitWorkflow({ onReload }: TradeCommitWorkflowPro
                   </div>
 
                   <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-1">Effective Date *</label>
+                    <label className="block text-terminal-sm font-medium text-text-primary mb-1">Effective Date *</label>
                     <input
                       type="date"
                       value={corpActionForm.effective_date}
                       onChange={e => setCorpActionForm({...corpActionForm, effective_date: e.target.value})}
-                      className="w-full border rounded-lg px-3 py-2"
+                      className="w-full border border-border rounded h-7 px-2 text-terminal-base font-mono"
                     />
                   </div>
 
                   <div className="grid grid-cols-2 gap-4">
                     <div>
-                      <label className="block text-sm font-medium text-gray-700 mb-1">Ratio From *</label>
+                      <label className="block text-terminal-sm font-medium text-text-primary mb-1">Ratio From *</label>
                       <input
                         type="number"
                         value={corpActionForm.ratio_from}
                         onChange={e => setCorpActionForm({...corpActionForm, ratio_from: parseInt(e.target.value) || 1})}
-                        className="w-full border rounded-lg px-3 py-2"
+                        className="w-full border border-border rounded h-7 px-2 text-terminal-base font-mono"
                         min="1"
                       />
                     </div>
                     <div>
-                      <label className="block text-sm font-medium text-gray-700 mb-1">Ratio To *</label>
+                      <label className="block text-terminal-sm font-medium text-text-primary mb-1">Ratio To *</label>
                       <input
                         type="number"
                         value={corpActionForm.ratio_to}
                         onChange={e => setCorpActionForm({...corpActionForm, ratio_to: parseInt(e.target.value) || 1})}
-                        className="w-full border rounded-lg px-3 py-2"
+                        className="w-full border border-border rounded h-7 px-2 text-terminal-base font-mono"
                         min="1"
                       />
                     </div>
                   </div>
-                  <p className="text-xs text-gray-500 -mt-2">
+                  <p className="text-terminal-xs text-text-muted -mt-2">
                     For 1:50 reverse split, enter 1 and 50. For 2:1 forward split, enter 2 and 1.
                   </p>
 
                   <div className="grid grid-cols-2 gap-4">
                     <div>
-                      <label className="block text-sm font-medium text-gray-700 mb-1">Pre-Split Shares</label>
+                      <label className="block text-terminal-sm font-medium text-text-primary mb-1">Pre-Split Shares</label>
                       <input
                         type="number"
                         value={corpActionForm.pre_split_shares}
                         onChange={e => setCorpActionForm({...corpActionForm, pre_split_shares: e.target.value})}
-                        className="w-full border rounded-lg px-3 py-2"
+                        className="w-full border border-border rounded h-7 px-2 text-terminal-base font-mono"
                         placeholder="e.g., 555"
                         step="0.0001"
                       />
                     </div>
                     <div>
-                      <label className="block text-sm font-medium text-gray-700 mb-1">Post-Split Shares</label>
+                      <label className="block text-terminal-sm font-medium text-text-primary mb-1">Post-Split Shares</label>
                       <input
                         type="number"
                         value={corpActionForm.post_split_shares}
                         onChange={e => setCorpActionForm({...corpActionForm, post_split_shares: e.target.value})}
-                        className="w-full border rounded-lg px-3 py-2"
+                        className="w-full border border-border rounded h-7 px-2 text-terminal-base font-mono"
                         placeholder="e.g., 11.1"
                         step="0.0001"
                       />
@@ -1096,57 +1096,57 @@ export default function TradeCommitWorkflow({ onReload }: TradeCommitWorkflowPro
                         onChange={e => setCorpActionForm({...corpActionForm, add_pre_split_lot: e.target.checked})}
                         className="rounded"
                       />
-                      <span className="text-sm font-medium text-gray-700">Add missing pre-split lot</span>
+                      <span className="text-terminal-sm font-medium text-text-primary">Add missing pre-split lot</span>
                     </label>
-                    <p className="text-xs text-gray-500 mt-1 ml-6">
+                    <p className="text-terminal-xs text-text-muted mt-1 ml-6">
                       Check this if you had shares before the split that are not in the system yet.
                     </p>
                   </div>
 
                   {corpActionForm.add_pre_split_lot && (
-                    <div className="ml-6 space-y-3 p-3 bg-gray-50 rounded-lg">
+                    <div className="ml-6 space-y-3 p-3 bg-bg-row rounded">
                       <div>
-                        <label className="block text-sm font-medium text-gray-700 mb-1">Original Cost Basis ($)</label>
+                        <label className="block text-terminal-sm font-medium text-text-primary mb-1">Original Cost Basis ($)</label>
                         <input
                           type="number"
                           value={corpActionForm.lot_cost_basis}
                           onChange={e => setCorpActionForm({...corpActionForm, lot_cost_basis: parseFloat(e.target.value) || 0})}
-                          className="w-full border rounded-lg px-3 py-2"
+                          className="w-full border border-border rounded h-7 px-2 text-terminal-base font-mono"
                           placeholder="0 if unknown"
                           step="0.01"
                         />
-                        <p className="text-xs text-gray-500 mt-1">Enter $0 if original cost is unknown.</p>
+                        <p className="text-terminal-xs text-text-muted mt-1">Enter $0 if original cost is unknown.</p>
                       </div>
                       <div>
-                        <label className="block text-sm font-medium text-gray-700 mb-1">Original Acquisition Date</label>
+                        <label className="block text-terminal-sm font-medium text-text-primary mb-1">Original Acquisition Date</label>
                         <input
                           type="date"
                           value={corpActionForm.lot_acquired_date}
                           onChange={e => setCorpActionForm({...corpActionForm, lot_acquired_date: e.target.value})}
-                          className="w-full border rounded-lg px-3 py-2"
+                          className="w-full border border-border rounded h-7 px-2 text-terminal-base font-mono"
                         />
-                        <p className="text-xs text-gray-500 mt-1">Leave blank to use split date.</p>
+                        <p className="text-terminal-xs text-text-muted mt-1">Leave blank to use split date.</p>
                       </div>
                     </div>
                   )}
 
                   <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-1">Notes</label>
+                    <label className="block text-terminal-sm font-medium text-text-primary mb-1">Notes</label>
                     <input
                       type="text"
                       value={corpActionForm.notes}
                       onChange={e => setCorpActionForm({...corpActionForm, notes: e.target.value})}
-                      className="w-full border rounded-lg px-3 py-2"
+                      className="w-full border border-border rounded h-7 px-2 text-terminal-base font-mono"
                       placeholder="e.g., 1:50 reverse split per SEC filing"
                     />
                   </div>
                   <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-1">Source Documentation</label>
+                    <label className="block text-terminal-sm font-medium text-text-primary mb-1">Source Documentation</label>
                     <input
                       type="text"
                       value={corpActionForm.source}
                       onChange={e => setCorpActionForm({...corpActionForm, source: e.target.value})}
-                      className="w-full border rounded-lg px-3 py-2"
+                      className="w-full border border-border rounded h-7 px-2 text-terminal-base font-mono"
                       placeholder="e.g., Broker statement - Robinhood"
                     />
                   </div>
@@ -1162,7 +1162,7 @@ export default function TradeCommitWorkflow({ onReload }: TradeCommitWorkflowPro
                         notes: '', source: '', add_pre_split_lot: false, lot_cost_basis: 0, lot_acquired_date: ''
                       });
                     }}
-                    className="flex-1 px-4 py-2 border rounded-lg text-gray-700 hover:bg-gray-50"
+                    className="flex-1 px-4 py-2 border border-border rounded text-terminal-sm text-text-primary hover:bg-bg-row"
                   >
                     Cancel
                   </button>
@@ -1201,7 +1201,7 @@ export default function TradeCommitWorkflow({ onReload }: TradeCommitWorkflowPro
                         alert('Failed: ' + (err instanceof Error ? err.message : 'Unknown error'));
                       }
                     }}
-                    className="flex-1 px-4 py-2 bg-purple-600 text-white rounded-lg font-medium hover:bg-purple-700"
+                    className="flex-1 px-4 py-2 bg-purple-600 text-white rounded text-terminal-sm font-medium hover:bg-purple-700"
                   >
                     Record Corporate Action
                   </button>

--- a/src/components/dashboard/WashSaleReportTab.tsx
+++ b/src/components/dashboard/WashSaleReportTab.tsx
@@ -101,11 +101,11 @@ export default function WashSaleReportTab() {
     new Date(d).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: '2-digit' });
 
   if (loading) {
-    return <div className="p-8 text-center text-sm text-gray-500">Scanning for wash sale violations...</div>;
+    return <div className="p-8 text-center text-terminal-sm text-text-muted">Scanning for wash sale violations...</div>;
   }
 
   if (!data) {
-    return <div className="p-8 text-center text-sm text-red-600">Failed to load wash sale data</div>;
+    return <div className="p-8 text-center text-terminal-sm text-brand-red">Failed to load wash sale data</div>;
   }
 
   const { summary, bySymbol, taxImpact } = data;
@@ -113,17 +113,17 @@ export default function WashSaleReportTab() {
   return (
     <div>
       {/* Header */}
-      <div className="bg-[#2d1b4e] text-white px-4 py-2 flex items-center justify-between">
-        <span className="text-sm font-semibold">Wash Sale Report (IRS Publication 550)</span>
+      <div className="bg-brand-purple text-white px-3 py-1.5 flex items-center justify-between">
+        <span className="text-terminal-lg font-semibold">Wash Sale Report (IRS Publication 550)</span>
         <div className="flex gap-2">
-          <button onClick={loadData} className="text-xs bg-[#3d2b5e] px-3 py-1 rounded hover:bg-[#4d3b6e]">
+          <button onClick={loadData} className="text-terminal-sm bg-brand-purple-hover px-2 py-0.5 rounded hover:bg-brand-purple-hover">
             Re-scan
           </button>
           {summary.totalViolations > 0 && (
             <button
               onClick={applyAdjustments}
               disabled={applying}
-              className="text-xs bg-amber-600 px-3 py-1 rounded hover:bg-amber-700 disabled:opacity-50"
+              className="text-terminal-sm bg-amber-600 px-2 py-0.5 rounded hover:bg-amber-700 disabled:opacity-50"
             >
               {applying ? 'Applying...' : 'Apply Adjustments'}
             </button>
@@ -132,120 +132,120 @@ export default function WashSaleReportTab() {
       </div>
 
       {/* Summary cards */}
-      <div className="p-4 space-y-4">
+      <div className="p-3 space-y-3">
         {summary.totalViolations === 0 ? (
           <div className="text-center py-8">
-            <div className="text-2xl mb-2">No wash sale violations detected</div>
-            <div className="text-sm text-gray-500">
+            <div className="text-lg mb-2">No wash sale violations detected</div>
+            <div className="text-terminal-sm text-text-muted">
               All losing dispositions have been scanned against the 30-day replacement window.
             </div>
           </div>
         ) : (
           <>
             {/* Top metrics */}
-            <div className="grid grid-cols-4 gap-3">
-              <div className="border rounded-lg p-3 bg-red-50">
-                <div className="text-[10px] text-gray-500 uppercase">Disallowed Losses</div>
-                <div className="text-xl font-bold font-mono text-red-700">
+            <div className="grid grid-cols-4 gap-2">
+              <div className="border border-border rounded p-2 bg-red-50">
+                <div className="text-terminal-xs text-text-muted uppercase tracking-widest">Disallowed Losses</div>
+                <div className="text-lg font-bold font-mono text-brand-red">
                   {fmt(summary.totalDisallowedLosses)}
                 </div>
               </div>
-              <div className="border rounded-lg p-3">
-                <div className="text-[10px] text-gray-500 uppercase">Violations Found</div>
-                <div className="text-xl font-bold font-mono">{summary.totalViolations}</div>
+              <div className="border border-border rounded p-2">
+                <div className="text-terminal-xs text-text-muted uppercase tracking-widest">Violations Found</div>
+                <div className="text-lg font-bold font-mono">{summary.totalViolations}</div>
               </div>
-              <div className="border rounded-lg p-3">
-                <div className="text-[10px] text-gray-500 uppercase">Symbols Affected</div>
-                <div className="text-xl font-bold font-mono">{summary.symbolsAffected.length}</div>
+              <div className="border border-border rounded p-2">
+                <div className="text-terminal-xs text-text-muted uppercase tracking-widest">Symbols Affected</div>
+                <div className="text-lg font-bold font-mono">{summary.symbolsAffected.length}</div>
               </div>
-              <div className="border rounded-lg p-3 bg-amber-50">
-                <div className="text-[10px] text-gray-500 uppercase">Est. Tax Impact</div>
-                <div className="text-xl font-bold font-mono text-amber-700">
+              <div className="border border-border rounded p-2 bg-amber-50">
+                <div className="text-terminal-xs text-text-muted uppercase tracking-widest">Est. Tax Impact</div>
+                <div className="text-lg font-bold font-mono text-brand-amber">
                   {fmt(taxImpact.estimatedAdditionalTax)}
                 </div>
               </div>
             </div>
 
             {/* Type breakdown */}
-            <div className="grid grid-cols-4 gap-3 text-xs">
-              <div className="border rounded p-2">
-                <div className="text-gray-500">Stock to Stock</div>
+            <div className="grid grid-cols-4 gap-2 text-terminal-base">
+              <div className="border border-border rounded p-2">
+                <div className="text-text-muted">Stock to Stock</div>
                 <div className="font-bold font-mono">{summary.stockToStockCount}</div>
               </div>
-              <div className="border rounded p-2">
-                <div className="text-gray-500">Stock to Option</div>
+              <div className="border border-border rounded p-2">
+                <div className="text-text-muted">Stock to Option</div>
                 <div className="font-bold font-mono">{summary.stockToOptionCount}</div>
               </div>
-              <div className="border rounded p-2">
-                <div className="text-gray-500">Option to Stock</div>
+              <div className="border border-border rounded p-2">
+                <div className="text-text-muted">Option to Stock</div>
                 <div className="font-bold font-mono">{summary.optionToStockCount}</div>
               </div>
-              <div className="border rounded p-2">
-                <div className="text-gray-500">Option to Option</div>
+              <div className="border border-border rounded p-2">
+                <div className="text-text-muted">Option to Option</div>
                 <div className="font-bold font-mono">{summary.optionToOptionCount}</div>
               </div>
             </div>
 
             {/* Tax impact note */}
-            <div className="bg-amber-50 border border-amber-200 rounded-lg p-3 text-xs text-amber-800">
+            <div className="bg-amber-50 border border-amber-200 rounded p-2 text-terminal-sm text-amber-800">
               {taxImpact.note}
             </div>
 
             {/* Per-symbol breakdown */}
-            <div className="border rounded-lg overflow-hidden">
-              <div className="bg-gray-50 px-4 py-2 text-sm font-semibold">By Symbol</div>
-              <table className="w-full text-xs">
-                <thead className="bg-gray-100">
+            <div className="border border-border rounded overflow-hidden">
+              <div className="bg-bg-row px-3 py-1.5 text-terminal-lg font-semibold">By Symbol</div>
+              <table className="w-full text-terminal-base">
+                <thead className="bg-brand-purple text-white/70">
                   <tr>
-                    <th className="px-3 py-2 text-left">Symbol</th>
-                    <th className="px-3 py-2 text-right">Violations</th>
-                    <th className="px-3 py-2 text-right">Disallowed Loss</th>
-                    <th className="px-3 py-2 text-center">Details</th>
+                    <th className="py-1 px-2 text-left text-terminal-xs uppercase tracking-widest font-mono">Symbol</th>
+                    <th className="py-1 px-2 text-right text-terminal-xs uppercase tracking-widest font-mono">Violations</th>
+                    <th className="py-1 px-2 text-right text-terminal-xs uppercase tracking-widest font-mono">Disallowed Loss</th>
+                    <th className="py-1 px-2 text-center text-terminal-xs uppercase tracking-widest font-mono">Details</th>
                   </tr>
                 </thead>
                 <tbody>
-                  {bySymbol.map(group => (
+                  {bySymbol.map((group, idx) => (
                     <>
                       <tr
                         key={group.symbol}
-                        className="border-b hover:bg-gray-50 cursor-pointer"
+                        className={`border-b border-border-light hover:bg-bg-row cursor-pointer ${idx % 2 === 0 ? 'bg-white' : 'bg-bg-row'}`}
                         onClick={() => setExpandedSymbol(expandedSymbol === group.symbol ? null : group.symbol)}
                       >
-                        <td className="px-3 py-2 font-medium">{group.symbol}</td>
-                        <td className="px-3 py-2 text-right font-mono">{group.count}</td>
-                        <td className="px-3 py-2 text-right font-mono text-red-700 font-semibold">
+                        <td className="py-1 px-2 font-medium">{group.symbol}</td>
+                        <td className="py-1 px-2 text-right font-mono">{group.count}</td>
+                        <td className="py-1 px-2 text-right font-mono text-brand-red font-semibold">
                           {fmt(group.totalDisallowed)}
                         </td>
-                        <td className="px-3 py-2 text-center text-gray-400">
+                        <td className="py-1 px-2 text-center text-text-faint">
                           {expandedSymbol === group.symbol ? '\u25B2' : '\u25BC'}
                         </td>
                       </tr>
                       {expandedSymbol === group.symbol && group.violations.map((v, i) => (
-                        <tr key={`${v.dispositionId}-${i}`} className="bg-gray-50 border-b text-[11px]">
-                          <td className="px-3 py-1.5 pl-6" colSpan={4}>
+                        <tr key={`${v.dispositionId}-${i}`} className="bg-bg-row border-b border-border-light text-terminal-sm">
+                          <td className="py-1 px-2 pl-6" colSpan={4}>
                             <div className="grid grid-cols-2 gap-x-8 gap-y-1">
                               <div>
-                                <span className="text-gray-500">Sale:</span>{' '}
-                                <span className="font-mono">{fmtDate(v.saleDate)}</span>{' '}
+                                <span className="text-text-muted">Sale:</span>{' '}
+                                <span className="font-mono text-text-muted">{fmtDate(v.saleDate)}</span>{' '}
                                 {v.quantitySold} shares @ {fmt(v.proceedsPerShare)}
                               </div>
                               <div>
-                                <span className="text-gray-500">Replacement:</span>{' '}
+                                <span className="text-text-muted">Replacement:</span>{' '}
                                 <span className={`px-1 py-0.5 rounded text-[10px] font-medium ${
                                   v.replacementType === 'stock' ? 'bg-purple-100 text-purple-800' : 'bg-blue-100 text-blue-800'
                                 }`}>{v.replacementType}</span>{' '}
-                                <span className="font-mono">{fmtDate(v.replacementDate)}</span>{' '}
+                                <span className="font-mono text-text-muted">{fmtDate(v.replacementDate)}</span>{' '}
                                 {v.replacementQuantity} {v.replacementType === 'option' ? 'contracts' : 'shares'} @ {fmt(v.replacementCostPerShare)}
                               </div>
                               <div>
-                                <span className="text-gray-500">Realized Loss:</span>{' '}
-                                <span className="font-mono text-red-700">{fmt(v.realizedLoss)}</span>
+                                <span className="text-text-muted">Realized Loss:</span>{' '}
+                                <span className="font-mono text-brand-red">{fmt(v.realizedLoss)}</span>
                               </div>
                               <div>
-                                <span className="text-gray-500">Disallowed:</span>{' '}
-                                <span className="font-mono text-red-700 font-semibold">{fmt(v.disallowedLoss)}</span>
+                                <span className="text-text-muted">Disallowed:</span>{' '}
+                                <span className="font-mono text-brand-red font-semibold">{fmt(v.disallowedLoss)}</span>
                                 {' '}
-                                <span className="text-gray-500">Adjusted Basis:</span>{' '}
+                                <span className="text-text-muted">Adjusted Basis:</span>{' '}
                                 <span className="font-mono">{fmt(v.adjustedCostBasis)}</span>
                               </div>
                             </div>


### PR DESCRIPTION
Restyle 6 dashboard components to Bloomberg terminal density:

Group A (virtualized tables):
- JournalEntryEngine: ROW_HEIGHT 44→30, brand-purple theads, terminal font sizes
- GeneralLedger: ROW_HEIGHT 40→30, density-tightened controls and summary
- TradeCommitWorkflow: density-tightened all 3 sub-tables and corporate action form

Group B (report tabs):
- PositionReportTab: compact metric cards, brand-purple theads, alternating rows
- WashSaleReportTab: compact violation table and expandable details
- TaxReportTab: terminal density across Schedule D, Form 8949, Schedule C/SE, Form 1040

All 6 files: zero hardcoded hex, zero gray-* references, all design tokens applied.

https://claude.ai/code/session_01G3wmws3SMsURWZUXsqp27H