### PR TITLE
integrate Finnhub /stock/peers, expand peer groups beyond hard-filter…

### DIFF
--- a/src/lib/convergence/data-fetchers.ts
+++ b/src/lib/convergence/data-fetchers.ts
@@ -1083,6 +1083,50 @@ export async function fetchInsiderTransactions(
   }
 }
 
+// ===== FINNHUB PEER TICKERS FETCHER =====
+// Uses Finnhub /stock/peers to get peer company tickers for expanding peer groups
+// beyond hard-filter survivors. Returns tickers in the same country/sector/industry.
+
+const peerTickerCache = new Map<string, { peers: string[]; fetchedAt: number }>();
+const PEER_TICKER_CACHE_TTL = 24 * 60 * 60 * 1000; // 24 hours (peer lists change slowly)
+
+export async function fetchPeerTickers(
+  symbol: string,
+  apiKey?: string,
+): Promise<{ data: string[] | null; error: string | null }> {
+  const cached = peerTickerCache.get(symbol);
+  if (cached && Date.now() - cached.fetchedAt < PEER_TICKER_CACHE_TTL) {
+    return { data: cached.peers, error: null };
+  }
+
+  const key = apiKey || process.env.FINNHUB_API_KEY;
+  if (!key) return { data: null, error: 'FINNHUB_API_KEY not configured' };
+
+  try {
+    const resp = await fetchWithRetry(
+      `https://finnhub.io/api/v1/stock/peers?symbol=${symbol}&grouping=industry&token=${key}`,
+    );
+    if (!resp.ok) {
+      return { data: null, error: `stock/peers: HTTP ${resp.status}` };
+    }
+
+    const json = await resp.json();
+    if (!Array.isArray(json)) {
+      return { data: null, error: 'stock/peers: unexpected response format' };
+    }
+
+    // Finnhub returns the symbol itself in the list — filter it out
+    const peers = json.filter((t: unknown): t is string =>
+      typeof t === 'string' && t !== symbol
+    );
+
+    peerTickerCache.set(symbol, { peers, fetchedAt: Date.now() });
+    return { data: peers, error: null };
+  } catch (e: unknown) {
+    return { data: null, error: `stock/peers: ${e instanceof Error ? e.message : String(e)}` };
+  }
+}
+
 // ===== SEC FORM 4 INSIDER TRANSACTION FETCHER =====
 // DEPRECATED: Replaced by fetchInsiderTransactions() using Finnhub /stock/insider-transactions.
 // Kept for reference — will be removed after confirming the Finnhub path works in production.

--- a/src/lib/convergence/pipeline.ts
+++ b/src/lib/convergence/pipeline.ts
@@ -1,5 +1,5 @@
 import { getTastytradeClient } from '@/lib/tastytrade';
-import { fetchFinnhubBatch, fetchFredMacro, fetchFredDailySeries, fetchTTCandlesBatch, fetchAnnualFinancials, fetchNewsSentiment, fetchFinnhubNewsSentiment, fetchFinnhubEarningsQuality, fetchFinnhubInstitutionalOwnership, fetchFinnhubRevenueBreakdown, fetchQuarterlyFinancials, fetchSECFilingData, fetchInsiderTransactions, fetch10KBusinessDescription } from './data-fetchers';
+import { fetchFinnhubBatch, fetchFredMacro, fetchFredDailySeries, fetchTTCandlesBatch, fetchAnnualFinancials, fetchNewsSentiment, fetchFinnhubNewsSentiment, fetchFinnhubEarningsQuality, fetchFinnhubInstitutionalOwnership, fetchFinnhubRevenueBreakdown, fetchQuarterlyFinancials, fetchSECFilingData, fetchInsiderTransactions, fetchPeerTickers, fetch10KBusinessDescription } from './data-fetchers';
 import { computeCrossAssetCorrelations } from './cross-asset';
 import type { CrossAssetCorrelations } from './types';
 import type { FinnhubData, CandleBatchStats } from './data-fetchers';
@@ -412,9 +412,28 @@ export async function runPipeline(limit: number = 20, userId?: string): Promise<
 
   const survivors = hardFilters.survivors.map(s => scannerMap.get(s)!).filter(Boolean);
 
-  // ===== STEP C: Initial Sector Stats (will be enhanced with text peers in Step E11) =====
-  console.log('[Pipeline] Step C: Computing initial peer stats (industry-first, sector fallback)...');
-  let { stats: peerStats, assignment: peerGroupAssignment } = computePeerStats(survivors);
+  // ===== STEP C1: Fetch Finnhub peer tickers for each survivor =====
+  console.log('[Pipeline] Step C1: Fetching Finnhub /stock/peers for survivors...');
+  const finnhubPeersMap: Record<string, string[]> = {};
+  for (const item of survivors) {
+    try {
+      const result = await fetchPeerTickers(item.symbol);
+      if (result.data && result.data.length > 0) {
+        finnhubPeersMap[item.symbol] = result.data;
+      }
+    } catch {
+      // Non-critical — fall through to GICS grouping
+    }
+    await new Promise(r => setTimeout(r, 200)); // Finnhub rate limit
+  }
+  const peersFound = Object.values(finnhubPeersMap).filter(p => p.length > 0).length;
+  console.log(`[Pipeline] Step C1: Finnhub peers fetched for ${peersFound}/${survivors.length} survivors`);
+
+  // ===== STEP C2: Initial Peer Stats (will be enhanced with text peers in Step E11) =====
+  console.log('[Pipeline] Step C2: Computing initial peer stats (finnhub-peers → industry → sector fallback)...');
+  let { stats: peerStats, assignment: peerGroupAssignment } = computePeerStats(
+    survivors, undefined, finnhubPeersMap, scannerMap,
+  );
   let textPeerGroups: Record<string, TextBasedPeerGroup> = {};
 
   // ===== STEP D: Pre-Score and Limit =====
@@ -612,7 +631,7 @@ export async function runPipeline(limit: number = 20, userId?: string): Promise<
     textPeerGroups = computeTextPeerGroups(textProfiles);
     // Re-compute peer stats with text-based peer groups (3-tier: text_nlp → industry → sector)
     console.log('[Pipeline] Step E11b: Re-computing peer stats with text-based peer groups...');
-    const enhanced = computePeerStats(survivors, textPeerGroups);
+    const enhanced = computePeerStats(survivors, textPeerGroups, finnhubPeersMap, scannerMap);
     peerStats = enhanced.stats;
     peerGroupAssignment = enhanced.assignment;
   }

--- a/src/lib/convergence/sector-stats.ts
+++ b/src/lib/convergence/sector-stats.ts
@@ -10,7 +10,7 @@ export interface PeerMetricStats {
 
 export interface PeerStats {
   ticker_count: number;
-  peer_group_type: 'industry' | 'sector_fallback' | 'unknown' | 'text_nlp';
+  peer_group_type: 'industry' | 'sector_fallback' | 'unknown' | 'text_nlp' | 'finnhub_peers' | 'mixed';
   peer_group_name: string;
   metrics: {
     iv_percentile: PeerMetricStats;
@@ -79,7 +79,7 @@ function computeTermStructureSlope(ts: { date: string; iv: number }[]): number |
 
 function buildPeerStats(
   tickers: TTScannerData[],
-  peerGroupType: 'industry' | 'sector_fallback' | 'unknown' | 'text_nlp',
+  peerGroupType: PeerStats['peer_group_type'],
   peerGroupName: string,
   textPeerTrace?: PeerStats['text_peer_trace'],
 ): PeerStats {
@@ -361,17 +361,23 @@ export function computeTextPeerGroups(
 const MIN_INDUSTRY_PEERS = 5;
 
 /**
- * Compute peer group statistics with 3-tier grouping (Hoberg & Phillips 2010, 2016):
- *   1. Text-based peers (cosine similarity > 0.40, min 3 peers) — most precise
- *   2. GICS industry (min 5 peers) — standard fallback
- *   3. GICS sector — broadest fallback
+ * Compute peer group statistics with 4-tier grouping:
+ *   1. Text-based peers (cosine similarity > 0.40, min 3 peers) — most precise (Hoberg & Phillips 2010, 2016)
+ *   2. Finnhub /stock/peers — industry-matched peers from Finnhub, expanded with scanner universe data
+ *   3. GICS industry (min 5 peers) — standard fallback
+ *   4. GICS sector — broadest fallback
  *
- * @param scannerResults - All scanner data (full universe after hard filters)
+ * @param scannerResults - Scanner data for hard-filter survivors
  * @param textPeerGroups - Optional text-based peer groups from 10-K analysis
+ * @param finnhubPeers - Optional map: symbol → peer tickers from Finnhub /stock/peers
+ * @param fullUniverse - Optional map: symbol → TTScannerData for the full pre-filter scanner universe
+ *                       (used to resolve Finnhub peer tickers that aren't in the survivor set)
  */
 export function computePeerStats(
   scannerResults: TTScannerData[],
   textPeerGroups?: Record<string, TextBasedPeerGroup>,
+  finnhubPeers?: Record<string, string[]>,
+  fullUniverse?: Map<string, TTScannerData>,
 ): { stats: PeerStatsMap; assignment: PeerGroupAssignment } {
   // Step 1: Group by industry
   const byIndustry = new Map<string, TTScannerData[]>();
@@ -445,7 +451,35 @@ export function computePeerStats(
     }
   }
 
-  // Step 4: Build industry-level stats for groups with >= MIN_INDUSTRY_PEERS
+  // Step 4: Build Finnhub peer group stats (per symbol, from /stock/peers)
+  // Resolves peer tickers against the full scanner universe (not just survivors).
+  const finnhubPeerKeys = new Map<string, string>(); // symbol → result key
+  const finnhubPeersUsed: string[] = [];
+  if (finnhubPeers) {
+    const universe = fullUniverse ?? scannerBySymbol;
+
+    for (const [symbol, peerSymbols] of Object.entries(finnhubPeers)) {
+      if (!peerSymbols || peerSymbols.length === 0) continue;
+
+      // Collect scanner data for the symbol + its Finnhub peers from the universe
+      const peerTickers: TTScannerData[] = [];
+      const selfData = universe.get(symbol) ?? scannerBySymbol.get(symbol);
+      if (selfData) peerTickers.push(selfData);
+
+      for (const peerSym of peerSymbols) {
+        const peerData = universe.get(peerSym) ?? scannerBySymbol.get(peerSym);
+        if (peerData && peerData.symbol !== symbol) peerTickers.push(peerData);
+      }
+
+      if (peerTickers.length < 3) continue; // Need at least 3 for meaningful stats
+
+      const key = `finnhub_peers:${symbol}`;
+      result[key] = buildPeerStats(peerTickers, 'finnhub_peers', `finnhub_peers(${symbol})`);
+      finnhubPeerKeys.set(symbol, key);
+    }
+  }
+
+  // Step 5: Build industry-level stats for groups with >= MIN_INDUSTRY_PEERS
   const validIndustries = new Set<string>();
   for (const [industry, tickers] of byIndustry) {
     if (tickers.length >= MIN_INDUSTRY_PEERS) {
@@ -455,13 +489,13 @@ export function computePeerStats(
     }
   }
 
-  // Step 5: Build sector-level stats (used as fallback)
+  // Step 6: Build sector-level stats (used as broadest fallback)
   for (const [sector, tickers] of bySector) {
     const key = `sector:${sector}`;
     result[key] = buildPeerStats(tickers, 'sector_fallback', sector);
   }
 
-  // Step 6: Assign each ticker to its peer group (3-tier priority)
+  // Step 7: Assign each ticker to its peer group (4-tier priority)
   for (const item of scannerResults) {
     const symbol = item.symbol;
     const industry = tickerIndustry.get(symbol);
@@ -478,12 +512,20 @@ export function computePeerStats(
       }
     }
 
-    // Tier 2: GICS industry (min 5 peers)
+    // Tier 2: Finnhub /stock/peers (industry-matched, expanded from universe)
+    const fhKey = finnhubPeerKeys.get(symbol);
+    if (fhKey && result[fhKey] && !result[fhKey].insufficient_peers) {
+      assignment[symbol] = fhKey;
+      finnhubPeersUsed.push(symbol);
+      continue;
+    }
+
+    // Tier 3: GICS industry (min 5 peers)
     if (industry && validIndustries.has(industry)) {
       assignment[symbol] = `industry:${industry}`;
       industryUsed.push(symbol);
     } else if (sector) {
-      // Tier 3: GICS sector (broadest)
+      // Tier 4: GICS sector (broadest)
       assignment[symbol] = `sector:${sector}`;
       industryFallbacks.push(symbol);
     } else {
@@ -495,6 +537,9 @@ export function computePeerStats(
   // Log peer group assignments
   if (textNlpUsed.length > 0) {
     console.log(`[PeerStats] ${textNlpUsed.length} tickers using text-based NLP peers: ${textNlpUsed.slice(0, 10).join(', ')}${textNlpUsed.length > 10 ? '...' : ''}`);
+  }
+  if (finnhubPeersUsed.length > 0) {
+    console.log(`[PeerStats] ${finnhubPeersUsed.length} tickers using Finnhub /stock/peers: ${finnhubPeersUsed.slice(0, 10).join(', ')}${finnhubPeersUsed.length > 10 ? '...' : ''}`);
   }
   if (industryUsed.length > 0) {
     console.log(`[PeerStats] ${industryUsed.length} tickers using industry-level peers`);


### PR DESCRIPTION
… survivors

The scanner was computing peer stats only from ~18 hard-filter survivors, causing 7/10 sector peer groups to have insufficient peers (n=1-2). This forced z-scores to fall back to raw mode, compressing composites into the 46-58 range with no real differentiation.

Fix: for each survivor, call Finnhub /stock/peers?grouping=industry to get industry-matched peer tickers, then resolve them against the full 542-ticker scanner universe (already loaded). This expands peer groups without any extra metric API calls.

- Add fetchPeerTickers(symbol, apiKey) in data-fetchers.ts
  - Calls /stock/peers?grouping=industry, 24h cache, proper error handling
- Update computePeerStats() in sector-stats.ts
  - New 4-tier priority: text_nlp → finnhub_peers → GICS industry → GICS sector
  - Accepts optional finnhubPeers map + fullUniverse scanner map
  - Resolves Finnhub peer tickers against full universe for metric data
  - New peer_group_type values: 'finnhub_peers', 'mixed'
- Wire into pipeline.ts as Step C1 (before initial peer stats)
  - 18 new API calls per scan (well within 300/min premium limit)
  - ~3.6s extra pipeline time (200ms delay between calls)
- No changes to vol-edge.ts — existing transform logic handles new groups

https://claude.ai/code/session_01PRpvRzj4ffNx7oDmSnb5CT