### PR TITLE
refactor: consolidate duplicate TradeCard interfaces — single source …

### DIFF
--- a/src/components/convergence/ConvergenceIntelligence.tsx
+++ b/src/components/convergence/ConvergenceIntelligence.tsx
@@ -72,108 +72,25 @@ interface BatchResponse {
   timing: { pipeline_ms: number; ai_ms: number; total_ms: number };
 }
 
-// ── Single-ticker types (from /api/test/convergence) ────────────────
+// ── Types (canonical imports) ────────────────────────────────────────
 
-interface LegData { type: string; side: string; strike: number; price: number }
-
-interface TradeCardSetup {
-  strategy_name: string;
-  legs: LegData[];
-  expiration_date: string;
-  dte: number;
-  net_credit: number | null;
-  net_debit: number | null;
-  max_profit: number | null;
-  max_loss: number | null;
-  breakevens: number[];
-  probability_of_profit: number | null;
-  pop_method: 'breakeven_d2' | 'delta_approx';
-  hv_pop: number | null;
-  risk_reward_ratio: number | null;
-  greeks: { delta: number; gamma: number; theta: number; vega: number; theta_per_day: number };
-  ev: number;
-  ev_per_risk: number;
-  has_wide_spread: boolean;
-  is_unlimited_risk: boolean;
-}
-
-interface TradeCardWhy {
-  composite_score: number;
-  letter_grade: string;
-  direction: string;
-  convergence_gate: string;
-  category_scores: { vol_edge: number; quality: number; regime: number; info_edge: number };
-  plain_english_signals: string[];
-  regime_context: string;
-  risk_flags: string[];
-}
-
-interface TradeCardKeyStats {
-  current_price: number | null;
-  iv_rank: number | null;
-  iv_percentile: number | null;
-  iv30: number | null;
-  hv30: number | null;
-  iv_hv_spread: number | null;
-  earnings_date: string | null;
-  days_to_earnings: number | null;
-  market_cap: number | null;
-  sector: string | null;
-  beta: number | null;
-  spy_correlation: number | null;
-  pe_ratio: number | null;
-  dividend_yield: number | null;
-  liquidity_rating: number | null;
-  lendability: string | null;
-  buzz_ratio: number | null;
-  sentiment_momentum: number | null;
-  analyst_consensus: string | null;
-}
-
-interface TradeCardData {
-  symbol: string;
-  label: string;
-  setup: TradeCardSetup;
-  why: TradeCardWhy;
-  key_stats: TradeCardKeyStats;
-}
+import type {
+  VolEdgeResult,
+  QualityGateResult,
+  RegimeResult,
+  InfoEdgeResult,
+  TradeCardSetup,
+  TradeCardWhy,
+  TradeCardKeyStats,
+  TradeCardData,
+} from '@/lib/convergence/types';
+import type { TickerDetail } from '@/lib/convergence/filter-engine';
 
 interface Headline {
   datetime: number;
   headline: string;
   source: string;
   sentiment: string;
-}
-
-// ── Score breakdown types (imported from canonical types.ts) ──
-import type {
-  VolEdgeResult,
-  QualityGateResult,
-  RegimeResult,
-  InfoEdgeResult,
-} from '@/lib/convergence/types';
-
-interface TickerDetail {
-  symbol: string;
-  pipeline_runtime_ms: number;
-  scores: {
-    vol_edge: VolEdgeResult;
-    quality: QualityGateResult;
-    regime: RegimeResult;
-    info_edge: InfoEdgeResult;
-    composite: {
-      score: number;
-      direction: string;
-      convergence_gate: string;
-      categories_above_50: number;
-      category_scores: { vol_edge: number; quality: number; regime: number; info_edge: number };
-    };
-  };
-  trade_cards?: TradeCardData[];
-  data_gaps: string[];
-  _chain_stats?: Record<string, unknown>;
-  _fetch_errors?: Record<string, string>;
-  _rejection_reasons?: RejectionReason[];
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────

--- a/src/components/convergence/ScannerResultsTable.tsx
+++ b/src/components/convergence/ScannerResultsTable.tsx
@@ -10,108 +10,25 @@ import Button from '@/components/ui/Button';
    Single ticker lookups continue to use the existing TickerCard.
    =================================================================== */
 
-// ── Types (structural match with ConvergenceIntelligence) ───────────
+// ── Types (canonical imports) ────────────────────────────────────────
 
-interface LegData { type: string; side: string; strike: number; price: number }
-
-interface TradeCardSetup {
-  strategy_name: string;
-  legs: LegData[];
-  expiration_date: string;
-  dte: number;
-  net_credit: number | null;
-  net_debit: number | null;
-  max_profit: number | null;
-  max_loss: number | null;
-  breakevens: number[];
-  probability_of_profit: number | null;
-  pop_method: 'breakeven_d2' | 'delta_approx';
-  hv_pop: number | null;
-  risk_reward_ratio: number | null;
-  greeks: { delta: number; gamma: number; theta: number; vega: number; theta_per_day: number };
-  ev: number;
-  ev_per_risk: number;
-  has_wide_spread: boolean;
-  is_unlimited_risk: boolean;
-}
-
-interface TradeCardWhy {
-  composite_score: number;
-  letter_grade: string;
-  direction: string;
-  convergence_gate: string;
-  category_scores: { vol_edge: number; quality: number; regime: number; info_edge: number };
-  plain_english_signals: string[];
-  regime_context: string;
-  risk_flags: string[];
-}
-
-interface TradeCardKeyStats {
-  current_price: number | null;
-  iv_rank: number | null;
-  iv_percentile: number | null;
-  iv30: number | null;
-  hv30: number | null;
-  iv_hv_spread: number | null;
-  earnings_date: string | null;
-  days_to_earnings: number | null;
-  market_cap: number | null;
-  sector: string | null;
-  beta: number | null;
-  spy_correlation: number | null;
-  pe_ratio: number | null;
-  dividend_yield: number | null;
-  liquidity_rating: number | null;
-  lendability: string | null;
-  buzz_ratio: number | null;
-  sentiment_momentum: number | null;
-  analyst_consensus: string | null;
-}
-
-interface TradeCardData {
-  symbol: string;
-  label: string;
-  setup: TradeCardSetup;
-  why: TradeCardWhy;
-  key_stats: TradeCardKeyStats;
-}
+import type {
+  VolEdgeResult,
+  QualityGateResult,
+  RegimeResult,
+  InfoEdgeResult,
+  TradeCardSetup,
+  TradeCardWhy,
+  TradeCardKeyStats,
+  TradeCardData,
+} from '@/lib/convergence/types';
+import type { TickerDetail } from '@/lib/convergence/filter-engine';
 
 interface Headline {
   datetime: number;
   headline: string;
   source: string;
   sentiment: string;
-}
-
-// ── Score breakdown types (imported from canonical types.ts) ──
-import type {
-  VolEdgeResult,
-  QualityGateResult,
-  RegimeResult,
-  InfoEdgeResult,
-} from '@/lib/convergence/types';
-
-interface TickerDetail {
-  symbol: string;
-  pipeline_runtime_ms: number;
-  scores: {
-    vol_edge: VolEdgeResult;
-    quality: QualityGateResult;
-    regime: RegimeResult;
-    info_edge: InfoEdgeResult;
-    composite: {
-      score: number;
-      direction: string;
-      convergence_gate: string;
-      categories_above_50: number;
-      category_scores: { vol_edge: number; quality: number; regime: number; info_edge: number };
-    };
-  };
-  trade_cards?: TradeCardData[];
-  data_gaps: string[];
-  _chain_stats?: Record<string, unknown>;
-  _fetch_errors?: Record<string, string>;
-  _rejection_reasons?: { strategy: string; reason: string; gate: string; details?: { value: number; threshold: number; spreadWidth?: number } }[];
 }
 
 // ── Props ────────────────────────────────────────────────────────────

--- a/src/lib/convergence/filter-engine.ts
+++ b/src/lib/convergence/filter-engine.ts
@@ -14,73 +14,16 @@
 
 import type { ScannerFilters } from './filter-types';
 import { isCreditStrategy, DEFAULT_FILTERS } from './filter-types';
-import type { VolEdgeResult, QualityGateResult, RegimeResult, InfoEdgeResult } from './types';
-
-// ── Types matching ConvergenceIntelligence / ScannerResultsTable ─────
-
-interface LegData { type: string; side: string; strike: number; price: number }
-
-interface TradeCardSetup {
-  strategy_name: string;
-  legs: LegData[];
-  expiration_date: string;
-  dte: number;
-  net_credit: number | null;
-  net_debit: number | null;
-  max_profit: number | null;
-  max_loss: number | null;
-  breakevens: number[];
-  probability_of_profit: number | null;
-  pop_method: 'breakeven_d2' | 'delta_approx';
-  hv_pop: number | null;
-  risk_reward_ratio: number | null;
-  greeks: { delta: number; gamma: number; theta: number; vega: number; theta_per_day: number };
-  ev: number;
-  ev_per_risk: number;
-  has_wide_spread: boolean;
-  is_unlimited_risk: boolean;
-}
-
-interface TradeCardKeyStats {
-  current_price: number | null;
-  iv_rank: number | null;
-  iv_percentile: number | null;
-  iv30: number | null;
-  hv30: number | null;
-  iv_hv_spread: number | null;
-  earnings_date: string | null;
-  days_to_earnings: number | null;
-  market_cap: number | null;
-  sector: string | null;
-  beta: number | null;
-  spy_correlation: number | null;
-  pe_ratio: number | null;
-  dividend_yield: number | null;
-  liquidity_rating: number | null;
-  lendability: string | null;
-  buzz_ratio: number | null;
-  sentiment_momentum: number | null;
-  analyst_consensus: string | null;
-}
-
-interface TradeCardWhy {
-  composite_score: number;
-  letter_grade: string;
-  direction: string;
-  convergence_gate: string;
-  category_scores: { vol_edge: number; quality: number; regime: number; info_edge: number };
-  plain_english_signals: string[];
-  regime_context: string;
-  risk_flags: string[];
-}
-
-interface TradeCardData {
-  symbol: string;
-  label: string;
-  setup: TradeCardSetup;
-  why: TradeCardWhy;
-  key_stats: TradeCardKeyStats;
-}
+import type {
+  VolEdgeResult,
+  QualityGateResult,
+  RegimeResult,
+  InfoEdgeResult,
+  TradeCardSetup,
+  TradeCardWhy,
+  TradeCardKeyStats,
+  TradeCardData,
+} from './types';
 
 export interface TickerDetail {
   symbol: string;

--- a/src/lib/convergence/pipeline.ts
+++ b/src/lib/convergence/pipeline.ts
@@ -19,7 +19,7 @@ import type {
   TTScannerData,
   ConvergenceInput,
   FredMacroData,
-  TradeCardData,
+  LegacyTradeCardData,
   AnnualFinancials,
   OptionsFlowData,
   NewsSentimentData,
@@ -845,8 +845,8 @@ export async function runPipeline(limit: number = 20, userId?: string): Promise<
       for (const ticker of scoredTickers) {
         const tickerCards = chainResult.cards.get(ticker.symbol);
         if (tickerCards && tickerCards.length > 0) {
-          // Convert StrategyCard to serializable TradeCardData
-          const tradeCards: TradeCardData[] = tickerCards.map(card => ({
+          // Convert StrategyCard to serializable LegacyTradeCardData
+          const tradeCards: LegacyTradeCardData[] = tickerCards.map(card => ({
             name: card.name,
             legs: card.legs.map(leg => ({
               type: leg.type,

--- a/src/lib/convergence/types.ts
+++ b/src/lib/convergence/types.ts
@@ -1003,7 +1003,8 @@ export interface TradeCardLeg {
   price: number;
 }
 
-export interface TradeCardData {
+/** @deprecated Use TradeCardData (the unified setup+why+key_stats shape) for new code. */
+export interface LegacyTradeCardData {
   name: string;
   legs: TradeCardLeg[];
   expiration: string;
@@ -1025,7 +1026,7 @@ export interface StrategySuggestion {
   suggested_strategy: string;
   suggested_dte: number;
   note: string;
-  trade_cards?: TradeCardData[];
+  trade_cards?: LegacyTradeCardData[];
   full_trade_cards?: TradeCard[];
 }
 
@@ -1110,12 +1111,20 @@ export interface TradeCardKeyStats {
   buzz_ratio: number | null;
   sentiment_momentum: number | null;
   analyst_consensus: string | null;
-  social_sentiment?: SocialSentiment;
 }
 
 export interface TradeCard {
   symbol: string;
   generated_at: string;
+  label: string;
+  setup: TradeCardSetup;
+  why: TradeCardWhy;
+  key_stats: TradeCardKeyStats;
+}
+
+/** Client-side trade card shape (TradeCard minus generated_at). */
+export interface TradeCardData {
+  symbol: string;
   label: string;
   setup: TradeCardSetup;
   why: TradeCardWhy;


### PR DESCRIPTION
…of truth in types.ts and filter-engine.ts

- Rename stale TradeCardData → LegacyTradeCardData (used by pipeline.ts StrategySuggestion)
- Add new TradeCardData (symbol, label, setup, why, key_stats) to types.ts
- Remove social_sentiment from TradeCardKeyStats (never populated by buildKeyStats)
- Remove 4 duplicate interface blocks from filter-engine.ts, ConvergenceIntelligence.tsx, ScannerResultsTable.tsx — all now import from types.ts
- TickerDetail remains canonical export in filter-engine.ts

Net: -214 lines, 5 interfaces now have exactly 1 definition each.

https://claude.ai/code/session_012a3eCqbi2o6DEhAzNwzwUm