### PR TITLE
fix: correct EV/EBITDA field name (evEbitdaTTM), add financials debug…

### DIFF
--- a/src/app/api/test/convergence/route.ts
+++ b/src/app/api/test/convergence/route.ts
@@ -375,6 +375,70 @@ export async function GET(request: Request) {
     }
   }
 
+  // DEBUG: Dump ALL XBRL fields from most recent annual financials-reported
+  // This tells us exactly what building blocks are available for ROIC calculation
+  let debugFinnhubFinancials: Record<string, unknown> = { error: 'not fetched' };
+  if (finnhubKey) {
+    try {
+      const fResp = await fetch(
+        `https://finnhub.io/api/v1/stock/financials-reported?symbol=${symbol}&freq=annual&token=${finnhubKey}`,
+      );
+      if (fResp.ok) {
+        const fJson = await fResp.json();
+        const reports = fJson?.data || [];
+        if (reports.length > 0) {
+          // Sort descending by year, take most recent
+          reports.sort((a: { year: number }, b: { year: number }) => b.year - a.year);
+          const latest = reports[0];
+          const report = latest.report || {};
+
+          // Dump all concepts from income statement (ic) and balance sheet (bs)
+          const icItems: { concept: string; value: number }[] = report.ic || [];
+          const bsItems: { concept: string; value: number }[] = report.bs || [];
+          const cfItems: { concept: string; value: number }[] = report.cf || [];
+
+          const icFields: Record<string, number> = {};
+          for (const item of icItems) icFields[item.concept] = item.value;
+
+          const bsFields: Record<string, number> = {};
+          for (const item of bsItems) bsFields[item.concept] = item.value;
+
+          const cfFields: Record<string, number> = {};
+          for (const item of cfItems) cfFields[item.concept] = item.value;
+
+          // Also filter for ROIC-relevant concepts
+          const roicRelevant: Record<string, number> = {};
+          const roicPatterns = [/operat/i, /tax/i, /income/i, /asset/i, /liabilit/i, /debt/i, /equity/i, /cash/i, /invest/i, /capital/i, /ebitda/i, /goodwill/i];
+          for (const items of [icItems, bsItems, cfItems]) {
+            for (const item of items) {
+              if (roicPatterns.some(p => p.test(item.concept))) {
+                roicRelevant[item.concept] = item.value;
+              }
+            }
+          }
+
+          debugFinnhubFinancials = {
+            year: latest.year,
+            filed_date: latest.filedDate || latest.acceptedDate || null,
+            ic_field_count: icItems.length,
+            bs_field_count: bsItems.length,
+            cf_field_count: cfItems.length,
+            ic_all_fields: icFields,
+            bs_all_fields: bsFields,
+            cf_all_fields: cfFields,
+            roic_relevant_fields: roicRelevant,
+          };
+        } else {
+          debugFinnhubFinancials = { error: 'no annual reports returned' };
+        }
+      } else {
+        debugFinnhubFinancials = { error: `HTTP ${fResp.status}` };
+      }
+    } catch (e: unknown) {
+      debugFinnhubFinancials = { error: e instanceof Error ? e.message : String(e) };
+    }
+  }
+
   return NextResponse.json({
     ...response,
     trade_cards: tradeCards.length > 0 ? tradeCards : undefined,
@@ -383,5 +447,6 @@ export async function GET(request: Request) {
     _rejection_reasons: chainRejections.length > 0 ? chainRejections : undefined,
     _raw_tt_fields: ttScannerResult.raw ? Object.keys(ttScannerResult.raw as object).sort() : undefined,
     _debug_finnhub_fields: Object.keys(debugFinnhubFields).length > 0 ? debugFinnhubFields : 'NO_MATCHING_FIELDS',
+    _debug_finnhub_financials: debugFinnhubFinancials,
   });
 }

--- a/src/lib/convergence/quality-gate.ts
+++ b/src/lib/convergence/quality-gate.ts
@@ -386,8 +386,8 @@ function scoreProfitability(input: ConvergenceInput): ProfitabilityTrace {
   }
 
   // --- EV/EBITDA (7%) — enterprise valuation (TTM preferred, Annual fallback) ---
-  const evEbitdaTTM = typeof metric['currentEv/ebitdaTTM'] === 'number' ? metric['currentEv/ebitdaTTM'] as number : null;
-  const evEbitdaAnnual = typeof metric['currentEv/ebitdaAnnual'] === 'number' ? metric['currentEv/ebitdaAnnual'] as number : null;
+  const evEbitdaTTM = typeof metric['evEbitdaTTM'] === 'number' ? metric['evEbitdaTTM'] as number : null;
+  const evEbitdaAnnual = typeof metric['evEbitdaAnnual'] === 'number' ? metric['evEbitdaAnnual'] as number : null;
   const evEbitda = evEbitdaTTM ?? evEbitdaAnnual;
   const evEbitdaSource = evEbitdaTTM !== null ? 'TTM' : evEbitdaAnnual !== null ? 'Annual' : 'N/A';
   let evEbitdaScore = 50; // neutral default — missing data
@@ -763,7 +763,7 @@ export function scoreQualityGate(input: ConvergenceInput): QualityGateResult {
   if (typeof metric['freeCashFlowPerShareTTM'] !== 'number') imputedFields.push('profitability.fcf');
   if (typeof metric['roicTTM'] !== 'number' && typeof metric['roicAnnual'] !== 'number') imputedFields.push('profitability.roic');
   if (typeof metric['psTTM'] !== 'number' && typeof metric['psAnnual'] !== 'number') imputedFields.push('profitability.ps');
-  if (typeof metric['currentEv/ebitdaTTM'] !== 'number' && typeof metric['currentEv/ebitdaAnnual'] !== 'number') imputedFields.push('profitability.ev_ebitda');
+  if (typeof metric['evEbitdaTTM'] !== 'number' && typeof metric['evEbitdaAnnual'] !== 'number') imputedFields.push('profitability.ev_ebitda');
   if (input.finnhubEarnings.length === 0) imputedFields.push('profitability.earnings_consistency');
   if (tt?.daysTillEarnings == null) imputedFields.push('profitability.earnings_dte');
   if (safety.piotroski.change_signals.computable_count === 0) imputedFields.push('profitability.fscore_change_signals');


### PR DESCRIPTION
… for ROIC derivation

Task 1: Fix EV/EBITDA field names in quality-gate.ts
- currentEv/ebitdaTTM → evEbitdaTTM (lines 389, 766)
- currentEv/ebitdaAnnual → evEbitdaAnnual (lines 390, 766)

Task 2: Add _debug_finnhub_financials to test endpoint
- Fetches /stock/financials-reported for most recent annual report
- Dumps ALL ic/bs/cf XBRL concept names and values
- Filters ROIC-relevant concepts separately for quick reference
- Test-only, not in production pipeline

https://claude.ai/code/session_01KE4jEEqEa3CLX35LBg36u9