### PR TITLE
fix: deduplicate Plaid accounts + add unique constraint

### DIFF
--- a/prisma/migrations/20260301000100_dedup_accounts_unique_constraint/migration.sql
+++ b/prisma/migrations/20260301000100_dedup_accounts_unique_constraint/migration.sql
@@ -1,0 +1,21 @@
+-- PREREQUISITE: Before running this migration, remove duplicate accounts.
+--
+-- Identify duplicates:
+--   SELECT id, "accountId", mask, "entityType", "currentBalance", "createdAt"
+--   FROM accounts
+--   WHERE "userId" = 'cmfi3rcrl0000zcj0ajbj4za5' AND mask = '7948'
+--   ORDER BY "createdAt";
+--
+-- The OLDER record (earlier createdAt, has entityType set) is the keeper.
+-- The NEWER record (UNASSIGNED entityType) is the duplicate to delete.
+--
+-- Before deleting, check for linked transactions:
+--   SELECT COUNT(*) FROM transactions WHERE "accountId" = '<duplicate_id>';
+--   If > 0, reassign: UPDATE transactions SET "accountId" = '<keeper_id>' WHERE "accountId" = '<duplicate_id>';
+--
+-- Then delete the duplicate:
+--   DELETE FROM accounts WHERE id = '<duplicate_id>';
+
+-- Add composite unique constraint: one Plaid account per user
+-- (accountId already has @unique globally; this adds user-scoping as a safety net)
+CREATE UNIQUE INDEX "accounts_userId_accountId_key" ON "accounts"("userId", "accountId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -51,6 +51,8 @@ model accounts {
   users                   users?                    @relation(fields: [userId], references: [id], onDelete: NoAction, onUpdate: NoAction)
   investment_transactions investment_transactions[]
   transactions            transactions[]
+
+  @@unique([userId, accountId])
 }
 
 // ═══════════════════════════════════════════════════════════════════

--- a/src/app/api/plaid/exchange-token/route.ts
+++ b/src/app/api/plaid/exchange-token/route.ts
@@ -75,8 +75,41 @@ export async function POST(request: Request) {
     });
 
     for (const account of accountsResponse.data.accounts) {
+      // Dedup: check if this account already exists
+      // Check 1: exact Plaid account_id match (same link)
+      let existing = await prisma.accounts.findUnique({
+        where: { accountId: account.account_id }
+      });
+
+      // Check 2: same user + mask + type (re-link scenario where Plaid
+      // issues a new account_id for the same physical account)
+      if (!existing && account.mask) {
+        existing = await prisma.accounts.findFirst({
+          where: {
+            userId: user.id,
+            mask: account.mask,
+            type: account.type,
+          }
+        });
+      }
+
+      if (existing) {
+        // Update existing account: refresh balance, re-link to new Plaid item
+        await prisma.accounts.update({
+          where: { id: existing.id },
+          data: {
+            accountId: account.account_id,
+            plaidItemId: plaidItemId,
+            currentBalance: account.balances.current || 0,
+            availableBalance: account.balances.available || account.balances.current || 0,
+            updatedAt: new Date(),
+          }
+        });
+        continue;
+      }
+
       const accountId = `acc_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
-      
+
       await prisma.accounts.create({
         data: {
           id: accountId,


### PR DESCRIPTION
- Check for existing account before creating (exact Plaid account_id match, then fallback to userId + mask + type for re-link scenarios)
- On match, update balance and re-link to new Plaid item instead of creating duplicate
- Add @@unique([userId, accountId]) constraint migration
- Existing duplicate must be cleaned up before running migration

https://claude.ai/code/session_014JHbDWu1JW5fHNcg3yuKHF