### PR TITLE
fix: ledger balance respects debit-normal vs credit-normal accounts

### DIFF
--- a/src/components/dashboard/GeneralLedger.tsx
+++ b/src/components/dashboard/GeneralLedger.tsx
@@ -56,12 +56,14 @@ type SortDir = 'asc' | 'desc';
 
 const ROW_HEIGHT = 30;
 
-const fmtMoney = (n: number): string =>
-  '$' +
-  Math.abs(n).toLocaleString('en-US', {
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  });
+const fmtMoney = (n: number): string => {
+  const sign = n < 0 ? '-' : '';
+  return sign + '$' +
+    Math.abs(n).toLocaleString('en-US', {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    });
+};
 
 const fmtDate = (iso: string): string => {
   const d = new Date(iso);

--- a/src/components/dashboard/LedgerTab.tsx
+++ b/src/components/dashboard/LedgerTab.tsx
@@ -127,11 +127,11 @@ export default function LedgerTab() {
                 <div className="text-right">
                   <div className="text-sm text-text-secondary">Closing Balance</div>
                   <div className={`text-sm font-bold ${
-                    ledger.closingBalance > 0 ? 'text-brand-green' : 
-                    ledger.closingBalance < 0 ? 'text-brand-red' : 
+                    ledger.closingBalance > 0 ? 'text-brand-green' :
+                    ledger.closingBalance < 0 ? 'text-brand-red' :
                     'text-text-faint'
                   }`}>
-                    ${Math.abs(ledger.closingBalance).toFixed(2)}
+                    {ledger.closingBalance < 0 ? '-' : ''}${Math.abs(ledger.closingBalance).toFixed(2)}
                   </div>
                 </div>
               </div>
@@ -161,7 +161,7 @@ export default function LedgerTab() {
                           {entry.entryType === 'C' ? `$${entry.amount.toFixed(2)}` : '—'}
                         </td>
                         <td className="px-4 py-2 text-right font-bold">
-                          ${Math.abs(entry.runningBalance).toFixed(2)}
+                          {entry.runningBalance < 0 ? '-' : ''}${Math.abs(entry.runningBalance).toFixed(2)}
                         </td>
                       </tr>
                     ))}


### PR DESCRIPTION
- Asset/expense (debit-normal): balance = debits - credits
- Liability/revenue/equity (credit-normal): balance = credits - debits
- Fixes: 1010 showing +$228 when should be -$228
- Running balance in detail view now correct
- Summary balance matches closing balance
- Bug was purely display: fmtMoney used Math.abs() stripping the sign
- API balance calculation and DB settled_balance are both correct

https://claude.ai/code/session_014JHbDWu1JW5fHNcg3yuKHF