### PR TITLE
security: hash admin password, admin-only maintenance routes, dev-mod…

### DIFF
--- a/src/app/api/admin/backfill-transaction-fields/route.ts
+++ b/src/app/api/admin/backfill-transaction-fields/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { plaidClient } from '@/lib/plaid';
-import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { requireAdmin } from '@/lib/require-admin';
 
 /**
  * POST /api/admin/backfill-transaction-fields
@@ -18,10 +18,9 @@ import { getVerifiedEmail } from '@/lib/cookie-auth';
  */
 export async function POST() {
   try {
-    const userEmail = await getVerifiedEmail();
-    if (!userEmail) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
+    const adminResult = await requireAdmin();
+    if (adminResult instanceof NextResponse) return adminResult;
+    const userEmail = adminResult;
 
     const user = await prisma.users.findFirst({
       where: { email: { equals: userEmail, mode: 'insensitive' } }

--- a/src/app/api/admin/fix-coa-ownership/route.ts
+++ b/src/app/api/admin/fix-coa-ownership/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
-import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { requireAdmin } from '@/lib/require-admin';
 
 /**
  * POST /api/admin/fix-coa-ownership
@@ -14,10 +14,9 @@ import { getVerifiedEmail } from '@/lib/cookie-auth';
  */
 export async function POST() {
   try {
-    const userEmail = await getVerifiedEmail();
-    if (!userEmail) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
+    const adminResult = await requireAdmin();
+    if (adminResult instanceof NextResponse) return adminResult;
+    const userEmail = adminResult;
 
     const user = await prisma.users.findFirst({
       where: { email: { equals: userEmail, mode: 'insensitive' } }

--- a/src/app/api/admin/fix-unbalanced-entries/route.ts
+++ b/src/app/api/admin/fix-unbalanced-entries/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
-import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { requireAdmin } from '@/lib/require-admin';
 
 /**
  * POST /api/admin/fix-unbalanced-entries
@@ -22,10 +22,9 @@ import { getVerifiedEmail } from '@/lib/cookie-auth';
  */
 export async function POST() {
   try {
-    const userEmail = await getVerifiedEmail();
-    if (!userEmail) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
+    const adminResult = await requireAdmin();
+    if (adminResult instanceof NextResponse) return adminResult;
+    const userEmail = adminResult;
 
     const user = await prisma.users.findFirst({
       where: { email: { equals: userEmail, mode: 'insensitive' } }

--- a/src/app/api/admin/recalculate-balances/route.ts
+++ b/src/app/api/admin/recalculate-balances/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
-import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { requireAdmin } from '@/lib/require-admin';
 
 /**
  * POST /api/admin/recalculate-balances
@@ -15,10 +15,9 @@ import { getVerifiedEmail } from '@/lib/cookie-auth';
  */
 export async function POST() {
   try {
-    const userEmail = await getVerifiedEmail();
-    if (!userEmail) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
+    const adminResult = await requireAdmin();
+    if (adminResult instanceof NextResponse) return adminResult;
+    const userEmail = adminResult;
 
     const user = await prisma.users.findFirst({
       where: { email: { equals: userEmail, mode: 'insensitive' } }

--- a/src/app/api/admin/verify/route.ts
+++ b/src/app/api/admin/verify/route.ts
@@ -1,14 +1,21 @@
 import { NextResponse } from 'next/server';
+import bcrypt from 'bcryptjs';
 
 export async function POST(request: Request) {
-  const adminPassword = process.env.ADMIN_PASSWORD;
-  if (!adminPassword) {
+  const adminPasswordHash = process.env.ADMIN_PASSWORD;
+  if (!adminPasswordHash) {
     return NextResponse.json({ error: 'Admin access is not configured' }, { status: 403 });
   }
 
   const { password } = await request.json();
 
-  if (password === adminPassword) {
+  if (!password || typeof password !== 'string') {
+    return NextResponse.json({ error: 'Invalid password' }, { status: 401 });
+  }
+
+  const isValid = await bcrypt.compare(password, adminPasswordHash);
+
+  if (isValid) {
     return NextResponse.json({ success: true });
   } else {
     return NextResponse.json({ error: 'Invalid password' }, { status: 401 });

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -15,11 +15,11 @@ export async function verifyAuth(request: NextRequest): Promise<string | null> {
   try {
     // Check for auth token in cookies
     const token = request.cookies.get('auth-token')?.value;
-    
+
     if (!token) {
       console.log('No auth token found in cookies');
-      // For development, create a default user ID
-      if (process.env.NODE_ENV === 'development') {
+      // For local development only — never on Vercel
+      if (process.env.NODE_ENV === 'development' && !process.env.VERCEL) {
         return 'default-dev-user';
       }
       return null;
@@ -27,7 +27,7 @@ export async function verifyAuth(request: NextRequest): Promise<string | null> {
 
     // Verify JWT token
     const decoded = jwt.verify(token, JWT_SECRET) as UserPayload;
-    
+
     if (!decoded.userId) {
       console.log('Invalid token payload');
       return null;
@@ -36,8 +36,8 @@ export async function verifyAuth(request: NextRequest): Promise<string | null> {
     return decoded.userId;
   } catch (error) {
     console.error('Auth verification failed:', error);
-    // For development, return a default user ID
-    if (process.env.NODE_ENV === 'development') {
+    // For local development only — never on Vercel
+    if (process.env.NODE_ENV === 'development' && !process.env.VERCEL) {
       return 'default-dev-user';
     }
     return null;

--- a/src/lib/require-admin.ts
+++ b/src/lib/require-admin.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
+
+/**
+ * Verify the caller is an authenticated admin (OWNER_EMAIL).
+ * Returns the verified email on success, or a 401/403 NextResponse on failure.
+ */
+export async function requireAdmin(): Promise<string | NextResponse> {
+  const userEmail = await getVerifiedEmail();
+  if (!userEmail) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const ownerEmail = process.env.OWNER_EMAIL;
+  if (!ownerEmail || userEmail.toLowerCase() !== ownerEmail.toLowerCase()) {
+    return NextResponse.json({ error: 'Forbidden: admin access required' }, { status: 403 });
+  }
+
+  return userEmail;
+}


### PR DESCRIPTION
…e guard

FIX 1: Admin verify route now uses bcrypt.compare() against a hashed ADMIN_PASSWORD env var instead of plaintext string equality. ADMIN_PASSWORD must now store a bcrypt hash in Vercel.

FIX 2: All 4 admin maintenance routes (backfill-transaction-fields, fix-coa-ownership, fix-unbalanced-entries, recalculate-balances) now require OWNER_EMAIL via a shared requireAdmin() helper. Previously any authenticated user could call them.

FIX 3: The default-dev-user auth fallback now requires both NODE_ENV=development AND absence of VERCEL env var, preventing accidental activation on Vercel preview deployments.

https://claude.ai/code/session_01AHpyG2kpyPHr43Lbj1mxYg