### PR TITLE
fix: type CommitResult for idempotency guard return

### DIFF
--- a/src/lib/journal-entry-service.ts
+++ b/src/lib/journal-entry-service.ts
@@ -1,6 +1,8 @@
-import { PrismaClient } from '@prisma/client';
+import { PrismaClient, journal_entries } from '@prisma/client';
 
 type Tx = Omit<PrismaClient, '$connect' | '$disconnect' | '$on' | '$transaction' | '$use' | '$extends'>;
+
+export type CommitResult = journal_entries & { alreadyExisted?: boolean };
 
 interface CommitPlaidTransactionParams {
   userId: string;
@@ -37,7 +39,7 @@ function updateBalance(entryType: string, accountBalanceType: string, amountCent
 export async function commitPlaidTransaction(
   prisma: PrismaClient,
   params: CommitPlaidTransactionParams
-) {
+): Promise<CommitResult> {
   const {
     userId,
     entityId,


### PR DESCRIPTION
Export CommitResult = journal_entries & { alreadyExisted?: boolean } from journal-entry-service.ts with explicit return type annotation. TypeScript now resolves .alreadyExisted on the commit result.

https://claude.ai/code/session_014JHbDWu1JW5fHNcg3yuKHF