### PR TITLE
feat: clickable budget actuals with transaction drill-down

### DIFF
--- a/src/app/api/hub/drill-down/route.ts
+++ b/src/app/api/hub/drill-down/route.ts
@@ -1,0 +1,99 @@
+import { NextResponse } from 'next/server';
+import { Prisma } from '@prisma/client';
+import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
+
+export async function GET(request: Request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const coaCodes = searchParams.get('coaCodes')?.split(',').filter(Boolean);
+    const month = parseInt(searchParams.get('month') || '');
+    const year = parseInt(searchParams.get('year') || '');
+    const entityType = searchParams.get('entityType') || 'personal';
+
+    if (!coaCodes?.length || isNaN(month) || isNaN(year)) {
+      return NextResponse.json(
+        { error: 'coaCodes, month, and year are required' },
+        { status: 400 }
+      );
+    }
+
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const user = await prisma.users.findFirst({
+      where: { email: { equals: userEmail, mode: 'insensitive' } },
+    });
+    if (!user) {
+      return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    }
+
+    // month is 0-indexed from frontend, EXTRACT(MONTH) is 1-based
+    const dbMonth = month + 1;
+
+    // Entity type mapping: business section uses sole_prop
+    const entityTypes = entityType === 'sole_prop'
+      ? ['sole_prop', 'business']
+      : [entityType];
+
+    const rows: Array<{
+      amount: string;
+      entry_type: string;
+      date: Date;
+      description: string;
+      source_id: string | null;
+      code: string;
+      account_name: string;
+      merchant_name: string | null;
+      transaction_name: string | null;
+    }> = await prisma.$queryRaw`
+      SELECT
+        le.amount::text,
+        le.entry_type,
+        je.date,
+        je.description,
+        je.source_id,
+        coa.code,
+        coa.name as account_name,
+        t."merchantName" as merchant_name,
+        t.name as transaction_name
+      FROM ledger_entries le
+      JOIN journal_entries je ON le.journal_entry_id = je.id
+      JOIN chart_of_accounts coa ON le.account_id = coa.id
+      JOIN entities e ON coa.entity_id = e.id
+      LEFT JOIN transactions t ON je.source_id = t."transactionId"
+      WHERE je."userId" = ${user.id}
+        AND je.is_reversal = false
+        AND je.reversed_by_entry_id IS NULL
+        AND EXTRACT(YEAR FROM je.date) = ${year}
+        AND EXTRACT(MONTH FROM je.date) = ${dbMonth}
+        AND coa.code IN (${Prisma.join(coaCodes)})
+        AND e.entity_type IN (${Prisma.join(entityTypes)})
+        AND le.entry_type = 'D'
+      ORDER BY je.date DESC, je.created_at DESC
+    `;
+
+    const transactions = rows.map(row => ({
+      date: row.date.toISOString().split('T')[0],
+      merchant: row.merchant_name || row.description,
+      description: row.transaction_name || row.description,
+      amount: Math.round(Number(row.amount) / 100 * 100) / 100, // cents → dollars
+      coaCode: row.code,
+      coaName: row.account_name,
+    }));
+
+    const total = Math.round(transactions.reduce((s, t) => s + t.amount, 0) * 100) / 100;
+
+    return NextResponse.json({
+      transactions,
+      total,
+      count: transactions.length,
+      meta: { coaCodes, month, year },
+    });
+  } catch (error) {
+    console.error('Drill-down error:', error);
+    return NextResponse.json({ error: 'Failed to fetch drill-down' }, { status: 500 });
+  }
+}

--- a/src/app/hub/page.tsx
+++ b/src/app/hub/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, Fragment } from 'react';
 import { useRouter } from 'next/navigation';
 import { useSession } from 'next-auth/react';
 import { AppLayout, Card, Badge } from '@/components/ui';
+import BudgetDrillDown from '@/components/hub/BudgetDrillDown';
 
 import dynamic from 'next/dynamic';
 
@@ -123,6 +124,15 @@ export default function HubPage() {
     home: true, auto: true, shopping: true, personal: true, health: true, growth: true, trip: true,
   });
 
+  const [drillDown, setDrillDown] = useState<{
+    coaCodes: string[];
+    month: number;
+    year: number;
+    categoryName: string;
+    cellAmount: number;
+    entityType: string;
+  } | null>(null);
+
   useEffect(() => { loadCalendar(); }, [selectedYear, selectedMonth]);
 
   const loadCalendar = async () => {
@@ -196,6 +206,9 @@ export default function HubPage() {
 
   const fmt = (n: number) => n ? `$${n.toLocaleString('en-US', { minimumFractionDigits: 0, maximumFractionDigits: 0 })}` : '—';
   const formatCurrency = (amount: number) => new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', minimumFractionDigits: 0 }).format(amount);
+  const openDrill = (coaCodes: string[], month: number, name: string, amount: number, entityType: string) => {
+    if (amount > 0) setDrillDown({ coaCodes, month, year: selectedYear, categoryName: name, cellAmount: amount, entityType });
+  };
 
   const getDaysInMonth = (year: number, month: number) => new Date(year, month + 1, 0).getDate();
   const getFirstDayOfMonth = (year: number, month: number) => new Date(year, month, 1).getDay();
@@ -558,7 +571,7 @@ export default function HubPage() {
                           {MONTHS_SHORT.map((_, i) => {
                             const bud = budgetRow[i] || 0;
                             const act = actualRow[i] || 0;
-                            return (<td key={i} className={`py-1.5 px-2 text-right font-mono border-r border-border-light ${act > 0 && act > bud ? 'text-brand-red bg-red-50' : act > 0 ? 'text-emerald-700 bg-emerald-50' : 'text-text-faint'}`}>{fmt(act)}</td>);
+                            return (<td key={i} onClick={() => openDrill([code], i, name, act, 'personal')} className={`py-1.5 px-2 text-right font-mono border-r border-border-light ${act > 0 ? 'cursor-pointer' : ''} ${act > 0 && act > bud ? 'text-brand-red bg-red-50' : act > 0 ? 'text-emerald-700 bg-emerald-50' : 'text-text-faint'}`}>{fmt(act)}</td>);
                           })}
                           <td className={`py-1.5 px-3 text-right font-mono font-semibold ${actualTotal > 0 && actualTotal > budgetTotal ? 'text-brand-red bg-red-100/50' : actualTotal > 0 ? 'text-emerald-700 bg-emerald-100/50' : 'text-text-faint bg-bg-row/50'}`}>{fmt(actualTotal)}</td>
                         </tr>
@@ -582,7 +595,7 @@ export default function HubPage() {
                     {MONTHS_SHORT.map((_, i) => {
                       const budMonth = Object.values(homebaseBudget.budgetData).reduce((s, coa) => s + (coa[i] || 0), 0);
                       const actMonth = Object.values(homebaseBudget.actualData).reduce((s, coa) => s + (coa[i] || 0), 0);
-                      return (<td key={i} className={`py-2 px-2 text-right font-mono border-r border-brand-purple-hover ${actMonth > 0 && actMonth > budMonth ? 'text-red-300' : actMonth > 0 ? 'text-emerald-300' : ''}`}>{fmt(actMonth)}</td>);
+                      return (<td key={i} onClick={() => openDrill(Object.keys(homebaseBudget.coaNames), i, 'Homebase Total', actMonth, 'personal')} className={`py-2 px-2 text-right font-mono border-r border-brand-purple-hover ${actMonth > 0 ? 'cursor-pointer' : ''} ${actMonth > 0 && actMonth > budMonth ? 'text-red-300' : actMonth > 0 ? 'text-emerald-300' : ''}`}>{fmt(actMonth)}</td>);
                     })}
                     <td className={`py-2 px-3 text-right font-mono bg-panel-highlight ${yearlyHomebaseActual > yearlyHomebaseBudget ? 'text-red-300' : yearlyHomebaseActual > 0 ? 'text-emerald-300' : ''}`}>{fmt(yearlyHomebaseActual)}</td>
                   </tr>
@@ -634,7 +647,7 @@ export default function HubPage() {
                           {MONTHS_SHORT.map((_, i) => {
                             const bud = budgetRow[i] || 0;
                             const act = actualRow[i] || 0;
-                            return (<td key={i} className={`py-1.5 px-2 text-right font-mono border-r border-border-light ${act > 0 && act > bud ? 'text-brand-red bg-red-50' : act > 0 ? 'text-emerald-700 bg-emerald-50' : 'text-text-faint'}`}>{fmt(act)}</td>);
+                            return (<td key={i} onClick={() => openDrill([code], i, name, act, 'personal')} className={`py-1.5 px-2 text-right font-mono border-r border-border-light ${act > 0 ? 'cursor-pointer' : ''} ${act > 0 && act > bud ? 'text-brand-red bg-red-50' : act > 0 ? 'text-emerald-700 bg-emerald-50' : 'text-text-faint'}`}>{fmt(act)}</td>);
                           })}
                           <td className={`py-1.5 px-3 text-right font-mono font-semibold ${actualTotal > 0 && actualTotal > budgetTotal ? 'text-brand-red bg-red-100/50' : actualTotal > 0 ? 'text-emerald-700 bg-emerald-100/50' : 'text-text-faint bg-bg-row/50'}`}>{fmt(actualTotal)}</td>
                         </tr>
@@ -658,7 +671,7 @@ export default function HubPage() {
                     {MONTHS_SHORT.map((_, i) => {
                       const budMonth = Object.values(nomadBudget.budgetData).reduce((s, coa) => s + (coa[i] || 0), 0);
                       const actMonth = Object.values(nomadBudget.actualData).reduce((s, coa) => s + (coa[i] || 0), 0);
-                      return (<td key={i} className={`py-2 px-2 text-right font-mono border-r border-brand-purple-hover ${actMonth > 0 && actMonth > budMonth ? 'text-red-300' : actMonth > 0 ? 'text-emerald-300' : ''}`}>{fmt(actMonth)}</td>);
+                      return (<td key={i} onClick={() => openDrill(Object.keys(nomadBudget.coaNames), i, 'Travel Total', actMonth, 'personal')} className={`py-2 px-2 text-right font-mono border-r border-brand-purple-hover ${actMonth > 0 ? 'cursor-pointer' : ''} ${actMonth > 0 && actMonth > budMonth ? 'text-red-300' : actMonth > 0 ? 'text-emerald-300' : ''}`}>{fmt(actMonth)}</td>);
                     })}
                     <td className={`py-2 px-3 text-right font-mono bg-panel-highlight ${yearlyTravelActual > yearlyTravelBudget ? 'text-red-300' : yearlyTravelActual > 0 ? 'text-emerald-300' : ''}`}>{fmt(yearlyTravelActual)}</td>
                   </tr>
@@ -711,7 +724,7 @@ export default function HubPage() {
                             {MONTHS_SHORT.map((_, i) => {
                               const bud = budgetRow[i] || 0;
                               const act = actualRow[i] || 0;
-                              return (<td key={i} className={`py-1.5 px-2 text-right font-mono border-r border-border-light ${act > 0 && act > bud ? 'text-brand-red bg-red-50' : act > 0 ? 'text-emerald-700 bg-emerald-50' : 'text-text-faint'}`}>{fmt(act)}</td>);
+                              return (<td key={i} onClick={() => openDrill([code], i, name, act, 'sole_prop')} className={`py-1.5 px-2 text-right font-mono border-r border-border-light ${act > 0 ? 'cursor-pointer' : ''} ${act > 0 && act > bud ? 'text-brand-red bg-red-50' : act > 0 ? 'text-emerald-700 bg-emerald-50' : 'text-text-faint'}`}>{fmt(act)}</td>);
                             })}
                             <td className={`py-1.5 px-3 text-right font-mono font-semibold ${actualTotal > 0 && actualTotal > budgetTotal ? 'text-brand-red bg-red-100/50' : actualTotal > 0 ? 'text-emerald-700 bg-emerald-100/50' : 'text-text-faint bg-bg-row/50'}`}>{fmt(actualTotal)}</td>
                           </tr>
@@ -735,7 +748,7 @@ export default function HubPage() {
                       {MONTHS_SHORT.map((_, i) => {
                         const budMonth = Object.values(businessBudget.budgetData).reduce((s, coa) => s + (coa[i] || 0), 0);
                         const actMonth = Object.values(businessBudget.actualData).reduce((s, coa) => s + (coa[i] || 0), 0);
-                        return (<td key={i} className={`py-2 px-2 text-right font-mono border-r border-brand-purple-hover ${actMonth > 0 && actMonth > budMonth ? 'text-red-300' : actMonth > 0 ? 'text-emerald-300' : ''}`}>{fmt(actMonth)}</td>);
+                        return (<td key={i} onClick={() => openDrill(Object.keys(businessBudget.coaNames), i, 'Business Total', actMonth, 'sole_prop')} className={`py-2 px-2 text-right font-mono border-r border-brand-purple-hover ${actMonth > 0 ? 'cursor-pointer' : ''} ${actMonth > 0 && actMonth > budMonth ? 'text-red-300' : actMonth > 0 ? 'text-emerald-300' : ''}`}>{fmt(actMonth)}</td>);
                       })}
                       <td className={`py-2 px-3 text-right font-mono bg-panel-highlight ${yearlyBusinessActual > yearlyBusinessBudget ? 'text-red-300' : yearlyBusinessActual > 0 ? 'text-emerald-300' : ''}`}>{fmt(yearlyBusinessActual)}</td>
                     </tr>
@@ -757,6 +770,13 @@ export default function HubPage() {
 
         </div>
       </div>
+      {drillDown && (
+        <BudgetDrillDown
+          isOpen={true}
+          onClose={() => setDrillDown(null)}
+          {...drillDown}
+        />
+      )}
     </AppLayout>
   );
 }

--- a/src/components/hub/BudgetDrillDown.tsx
+++ b/src/components/hub/BudgetDrillDown.tsx
@@ -1,0 +1,192 @@
+'use client';
+
+import { useState, useEffect, useRef } from 'react';
+
+const MONTHS = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
+
+interface DrillDownTransaction {
+  date: string;
+  merchant: string;
+  description: string;
+  amount: number;
+  coaCode: string;
+  coaName: string;
+}
+
+interface BudgetDrillDownProps {
+  isOpen: boolean;
+  onClose: () => void;
+  coaCodes: string[];
+  month: number;
+  year: number;
+  categoryName: string;
+  cellAmount: number;
+  entityType: string;
+}
+
+export default function BudgetDrillDown({
+  isOpen,
+  onClose,
+  coaCodes,
+  month,
+  year,
+  categoryName,
+  cellAmount,
+  entityType,
+}: BudgetDrillDownProps) {
+  const [transactions, setTransactions] = useState<DrillDownTransaction[]>([]);
+  const [total, setTotal] = useState(0);
+  const [count, setCount] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    setLoading(true);
+    setError(null);
+
+    const params = new URLSearchParams({
+      coaCodes: coaCodes.join(','),
+      month: month.toString(),
+      year: year.toString(),
+      entityType,
+    });
+
+    fetch(`/api/hub/drill-down?${params}`)
+      .then(res => {
+        if (!res.ok) throw new Error('Failed to fetch');
+        return res.json();
+      })
+      .then(data => {
+        setTransactions(data.transactions || []);
+        setTotal(data.total || 0);
+        setCount(data.count || 0);
+      })
+      .catch(err => setError(err.message))
+      .finally(() => setLoading(false));
+  }, [isOpen, coaCodes, month, year, entityType]);
+
+  // Click outside to close
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleClick = (e: MouseEvent) => {
+      if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
+        onClose();
+      }
+    };
+    // Delay to avoid the opening click triggering close
+    const timer = setTimeout(() => document.addEventListener('mousedown', handleClick), 50);
+    return () => { clearTimeout(timer); document.removeEventListener('mousedown', handleClick); };
+  }, [isOpen, onClose]);
+
+  // Escape key to close
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
+    document.addEventListener('keydown', handleKey);
+    return () => document.removeEventListener('keydown', handleKey);
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  const fmt = (n: number) => `$${n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+  const totalMismatch = Math.abs(total - cellAmount) > 0.01;
+
+  return (
+    <div className="fixed inset-0 z-50 flex justify-end">
+      {/* Backdrop */}
+      <div className="absolute inset-0 bg-black/30" />
+
+      {/* Panel */}
+      <div
+        ref={panelRef}
+        className="relative w-full max-w-lg bg-white shadow-2xl flex flex-col animate-in slide-in-from-right duration-200"
+        style={{ animation: 'slideInRight 0.2s ease-out' }}
+      >
+        {/* Header */}
+        <div className="bg-brand-purple text-white px-5 py-4 flex items-start justify-between">
+          <div>
+            <h3 className="text-sm font-semibold">{categoryName}</h3>
+            <p className="text-xs text-white/70 mt-0.5 font-mono">
+              {MONTHS[month]} {year} · {coaCodes.length === 1 ? coaCodes[0] : `${coaCodes.length} accounts`}
+            </p>
+          </div>
+          <button onClick={onClose} className="text-white/70 hover:text-white transition-colors p-1 -mr-1 -mt-1">
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="flex-1 overflow-y-auto">
+          {loading ? (
+            <div className="p-5 space-y-3">
+              {[...Array(6)].map((_, i) => (
+                <div key={i} className="h-10 bg-bg-row/50 rounded animate-pulse" />
+              ))}
+            </div>
+          ) : error ? (
+            <div className="p-8 text-center text-brand-red text-sm">{error}</div>
+          ) : transactions.length === 0 ? (
+            <div className="p-8 text-center text-text-faint text-sm">No transactions found for this period</div>
+          ) : (
+            <table className="w-full text-xs">
+              <thead>
+                <tr className="border-b border-border bg-bg-row/50 text-text-muted">
+                  <th className="text-left py-2 px-4 font-medium">Date</th>
+                  <th className="text-left py-2 px-2 font-medium">Merchant</th>
+                  {coaCodes.length > 1 && <th className="text-left py-2 px-2 font-medium">Account</th>}
+                  <th className="text-right py-2 px-4 font-medium">Amount</th>
+                </tr>
+              </thead>
+              <tbody>
+                {transactions.map((txn, i) => (
+                  <tr key={i} className={`border-b border-border-light hover:bg-brand-purple-wash/20 ${i % 2 === 0 ? 'bg-white' : 'bg-bg-row/30'}`}>
+                    <td className="py-2 px-4 font-mono text-text-muted whitespace-nowrap">{txn.date}</td>
+                    <td className="py-2 px-2 text-text-primary truncate max-w-[200px]" title={txn.description}>
+                      {txn.merchant}
+                    </td>
+                    {coaCodes.length > 1 && (
+                      <td className="py-2 px-2 text-text-muted font-mono whitespace-nowrap">{txn.coaCode}</td>
+                    )}
+                    <td className="py-2 px-4 text-right font-mono text-text-primary whitespace-nowrap">{fmt(txn.amount)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+
+        {/* Footer */}
+        {!loading && !error && transactions.length > 0 && (
+          <div className="border-t border-border bg-bg-row/50 px-5 py-3">
+            <div className="flex items-center justify-between">
+              <span className="text-xs text-text-muted">{count} transaction{count !== 1 ? 's' : ''}</span>
+              <div className="flex items-center gap-2">
+                {totalMismatch && (
+                  <span className="text-amber-600 text-xs flex items-center gap-1" title={`Expected ${fmt(cellAmount)}, got ${fmt(total)}`}>
+                    <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                    </svg>
+                    mismatch
+                  </span>
+                )}
+                <span className="text-sm font-semibold font-mono text-text-primary">{fmt(total)}</span>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* CSS animation */}
+      <style jsx>{`
+        @keyframes slideInRight {
+          from { transform: translateX(100%); }
+          to { transform: translateX(0); }
+        }
+      `}</style>
+    </div>
+  );
+}


### PR DESCRIPTION
- New /api/hub/drill-down endpoint returns committed transactions for any COA code(s) + month, with entity type scoping
- BudgetDrillDown drawer slides in from right showing date, merchant, amount per transaction with total verification
- All ACT cells across Homebase, Travel, and Business sections are clickable when amount > 0 (individual rows + total rows)
- Total in drawer must match cell amount — mismatch warning shown
- Every dollar traceable from budget grid to individual transaction

https://claude.ai/code/session_014JHbDWu1JW5fHNcg3yuKHF