### PR TITLE
feat: add realized volatility cone to trade cards — HV10/20/30/60 vs …

### DIFF
--- a/src/components/convergence/ConvergenceIntelligence.tsx
+++ b/src/components/convergence/ConvergenceIntelligence.tsx
@@ -653,6 +653,48 @@ function TickerCard({ detail, sentiment, savedCards, savingCards, saveErrors, on
                 )}
               </span>
             </div>
+            {/* Vol Cone row */}
+            {(() => {
+              const cone = ks.vol_cone;
+              if (!cone) return null;
+              const hvEntries = [
+                { label: 'HV10', val: cone.hv10 },
+                { label: 'HV20', val: cone.hv20 },
+                { label: 'HV30', val: cone.hv30 },
+                { label: 'HV60', val: cone.hv60 },
+              ].filter(x => x.val != null);
+              if (hvEntries.length === 0) return null;
+              return (
+                <div>
+                  <span
+                    className="text-text-muted font-medium"
+                    title="Realized volatility at multiple lookback windows vs current implied vol. Close-to-close log returns annualized ×√252. Shows whether current IV is high or low relative to how much the stock has actually moved at different time horizons."
+                  >
+                    Vol Cone:{' '}
+                  </span>
+                  <span className="text-text-secondary font-mono">
+                    {hvEntries.map((x, i, arr) => (
+                      <span key={x.label}>
+                        <span className="text-text-muted text-[9px]">{x.label}{' '}</span>
+                        <span className={
+                          cone.current_iv != null && x.val! > cone.current_iv
+                            ? 'text-brand-green'
+                            : cone.current_iv != null && x.val! < cone.current_iv * 0.8
+                            ? 'text-brand-red'
+                            : 'text-text-secondary'
+                        }>
+                          {x.val}%
+                        </span>
+                        {i < arr.length - 1 && <span className="text-text-muted"> | </span>}
+                      </span>
+                    ))}
+                    {cone.current_iv != null && (
+                      <span className="text-text-muted"> vs IV {cone.current_iv}%</span>
+                    )}
+                  </span>
+                </div>
+              );
+            })()}
             {/* Company row */}
             <div>
               <span className="text-text-muted font-medium">Company: </span>

--- a/src/lib/convergence/trade-cards.ts
+++ b/src/lib/convergence/trade-cards.ts
@@ -3,7 +3,9 @@
 
 import type { FullScoringResult } from './composite';
 import type {
+  CandleData,
   ConvergenceInput,
+  RealizedVolCone,
   TradeCard,
   TradeCardSetup,
   TradeCardWhy,
@@ -245,6 +247,43 @@ function analystConsensusLabel(scoring: FullScoringResult): string | null {
   return 'Hold';
 }
 
+// ===== REALIZED VOLATILITY CONE =====
+
+function computeVolCone(candles: CandleData[], currentIv: number | null): RealizedVolCone {
+  if (!candles || candles.length < 11) {
+    return {
+      hv10: null, hv20: null, hv30: null, hv60: null,
+      current_iv: currentIv,
+      candles_used: candles?.length ?? 0,
+      note: 'Insufficient candle data',
+    };
+  }
+
+  function computeHV(windowDays: number): number | null {
+    if (candles.length < windowDays + 1) return null;
+    const slice = candles.slice(candles.length - windowDays - 1);
+    const logReturns: number[] = [];
+    for (let i = 1; i < slice.length; i++) {
+      if (slice[i - 1].close <= 0 || slice[i].close <= 0) continue;
+      logReturns.push(Math.log(slice[i].close / slice[i - 1].close));
+    }
+    if (logReturns.length < windowDays * 0.8) return null;
+    const mean = logReturns.reduce((a, b) => a + b, 0) / logReturns.length;
+    const variance = logReturns.reduce((s, r) => s + Math.pow(r - mean, 2), 0) / (logReturns.length - 1);
+    return Math.round(Math.sqrt(variance) * Math.sqrt(252) * 100 * 10) / 10;
+  }
+
+  return {
+    hv10: computeHV(10),
+    hv20: computeHV(20),
+    hv30: computeHV(30),
+    hv60: computeHV(60),
+    current_iv: currentIv != null ? Math.round(currentIv * 10) / 10 : null,
+    candles_used: candles.length,
+    note: 'Close-to-close log returns, annualized ×√252',
+  };
+}
+
 // ===== KEY STATS BUILDER =====
 
 function buildKeyStats(input: ConvergenceInput, scoring: FullScoringResult): TradeCardKeyStats {
@@ -261,6 +300,7 @@ function buildKeyStats(input: ConvergenceInput, scoring: FullScoringResult): Tra
     iv30: tt?.iv30 ?? null,
     hv30: tt?.hv30 ?? null,
     iv_hv_spread: tt?.ivHvSpread ?? null,
+    vol_cone: computeVolCone(input.candles, tt?.iv30 ?? null),
     earnings_date: tt?.earningsDate ?? null,
     days_to_earnings: tt?.daysTillEarnings ?? null,
     market_cap: tt?.marketCap ?? null,

--- a/src/lib/convergence/types.ts
+++ b/src/lib/convergence/types.ts
@@ -1090,6 +1090,16 @@ export interface SocialSentiment {
   dataAge: string;        // ISO timestamp
 }
 
+export interface RealizedVolCone {
+  hv10: number | null;
+  hv20: number | null;
+  hv30: number | null;
+  hv60: number | null;
+  current_iv: number | null;
+  candles_used: number;
+  note: string;
+}
+
 export interface TradeCardKeyStats {
   current_price: number | null;
   iv_rank: number | null;
@@ -1097,6 +1107,7 @@ export interface TradeCardKeyStats {
   iv30: number | null;
   hv30: number | null;
   iv_hv_spread: number | null;
+  vol_cone: RealizedVolCone | null;
   earnings_date: string | null;
   days_to_earnings: number | null;
   market_cap: number | null;


### PR DESCRIPTION
…current IV

- New RealizedVolCone interface in types.ts with hv10/hv20/hv30/hv60
- computeVolCone() in trade-cards.ts: close-to-close log returns, annualized ×√252
- 80% data quality threshold per window (rejects sparse candle data)
- Vol Cone row in Key Stats section E with color coding: green = HV > IV (options cheap), red = HV < 80% IV (options expensive)
- Fetches 120 days of TT candles → supports HV60 with margin

https://claude.ai/code/session_012a3eCqbi2o6DEhAzNwzwUm