### PR TITLE
fix: cross-entity COA lookup in transaction commit

### DIFF
--- a/src/app/api/transactions/commit-to-ledger/route.ts
+++ b/src/app/api/transactions/commit-to-ledger/route.ts
@@ -87,9 +87,23 @@ export async function POST(request: NextRequest) {
           continue;
         }
 
+        // Resolve the bank account's entity from the linked account's entityType.
+        // This may differ from resolvedEntityId when cross-entity categorization
+        // is used (e.g., personal bank account paying a business expense).
+        let bankEntityId = resolvedEntityId;
+        if (linkedAccount.entityType) {
+          const bankEntity = await prisma.entities.findFirst({
+            where: { userId: user.id, entity_type: linkedAccount.entityType },
+          });
+          if (bankEntity) {
+            bankEntityId = bankEntity.id;
+          }
+        }
+
         const journalEntry = await commitPlaidTransaction(prisma, {
           userId: user.id,
           entityId: resolvedEntityId,
+          bankEntityId,
           transactionId: plaidTxn.transactionId,
           accountCode,
           bankAccountCode,

--- a/src/components/dashboard/SpendingTab.tsx
+++ b/src/components/dashboard/SpendingTab.tsx
@@ -13,6 +13,7 @@ export interface CoaOption {
   name: string;
   accountType: string;
   balanceType: string;
+  entity_id?: string;
   entity_type?: string | null;
 }
 
@@ -910,7 +911,7 @@ function VirtualTable({
                       <option value="">{txn.predicted_coa_code ? `${txn.predicted_coa_code} - ${coaLookup.get(txn.predicted_coa_code)?.name || 'Unknown'}` : 'Select...'}</option>
                       {Object.entries(coaGroupedByEntity).map(([entity, opts]) => (
                         <optgroup key={entity} label={entity || 'General'}>
-                          {opts.map(o => <option key={o.id} value={o.code}>{o.code} - {o.name}</option>)}
+                          {opts.map(o => <option key={o.id} value={`${o.code}|${o.entity_id || ''}`}>{o.code} - {o.name}</option>)}
                         </optgroup>
                       ))}
                       <option value="__NEW__">+ Add Category</option>
@@ -1081,7 +1082,7 @@ function MerchantGroupTable({
                         <option value="">Select...</option>
                         {Object.entries(coaGroupedByEntity).map(([entity, opts]) => (
                           <optgroup key={entity} label={entity || 'General'}>
-                            {opts.map(o => <option key={o.id} value={o.code}>{o.code} - {o.name}</option>)}
+                            {opts.map(o => <option key={o.id} value={`${o.code}|${o.entity_id || ''}`}>{o.code} - {o.name}</option>)}
                           </optgroup>
                         ))}
                       </select>
@@ -1252,18 +1253,15 @@ export default function SpendingTab({ transactions, committedTransactions, coaOp
     if (ids.length === 0) return;
     if (!batchCoa) { alert('Select a COA account first'); return; }
 
-    // TODO: Batch commit with mixed entities needs entity-aware grouping —
-    // group by entity_id and send separate requests per entity (same pattern
-    // as would be used in a prediction-based commit). For now, use the first
-    // transaction's entity_id as a best-effort default.
-    const firstTxn = transactions.find(t => ids.includes(t.id));
+    // Parse "code|entity_id" from dropdown value
+    const [accountCode, coaEntityId] = batchCoa.split('|');
 
     setCommitting(true);
     try {
       const res = await fetch('/api/transactions/commit-to-ledger', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ transactionIds: ids, accountCode: batchCoa, subAccount: batchSub || null, entityId: firstTxn?.entity_id || undefined })
+        body: JSON.stringify({ transactionIds: ids, accountCode, subAccount: batchSub || null, entityId: coaEntityId || undefined })
       });
       const data = await res.json();
       if (data.success) {
@@ -1291,11 +1289,12 @@ export default function SpendingTab({ transactions, committedTransactions, coaOp
     let committed = 0;
     try {
       for (const [id, change] of entries) {
-        const txn = transactions.find(t => t.id === id);
+        // Parse "code|entity_id" from dropdown value
+        const [accountCode, coaEntityId] = change.coa.split('|');
         const res = await fetch('/api/transactions/commit-to-ledger', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ transactionIds: [id], accountCode: change.coa, subAccount: change.sub || null, entityId: txn?.entity_id || undefined })
+          body: JSON.stringify({ transactionIds: [id], accountCode, subAccount: change.sub || null, entityId: coaEntityId || undefined })
         });
         const data = await res.json();
         if (data.success) committed += data.committed;
@@ -1657,7 +1656,7 @@ export default function SpendingTab({ transactions, committedTransactions, coaOp
               <option value="">Select COA...</option>
               {Object.entries(coaGroupedByEntity).map(([entity, opts]) => (
                 <optgroup key={entity} label={entity || 'General'}>
-                  {opts.map(o => <option key={o.id} value={o.code}>{o.code} - {o.name}</option>)}
+                  {opts.map(o => <option key={o.id} value={`${o.code}|${o.entity_id || ''}`}>{o.code} - {o.name}</option>)}
                 </optgroup>
               ))}
               <option value="__NEW__">+ Add Category</option>

--- a/src/lib/journal-entry-service.ts
+++ b/src/lib/journal-entry-service.ts
@@ -5,6 +5,7 @@ type Tx = Omit<PrismaClient, '$connect' | '$disconnect' | '$on' | '$transaction'
 interface CommitPlaidTransactionParams {
   userId: string;
   entityId: string;
+  bankEntityId?: string;
   transactionId: string;
   accountCode: string;
   bankAccountCode: string;
@@ -40,6 +41,7 @@ export async function commitPlaidTransaction(
   const {
     userId,
     entityId,
+    bankEntityId,
     transactionId,
     accountCode,
     bankAccountCode,
@@ -63,15 +65,18 @@ export async function commitPlaidTransaction(
       );
     }
 
-    // Look up bank COA account
+    // Look up bank COA account — use bankEntityId (the bank account's entity)
+    // which may differ from entityId (the expense COA's entity) in cross-entity
+    // categorization scenarios (e.g., personal bank pays business expense).
+    const resolvedBankEntityId = bankEntityId || entityId;
     const bankAccount = await tx.chart_of_accounts.findUnique({
       where: {
-        userId_entity_id_code: { userId, entity_id: entityId, code: bankAccountCode },
+        userId_entity_id_code: { userId, entity_id: resolvedBankEntityId, code: bankAccountCode },
       },
     });
     if (!bankAccount) {
       throw new Error(
-        `Bank COA account not found: code=${bankAccountCode}, entityId=${entityId}, userId=${userId}`
+        `Bank COA account not found: code=${bankAccountCode}, entityId=${resolvedBankEntityId}, userId=${userId}`
       );
     }
 


### PR DESCRIPTION
- COA dropdown now sends entity_id alongside code (pipe-delimited value)
- Commit API uses code + entity_id for expense/income COA lookup
- Bank COA lookup resolves entity from linked account's entityType
- Enables cross-entity categorization (personal pays business expense)
- Resolves 'COA account not found' error for codes like 6240

https://claude.ai/code/session_01G3wmws3SMsURWZUXsqp27H