### PR TITLE
fix: pipeline flow panel — Step D crash, Step B survivors null check,…

### DIFF
--- a/src/components/convergence/ConvergenceIntelligence.tsx
+++ b/src/components/convergence/ConvergenceIntelligence.tsx
@@ -924,8 +924,10 @@ function PipelineFlowPanel({ result, progress, universe }: { result: any; progre
             <span className="text-brand-purple font-bold">STEP A</span>
             <span className="text-text-secondary">TT Scanner</span>
             {(ps?.total_universe ?? progress?.a?.data?.total_universe) ? (
-              <span className="text-brand-green">{ps?.total_universe ?? progress?.a?.data?.total_universe ?? 0} symbols fetched</span>
-              <span className="text-text-muted">({universe})</span>
+              <>
+                <span className="text-brand-green">{ps?.total_universe ?? progress?.a?.data?.total_universe ?? 0} symbols fetched</span>
+                <span className="text-text-muted">({universe})</span>
+              </>
             ) : (
               <span className="text-text-muted animate-pulse">waiting...</span>
             )}


### PR DESCRIPTION
… Step A universe label, add Step C

- FIX 1: Step D no longer reads hf?.output_count directly; uses bData?.output
- FIX 2: Step B survivors shows "none yet" when null/empty
- FIX 3: Step A header shows universe name via new prop
- FIX 4: Add Step C (Peer Grouping) between Step B and Step D

https://claude.ai/code/session_01JnmQs9ZbzeVHRNiBigkKFi