### PR TITLE
feat: add text-based peer classification from 10-K business descriptions

### DIFF
--- a/src/lib/convergence/data-fetchers.ts
+++ b/src/lib/convergence/data-fetchers.ts
@@ -29,6 +29,7 @@ import type {
   FredDailyHistory,
   SECForm4Transaction,
   SECForm4Data,
+  CompanyTextProfile,
 } from './types';
 import { classifyNewsHeadlines } from './news-classifier';
 import { getTastytradeClient } from '@/lib/tastytrade';
@@ -1389,6 +1390,302 @@ function extractNestedValue(xml: string, parentTag: string, childTag: string): s
   const parentRegex = new RegExp(`<${parentTag}>[\\s\\S]*?<${childTag}>\\s*([^<]+)\\s*<\\/`, 'i');
   const match = xml.match(parentRegex);
   return match?.[1]?.trim() ?? null;
+}
+
+// ===== SEC 10-K BUSINESS DESCRIPTION FETCHER (Hoberg & Phillips 2010, 2016) =====
+// Fetches Item 1 (Business Description) from the most recent 10-K filing.
+// Text-based peer classification uses TF-IDF cosine similarity on business descriptions
+// to identify economic peers that static GICS codes miss.
+
+const tenKTextCache = new Map<string, { data: CompanyTextProfile; fetchedAt: number }>();
+const TEN_K_TEXT_CACHE_TTL = 30 * 24 * 60 * 60 * 1000; // 30 days (10-K only changes annually)
+
+// Common stop words + legal boilerplate terms to filter from TF-IDF
+const STOP_WORDS = new Set([
+  // Standard English stop words
+  'the','be','to','of','and','a','in','that','have','i','it','for','not','on','with','he',
+  'as','you','do','at','this','but','his','by','from','they','we','her','she','or','an',
+  'will','my','one','all','would','there','their','what','so','up','out','if','about','who',
+  'get','which','go','me','when','make','can','like','time','no','just','him','know','take',
+  'people','into','year','your','good','some','could','them','see','other','than','then',
+  'now','look','only','come','its','over','think','also','back','after','use','two','how',
+  'our','work','first','well','way','even','new','want','because','any','these','give',
+  'day','most','us','are','is','was','were','been','being','has','had','does','did','may',
+  'might','shall','should','must','need','such','each','every','both','few','more','many',
+  'very','own','same','much','through','during','before','between','under','above','below',
+  // SEC / 10-K boilerplate terms
+  'company','corporation','incorporated','llc','inc','ltd','pursuant','herein','thereof',
+  'foregoing','fiscal','quarter','annual','report','filing','securities','exchange',
+  'commission','act','section','item','form','filed','registrant','subsidiary','subsidiaries',
+  'respectively','approximately','certain','significant','various','following','described',
+  'including','related','primarily','generally','operations','business','financial',
+  'statements','management','results','period','ended','year','ended','december','january',
+  'february','march','april','june','july','august','september','october','november',
+  'million','billion','thousand','percent','total','net','gross','operating',
+]);
+
+// Product/service indicator terms for extracting productTerms
+const PRODUCT_INDICATORS = new Set([
+  'platform','software','service','product','solution','technology','system','application',
+  'device','equipment','tool','engine','network','infrastructure','cloud','data','analytics',
+  'ai','machine','learning','automation','semiconductor','chip','processor','sensor',
+  'pharmaceutical','drug','therapy','treatment','vaccine','diagnostic','medical','device',
+  'energy','oil','gas','renewable','solar','wind','electric','battery','power',
+  'financial','banking','insurance','lending','payment','trading','investment','asset',
+  'retail','commerce','marketplace','delivery','logistics','shipping','warehouse',
+  'media','content','streaming','advertising','entertainment','gaming','social',
+  'automotive','vehicle','mobility','transportation','aerospace','defense',
+  'food','beverage','restaurant','consumer','healthcare','biotech','genomics',
+  'telecom','wireless','broadband','satellite','cybersecurity','security',
+]);
+
+export async function fetch10KBusinessDescription(
+  symbol: string,
+  finnhubApiKey?: string,
+): Promise<{ data: CompanyTextProfile | null; error: string | null }> {
+  const cached = tenKTextCache.get(symbol);
+  if (cached && Date.now() - cached.fetchedAt < TEN_K_TEXT_CACHE_TTL) {
+    return { data: cached.data, error: null };
+  }
+
+  // Step 1: Get CIK (reuses existing CIK lookup + cache)
+  const cik = await lookupCIK(symbol, finnhubApiKey);
+  if (!cik) {
+    return { data: null, error: 'sec-10k-text: CIK lookup failed' };
+  }
+
+  try {
+    // Step 2: Search for most recent 10-K filing via EFTS full-text search
+    const twoYearsAgo = new Date();
+    twoYearsAgo.setFullYear(twoYearsAgo.getFullYear() - 2);
+    const startDt = twoYearsAgo.toISOString().slice(0, 10);
+    const endDt = new Date().toISOString().slice(0, 10);
+
+    const searchUrl = `https://efts.sec.gov/LATEST/search-index?q=%22${encodeURIComponent(symbol)}%22&dateRange=custom&startdt=${startDt}&enddt=${endDt}&forms=10-K`;
+    const searchResp = await fetch(searchUrl, {
+      headers: { 'User-Agent': SEC_USER_AGENT },
+    });
+
+    let accessionNumber: string | null = null;
+    let filingDate: string = '';
+
+    if (searchResp.ok) {
+      const searchJson = await searchResp.json();
+      const hits = searchJson?.hits?.hits;
+      if (Array.isArray(hits) && hits.length > 0) {
+        accessionNumber = hits[0]?._source?.file_num || hits[0]?._id;
+        filingDate = hits[0]?._source?.file_date || '';
+      }
+    }
+
+    // Fallback: use submissions endpoint to find 10-K accession number
+    if (!accessionNumber) {
+      const subsResp = await fetch(`https://data.sec.gov/submissions/CIK${cik}.json`, {
+        headers: { 'User-Agent': SEC_USER_AGENT },
+      });
+
+      if (!subsResp.ok) {
+        return { data: null, error: `sec-10k-text: submissions HTTP ${subsResp.status}` };
+      }
+
+      const subsJson = await subsResp.json();
+      const recent = subsJson?.filings?.recent;
+      if (!recent || !Array.isArray(recent.form)) {
+        return { data: null, error: 'sec-10k-text: no recent filings' };
+      }
+
+      // Find most recent 10-K
+      for (let i = 0; i < recent.form.length; i++) {
+        if (recent.form[i] === '10-K' || recent.form[i] === '10-K/A') {
+          accessionNumber = recent.accessionNumber?.[i];
+          filingDate = recent.filingDate?.[i] || '';
+          break;
+        }
+      }
+    }
+
+    if (!accessionNumber) {
+      return { data: null, error: 'sec-10k-text: no 10-K filing found' };
+    }
+
+    await delay(150); // SEC rate limit
+
+    // Step 3: Fetch filing index to find the primary document
+    const accClean = accessionNumber.replace(/-/g, '');
+    const cikTrimmed = cik.replace(/^0+/, '');
+    const indexUrl = `https://www.sec.gov/Archives/edgar/data/${cikTrimmed}/${accClean}/index.json`;
+    const indexResp = await fetch(indexUrl, {
+      headers: { 'User-Agent': SEC_USER_AGENT },
+    });
+
+    if (!indexResp.ok) {
+      return { data: null, error: `sec-10k-text: filing index HTTP ${indexResp.status}` };
+    }
+
+    const indexJson = await indexResp.json();
+    const items = indexJson?.directory?.item;
+    if (!Array.isArray(items)) {
+      return { data: null, error: 'sec-10k-text: no items in filing index' };
+    }
+
+    // Find the primary .htm document (usually the largest .htm file, not R9999.htm)
+    let primaryDoc: string | null = null;
+    let maxSize = 0;
+    for (const item of items) {
+      const name = item?.name as string;
+      if (!name) continue;
+      const lowerName = name.toLowerCase();
+      // Look for .htm files that aren't exhibits (ex*) or R-files
+      if ((lowerName.endsWith('.htm') || lowerName.endsWith('.html')) &&
+          !lowerName.startsWith('r') && !lowerName.startsWith('ex')) {
+        const size = Number(item?.size ?? 0);
+        if (size > maxSize) {
+          maxSize = size;
+          primaryDoc = name;
+        }
+      }
+    }
+
+    if (!primaryDoc) {
+      // Fallback: just pick the first .htm file
+      for (const item of items) {
+        const name = item?.name as string;
+        if (name && (name.toLowerCase().endsWith('.htm') || name.toLowerCase().endsWith('.html'))) {
+          primaryDoc = name;
+          break;
+        }
+      }
+    }
+
+    if (!primaryDoc) {
+      return { data: null, error: 'sec-10k-text: no primary document found' };
+    }
+
+    await delay(150); // SEC rate limit
+
+    // Step 4: Fetch the primary document and extract business description
+    const docUrl = `https://www.sec.gov/Archives/edgar/data/${cikTrimmed}/${accClean}/${primaryDoc}`;
+    const docResp = await fetch(docUrl, {
+      headers: { 'User-Agent': SEC_USER_AGENT },
+    });
+
+    if (!docResp.ok) {
+      return { data: null, error: `sec-10k-text: document HTTP ${docResp.status}` };
+    }
+
+    const htmlText = await docResp.text();
+
+    // Extract business description from Item 1
+    const businessDescription = extractBusinessDescription(htmlText);
+
+    if (!businessDescription || businessDescription.split(/\s+/).length < 50) {
+      return { data: null, error: 'sec-10k-text: business description too short or not found' };
+    }
+
+    // Extract keywords and product terms
+    const words = tokenize(businessDescription);
+    const keywords = extractTopTerms(words, 20);
+    const productTerms = words.filter(w => PRODUCT_INDICATORS.has(w));
+    const uniqueProductTerms = [...new Set(productTerms)].slice(0, 20);
+
+    const result: CompanyTextProfile = {
+      symbol,
+      businessDescription,
+      filingDate,
+      keywords,
+      productTerms: uniqueProductTerms,
+    };
+
+    tenKTextCache.set(symbol, { data: result, fetchedAt: Date.now() });
+    return { data: result, error: null };
+  } catch (e: unknown) {
+    return { data: null, error: `sec-10k-text: ${e instanceof Error ? e.message : String(e)}` };
+  }
+}
+
+/**
+ * Extract Item 1 (Business Description) from a 10-K HTML filing.
+ * Strips HTML tags and extracts the section between Item 1 and Item 1A (or Item 2).
+ * Returns at most 2000 words of text content.
+ */
+function extractBusinessDescription(html: string): string {
+  // Strip HTML tags to get raw text
+  const text = html
+    .replace(/<style[^>]*>[\s\S]*?<\/style>/gi, '')
+    .replace(/<script[^>]*>[\s\S]*?<\/script>/gi, '')
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/&amp;/gi, '&')
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>')
+    .replace(/&#\d+;/gi, ' ')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  // Try to locate Item 1 / Business section boundaries
+  // Common patterns: "Item 1." "ITEM 1." "Item\s+1\b" followed by "Business"
+  const item1Pattern = /item\s*1[\.\s]*[\-–—]?\s*(?:business|overview|general)/i;
+  const item1SimplePattern = /item\s*1[\.\s]+(?!a\b|b\b)/i;
+  const item1APattern = /item\s*1a[\.\s]*[\-–—]?\s*risk\s*factors/i;
+  const item2Pattern = /item\s*2[\.\s]*[\-–—]?\s*properties/i;
+
+  let startIdx = text.search(item1Pattern);
+  if (startIdx === -1) {
+    startIdx = text.search(item1SimplePattern);
+  }
+
+  // Find end boundary (Item 1A or Item 2)
+  let endIdx = -1;
+  if (startIdx >= 0) {
+    const afterStart = text.slice(startIdx + 20); // skip past "Item 1. Business" header
+    const endMatch1A = afterStart.search(item1APattern);
+    const endMatch2 = afterStart.search(item2Pattern);
+
+    if (endMatch1A >= 0 && endMatch2 >= 0) {
+      endIdx = startIdx + 20 + Math.min(endMatch1A, endMatch2);
+    } else if (endMatch1A >= 0) {
+      endIdx = startIdx + 20 + endMatch1A;
+    } else if (endMatch2 >= 0) {
+      endIdx = startIdx + 20 + endMatch2;
+    }
+  }
+
+  let rawSection: string;
+  if (startIdx >= 0 && endIdx > startIdx) {
+    rawSection = text.slice(startIdx, endIdx);
+  } else if (startIdx >= 0) {
+    // No clear end boundary: take next 15000 chars
+    rawSection = text.slice(startIdx, startIdx + 15000);
+  } else {
+    // Could not find Item 1 — take a chunk from early in the document
+    // Skip the first 2000 chars (usually cover page / TOC)
+    rawSection = text.slice(2000, 17000);
+  }
+
+  // Limit to 2000 words
+  const words = rawSection.split(/\s+/).filter(w => w.length > 0);
+  return words.slice(0, 2000).join(' ');
+}
+
+/** Tokenize text into lowercase words, removing stop words and short tokens */
+function tokenize(text: string): string[] {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z\s]/g, ' ')
+    .split(/\s+/)
+    .filter(w => w.length > 2 && !STOP_WORDS.has(w));
+}
+
+/** Extract top N terms by frequency (simple TF for a single document) */
+function extractTopTerms(words: string[], n: number): string[] {
+  const freq = new Map<string, number>();
+  for (const w of words) {
+    freq.set(w, (freq.get(w) ?? 0) + 1);
+  }
+  return [...freq.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, n)
+    .map(([word]) => word);
 }
 
 // ===== FINNHUB INSTITUTIONAL OWNERSHIP FETCHER =====

--- a/src/lib/convergence/pipeline.ts
+++ b/src/lib/convergence/pipeline.ts
@@ -1,5 +1,5 @@
 import { getTastytradeClient } from '@/lib/tastytrade';
-import { fetchFinnhubBatch, fetchFredMacro, fetchFredDailySeries, fetchTTCandlesBatch, fetchAnnualFinancials, fetchOptionsFlow, fetchNewsSentiment, fetchFinnhubNewsSentiment, fetchFinnhubEarningsQuality, fetchFinnhubInstitutionalOwnership, fetchFinnhubRevenueBreakdown, fetchQuarterlyFinancials, fetchSECFilingData, fetchSECForm4Data } from './data-fetchers';
+import { fetchFinnhubBatch, fetchFredMacro, fetchFredDailySeries, fetchTTCandlesBatch, fetchAnnualFinancials, fetchOptionsFlow, fetchNewsSentiment, fetchFinnhubNewsSentiment, fetchFinnhubEarningsQuality, fetchFinnhubInstitutionalOwnership, fetchFinnhubRevenueBreakdown, fetchQuarterlyFinancials, fetchSECFilingData, fetchSECForm4Data, fetch10KBusinessDescription } from './data-fetchers';
 import { computeCrossAssetCorrelations } from './cross-asset';
 import type { CrossAssetCorrelations } from './types';
 import type { FinnhubData, CandleBatchStats } from './data-fetchers';
@@ -8,7 +8,7 @@ import type { ChainFetchStats, ChainFetchResult } from './chain-fetcher';
 import type { RejectionReason } from '@/lib/strategy-builder';
 import { fetchSentimentBatch } from './sentiment';
 import type { SentimentResult } from './sentiment';
-import { computePeerStats } from './sector-stats';
+import { computePeerStats, computeTextPeerGroups } from './sector-stats';
 import type { PeerStatsMap, PeerGroupAssignment } from './sector-stats';
 import { scoreAll } from './composite';
 import type { FullScoringResult } from './composite';
@@ -30,6 +30,8 @@ import type {
   QuarterlyFinancials,
   SECFilingData,
   SECForm4Data,
+  CompanyTextProfile,
+  TextBasedPeerGroup,
 } from './types';
 
 // ===== TYPES =====
@@ -103,6 +105,7 @@ export interface PipelineResult {
   };
   hard_filters: HardFiltersResult;
   peer_stats: PeerStatsMap;
+  text_peer_groups: Record<string, TextBasedPeerGroup>;
   pre_scores: PreScoreRow[];
   rankings: {
     scored_count: number;
@@ -409,9 +412,10 @@ export async function runPipeline(limit: number = 20, userId?: string): Promise<
 
   const survivors = hardFilters.survivors.map(s => scannerMap.get(s)!).filter(Boolean);
 
-  // ===== STEP C: Sector Stats =====
-  console.log('[Pipeline] Step C: Computing peer stats (industry-first, sector fallback)...');
-  const { stats: peerStats, assignment: peerGroupAssignment } = computePeerStats(survivors);
+  // ===== STEP C: Initial Sector Stats (will be enhanced with text peers in Step E11) =====
+  console.log('[Pipeline] Step C: Computing initial peer stats (industry-first, sector fallback)...');
+  let { stats: peerStats, assignment: peerGroupAssignment } = computePeerStats(survivors);
+  let textPeerGroups: Record<string, TextBasedPeerGroup> = {};
 
   // ===== STEP D: Pre-Score and Limit =====
   console.log('[Pipeline] Step D: Pre-scoring and limiting...');
@@ -593,6 +597,33 @@ export async function runPipeline(limit: number = 20, userId?: string): Promise<
   }
   console.log(`[Pipeline] Step E10: SEC Form 4 data fetched for ${topSymbols.length} symbols`);
 
+  // Fetch 10-K business descriptions for text-based peer classification (Hoberg & Phillips 2010, 2016)
+  console.log('[Pipeline] Step E11: Fetching 10-K business descriptions for text peer classification...');
+  const textProfiles: CompanyTextProfile[] = [];
+  for (const symbol of topSymbols) {
+    try {
+      const result = await fetch10KBusinessDescription(symbol);
+      if (result.data) {
+        textProfiles.push(result.data);
+      }
+      if (result.error) errors.push(`Step E11 (10k-text ${symbol}): ${result.error}`);
+    } catch (e: unknown) {
+      // Non-fatal: text peer classification is an enhancement, not required
+    }
+    await new Promise(r => setTimeout(r, 150)); // SEC rate limit: 10 req/sec → 150ms between
+  }
+  console.log(`[Pipeline] Step E11: 10-K text profiles fetched for ${textProfiles.length}/${topSymbols.length} symbols`);
+
+  // Compute text-based peer groups from 10-K descriptions
+  if (textProfiles.length >= 2) {
+    textPeerGroups = computeTextPeerGroups(textProfiles);
+    // Re-compute peer stats with text-based peer groups (3-tier: text_nlp → industry → sector)
+    console.log('[Pipeline] Step E11b: Re-computing peer stats with text-based peer groups...');
+    const enhanced = computePeerStats(survivors, textPeerGroups);
+    peerStats = enhanced.stats;
+    peerGroupAssignment = enhanced.assignment;
+  }
+
   // ===== STEP F: Score All 4 Categories =====
   console.log('[Pipeline] Step F: Scoring all categories...');
   const scoredTickers: {
@@ -638,6 +669,7 @@ export async function runPipeline(limit: number = 20, userId?: string): Promise<
       crossAssetCorrelations,
       peerStats,
       peerGroupAssignment,
+      textPeerGroups: Object.keys(textPeerGroups).length > 0 ? textPeerGroups : undefined,
     };
 
     try {
@@ -690,6 +722,7 @@ export async function runPipeline(limit: number = 20, userId?: string): Promise<
         crossAssetCorrelations,
         peerStats,
         peerGroupAssignment,
+        textPeerGroups: Object.keys(textPeerGroups).length > 0 ? textPeerGroups : undefined,
       };
 
       try {
@@ -907,6 +940,7 @@ export async function runPipeline(limit: number = 20, userId?: string): Promise<
     },
     hard_filters: hardFilters,
     peer_stats: peerStats,
+    text_peer_groups: textPeerGroups,
     pre_scores: preScores,
     rankings: {
       scored_count: scoredTickers.length,

--- a/src/lib/convergence/sector-stats.ts
+++ b/src/lib/convergence/sector-stats.ts
@@ -1,4 +1,4 @@
-import type { TTScannerData } from './types';
+import type { TTScannerData, CompanyTextProfile, TextBasedPeerGroup } from './types';
 
 // ===== TYPES =====
 
@@ -10,7 +10,7 @@ export interface PeerMetricStats {
 
 export interface PeerStats {
   ticker_count: number;
-  peer_group_type: 'industry' | 'sector_fallback' | 'unknown';
+  peer_group_type: 'industry' | 'sector_fallback' | 'unknown' | 'text_nlp';
   peer_group_name: string;
   metrics: {
     iv_percentile: PeerMetricStats;
@@ -28,6 +28,12 @@ export interface PeerStats {
     term_structure_slope: PeerMetricStats;
   };
   insufficient_peers?: boolean;
+  text_peer_trace?: {
+    peer_source: 'text_nlp' | 'gics_industry' | 'gics_sector';
+    text_peers: string[];
+    avg_similarity: number;
+    keywords_shared: string[];
+  };
 }
 
 export type PeerStatsMap = Record<string, PeerStats>;
@@ -73,8 +79,9 @@ function computeTermStructureSlope(ts: { date: string; iv: number }[]): number |
 
 function buildPeerStats(
   tickers: TTScannerData[],
-  peerGroupType: 'industry' | 'sector_fallback' | 'unknown',
+  peerGroupType: 'industry' | 'sector_fallback' | 'unknown' | 'text_nlp',
   peerGroupName: string,
+  textPeerTrace?: PeerStats['text_peer_trace'],
 ): PeerStats {
   if (tickers.length < 3) {
     const empty: PeerMetricStats = { mean: 0, std: 0, sortedValues: [] };
@@ -98,6 +105,7 @@ function buildPeerStats(
         term_structure_slope: { ...empty },
       },
       insufficient_peers: true,
+      ...(textPeerTrace ? { text_peer_trace: textPeerTrace } : {}),
     };
   }
 
@@ -120,15 +128,250 @@ function buildPeerStats(
       eps: computeMetricStats(tickers.map(t => t.eps)),
       term_structure_slope: computeMetricStats(tickers.map(t => computeTermStructureSlope(t.termStructure))),
     },
+    ...(textPeerTrace ? { text_peer_trace: textPeerTrace } : {}),
   };
+}
+
+// ===== TF-IDF TEXT SIMILARITY ENGINE (Hoberg & Phillips 2010, 2016) =====
+// Firms that use similar product descriptions in 10-K filings are better economic peers
+// than static GICS industry codes. Runs in milliseconds on ~16 documents.
+
+const MIN_TEXT_PEERS = 3;
+const TEXT_SIMILARITY_THRESHOLD = 0.40;
+
+/** Tokenize business description into lowercase words */
+function tokenizeForTfIdf(text: string): string[] {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z\s]/g, ' ')
+    .split(/\s+/)
+    .filter(w => w.length > 2);
+}
+
+/** Compute TF (term frequency) for a single document */
+function computeTF(words: string[]): Map<string, number> {
+  const freq = new Map<string, number>();
+  for (const w of words) {
+    freq.set(w, (freq.get(w) ?? 0) + 1);
+  }
+  // Normalize by document length
+  const len = words.length || 1;
+  for (const [word, count] of freq) {
+    freq.set(word, count / len);
+  }
+  return freq;
+}
+
+/** Compute IDF (inverse document frequency) across all documents */
+function computeIDF(documents: Map<string, number>[]): Map<string, number> {
+  const docCount = documents.length;
+  if (docCount === 0) return new Map();
+
+  // Count how many documents contain each term
+  const docFreq = new Map<string, number>();
+  for (const doc of documents) {
+    for (const word of doc.keys()) {
+      docFreq.set(word, (docFreq.get(word) ?? 0) + 1);
+    }
+  }
+
+  // IDF = log(N / df) — standard formula
+  const idf = new Map<string, number>();
+  for (const [word, df] of docFreq) {
+    idf.set(word, Math.log(docCount / df));
+  }
+  return idf;
+}
+
+/** Compute TF-IDF vector for a single document */
+function computeTfIdfVector(tf: Map<string, number>, idf: Map<string, number>): Map<string, number> {
+  const vec = new Map<string, number>();
+  for (const [word, tfVal] of tf) {
+    const idfVal = idf.get(word) ?? 0;
+    const tfidf = tfVal * idfVal;
+    if (tfidf > 0) {
+      vec.set(word, tfidf);
+    }
+  }
+  return vec;
+}
+
+/** Compute cosine similarity between two TF-IDF vectors */
+function cosineSimilarity(a: Map<string, number>, b: Map<string, number>): number {
+  let dotProduct = 0;
+  let normA = 0;
+  let normB = 0;
+
+  for (const [word, valA] of a) {
+    normA += valA * valA;
+    const valB = b.get(word);
+    if (valB !== undefined) {
+      dotProduct += valA * valB;
+    }
+  }
+  for (const valB of b.values()) {
+    normB += valB * valB;
+  }
+
+  const denominator = Math.sqrt(normA) * Math.sqrt(normB);
+  if (denominator === 0) return 0;
+  return dotProduct / denominator;
+}
+
+/** Get top N keywords from a TF-IDF vector */
+function getTopKeywords(vec: Map<string, number>, n: number): string[] {
+  return [...vec.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, n)
+    .map(([word]) => word);
+}
+
+/** Find shared keywords between two TF-IDF vectors (top 5 by combined weight) */
+function getSharedKeywords(a: Map<string, number>, b: Map<string, number>, n: number): string[] {
+  const shared: [string, number][] = [];
+  for (const [word, valA] of a) {
+    const valB = b.get(word);
+    if (valB !== undefined) {
+      shared.push([word, valA + valB]);
+    }
+  }
+  return shared
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, n)
+    .map(([word]) => word);
+}
+
+/**
+ * Compute text-based peer groups from 10-K business descriptions.
+ * Uses TF-IDF with cosine similarity (Hoberg & Phillips 2010, 2016).
+ *
+ * @param profiles - CompanyTextProfile for each scored ticker
+ * @returns Map of symbol → TextBasedPeerGroup
+ */
+export function computeTextPeerGroups(
+  profiles: CompanyTextProfile[],
+): Record<string, TextBasedPeerGroup> {
+  if (profiles.length < 2) return {};
+
+  // Step 1: Tokenize and compute TF for each document
+  const symbolWords = new Map<string, string[]>();
+  const tfMaps: Map<string, number>[] = [];
+  const symbols: string[] = [];
+
+  for (const profile of profiles) {
+    const words = tokenizeForTfIdf(profile.businessDescription);
+    if (words.length < 20) continue; // Skip profiles with too little text
+    symbolWords.set(profile.symbol, words);
+    tfMaps.push(computeTF(words));
+    symbols.push(profile.symbol);
+  }
+
+  if (symbols.length < 2) return {};
+
+  // Step 2: Compute IDF across all documents
+  const idf = computeIDF(tfMaps);
+
+  // Step 3: Compute TF-IDF vectors
+  const tfidfVectors = new Map<string, Map<string, number>>();
+  for (let i = 0; i < symbols.length; i++) {
+    tfidfVectors.set(symbols[i], computeTfIdfVector(tfMaps[i], idf));
+  }
+
+  // Step 4: Compute pairwise cosine similarity
+  const similarities = new Map<string, Map<string, number>>();
+  for (const sym of symbols) {
+    similarities.set(sym, new Map());
+  }
+
+  for (let i = 0; i < symbols.length; i++) {
+    for (let j = i + 1; j < symbols.length; j++) {
+      const sim = round(cosineSimilarity(
+        tfidfVectors.get(symbols[i])!,
+        tfidfVectors.get(symbols[j])!,
+      ), 4);
+      similarities.get(symbols[i])!.set(symbols[j], sim);
+      similarities.get(symbols[j])!.set(symbols[i], sim);
+    }
+  }
+
+  // Step 5: Build text peer groups for each symbol
+  const result: Record<string, TextBasedPeerGroup> = {};
+
+  for (const sym of symbols) {
+    const simMap = similarities.get(sym)!;
+    const peers: [string, number][] = [];
+
+    for (const [peerSym, sim] of simMap) {
+      if (sim >= TEXT_SIMILARITY_THRESHOLD) {
+        peers.push([peerSym, sim]);
+      }
+    }
+
+    // Sort by similarity descending
+    peers.sort((a, b) => b[1] - a[1]);
+
+    const textPeers = peers.map(([s]) => s);
+    const similarityScores: Record<string, number> = {};
+    for (const [s, sim] of peers) {
+      similarityScores[s] = sim;
+    }
+
+    // Generate group name from shared keywords across peers
+    let textPeerGroupName = 'text_peers';
+    if (peers.length > 0) {
+      const myVec = tfidfVectors.get(sym)!;
+      // Collect shared keywords across all peers
+      const allShared: Map<string, number> = new Map();
+      for (const [peerSym] of peers) {
+        const peerVec = tfidfVectors.get(peerSym)!;
+        const shared = getSharedKeywords(myVec, peerVec, 10);
+        for (const kw of shared) {
+          allShared.set(kw, (allShared.get(kw) ?? 0) + 1);
+        }
+      }
+      const topShared = [...allShared.entries()]
+        .sort((a, b) => b[1] - a[1])
+        .slice(0, 3)
+        .map(([w]) => w);
+      if (topShared.length > 0) {
+        textPeerGroupName = topShared.join('_');
+      }
+    }
+
+    // Determine peer source based on whether we have enough text peers
+    const peerSource: TextBasedPeerGroup['peerSource'] =
+      textPeers.length >= MIN_TEXT_PEERS ? 'text_nlp' : 'gics_industry';
+
+    result[sym] = {
+      symbol: sym,
+      textPeers,
+      similarityScores,
+      textPeerGroupName,
+      peerSource,
+    };
+  }
+
+  console.log(`[TextPeers] Computed pairwise similarity for ${symbols.length} tickers, ${Object.values(result).filter(g => g.peerSource === 'text_nlp').length} using text-based peers`);
+
+  return result;
 }
 
 // ===== MAIN FUNCTIONS =====
 
 const MIN_INDUSTRY_PEERS = 5;
 
+/**
+ * Compute peer group statistics with 3-tier grouping (Hoberg & Phillips 2010, 2016):
+ *   1. Text-based peers (cosine similarity > 0.40, min 3 peers) — most precise
+ *   2. GICS industry (min 5 peers) — standard fallback
+ *   3. GICS sector — broadest fallback
+ *
+ * @param scannerResults - All scanner data (full universe after hard filters)
+ * @param textPeerGroups - Optional text-based peer groups from 10-K analysis
+ */
 export function computePeerStats(
   scannerResults: TTScannerData[],
+  textPeerGroups?: Record<string, TextBasedPeerGroup>,
 ): { stats: PeerStatsMap; assignment: PeerGroupAssignment } {
   // Step 1: Group by industry
   const byIndustry = new Map<string, TTScannerData[]>();
@@ -137,12 +380,15 @@ export function computePeerStats(
   // Track each ticker's industry and sector for assignment
   const tickerIndustry = new Map<string, string | null>();
   const tickerSector = new Map<string, string | null>();
+  // Quick scanner data lookup
+  const scannerBySymbol = new Map<string, TTScannerData>();
 
   for (const item of scannerResults) {
     const industry = item.industry || null;
     const sector = item.sector || null;
     tickerIndustry.set(item.symbol, industry);
     tickerSector.set(item.symbol, sector);
+    scannerBySymbol.set(item.symbol, item);
 
     // Always add to sector group (used for fallback)
     const sectorKey = sector || 'UNKNOWN';
@@ -158,10 +404,48 @@ export function computePeerStats(
 
   const result: PeerStatsMap = {};
   const assignment: PeerGroupAssignment = {};
+  const textNlpUsed: string[] = [];
   const industryFallbacks: string[] = [];
   const industryUsed: string[] = [];
 
-  // Step 3: Build industry-level stats for groups with >= MIN_INDUSTRY_PEERS
+  // Step 3: Build text-based peer group stats (highest priority)
+  if (textPeerGroups) {
+    for (const [symbol, group] of Object.entries(textPeerGroups)) {
+      if (group.peerSource !== 'text_nlp' || group.textPeers.length < MIN_TEXT_PEERS) continue;
+
+      const key = `text_nlp:${symbol}`;
+      // Collect scanner data for all peers + the symbol itself
+      const peerTickers: TTScannerData[] = [];
+      const selfData = scannerBySymbol.get(symbol);
+      if (selfData) peerTickers.push(selfData);
+      for (const peerSym of group.textPeers) {
+        const peerData = scannerBySymbol.get(peerSym);
+        if (peerData) peerTickers.push(peerData);
+      }
+
+      if (peerTickers.length < MIN_TEXT_PEERS) continue;
+
+      // Find shared keywords for trace
+      const simScores = Object.values(group.similarityScores);
+      const avgSim = simScores.length > 0
+        ? round(simScores.reduce((a, b) => a + b, 0) / simScores.length, 4)
+        : 0;
+
+      // Get top 5 shared keywords from the group name or group data
+      const sharedKeywords = group.textPeerGroupName.split('_').slice(0, 5);
+
+      const trace: PeerStats['text_peer_trace'] = {
+        peer_source: 'text_nlp',
+        text_peers: group.textPeers,
+        avg_similarity: avgSim,
+        keywords_shared: sharedKeywords,
+      };
+
+      result[key] = buildPeerStats(peerTickers, 'text_nlp', group.textPeerGroupName, trace);
+    }
+  }
+
+  // Step 4: Build industry-level stats for groups with >= MIN_INDUSTRY_PEERS
   const validIndustries = new Set<string>();
   for (const [industry, tickers] of byIndustry) {
     if (tickers.length >= MIN_INDUSTRY_PEERS) {
@@ -171,35 +455,47 @@ export function computePeerStats(
     }
   }
 
-  // Step 4: Build sector-level stats (used as fallback)
-  const sectorKeys = new Map<string, string>();
+  // Step 5: Build sector-level stats (used as fallback)
   for (const [sector, tickers] of bySector) {
     const key = `sector:${sector}`;
-    sectorKeys.set(sector, key);
     result[key] = buildPeerStats(tickers, 'sector_fallback', sector);
   }
 
-  // Step 5: Assign each ticker to its peer group
+  // Step 6: Assign each ticker to its peer group (3-tier priority)
   for (const item of scannerResults) {
-    const industry = tickerIndustry.get(item.symbol);
-    const sector = tickerSector.get(item.symbol);
+    const symbol = item.symbol;
+    const industry = tickerIndustry.get(symbol);
+    const sector = tickerSector.get(symbol);
+    const textGroup = textPeerGroups?.[symbol];
 
+    // Tier 1: Text-based peers (highest precision)
+    if (textGroup && textGroup.peerSource === 'text_nlp' && textGroup.textPeers.length >= MIN_TEXT_PEERS) {
+      const key = `text_nlp:${symbol}`;
+      if (result[key] && !result[key].insufficient_peers) {
+        assignment[symbol] = key;
+        textNlpUsed.push(symbol);
+        continue;
+      }
+    }
+
+    // Tier 2: GICS industry (min 5 peers)
     if (industry && validIndustries.has(industry)) {
-      // Industry group has >= 5 peers — use industry
-      assignment[item.symbol] = `industry:${industry}`;
-      industryUsed.push(item.symbol);
+      assignment[symbol] = `industry:${industry}`;
+      industryUsed.push(symbol);
     } else if (sector) {
-      // Industry too small or null — fall back to sector
-      assignment[item.symbol] = `sector:${sector}`;
-      industryFallbacks.push(item.symbol);
+      // Tier 3: GICS sector (broadest)
+      assignment[symbol] = `sector:${sector}`;
+      industryFallbacks.push(symbol);
     } else {
-      // Both null — use UNKNOWN
-      assignment[item.symbol] = `sector:UNKNOWN`;
-      industryFallbacks.push(item.symbol);
+      assignment[symbol] = `sector:UNKNOWN`;
+      industryFallbacks.push(symbol);
     }
   }
 
   // Log peer group assignments
+  if (textNlpUsed.length > 0) {
+    console.log(`[PeerStats] ${textNlpUsed.length} tickers using text-based NLP peers: ${textNlpUsed.slice(0, 10).join(', ')}${textNlpUsed.length > 10 ? '...' : ''}`);
+  }
   if (industryUsed.length > 0) {
     console.log(`[PeerStats] ${industryUsed.length} tickers using industry-level peers`);
   }

--- a/src/lib/convergence/types.ts
+++ b/src/lib/convergence/types.ts
@@ -326,6 +326,24 @@ export interface EarningsSurpriseSignal {
   isRecentFiling: boolean;          // filed within 72 hours
 }
 
+// ===== SEC 10-K TEXT PROFILE (Hoberg & Phillips 2010, 2016) =====
+
+export interface CompanyTextProfile {
+  symbol: string;
+  businessDescription: string;       // extracted text (max 2000 words)
+  filingDate: string;
+  keywords: string[];                // top 20 TF-IDF keywords
+  productTerms: string[];            // product/service terms extracted
+}
+
+export interface TextBasedPeerGroup {
+  symbol: string;
+  textPeers: string[];               // symbols of closest text-based peers
+  similarityScores: Record<string, number>;  // symbol → cosine similarity
+  textPeerGroupName: string;         // auto-generated label from shared keywords
+  peerSource: 'text_nlp' | 'gics_industry' | 'gics_sector';
+}
+
 // ===== FINNHUB INSTITUTIONAL OWNERSHIP (from /stock/ownership + /stock/fund-ownership) =====
 
 export interface FinnhubInstitutionalOwnership {
@@ -413,6 +431,7 @@ export interface ConvergenceInput {
   crossAssetCorrelations: CrossAssetCorrelations | null;
   peerStats?: Record<string, { ticker_count?: number; peer_group_type?: string; peer_group_name?: string; metrics: Record<string, { mean: number; std: number; sortedValues?: number[] }> }>;
   peerGroupAssignment?: Record<string, string>;
+  textPeerGroups?: Record<string, TextBasedPeerGroup>;
 }
 
 // ===== DATA CONFIDENCE =====


### PR DESCRIPTION
Implements Hoberg & Phillips (2010, 2016) text-based peer classification as a third tier of peer grouping, more precise than static GICS codes:

1. Text-based peers (TF-IDF cosine similarity > 0.40, min 3) — most precise
2. GICS industry (min 5 peers) — standard fallback
3. GICS sector — broadest fallback

- Fetches Item 1 (Business Description) from most recent 10-K via SEC EDGAR
- Extracts and tokenizes business description text (max 2000 words)
- Computes TF-IDF vectors and pairwise cosine similarity across scored tickers
- Auto-generates text peer group names from shared keywords
- Adds text_peer_trace to PeerStats with peer_source, text_peers, avg_similarity, and keywords_shared
- 30-day cache for 10-K text (only changes annually)
- 150ms rate limiting between SEC API calls

https://claude.ai/code/session_01PRpvRzj4ffNx7oDmSnb5CT