### PR TITLE
fix: metrics DONE query joins through accounts + SOC2 IMMUT try/catch

### DIFF
--- a/src/app/api/metrics/route.ts
+++ b/src/app/api/metrics/route.ts
@@ -77,10 +77,11 @@ export async function GET() {
     // 5. DONE — Categorization completeness
     const doneRows: any[] = await prisma.$queryRaw`
       SELECT
-        COUNT(*) FILTER (WHERE review_status = 'committed')::bigint as committed,
+        COUNT(*) FILTER (WHERE t.review_status = 'committed')::bigint as committed,
         COUNT(*)::bigint as total
-      FROM transactions
-      WHERE "userId" = ${userId}
+      FROM transactions t
+      JOIN accounts a ON t."accountId" = a.id
+      WHERE a."userId" = ${userId}
     `;
     const committed = Number(doneRows[0]?.committed ?? 0);
     const total = Number(doneRows[0]?.total ?? 0);

--- a/src/app/api/soc2/route.ts
+++ b/src/app/api/soc2/route.ts
@@ -67,16 +67,25 @@ export async function GET() {
     };
 
     // IMMUT — Immutability (check for triggers)
-    const triggers: any[] = await prisma.$queryRaw`
-      SELECT tgname FROM pg_trigger
-      WHERE tgrelid = 'journal_entries'::regclass
-        AND tgname IN ('protect_journal_entry_fields', 'no_journal_entry_deletes')
-    `;
-    const immut: ProofResult = {
-      status: triggers.length >= 2 ? 'pass' : triggers.length > 0 ? 'warn' : 'fail',
-      summary: `${triggers.length}/2 immutability triggers active`,
-      details: triggers.map(t => ({ trigger: t.tgname })),
-    };
+    let immut: ProofResult;
+    try {
+      const triggers: any[] = await prisma.$queryRaw`
+        SELECT tgname FROM pg_trigger
+        WHERE tgrelid = 'journal_entries'::regclass
+          AND tgname IN ('protect_journal_entry_fields', 'no_journal_entry_deletes')
+      `;
+      immut = {
+        status: triggers.length >= 2 ? 'pass' : triggers.length > 0 ? 'warn' : 'fail',
+        summary: `${triggers.length}/2 immutability triggers active`,
+        details: triggers.map(t => ({ trigger: t.tgname })),
+      };
+    } catch {
+      immut = {
+        status: 'warn',
+        summary: 'Could not verify triggers — insufficient DB permissions',
+        details: [],
+      };
+    }
 
     // CHGMG — Change Management (static)
     const chgmg: ProofResult = {


### PR DESCRIPTION
- transactions table has no userId column — join via accounts
- IMMUT trigger check wrapped in try/catch for restricted DB configs
- Audit findings from 70-point platform review

https://claude.ai/code/session_014JHbDWu1JW5fHNcg3yuKHF