### PR TITLE
fix: admin dashboard users tab data loading

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -153,8 +153,9 @@ export default function AdminPage() {
             Admin Dashboard
           </h1>
           <button
-            onClick={() => {
+            onClick={async () => {
               sessionStorage.removeItem('adminAuth');
+              await fetch('/api/admin/verify', { method: 'DELETE' });
               router.push('/');
             }}
             className="px-4 py-2 bg-red-500 text-white rounded hover:bg-red-600"

--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -1,11 +1,15 @@
 import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
-import { requireAdmin } from '@/lib/require-admin';
+import { cookies } from 'next/headers';
+import { verifyCookie } from '@/lib/cookie-auth';
 
 export async function GET() {
   try {
-    const adminResult = await requireAdmin();
-    if (adminResult instanceof NextResponse) return adminResult;
+    const cookieStore = await cookies();
+    const raw = cookieStore.get('adminSession')?.value;
+    if (!raw || verifyCookie(raw) !== 'admin-session') {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
 
     const users = await prisma.users.findMany({
       orderBy: { createdAt: 'desc' },

--- a/src/app/api/admin/verify/route.ts
+++ b/src/app/api/admin/verify/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import bcrypt from 'bcryptjs';
+import { signCookie } from '@/lib/cookie-auth';
 
 export async function POST(request: Request) {
   const adminPasswordHash = process.env.ADMIN_PASSWORD;
@@ -16,8 +17,28 @@ export async function POST(request: Request) {
   const isValid = await bcrypt.compare(password, adminPasswordHash);
 
   if (isValid) {
-    return NextResponse.json({ success: true });
+    const response = NextResponse.json({ success: true });
+    response.cookies.set('adminSession', signCookie('admin-session'), {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax',
+      path: '/',
+      maxAge: 60 * 60 * 4, // 4 hours
+    });
+    return response;
   } else {
     return NextResponse.json({ error: 'Invalid password' }, { status: 401 });
   }
+}
+
+export async function DELETE() {
+  const response = NextResponse.json({ success: true });
+  response.cookies.set('adminSession', '', {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    path: '/',
+    maxAge: 0,
+  });
+  return response;
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -51,6 +51,7 @@ const PUBLIC_PATHS = [
   '/',
   '/admin',
   '/api/admin/verify',
+  '/api/admin/users',
   '/api/auth',
   '/_next',
   '/favicon.ico',


### PR DESCRIPTION
Two problems prevented the User Signups tab from loading:

1. Middleware blocked /api/admin/users — added to PUBLIC_PATHS
2. requireAdmin() checked the userEmail HMAC cookie, but admin login only set sessionStorage (client-side) — the server had no way to verify the admin session

Fix: /api/admin/verify now sets an HMAC-signed httpOnly adminSession cookie on successful password check. The users route verifies this cookie directly instead of requireAdmin(). Logout clears the cookie via DELETE /api/admin/verify.

Maintenance routes (backfill, fix-coa, recalculate, etc.) remain protected by both middleware and requireAdmin().

https://claude.ai/code/session_01AHpyG2kpyPHr43Lbj1mxYg