### PR TITLE
feat: GAAP year-end close with closing entries to retained earnings

### DIFF
--- a/src/app/api/year-end-close/route.ts
+++ b/src/app/api/year-end-close/route.ts
@@ -1,0 +1,412 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { Prisma } from '@prisma/client';
+import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
+
+// GAAP Year-End Close API
+//
+// Creates closing journal entries that zero out revenue and expense accounts
+// and transfer net income to Retained Earnings (3900).
+//
+// PATHWAY 8: Year-end close bypasses period close enforcement.
+// Closing entries are the privileged reason periods are closed.
+// Audit trail: source_type = 'year_end_close', created_by = userEmail
+//
+// Idempotency: source_type = 'year_end_close', source_id = year (string)
+// All amounts in BigInt cents per SOC2 BAL control.
+
+interface RevExpRow {
+  account_id: string;
+  account_code: string;
+  account_name: string;
+  account_type: string;
+  balance_type: string;
+  total_debits: bigint;
+  total_credits: bigint;
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const user = await prisma.users.findFirst({
+      where: { email: { equals: userEmail, mode: 'insensitive' } },
+    });
+    if (!user) {
+      return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    }
+
+    const { entityId, year } = await request.json();
+
+    if (!entityId || !year) {
+      return NextResponse.json({ error: 'Missing required fields: entityId, year' }, { status: 400 });
+    }
+
+    // 1. Validate entity belongs to user
+    const entity = await prisma.entities.findFirst({
+      where: { id: entityId, userId: user.id },
+    });
+    if (!entity) {
+      return NextResponse.json({ error: 'Entity not found or does not belong to user' }, { status: 404 });
+    }
+
+    // 2. Check all 12 months are period-closed for this entity+year
+    const closedPeriods = await prisma.$queryRaw<{ month: number }[]>`
+      SELECT month FROM closing_periods
+      WHERE "userId" = ${user.id}
+        AND entity_id = ${entityId}
+        AND year = ${year}
+        AND status = 'closed'
+    `;
+    const closedMonths = new Set(closedPeriods.map((p: { month: number }) => p.month));
+    const openMonths: number[] = [];
+    for (let m = 1; m <= 12; m++) {
+      if (!closedMonths.has(m)) openMonths.push(m);
+    }
+    if (openMonths.length > 0) {
+      return NextResponse.json({
+        error: `Cannot close year. Open months: [${openMonths.join(', ')}]`,
+        openMonths,
+      }, { status: 400 });
+    }
+
+    // 3. Idempotency check — has this year already been closed?
+    const existingClose = await prisma.journal_entries.findFirst({
+      where: {
+        userId: user.id,
+        entity_id: entityId,
+        source_type: 'year_end_close',
+        source_id: String(year),
+        is_reversal: false,
+        reversed_by_entry_id: null,
+      },
+    });
+    if (existingClose) {
+      return NextResponse.json({
+        error: `Year-end close already completed for ${year}`,
+        closingEntryId: existingClose.id,
+      }, { status: 409 });
+    }
+
+    // 4. Compute revenue and expense balances for the year
+    const yearStart = `${year}-01-01`;
+    const yearEnd = `${year}-12-31`;
+
+    const rows: RevExpRow[] = await prisma.$queryRaw`
+      SELECT
+        coa.id AS account_id,
+        coa.code AS account_code,
+        coa.name AS account_name,
+        coa.account_type,
+        coa.balance_type,
+        COALESCE(SUM(CASE WHEN le.entry_type = 'D' THEN le.amount ELSE 0 END), 0) AS total_debits,
+        COALESCE(SUM(CASE WHEN le.entry_type = 'C' THEN le.amount ELSE 0 END), 0) AS total_credits
+      FROM ledger_entries le
+      JOIN journal_entries je ON le.journal_entry_id = je.id
+      JOIN chart_of_accounts coa ON le.account_id = coa.id
+      WHERE je."userId" = ${user.id}
+        AND je.entity_id = ${entityId}
+        AND je.is_reversal = false
+        AND je.reversed_by_entry_id IS NULL
+        AND coa.account_type IN ('revenue', 'expense')
+        AND je.date >= ${yearStart}::date
+        AND je.date <= ${yearEnd}::date
+      GROUP BY coa.id, coa.code, coa.name, coa.account_type, coa.balance_type
+      HAVING SUM(CASE WHEN le.entry_type = 'D' THEN le.amount ELSE 0 END) != 0
+          OR SUM(CASE WHEN le.entry_type = 'C' THEN le.amount ELSE 0 END) != 0
+      ORDER BY coa.code
+    `;
+
+    // 5. Compute net income
+    let totalRevenue = BigInt(0);
+    let totalExpenses = BigInt(0);
+
+    for (const row of rows) {
+      const debits = BigInt(row.total_debits);
+      const credits = BigInt(row.total_credits);
+
+      if (row.account_type === 'revenue') {
+        // Revenue is credit-normal: balance = credits - debits
+        totalRevenue += credits - debits;
+      } else {
+        // Expense is debit-normal: balance = debits - credits
+        totalExpenses += debits - credits;
+      }
+    }
+
+    const netIncome = totalRevenue - totalExpenses;
+
+    // 6. Find or create Retained Earnings account (3900)
+    let retainedEarnings = await prisma.chart_of_accounts.findFirst({
+      where: {
+        userId: user.id,
+        entity_id: entityId,
+        code: '3900',
+        account_type: 'equity',
+      },
+    });
+    if (!retainedEarnings) {
+      retainedEarnings = await prisma.chart_of_accounts.create({
+        data: {
+          id: crypto.randomUUID(),
+          userId: user.id,
+          entity_id: entityId,
+          code: '3900',
+          name: 'Retained Earnings',
+          account_type: 'equity',
+          balance_type: 'C',
+          created_by: userEmail,
+        },
+      });
+    }
+
+    // 7. Create closing journal entry in a transaction
+    // PATHWAY 8: Year-end close bypasses period close enforcement.
+    // Closing entries are the privileged reason periods are closed.
+    // Audit trail: source_type = 'year_end_close', created_by = userEmail
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await prisma.$transaction(async (tx: any) => {
+      const journalEntry = await tx.journal_entries.create({
+        data: {
+          userId: user.id,
+          entity_id: entityId,
+          date: new Date(year, 11, 31), // Dec 31
+          description: `Year-end closing entry for ${year}`,
+          source_type: 'year_end_close',
+          source_id: String(year),
+          status: 'posted',
+          is_reversal: false,
+          created_by: userEmail,
+        },
+      });
+
+      let totalLedgerDebits = BigInt(0);
+      let totalLedgerCredits = BigInt(0);
+      let accountsClosed = 0;
+
+      // Close each revenue and expense account
+      for (const row of rows) {
+        const debits = BigInt(row.total_debits);
+        const credits = BigInt(row.total_credits);
+
+        if (row.account_type === 'revenue') {
+          // Revenue is credit-normal: balance = credits - debits
+          const balance = credits - debits;
+          if (balance === BigInt(0)) continue;
+
+          // Debit revenue account to zero it out
+          const absBalance = balance > BigInt(0) ? balance : -balance;
+          const entryType = balance > BigInt(0) ? 'D' : 'C';
+
+          await tx.ledger_entries.create({
+            data: {
+              journal_entry_id: journalEntry.id,
+              account_id: row.account_id,
+              entry_type: entryType,
+              amount: absBalance,
+              created_by: userEmail,
+            },
+          });
+
+          if (entryType === 'D') {
+            totalLedgerDebits += absBalance;
+          } else {
+            totalLedgerCredits += absBalance;
+          }
+
+          // Update account settled_balance
+          // Debiting a credit-normal account decreases its balance
+          const balanceChange = entryType === 'C' ? absBalance : -absBalance;
+          await tx.chart_of_accounts.update({
+            where: { id: row.account_id },
+            data: {
+              settled_balance: { increment: balanceChange },
+              version: { increment: 1 },
+            },
+          });
+        } else {
+          // Expense is debit-normal: balance = debits - credits
+          const balance = debits - credits;
+          if (balance === BigInt(0)) continue;
+
+          // Credit expense account to zero it out
+          const absBalance = balance > BigInt(0) ? balance : -balance;
+          const entryType = balance > BigInt(0) ? 'C' : 'D';
+
+          await tx.ledger_entries.create({
+            data: {
+              journal_entry_id: journalEntry.id,
+              account_id: row.account_id,
+              entry_type: entryType,
+              amount: absBalance,
+              created_by: userEmail,
+            },
+          });
+
+          if (entryType === 'D') {
+            totalLedgerDebits += absBalance;
+          } else {
+            totalLedgerCredits += absBalance;
+          }
+
+          // Update account settled_balance
+          // Crediting a debit-normal account decreases its balance
+          const balanceChange = entryType === 'D' ? absBalance : -absBalance;
+          await tx.chart_of_accounts.update({
+            where: { id: row.account_id },
+            data: {
+              settled_balance: { increment: balanceChange },
+              version: { increment: 1 },
+            },
+          });
+        }
+
+        accountsClosed++;
+      }
+
+      // Retained Earnings line
+      if (netIncome !== BigInt(0)) {
+        const absNetIncome = netIncome > BigInt(0) ? netIncome : -netIncome;
+        // Profit: CREDIT RE; Loss: DEBIT RE
+        const reEntryType = netIncome > BigInt(0) ? 'C' : 'D';
+
+        await tx.ledger_entries.create({
+          data: {
+            journal_entry_id: journalEntry.id,
+            account_id: retainedEarnings!.id,
+            entry_type: reEntryType,
+            amount: absNetIncome,
+            created_by: userEmail,
+          },
+        });
+
+        if (reEntryType === 'D') {
+          totalLedgerDebits += absNetIncome;
+        } else {
+          totalLedgerCredits += absNetIncome;
+        }
+
+        // Update RE settled_balance
+        // RE is credit-normal (balance_type 'C')
+        const reBalanceChange = reEntryType === 'C' ? absNetIncome : -absNetIncome;
+        await tx.chart_of_accounts.update({
+          where: { id: retainedEarnings!.id },
+          data: {
+            settled_balance: { increment: reBalanceChange },
+            version: { increment: 1 },
+          },
+        });
+      }
+
+      // CRITICAL: Balance verification (SOC2 BAL control)
+      if (totalLedgerDebits !== totalLedgerCredits) {
+        throw new Error(
+          `Year-end closing entry is unbalanced: debits=${totalLedgerDebits.toString()}, credits=${totalLedgerCredits.toString()}. Rolling back.`
+        );
+      }
+
+      return { journalEntry, accountsClosed };
+    });
+
+    return NextResponse.json({
+      closingEntryId: result.journalEntry.id,
+      netIncome: Number(netIncome),
+      accountsClosed: result.accountsClosed,
+      year,
+      entityName: entity.name,
+    });
+  } catch (error) {
+    console.error('Year-end close error:', error);
+    const message = error instanceof Error ? error.message : 'Internal server error';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const user = await prisma.users.findFirst({
+      where: { email: { equals: userEmail, mode: 'insensitive' } },
+    });
+    if (!user) {
+      return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    }
+
+    const { searchParams } = new URL(request.url);
+    const entityId = searchParams.get('entityId');
+    const year = searchParams.get('year');
+
+    if (!entityId || !year) {
+      return NextResponse.json({ error: 'Missing required params: entityId, year' }, { status: 400 });
+    }
+
+    // Validate entity belongs to user
+    const entity = await prisma.entities.findFirst({
+      where: { id: entityId, userId: user.id },
+    });
+    if (!entity) {
+      return NextResponse.json({ error: 'Entity not found or does not belong to user' }, { status: 404 });
+    }
+
+    // Check if a closing entry exists
+    const closingEntry = await prisma.journal_entries.findFirst({
+      where: {
+        userId: user.id,
+        entity_id: entityId,
+        source_type: 'year_end_close',
+        source_id: year,
+        is_reversal: false,
+        reversed_by_entry_id: null,
+      },
+      select: {
+        id: true,
+        created_at: true,
+      },
+    });
+
+    if (closingEntry) {
+      // Compute net income from the ledger entries of this closing entry
+      const ledgerEntries = await prisma.ledger_entries.findMany({
+        where: { journal_entry_id: closingEntry.id },
+        include: { account: true },
+      });
+
+      // Net income = sum of credits to RE minus debits to RE
+      let netIncome = BigInt(0);
+      for (const le of ledgerEntries) {
+        if (le.account.code === '3900' && le.account.account_type === 'equity') {
+          if (le.entry_type === 'C') {
+            netIncome += le.amount;
+          } else {
+            netIncome -= le.amount;
+          }
+        }
+      }
+
+      return NextResponse.json({
+        isClosed: true,
+        closingEntryId: closingEntry.id,
+        netIncome: Number(netIncome),
+        closedAt: closingEntry.created_at.toISOString(),
+      });
+    }
+
+    return NextResponse.json({
+      isClosed: false,
+      closingEntryId: null,
+      netIncome: null,
+      closedAt: null,
+    });
+  } catch (error) {
+    console.error('Year-end close status error:', error);
+    const message = error instanceof Error ? error.message : 'Internal server error';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -18,6 +18,7 @@ import TaxSettings, { loadTaxSettings } from '@/components/dashboard/TaxSettings
 import type { TaxSettingsValues } from '@/components/dashboard/TaxSettings';
 import BankReconciliation from '@/components/dashboard/BankReconciliation';
 import PeriodClose from '@/components/dashboard/PeriodClose';
+import CloseBooksTab from '@/components/dashboard/CloseBooksTab';
 
 
 interface Transaction {
@@ -422,6 +423,7 @@ export default function Dashboard() {
 
   const SECONDARY_TABS = [
     { key: 'close', label: 'Period Close' },
+    { key: 'year-end-close', label: 'Year-End Close' },
     { key: 'positions', label: 'Positions' },
     { key: 'wash-sales', label: 'Wash Sales' },
     { key: 'export', label: 'Export' },
@@ -923,6 +925,19 @@ export default function Dashboard() {
                         }
                       }}
                       onReload={() => { loadPeriodCloses(); loadReconciliations(); }}
+                    />
+                  </div>
+                </div>
+              )}
+
+              {/* Year-End Close */}
+              {activeSection === 'year-end-close' && (
+                <div>
+                  <div className="px-3 py-1.5 bg-bg-row border-b border-border"><span className="text-terminal-base font-mono font-semibold text-text-primary">Year-End Close</span></div>
+                  <div className="p-2">
+                    <CloseBooksTab
+                      entityId={defaultEntityId}
+                      selectedYear={selectedYear}
                     />
                   </div>
                 </div>

--- a/src/components/dashboard/CloseBooksTab.tsx
+++ b/src/components/dashboard/CloseBooksTab.tsx
@@ -1,263 +1,170 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 
-interface ClosingPeriod {
-  id: string;
-  periodType: 'monthly' | 'quarterly' | 'yearly';
-  periodEnd: string;
-  status: 'open' | 'closed';
-  closedAt?: Date;
-  closedBy?: string;
+interface YearEndStatus {
+  isClosed: boolean;
+  closingEntryId: string | null;
+  netIncome: number | null;
+  closedAt: string | null;
 }
 
-export default function CloseBooksTab() {
-  const [periods, setPeriods] = useState<ClosingPeriod[]>([]);
+interface CloseBooksTabProps {
+  entityId: string | null;
+  selectedYear: number;
+}
+
+export default function CloseBooksTab({ entityId, selectedYear }: CloseBooksTabProps) {
+  const [status, setStatus] = useState<YearEndStatus | null>(null);
   const [loading, setLoading] = useState(false);
-  const [selectedPeriod, setSelectedPeriod] = useState('');
-  const [periodType, setPeriodType] = useState<'monthly' | 'quarterly' | 'yearly'>('monthly');
+  const [checking, setChecking] = useState(false);
 
-  useEffect(() => {
-    loadPeriods();
-  }, []);
-
-  const loadPeriods = async () => {
+  const loadStatus = useCallback(async () => {
+    if (!entityId) return;
+    setChecking(true);
     try {
-      const res = await fetch('/api/closing-periods');
+      const res = await fetch(`/api/year-end-close?entityId=${entityId}&year=${selectedYear}`);
       if (res.ok) {
         const data = await res.json();
-        setPeriods(data.periods || []);
+        setStatus(data);
       }
     } catch (error) {
-      console.error('Error loading periods:', error);
+      console.error('Error loading year-end close status:', error);
     }
-  };
+    setChecking(false);
+  }, [entityId, selectedYear]);
 
-  const generatePeriodEnd = () => {
-    const now = new Date();
-    if (periodType === 'monthly') {
-      return new Date(now.getFullYear(), now.getMonth(), 0).toISOString().split('T')[0]; // Last day of previous month
-    } else if (periodType === 'quarterly') {
-      const quarter = Math.floor(now.getMonth() / 3);
-      return new Date(now.getFullYear(), quarter * 3, 0).toISOString().split('T')[0];
-    } else {
-      return new Date(now.getFullYear() - 1, 11, 31).toISOString().split('T')[0];
-    }
-  };
+  useEffect(() => {
+    loadStatus();
+  }, [loadStatus]);
 
-  const handleClosePeriod = async () => {
-    if (!selectedPeriod) {
-      alert('Please enter a period end date');
+  const handleYearEndClose = async () => {
+    if (!entityId) {
+      alert('No entity found. Create an entity first.');
       return;
     }
 
     const confirm = window.confirm(
-      `Are you sure you want to close the books for period ending ${selectedPeriod}?\n\n` +
+      `Are you sure you want to perform the year-end close for ${selectedYear}?\n\n` +
       `This will:\n` +
-      `• Close all revenue and expense accounts\n` +
-      `• Transfer net income to equity\n` +
-      `• Mark the period as closed\n\n` +
-      `This action cannot be easily undone.`
+      `• Close all revenue and expense accounts to zero\n` +
+      `• Transfer net income to Retained Earnings (3900)\n` +
+      `• Create a closing journal entry dated Dec 31, ${selectedYear}\n\n` +
+      `All 12 months must be period-closed first.`
     );
 
     if (!confirm) return;
 
     setLoading(true);
     try {
-      const res = await fetch('/api/closing-periods/close', {
+      const res = await fetch('/api/year-end-close', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          periodEnd: selectedPeriod,
-          periodType
-        })
+        body: JSON.stringify({ entityId, year: selectedYear }),
       });
 
       const result = await res.json();
 
       if (res.ok) {
-        alert(`✅ Books closed successfully!\n\nNet Income: $${result.netIncome?.toFixed(2) || '0.00'}\nClosing Entry ID: ${result.closingEntryId}`);
-        loadPeriods();
-        setSelectedPeriod('');
+        const netDollars = (result.netIncome / 100).toFixed(2);
+        alert(
+          `Books closed successfully!\n\n` +
+          `Net Income: $${netDollars}\n` +
+          `Accounts Closed: ${result.accountsClosed}\n` +
+          `Closing Entry ID: ${result.closingEntryId}`
+        );
+        loadStatus();
       } else {
-        alert(`❌ Error: ${result.error || 'Failed to close books'}`);
+        alert(`Error: ${result.error || 'Failed to close year'}`);
       }
     } catch (error) {
-      alert('Failed to close period');
+      alert('Failed to perform year-end close');
     }
     setLoading(false);
   };
 
-  const handleReopenPeriod = async (periodId: string) => {
-    const confirm = window.confirm(
-      'Are you sure you want to reopen this period?\n\n' +
-      'This will reverse the closing entries and allow modifications.'
-    );
-
-    if (!confirm) return;
-
-    setLoading(true);
-    try {
-      const res = await fetch('/api/closing-periods/reopen', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ periodId })
-      });
-
-      if (res.ok) {
-        alert('✅ Period reopened successfully!');
-        loadPeriods();
-      } else {
-        alert('❌ Failed to reopen period');
-      }
-    } catch (error) {
-      alert('Failed to reopen period');
-    }
-    setLoading(false);
+  const formatCents = (cents: number | null) => {
+    if (cents === null) return '—';
+    const dollars = cents / 100;
+    return dollars < 0
+      ? `-$${Math.abs(dollars).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
+      : `$${dollars.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
   };
 
   return (
     <div className="space-y-6">
       <div className="flex justify-between items-center">
         <div>
-          <h2 className="text-sm font-bold">Close Books</h2>
-          <p className="text-sm text-text-secondary mt-1">Period-end closing process</p>
+          <h2 className="text-sm font-bold">Year-End Close</h2>
+          <p className="text-sm text-text-secondary mt-1">GAAP year-end closing entries for {selectedYear}</p>
         </div>
-        <button 
-          onClick={loadPeriods}
+        <button
+          onClick={loadStatus}
+          disabled={checking}
           className="px-4 py-2 bg-brand-purple text-white rounded text-sm"
         >
           Refresh
         </button>
       </div>
 
-      {/* Close New Period */}
-      <div className="bg-white border rounded p-6">
-        <h3 className="text-terminal-lg font-semibold mb-4">Close New Period</h3>
-        
-        <div className="space-y-4">
-          <div className="grid grid-cols-2 gap-4">
+      {/* Status */}
+      {status?.isClosed ? (
+        <div className="bg-green-50 border border-green-200 rounded p-6">
+          <h3 className="text-terminal-lg font-semibold text-green-900 mb-3">Year {selectedYear} Closed</h3>
+          <div className="grid grid-cols-2 gap-4 text-sm">
             <div>
-              <label className="block text-sm font-medium text-text-secondary mb-1">Period Type</label>
-              <select
-                value={periodType}
-                onChange={(e) => {
-                  setPeriodType(e.target.value as any);
-                  setSelectedPeriod(generatePeriodEnd());
-                }}
-                className="w-full px-3 py-2 border rounded"
-              >
-                <option value="monthly">Monthly</option>
-                <option value="quarterly">Quarterly</option>
-                <option value="yearly">Yearly</option>
-              </select>
+              <span className="text-green-700 font-medium">Net Income:</span>
+              <span className="ml-2 text-green-900 font-semibold">{formatCents(status.netIncome)}</span>
             </div>
             <div>
-              <label className="block text-sm font-medium text-text-secondary mb-1">Period End Date</label>
-              <input
-                type="date"
-                value={selectedPeriod}
-                onChange={(e) => setSelectedPeriod(e.target.value)}
-                className="w-full px-3 py-2 border rounded"
-              />
+              <span className="text-green-700 font-medium">Closed At:</span>
+              <span className="ml-2 text-green-900">{status.closedAt ? new Date(status.closedAt).toLocaleString() : '—'}</span>
+            </div>
+            <div className="col-span-2">
+              <span className="text-green-700 font-medium">Closing Entry:</span>
+              <span className="ml-2 text-green-900 font-mono text-xs">{status.closingEntryId}</span>
             </div>
           </div>
-
-          <div className="bg-yellow-50 border border-yellow-200 rounded p-4">
-            <h4 className="text-sm font-semibold text-yellow-900 mb-2">Pre-Closing Checklist</h4>
-            <ul className="text-sm text-yellow-800 space-y-1">
-              <li>✓ All transactions for the period have been recorded</li>
-              <li>✓ Bank accounts have been reconciled</li>
-              <li>✓ All adjusting entries have been made</li>
-              <li>✓ Financial statements have been reviewed</li>
-              <li>✓ All accounts are accurate and balanced</li>
-            </ul>
-          </div>
-
-          <button
-            onClick={handleClosePeriod}
-            disabled={!selectedPeriod || loading}
-            className={`w-full py-3 rounded text-sm font-medium ${
-              selectedPeriod && !loading
-                ? 'bg-red-600 text-white hover:bg-red-700'
-                : 'bg-border text-text-muted cursor-not-allowed'
-            }`}
-          >
-            {loading ? 'Closing Period...' : 'Close Books for This Period'}
-          </button>
         </div>
-      </div>
+      ) : (
+        <div className="bg-white border rounded p-6">
+          <h3 className="text-terminal-lg font-semibold mb-4">Close Year {selectedYear}</h3>
 
-      {/* Closed Periods History */}
-      <div className="bg-white border rounded overflow-hidden">
-        <div className="bg-bg-row px-6 py-4 border-b">
-          <h3 className="text-terminal-lg font-semibold">Closed Periods History</h3>
+          <div className="space-y-4">
+            <div className="bg-yellow-50 border border-yellow-200 rounded p-4">
+              <h4 className="text-sm font-semibold text-yellow-900 mb-2">Pre-Closing Checklist</h4>
+              <ul className="text-sm text-yellow-800 space-y-1">
+                <li>All 12 months must be period-closed</li>
+                <li>All transactions for the year have been recorded</li>
+                <li>Bank accounts have been reconciled</li>
+                <li>All adjusting entries have been made</li>
+                <li>Financial statements have been reviewed</li>
+              </ul>
+            </div>
+
+            <button
+              onClick={handleYearEndClose}
+              disabled={loading || !entityId}
+              className={`w-full py-3 rounded text-sm font-medium ${
+                !loading && entityId
+                  ? 'bg-red-600 text-white hover:bg-red-700'
+                  : 'bg-border text-text-muted cursor-not-allowed'
+              }`}
+            >
+              {loading ? 'Closing Year...' : `Close Books for ${selectedYear}`}
+            </button>
+          </div>
         </div>
-        
-        {periods.length === 0 ? (
-          <div className="px-6 py-8 text-center text-text-muted text-sm">
-            No periods have been closed yet
-          </div>
-        ) : (
-          <div className="overflow-auto">
-            <table className="w-full">
-              <thead className="bg-bg-row">
-                <tr>
-                  <th className="px-4 py-3 text-left text-xs font-semibold text-text-secondary">Period End</th>
-                  <th className="px-4 py-3 text-left text-xs font-semibold text-text-secondary">Type</th>
-                  <th className="px-4 py-3 text-left text-xs font-semibold text-text-secondary">Status</th>
-                  <th className="px-4 py-3 text-left text-xs font-semibold text-text-secondary">Closed At</th>
-                  <th className="px-4 py-3 text-center text-xs font-semibold text-text-secondary">Actions</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y">
-                {periods.map((period) => (
-                  <tr key={period.id} className="hover:bg-bg-row">
-                    <td className="px-4 py-3 text-sm font-medium">
-                      {new Date(period.periodEnd).toLocaleDateString()}
-                    </td>
-                    <td className="px-4 py-3 text-sm capitalize">{period.periodType}</td>
-                    <td className="px-4 py-3">
-                      <span className={`px-2 py-1 rounded text-xs font-medium ${
-                        period.status === 'closed' 
-                          ? 'bg-green-100 text-brand-green' 
-                          : 'bg-bg-row text-text-secondary'
-                      }`}>
-                        {period.status === 'closed' ? 'Closed' : 'Open'}
-                      </span>
-                    </td>
-                    <td className="px-4 py-3 text-sm text-text-secondary">
-                      {period.closedAt 
-                        ? new Date(period.closedAt).toLocaleString()
-                        : '—'
-                      }
-                    </td>
-                    <td className="px-4 py-3 text-center">
-                      {period.status === 'closed' && (
-                        <button
-                          onClick={() => handleReopenPeriod(period.id)}
-                          disabled={loading}
-                          className="px-3 py-1 text-xs bg-yellow-100 text-yellow-700 rounded hover:bg-yellow-200 disabled:opacity-50"
-                        >
-                          Reopen
-                        </button>
-                      )}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        )}
-      </div>
+      )}
 
       {/* Info Box */}
       <div className="bg-brand-purple-wash border border-blue-200 rounded p-4">
-        <h3 className="text-sm font-semibold text-blue-900 mb-2">About Closing Books</h3>
+        <h3 className="text-sm font-semibold text-blue-900 mb-2">About Year-End Close</h3>
         <p className="text-sm text-blue-800">
-          Closing the books is the final step in the accounting cycle. It transfers all revenue and expense 
-          balances to equity (retained earnings), resetting them to zero for the next period. This process 
-          creates a clear separation between accounting periods and ensures accurate financial reporting.
+          Year-end close is the final step in the annual accounting cycle. It creates closing journal entries that
+          zero out all revenue and expense accounts, transferring the net income (or loss) to Retained Earnings (3900).
+          This ensures clean income statement balances for the next fiscal year while preserving the cumulative
+          equity position on the balance sheet.
         </p>
       </div>
     </div>

--- a/src/lib/period-close-guard.ts
+++ b/src/lib/period-close-guard.ts
@@ -6,6 +6,8 @@
  *
  * Must be called before EVERY journal entry creation pathway.
  * See audit: 7 pathways identified (5 commits + 2 reversals).
+ *
+ * Pathway 8: year-end-close/route.ts — BYPASSES this guard (privileged system operation)
  */
 
 // Accept any Prisma-like client (PrismaClient or transaction context)


### PR DESCRIPTION
- POST /api/year-end-close: Creates closing journal entry that zeros out all revenue and expense accounts, transfers net income to Retained Earnings (3900). Pre-flight checks: all 12 months period-closed, idempotency via source_type/source_id, balance verification (SOC2 BAL).
- GET /api/year-end-close: Returns year-end close status for entity+year.
- Auto-creates Retained Earnings (3900) account per entity if missing.
- Pathway 8: Bypasses assertPeriodOpen (privileged system operation).
- Wires CloseBooksTab.tsx into dashboard as Year-End Close tab.
- Documents pathway 8 in period-close-guard.ts JSDoc header.

https://claude.ai/code/session_01PkxSeGDe6b7uTsGXDezCEr