### PR TITLE
fix: resolve TypeScript JSX type declarations by committing next-env.…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,7 +44,6 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
-next-env.d.ts
 
 /src/generated/prisma
 /src/scripts/

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
…d.ts

next-env.d.ts was gitignored, causing tsc to miss the Next.js type references (/// <reference types="next" />) needed to resolve JSX.IntrinsicElements. This produced 16,138 TS7026 errors on any fresh clone. Removed next-env.d.ts from .gitignore and committed the file so tsc --noEmit passes cleanly after npm install.

https://claude.ai/code/session_01AHpyG2kpyPHr43Lbj1mxYg