### PR TITLE
fix: allow /api/admin/verify through middleware

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -50,6 +50,7 @@ async function verifyCookieEdge(cookieValue: string): Promise<string | null> {
 const PUBLIC_PATHS = [
   '/',
   '/admin',
+  '/api/admin/verify',
   '/api/auth',
   '/_next',
   '/favicon.ico',


### PR DESCRIPTION
The admin verify endpoint uses bcrypt.compare() to check passwords itself — it must be publicly reachable so the admin login form can call it. Other /api/admin/* routes remain protected by middleware.

https://claude.ai/code/session_01AHpyG2kpyPHr43Lbj1mxYg