### PR TITLE
feat: add Finnhub earnings quality ML score as SUE cross-validation i…

### DIFF
--- a/src/app/api/test/convergence/route.ts
+++ b/src/app/api/test/convergence/route.ts
@@ -242,6 +242,8 @@ export async function GET(request: Request) {
     newsSentiment: newsSentimentResult.data,
     finnhubNewsSentiment: null, // Single-ticker route: FinBERT fetched separately in pipeline batch mode
     finnhubEarningsQuality: null, // Single-ticker route: EQ fetched separately in pipeline batch mode
+    finnhubInstitutionalOwnership: null, // Single-ticker route: fetched in pipeline batch mode
+    finnhubRevenueBreakdown: null, // Single-ticker route: fetched in pipeline batch mode
   };
 
   // ===== RUN SCORING =====

--- a/src/lib/convergence/data-fetchers.ts
+++ b/src/lib/convergence/data-fetchers.ts
@@ -18,6 +18,8 @@ import type {
   NewsSentimentPeriod,
   FinnhubNewsSentiment,
   FinnhubEarningsQuality,
+  FinnhubInstitutionalOwnership,
+  FinnhubRevenueBreakdown,
 } from './types';
 import { classifyNewsHeadlines } from './news-classifier';
 import { getTastytradeClient } from '@/lib/tastytrade';
@@ -741,6 +743,163 @@ function computePeriodSentiment(headlines: NewsHeadlineEntry[]): NewsSentimentPe
     : 50;
 
   return { bullish_matches: bullish, bearish_matches: bearish, neutral, score };
+}
+
+// ===== FINNHUB INSTITUTIONAL OWNERSHIP FETCHER =====
+
+const institutionalOwnershipCache = new Map<string, { data: FinnhubInstitutionalOwnership; fetchedAt: number }>();
+const INSTITUTIONAL_OWNERSHIP_CACHE_TTL = 60 * 60 * 1000; // 1 hour
+
+export async function fetchFinnhubInstitutionalOwnership(
+  symbol: string,
+  apiKey?: string,
+): Promise<{ data: FinnhubInstitutionalOwnership | null; error: string | null }> {
+  const cached = institutionalOwnershipCache.get(symbol);
+  if (cached && Date.now() - cached.fetchedAt < INSTITUTIONAL_OWNERSHIP_CACHE_TTL) {
+    return { data: cached.data, error: null };
+  }
+
+  const key = apiKey || process.env.FINNHUB_API_KEY;
+  if (!key) return { data: null, error: 'FINNHUB_API_KEY not configured' };
+
+  try {
+    // Fetch both ownership endpoints in parallel
+    const [ownershipResp, fundResp] = await Promise.all([
+      fetchWithRetry(`https://finnhub.io/api/v1/stock/ownership?symbol=${symbol}&token=${key}`).catch(() => null),
+      fetchWithRetry(`https://finnhub.io/api/v1/stock/fund-ownership?symbol=${symbol}&token=${key}`).catch(() => null),
+    ]);
+
+    type OwnershipEntry = { share?: number; change?: number; filingDate?: string };
+
+    let holders: OwnershipEntry[] = [];
+
+    if (ownershipResp?.ok) {
+      try {
+        const json = await ownershipResp.json();
+        if (Array.isArray(json?.ownership)) holders.push(...(json.ownership as OwnershipEntry[]));
+      } catch { /* ignore parse errors */ }
+    }
+
+    if (fundResp?.ok) {
+      try {
+        const json = await fundResp.json();
+        if (Array.isArray(json?.ownership)) holders.push(...(json.ownership as OwnershipEntry[]));
+      } catch { /* ignore parse errors */ }
+    }
+
+    if (holders.length === 0) {
+      return { data: null, error: 'institutional-ownership: no data from either endpoint' };
+    }
+
+    let totalShares = 0;
+    let totalChange = 0;
+    let netBuyers = 0;
+    let netSellers = 0;
+    let latestFilingDate: string | null = null;
+
+    for (const h of holders) {
+      totalShares += h.share ?? 0;
+      const change = h.change ?? 0;
+      totalChange += change;
+      if (change > 0) netBuyers++;
+      else if (change < 0) netSellers++;
+      if (h.filingDate && (!latestFilingDate || h.filingDate > latestFilingDate)) {
+        latestFilingDate = h.filingDate;
+      }
+    }
+
+    const result: FinnhubInstitutionalOwnership = {
+      totalInstitutionalShares: totalShares,
+      totalInstitutionalChange: totalChange,
+      topHolderCount: holders.length,
+      netBuyerCount: netBuyers,
+      netSellerCount: netSellers,
+      latestFilingDate,
+    };
+
+    institutionalOwnershipCache.set(symbol, { data: result, fetchedAt: Date.now() });
+    return { data: result, error: null };
+  } catch (e: unknown) {
+    return { data: null, error: `institutional-ownership: ${e instanceof Error ? e.message : String(e)}` };
+  }
+}
+
+// ===== FINNHUB REVENUE BREAKDOWN FETCHER =====
+
+const revenueBreakdownCache = new Map<string, { data: FinnhubRevenueBreakdown; fetchedAt: number }>();
+const REVENUE_BREAKDOWN_CACHE_TTL = 60 * 60 * 1000; // 1 hour
+
+export async function fetchFinnhubRevenueBreakdown(
+  symbol: string,
+  apiKey?: string,
+): Promise<{ data: FinnhubRevenueBreakdown | null; error: string | null }> {
+  const cached = revenueBreakdownCache.get(symbol);
+  if (cached && Date.now() - cached.fetchedAt < REVENUE_BREAKDOWN_CACHE_TTL) {
+    return { data: cached.data, error: null };
+  }
+
+  const key = apiKey || process.env.FINNHUB_API_KEY;
+  if (!key) return { data: null, error: 'FINNHUB_API_KEY not configured' };
+
+  try {
+    const resp = await fetchWithRetry(
+      `https://finnhub.io/api/v1/stock/revenue-breakdown?symbol=${symbol}&token=${key}`,
+    );
+    if (!resp.ok) {
+      return { data: null, error: `revenue-breakdown: HTTP ${resp.status}` };
+    }
+
+    const json = await resp.json();
+    // Finnhub returns { data: [{ period, revenue: [{ name, value }] }] }
+    const entries = json?.data;
+    if (!Array.isArray(entries) || entries.length === 0) {
+      return { data: null, error: 'revenue-breakdown: no data returned' };
+    }
+
+    // Use most recent period
+    const latest = entries.sort((a: { period?: string }, b: { period?: string }) =>
+      (b.period ?? '').localeCompare(a.period ?? ''),
+    )[0];
+
+    const rawSegments: Array<{ name?: string; value?: number }> = latest.revenue ?? [];
+    if (!Array.isArray(rawSegments) || rawSegments.length === 0) {
+      return { data: null, error: 'revenue-breakdown: no segments in latest period' };
+    }
+
+    const segments: Array<{ name: string; revenue: number }> = [];
+    let totalRevenue = 0;
+
+    for (const seg of rawSegments) {
+      const revenue = typeof seg.value === 'number' ? seg.value : 0;
+      if (revenue > 0) {
+        segments.push({ name: seg.name ?? 'Unknown', revenue });
+        totalRevenue += revenue;
+      }
+    }
+
+    if (totalRevenue <= 0 || segments.length === 0) {
+      return { data: null, error: 'revenue-breakdown: no positive revenue segments' };
+    }
+
+    // Compute HHI: sum of (segment_share²)
+    let hhi = 0;
+    for (const seg of segments) {
+      const share = seg.revenue / totalRevenue;
+      hhi += share * share;
+    }
+    hhi = Math.round(hhi * 10000) / 10000; // 4 decimal places
+
+    const result: FinnhubRevenueBreakdown = {
+      segments,
+      totalRevenue,
+      hhi,
+    };
+
+    revenueBreakdownCache.set(symbol, { data: result, fetchedAt: Date.now() });
+    return { data: result, error: null };
+  } catch (e: unknown) {
+    return { data: null, error: `revenue-breakdown: ${e instanceof Error ? e.message : String(e)}` };
+  }
 }
 
 // ===== FINNHUB FINBERT SENTIMENT FETCHER =====

--- a/src/lib/convergence/info-edge.ts
+++ b/src/lib/convergence/info-edge.ts
@@ -8,6 +8,7 @@ import type {
   EarningsMomentumTrace,
   FlowSignalTrace,
   NewsSentimentTrace,
+  InstitutionalOwnershipTrace,
   DataConfidence,
 } from './types';
 
@@ -718,7 +719,7 @@ function scoreFlowSignal(input: ConvergenceInput): FlowSignalTrace {
   if (!flow) {
     return {
       score: 50,
-      weight: 0.15,
+      weight: 0.10,
       inputs: { data_available: false },
       formula: 'No options flow data → neutral 50',
       notes: 'Finnhub option chain fetch failed or returned no data.',
@@ -788,7 +789,7 @@ function scoreFlowSignal(input: ConvergenceInput): FlowSignalTrace {
 
   return {
     score: round(score),
-    weight: 0.15,
+    weight: 0.10,
     inputs: {
       data_available: true,
       put_call_ratio: flow.put_call_ratio,
@@ -1030,18 +1031,113 @@ function scoreNewsSentiment(input: ConvergenceInput): NewsSentimentTrace {
   };
 }
 
-// ===== MAIN INFO EDGE SCORER =====
+// ===== INSTITUTIONAL OWNERSHIP SUB-SCORE =====
+// Chen, Jegadeesh & Wermers (2000): ΔIO — institutional purchases outperform sales.
+// Score the CHANGE in ownership, not the level.
+
+function scoreInstitutionalOwnership(input: ConvergenceInput): InstitutionalOwnershipTrace {
+  const ownership = input.finnhubInstitutionalOwnership;
+
+  if (!ownership) {
+    return {
+      score: 50,
+      weight: 0.05,
+      inputs: { data_available: false },
+      formula: 'No institutional ownership data → neutral 50',
+      notes: 'Finnhub ownership endpoints returned no data',
+      sub_scores: { institutional_ownership_score: 50 },
+      indicators: {
+        net_buyer_ratio: null,
+        net_buyers: 0,
+        net_sellers: 0,
+        total_holders: 0,
+        total_change: 0,
+        filing_staleness_days: null,
+        staleness_discounted: false,
+      },
+    };
+  }
+
+  const { netBuyerCount, netSellerCount, latestFilingDate, totalInstitutionalChange, topHolderCount } = ownership;
+  const totalActive = netBuyerCount + netSellerCount;
+
+  // Net buyer ratio: what fraction of active holders are buying?
+  let netBuyerRatio: number | null = null;
+  let ioScore = 50; // neutral default
+
+  if (totalActive > 0) {
+    netBuyerRatio = round(netBuyerCount / totalActive, 4);
+
+    // Map ratio to score: 1.0 → 85, 0.65 → 70, 0.50 → 50, 0.35 → 30, 0.0 → 15
+    if (netBuyerRatio > 0.80) ioScore = lerp(netBuyerRatio, 0.80, 1.0, 75, 85);
+    else if (netBuyerRatio > 0.65) ioScore = lerp(netBuyerRatio, 0.65, 0.80, 65, 75);
+    else if (netBuyerRatio > 0.50) ioScore = lerp(netBuyerRatio, 0.50, 0.65, 50, 65);
+    else if (netBuyerRatio > 0.35) ioScore = lerp(netBuyerRatio, 0.35, 0.50, 35, 50);
+    else if (netBuyerRatio > 0.20) ioScore = lerp(netBuyerRatio, 0.20, 0.35, 20, 35);
+    else ioScore = lerp(netBuyerRatio, 0.0, 0.20, 15, 20);
+
+    ioScore = round(clamp(ioScore, 0, 100));
+  }
+
+  // Staleness discount: 13F filings have 45-day delay; if > 90 days old, compress toward neutral by 30%
+  let stalenessDays: number | null = null;
+  let stalenessDiscounted = false;
+  if (latestFilingDate) {
+    stalenessDays = Math.round((Date.now() - new Date(latestFilingDate).getTime()) / (24 * 60 * 60 * 1000));
+    if (stalenessDays > 90) {
+      const distFromNeutral = ioScore - 50;
+      ioScore = round(50 + distFromNeutral * 0.70); // compress 30% toward neutral
+      stalenessDiscounted = true;
+    }
+  }
+
+  const formula = `NetBuyerRatio(${netBuyerRatio ?? 'N/A'}) → ${ioScore}${stalenessDiscounted ? ` [staleness discount: ${stalenessDays}d > 90d]` : ''} [${topHolderCount} holders]`;
+  const notes = [
+    `buyers=${netBuyerCount}`,
+    `sellers=${netSellerCount}`,
+    `ratio=${netBuyerRatio ?? 'N/A'}`,
+    `holders=${topHolderCount}`,
+    `change=${totalInstitutionalChange}`,
+    `filing=${latestFilingDate ?? 'N/A'}`,
+    stalenessDiscounted ? `stale(${stalenessDays}d)` : '',
+  ].filter(Boolean).join(', ');
+
+  return {
+    score: ioScore,
+    weight: 0.05,
+    inputs: {
+      data_available: true,
+      net_buyer_ratio: netBuyerRatio,
+      net_buyers: netBuyerCount,
+      net_sellers: netSellerCount,
+    },
+    formula,
+    notes,
+    sub_scores: { institutional_ownership_score: ioScore },
+    indicators: {
+      net_buyer_ratio: netBuyerRatio,
+      net_buyers: netBuyerCount,
+      net_sellers: netSellerCount,
+      total_holders: topHolderCount,
+      total_change: totalInstitutionalChange,
+      filing_staleness_days: stalenessDays,
+      staleness_discounted: stalenessDiscounted,
+    },
+  };
+}
 
 // ===== MAIN INFO EDGE SCORER =====
-// Weight rebalance (before → after):
-//   analyst_consensus:  0.25 → 0.15  (price target + U/D extracted to independent sub-scores)
-//   price_target:       (new) → 0.10  (ΔTPER, Da & Schaumburg 2011)
-//   upgrade_downgrade:  (new) → 0.10  (Womack 1996 asymmetric decay)
-//   insider_activity:   0.20 → 0.15
-//   earnings_momentum:  0.20 → 0.20  (unchanged — strongest academic signal)
-//   flow_signal:        0.20 → 0.15
-//   news_sentiment:     0.15 → 0.15  (unchanged)
-//   Total:              1.00    1.00
+// Weight rebalance history:
+//   Round 1 (2A/2B):                    Round 2 (2F):
+//   analyst_consensus:  0.15             0.15  (unchanged)
+//   price_target:       0.10             0.10  (unchanged)
+//   upgrade_downgrade:  0.10             0.10  (unchanged)
+//   insider_activity:   0.15             0.15  (unchanged)
+//   earnings_momentum:  0.20             0.20  (unchanged)
+//   flow_signal:        0.15          →  0.10  (reduced — weakest academic signal)
+//   news_sentiment:     0.15             0.15  (unchanged)
+//   institutional_own:  (new)            0.05  (Chen, Jegadeesh & Wermers 2000)
+//   Total:              1.00             1.00
 
 export function scoreInfoEdge(input: ConvergenceInput): InfoEdgeResult {
   const analystConsensus = scoreAnalystConsensus(input);
@@ -1051,6 +1147,7 @@ export function scoreInfoEdge(input: ConvergenceInput): InfoEdgeResult {
   const earningsMomentum = scoreEarningsMomentum(input);
   const flowSignal = scoreFlowSignal(input);
   const newsSentiment = scoreNewsSentiment(input);
+  const institutionalOwnership = scoreInstitutionalOwnership(input);
 
   const score = round(
     analystConsensus.weight * analystConsensus.score +
@@ -1059,7 +1156,8 @@ export function scoreInfoEdge(input: ConvergenceInput): InfoEdgeResult {
     insiderActivity.weight * insiderActivity.score +
     earningsMomentum.weight * earningsMomentum.score +
     flowSignal.weight * flowSignal.score +
-    newsSentiment.weight * newsSentiment.score,
+    newsSentiment.weight * newsSentiment.score +
+    institutionalOwnership.weight * institutionalOwnership.score,
     1,
   );
 
@@ -1079,8 +1177,9 @@ export function scoreInfoEdge(input: ConvergenceInput): InfoEdgeResult {
     if (input.optionsFlow.unusual_activity_ratio == null) imputedFields.push('flow_signal.unusual_activity');
   }
   if (!input.newsSentiment) imputedFields.push('news_sentiment');
+  if (!input.finnhubInstitutionalOwnership) imputedFields.push('institutional_ownership');
 
-  const totalSubScores = 7; // analyst, price_target, upgrade_downgrade, insider, earnings, flow, news
+  const totalSubScores = 8; // analyst, price_target, upgrade_downgrade, insider, earnings, flow, news, institutional
   const dataConfidence: DataConfidence = {
     total_sub_scores: totalSubScores,
     imputed_sub_scores: imputedFields.length,
@@ -1099,6 +1198,7 @@ export function scoreInfoEdge(input: ConvergenceInput): InfoEdgeResult {
       earnings_momentum: earningsMomentum,
       flow_signal: flowSignal,
       news_sentiment: newsSentiment,
+      institutional_ownership: institutionalOwnership,
     },
   };
 }

--- a/src/lib/convergence/pipeline.ts
+++ b/src/lib/convergence/pipeline.ts
@@ -1,5 +1,5 @@
 import { getTastytradeClient } from '@/lib/tastytrade';
-import { fetchFinnhubBatch, fetchFredMacro, fetchTTCandlesBatch, fetchAnnualFinancials, fetchOptionsFlow, fetchNewsSentiment, fetchFinnhubNewsSentiment, fetchFinnhubEarningsQuality } from './data-fetchers';
+import { fetchFinnhubBatch, fetchFredMacro, fetchTTCandlesBatch, fetchAnnualFinancials, fetchOptionsFlow, fetchNewsSentiment, fetchFinnhubNewsSentiment, fetchFinnhubEarningsQuality, fetchFinnhubInstitutionalOwnership, fetchFinnhubRevenueBreakdown } from './data-fetchers';
 import type { FinnhubData, CandleBatchStats } from './data-fetchers';
 import { fetchChainAndBuildCards, isMarketOpen } from './chain-fetcher';
 import type { ChainFetchStats, ChainFetchResult } from './chain-fetcher';
@@ -23,6 +23,8 @@ import type {
   NewsSentimentData,
   FinnhubNewsSentiment,
   FinnhubEarningsQuality,
+  FinnhubInstitutionalOwnership,
+  FinnhubRevenueBreakdown,
 } from './types';
 
 // ===== TYPES =====
@@ -504,6 +506,36 @@ export async function runPipeline(limit: number = 20, userId?: string): Promise<
   }
   console.log(`[Pipeline] Step E5: Earnings quality fetched for ${topSymbols.length} symbols`);
 
+  // Fetch institutional ownership per symbol (for ΔIO in Info-Edge)
+  console.log('[Pipeline] Step E6: Fetching institutional ownership data...');
+  const institutionalOwnershipMap = new Map<string, FinnhubInstitutionalOwnership | null>();
+  for (const symbol of topSymbols) {
+    try {
+      const result = await fetchFinnhubInstitutionalOwnership(symbol);
+      institutionalOwnershipMap.set(symbol, result.data);
+      if (result.error) errors.push(`Step E6 (institutional-ownership ${symbol}): ${result.error}`);
+    } catch (e: unknown) {
+      institutionalOwnershipMap.set(symbol, null);
+    }
+    await new Promise(r => setTimeout(r, 200)); // Finnhub rate limit
+  }
+  console.log(`[Pipeline] Step E6: Institutional ownership fetched for ${topSymbols.length} symbols`);
+
+  // Fetch revenue breakdown per symbol (for HHI in Quality gate)
+  console.log('[Pipeline] Step E7: Fetching revenue breakdown data...');
+  const revenueBreakdownMap = new Map<string, FinnhubRevenueBreakdown | null>();
+  for (const symbol of topSymbols) {
+    try {
+      const result = await fetchFinnhubRevenueBreakdown(symbol);
+      revenueBreakdownMap.set(symbol, result.data);
+      if (result.error) errors.push(`Step E7 (revenue-breakdown ${symbol}): ${result.error}`);
+    } catch (e: unknown) {
+      revenueBreakdownMap.set(symbol, null);
+    }
+    await new Promise(r => setTimeout(r, 200)); // Finnhub rate limit
+  }
+  console.log(`[Pipeline] Step E7: Revenue breakdown fetched for ${topSymbols.length} symbols`);
+
   // ===== STEP F: Score All 4 Categories =====
   console.log('[Pipeline] Step F: Scoring all categories...');
   const scoredTickers: {
@@ -541,6 +573,8 @@ export async function runPipeline(limit: number = 20, userId?: string): Promise<
       newsSentiment: newsSentimentMap.get(symbol) ?? null,
       finnhubNewsSentiment: finbertMap.get(symbol) ?? null,
       finnhubEarningsQuality: earningsQualityMap.get(symbol) ?? null,
+      finnhubInstitutionalOwnership: institutionalOwnershipMap.get(symbol) ?? null,
+      finnhubRevenueBreakdown: revenueBreakdownMap.get(symbol) ?? null,
       peerStats,
       peerGroupAssignment,
     };
@@ -587,6 +621,8 @@ export async function runPipeline(limit: number = 20, userId?: string): Promise<
         newsSentiment: newsSentimentMap.get(ticker.symbol) ?? null,
         finnhubNewsSentiment: finbertMap.get(ticker.symbol) ?? null,
         finnhubEarningsQuality: earningsQualityMap.get(ticker.symbol) ?? null,
+        finnhubInstitutionalOwnership: institutionalOwnershipMap.get(ticker.symbol) ?? null,
+        finnhubRevenueBreakdown: revenueBreakdownMap.get(ticker.symbol) ?? null,
         peerStats,
         peerGroupAssignment,
       };

--- a/src/lib/convergence/quality-gate.ts
+++ b/src/lib/convergence/quality-gate.ts
@@ -247,6 +247,35 @@ function scoreSafety(input: ConvergenceInput): SafetyTrace {
     formula += ` → -${borrowRatePenalty} borrow rate penalty (${borrowRate}% × 0.8) = ${score}`;
   }
 
+  // Revenue concentration HHI modifier
+  // HHI > 0.70 = concentrated revenue → higher fundamental risk → penalty
+  // HHI < 0.30 = diversified → lower risk → small bonus
+  const revBreakdown = input.finnhubRevenueBreakdown;
+  let concentrationModifier = 0;
+  let hhi: number | null = null;
+  let segmentCount = 0;
+  let largestSegmentPct: number | null = null;
+
+  if (revBreakdown) {
+    hhi = revBreakdown.hhi;
+    segmentCount = revBreakdown.segments.length;
+    if (revBreakdown.totalRevenue > 0 && revBreakdown.segments.length > 0) {
+      const largestRev = Math.max(...revBreakdown.segments.map(s => s.revenue));
+      largestSegmentPct = round((largestRev / revBreakdown.totalRevenue) * 100, 1);
+    }
+
+    if (hhi > 0.85) concentrationModifier = -0.15;       // Extremely concentrated
+    else if (hhi > 0.70) concentrationModifier = -0.10;   // Highly concentrated
+    else if (hhi < 0.20) concentrationModifier = 0.03;    // Well diversified — small bonus
+    else if (hhi < 0.30) concentrationModifier = 0.01;    // Moderately diversified
+    // 0.30-0.70: no modifier
+
+    if (concentrationModifier !== 0) {
+      score = clamp(round(score * (1 + concentrationModifier), 1), 0, 100);
+      formula += ` → ×${round(1 + concentrationModifier, 2)} HHI(${hhi}) = ${score}`;
+    }
+  }
+
   return {
     score: round(score),
     weight: 0.40,
@@ -260,7 +289,7 @@ function scoreSafety(input: ConvergenceInput): SafetyTrace {
       debt_to_equity: debtToEquity,
     },
     formula,
-    notes: `Liquidity: ${liqRating ?? 'N/A'}, MktCap: ${marketCap ? '$' + (marketCap / 1e9).toFixed(1) + 'B' : 'N/A'}, Beta: ${beta ?? 'N/A'}, D/E: ${debtToEquity ?? 'N/A'}${altmanCapped ? '. ALTMAN Z CAPPED: Z=' + altmanScore + ' < 1.8' : ''}${!hasCandles ? '. Volume excluded (no candle data)' : ''}`,
+    notes: `Liquidity: ${liqRating ?? 'N/A'}, MktCap: ${marketCap ? '$' + (marketCap / 1e9).toFixed(1) + 'B' : 'N/A'}, Beta: ${beta ?? 'N/A'}, D/E: ${debtToEquity ?? 'N/A'}${altmanCapped ? '. ALTMAN Z CAPPED: Z=' + altmanScore + ' < 1.8' : ''}${!hasCandles ? '. Volume excluded (no candle data)' : ''}${revBreakdown ? `. HHI=${hhi}, ${segmentCount} segments, largest=${largestSegmentPct}%` : ''}`,
     sub_scores: {
       liquidity_rating_score: round(liquidityRatingScore),
       market_cap_score: round(marketCapScore),
@@ -294,6 +323,12 @@ function scoreSafety(input: ConvergenceInput): SafetyTrace {
       borrow_rate: borrowRate,
       penalty: borrowRatePenalty,
       score_before_penalty: safetyScorePreBorrowPenalty,
+    },
+    revenue_concentration: {
+      hhi,
+      segment_count: segmentCount,
+      largest_segment_pct: largestSegmentPct,
+      concentration_modifier: concentrationModifier,
     },
   };
 }

--- a/src/lib/convergence/types.ts
+++ b/src/lib/convergence/types.ts
@@ -220,6 +220,25 @@ export interface FinnhubEarningsQuality {
   letterScore: string;         // Letter grade: A+, A, B+, B, C+, C, D
 }
 
+// ===== FINNHUB INSTITUTIONAL OWNERSHIP (from /stock/ownership + /stock/fund-ownership) =====
+
+export interface FinnhubInstitutionalOwnership {
+  totalInstitutionalShares: number;
+  totalInstitutionalChange: number; // net share change from most recent filings
+  topHolderCount: number;
+  netBuyerCount: number;           // holders who increased positions
+  netSellerCount: number;          // holders who decreased positions
+  latestFilingDate: string | null;
+}
+
+// ===== FINNHUB REVENUE BREAKDOWN (from /stock/revenue-breakdown) =====
+
+export interface FinnhubRevenueBreakdown {
+  segments: Array<{ name: string; revenue: number }>;
+  totalRevenue: number;
+  hhi: number; // Herfindahl-Hirschman Index (0-1, 1.0 = single segment)
+}
+
 // ===== FINNHUB FINBERT SENTIMENT (from /news-sentiment endpoint) =====
 
 export interface FinnhubNewsSentiment {
@@ -248,6 +267,8 @@ export interface ConvergenceInput {
   newsSentiment: NewsSentimentData | null;
   finnhubNewsSentiment: FinnhubNewsSentiment | null;
   finnhubEarningsQuality: FinnhubEarningsQuality | null;
+  finnhubInstitutionalOwnership: FinnhubInstitutionalOwnership | null;
+  finnhubRevenueBreakdown: FinnhubRevenueBreakdown | null;
   peerStats?: Record<string, { ticker_count?: number; peer_group_type?: string; peer_group_name?: string; metrics: Record<string, { mean: number; std: number; sortedValues?: number[] }> }>;
   peerGroupAssignment?: Record<string, string>;
 }
@@ -375,6 +396,12 @@ export interface SafetyTrace extends SubScoreTrace {
     borrow_rate: number | null;
     penalty: number;
     score_before_penalty: number;
+  };
+  revenue_concentration?: {
+    hhi: number | null;
+    segment_count: number;
+    largest_segment_pct: number | null;
+    concentration_modifier: number; // 0 to -0.15
   };
 }
 
@@ -681,6 +708,21 @@ export interface NewsSentimentTrace {
   };
 }
 
+export interface InstitutionalOwnershipTrace extends SubScoreTrace {
+  sub_scores: {
+    institutional_ownership_score: number;
+  };
+  indicators: {
+    net_buyer_ratio: number | null;
+    net_buyers: number;
+    net_sellers: number;
+    total_holders: number;
+    total_change: number;
+    filing_staleness_days: number | null;
+    staleness_discounted: boolean;
+  };
+}
+
 export interface InfoEdgeResult {
   score: number;
   data_confidence: DataConfidence;
@@ -692,6 +734,7 @@ export interface InfoEdgeResult {
     earnings_momentum: EarningsMomentumTrace;
     flow_signal: FlowSignalTrace;
     news_sentiment: NewsSentimentTrace;
+    institutional_ownership: InstitutionalOwnershipTrace;
   };
 }
 


### PR DESCRIPTION
…n Quality gate

New fetcher: fetchFinnhubEarningsQuality() in data-fetchers.ts
- Calls /stock/earnings-quality-score?symbol={SYMBOL}&freq=quarterly
- Returns composite score (0-100) and letterScore (A+ to D)
- 1-hour cache per symbol, graceful null on failure

SUE + ML Ensemble in quality-gate.ts scoreProfitability():
- Cross-validates SUE-based earningsQualityScore against Finnhub ML score
- When both agree (both >60 or both <40): +15% confidence boost (earnings quality score moves further from neutral)
- When they disagree (one high, other low): -20% compression (score compressed toward neutral — one model sees something the other doesn't)
- When one is in neutral zone: no modifier (no strong signal either way)
- Degrades gracefully to SUE-only when Finnhub data unavailable

New trace fields in earnings_quality_ensemble:
  finnhub_eq_score, finnhub_eq_letter, sue_score, ensemble_agreement ("agree"|"disagree"|"unavailable"), confidence_modifier

Pipeline Step E5: fetches earnings quality for each top symbol (200ms rate limit), passed as finnhubEarningsQuality in ConvergenceInput.

https://claude.ai/code/session_01KE4jEEqEa3CLX35LBg36u9