### PR TITLE
feat: add forward implied volatility to trade cards — strips near-ter…

### DIFF
--- a/src/components/convergence/ConvergenceIntelligence.tsx
+++ b/src/components/convergence/ConvergenceIntelligence.tsx
@@ -695,6 +695,40 @@ function TickerCard({ detail, sentiment, savedCards, savingCards, saveErrors, on
                 </div>
               );
             })()}
+            {/* Forward Vol row */}
+            {ks.forward_vol && (
+              <div>
+                <span
+                  className="text-text-muted font-medium"
+                  title="Forward implied volatility: what the options market is pricing for volatility BETWEEN two expiration dates, stripping out near-term event risk already priced in. Computed as σ_fwd=√[(σ²_far×T_far−σ²_near×T_near)÷(T_far−T_near)]. Negative forward variance (calendar arbitrage) is suppressed."
+                >
+                  Fwd Vol:{' '}
+                </span>
+                <span className="text-text-secondary font-mono">
+                  <span
+                    className={
+                      ks.vol_cone?.current_iv != null
+                        ? ks.forward_vol.forward_iv > ks.vol_cone.current_iv * 1.1
+                          ? 'text-brand-red'
+                          : ks.forward_vol.forward_iv < ks.vol_cone.current_iv * 0.9
+                          ? 'text-brand-green'
+                          : 'text-text-secondary'
+                        : 'text-text-secondary'
+                    }
+                  >
+                    {ks.forward_vol.forward_iv}%
+                  </span>
+                  <span className="text-text-muted">
+                    {' '}({ks.forward_vol.from_dte}→{ks.forward_vol.to_dte}d)
+                  </span>
+                  {ks.vol_cone?.current_iv != null && (
+                    <span className="text-text-muted">
+                      {' '}vs spot IV {ks.vol_cone.current_iv}%
+                    </span>
+                  )}
+                </span>
+              </div>
+            )}
             {/* Company row */}
             <div>
               <span className="text-text-muted font-medium">Company: </span>

--- a/src/lib/convergence/trade-cards.ts
+++ b/src/lib/convergence/trade-cards.ts
@@ -5,6 +5,7 @@ import type { FullScoringResult } from './composite';
 import type {
   CandleData,
   ConvergenceInput,
+  ForwardVolPoint,
   RealizedVolCone,
   TradeCard,
   TradeCardSetup,
@@ -247,6 +248,46 @@ function analystConsensusLabel(scoring: FullScoringResult): string | null {
   return 'Hold';
 }
 
+// ===== FORWARD IMPLIED VOLATILITY =====
+
+function computeForwardVol(termStructure: { date: string; iv: number }[]): ForwardVolPoint | null {
+  if (!termStructure || termStructure.length < 2) return null;
+
+  const sorted = [...termStructure].sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
+  const today = new Date();
+  const withDte = sorted
+    .map(p => ({ ...p, dte: Math.round((new Date(p.date).getTime() - today.getTime()) / (1000 * 60 * 60 * 24)) }))
+    .filter(p => p.dte > 0 && p.iv > 0);
+
+  const nearTerm = withDte.find(p => p.dte >= 20 && p.dte <= 60);
+  const farTerm = withDte.find(p =>
+    nearTerm ? p.dte >= nearTerm.dte + 20 && p.dte <= 120 : p.dte >= 45 && p.dte <= 120,
+  );
+
+  if (!nearTerm || !farTerm) return null;
+  if (nearTerm.iv <= 0 || farTerm.iv <= 0) return null;
+
+  // Forward vol: σ_fwd = √[(σ²_far × T_far − σ²_near × T_near) / (T_far − T_near)]
+  const tNear = nearTerm.dte / 365;
+  const tFar = farTerm.dte / 365;
+  const varFar = Math.pow(farTerm.iv / 100, 2) * tFar;
+  const varNear = Math.pow(nearTerm.iv / 100, 2) * tNear;
+  const varForward = varFar - varNear;
+
+  // Negative forward variance = calendar arbitrage in data, skip
+  if (varForward <= 0) return null;
+
+  const forwardIv = Math.sqrt(varForward / (tFar - tNear)) * 100;
+  return {
+    from_expiry: nearTerm.date,
+    to_expiry: farTerm.date,
+    from_dte: nearTerm.dte,
+    to_dte: farTerm.dte,
+    forward_iv: Math.round(forwardIv * 10) / 10,
+    note: 'σ_fwd=√[(σ²_far×T_far−σ²_near×T_near)÷(T_far−T_near)]',
+  };
+}
+
 // ===== REALIZED VOLATILITY CONE =====
 
 function computeVolCone(candles: CandleData[], currentIv: number | null): RealizedVolCone {
@@ -301,6 +342,7 @@ function buildKeyStats(input: ConvergenceInput, scoring: FullScoringResult): Tra
     hv30: tt?.hv30 ?? null,
     iv_hv_spread: tt?.ivHvSpread ?? null,
     vol_cone: computeVolCone(input.candles, tt?.iv30 ?? null),
+    forward_vol: computeForwardVol(input.ttScanner?.termStructure ?? []),
     earnings_date: tt?.earningsDate ?? null,
     days_to_earnings: tt?.daysTillEarnings ?? null,
     market_cap: tt?.marketCap ?? null,

--- a/src/lib/convergence/types.ts
+++ b/src/lib/convergence/types.ts
@@ -1090,6 +1090,15 @@ export interface SocialSentiment {
   dataAge: string;        // ISO timestamp
 }
 
+export interface ForwardVolPoint {
+  from_expiry: string;
+  to_expiry: string;
+  from_dte: number;
+  to_dte: number;
+  forward_iv: number;
+  note: string;
+}
+
 export interface RealizedVolCone {
   hv10: number | null;
   hv20: number | null;
@@ -1108,6 +1117,7 @@ export interface TradeCardKeyStats {
   hv30: number | null;
   iv_hv_spread: number | null;
   vol_cone: RealizedVolCone | null;
+  forward_vol: ForwardVolPoint | null;
   earnings_date: string | null;
   days_to_earnings: number | null;
   market_cap: number | null;


### PR DESCRIPTION
…m event premium from term structure

- New ForwardVolPoint interface in types.ts
- computeForwardVol() in trade-cards.ts: picks near (20-60 DTE) and far (near+20 to 120 DTE) expirations from TT term structure, applies σ_fwd=√[(σ²_far×T_far−σ²_near×T_near)÷(T_far−T_near)]
- Guards: null on <2 term structure points, null on negative forward variance (calendar arb)
- Fwd Vol row in Key Stats section E with color vs spot IV

https://claude.ai/code/session_012a3eCqbi2o6DEhAzNwzwUm