### PR TITLE
feat: pipeline flow — add Step A2, Step C peer table, Step F regime w…

### DIFF
--- a/src/components/convergence/ConvergenceIntelligence.tsx
+++ b/src/components/convergence/ConvergenceIntelligence.tsx
@@ -969,6 +969,50 @@ function PipelineFlowPanel({ result, progress, universe }: { result: any; progre
         )}
       </div>
 
+      {/* Step A2 */}
+      <div className="border-b border-border">
+        <div className="px-4 py-2 flex items-center justify-between cursor-pointer hover:bg-bg-row" onClick={() => toggle('a2')}>
+          <div className="flex items-center gap-3">
+            <span className="text-brand-purple font-bold">STEP A2</span>
+            <span className="text-text-secondary">Pre-Filter</span>
+            {progress?.a2 ? (
+              <span className="text-brand-red">
+                {progress.a2.data.input} → {progress.a2.data.output} survived
+                {(progress.a2.data.excluded as number) > 0 && ` (${progress.a2.data.excluded} excluded)`}
+              </span>
+            ) : (
+              <span className="text-text-muted animate-pulse">waiting...</span>
+            )}
+          </div>
+          <span className="text-text-muted">{expanded['a2'] ? '▲' : '▼'}</span>
+        </div>
+        {expanded['a2'] && progress?.a2 && (
+          <div className="px-8 py-2 border-t border-border bg-bg-row space-y-2">
+            <div className="text-text-muted">Formula: Pre-Score = (IV Rank × 60%) + (Liquidity × 40%). Tickers scoring below liquidity threshold are excluded before expensive data fetching begins.</div>
+            <div style={{ maxHeight: 200, overflowY: 'auto' }}>
+              <table className="w-full text-[10px]">
+                <thead><tr className="text-text-muted border-b border-border">
+                  <th className="text-right py-1 px-1">#</th><th className="text-left py-1 px-1">SYMBOL</th><th className="text-right py-1 px-1">PRE-SCORE</th><th className="text-right py-1 px-1">IV RANK</th><th className="text-right py-1 px-1">LIQUIDITY</th><th className="text-left py-1 px-1">WHAT HAPPENED</th>
+                </tr></thead>
+                <tbody>
+                  {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+                  {(progress.a2.data.tickers as any[] ?? []).map((t: any, i: number) => (
+                    <tr key={t.symbol} className="border-b border-border/50">
+                      <td className="py-0.5 px-1 text-right text-text-muted">{i + 1}</td>
+                      <td className="py-0.5 px-1 font-bold text-text-primary">{t.symbol}</td>
+                      <td className="py-0.5 px-1 text-right">{t.pre_score}</td>
+                      <td className="py-0.5 px-1 text-right">{t.iv_rank ?? '—'}</td>
+                      <td className="py-0.5 px-1 text-right">{t.liquidity ?? '—'}/5</td>
+                      <td className={`py-0.5 px-1 ${t.excluded ? 'text-brand-red' : 'text-brand-green'}`}>{t.reason}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        )}
+      </div>
+
       {/* Step B */}
       <div className="border-b border-border">
         <div className="px-4 py-2 flex items-center justify-between cursor-pointer hover:bg-bg-row" onClick={() => toggle('b')}>
@@ -1045,8 +1089,29 @@ function PipelineFlowPanel({ result, progress, universe }: { result: any; progre
           <span className="text-text-muted">{expanded['c'] ? '▲' : '▼'}</span>
         </div>
         {expanded['c'] && (
-          <div className="px-8 py-2 border-t border-border bg-bg-row text-text-muted">
-            Finnhub /stock/peers called for each survivor. Symbols grouped by industry peers for relative scoring in Step F.
+          <div className="px-8 py-2 border-t border-border bg-bg-row space-y-2">
+            <div className="text-text-muted">Each stock is compared against similar companies — not the whole market. If AAPL&apos;s IV is high, we check: is it high vs other Tech stocks? This prevents sector bias in scoring.</div>
+            {progress?.c && (
+              <div style={{ maxHeight: 200, overflowY: 'auto' }}>
+                <table className="w-full text-[10px]">
+                  <thead><tr className="text-text-muted border-b border-border">
+                    <th className="text-right py-1 px-1">#</th><th className="text-left py-1 px-1">SYMBOL</th><th className="text-left py-1 px-1">PEER GROUP</th><th className="text-right py-1 px-1">PEERS</th><th className="text-left py-1 px-1">GROUP TYPE</th>
+                  </tr></thead>
+                  <tbody>
+                    {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+                    {(progress.c.data.groups as any[] ?? []).map((g: any, i: number) => (
+                      <tr key={g.symbol} className="border-b border-border/50">
+                        <td className="py-0.5 px-1 text-right text-text-muted">{i + 1}</td>
+                        <td className="py-0.5 px-1 font-bold text-text-primary">{g.symbol}</td>
+                        <td className="py-0.5 px-1 text-text-secondary">{g.peer_group}</td>
+                        <td className="py-0.5 px-1 text-right">{g.peer_count}</td>
+                        <td className="py-0.5 px-1 text-text-muted">{g.group_type}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
           </div>
         )}
       </div>
@@ -1146,7 +1211,13 @@ function PipelineFlowPanel({ result, progress, universe }: { result: any; progre
           <span className="text-text-muted">{expanded['f'] ? '▲' : '▼'}</span>
         </div>
         {expanded['f'] && (
-          <div className="px-8 py-2 border-t border-border bg-bg-row">
+          <div className="px-8 py-2 border-t border-border bg-bg-row space-y-2">
+            {progress?.f?.data?.weights && (
+              <div className="p-2 bg-bg-card rounded text-[10px]">
+                <span className="text-text-muted">Weights used (regime: <span className="text-brand-gold">{progress.f.data.regime as string}</span>): </span>
+                Vol Edge {(progress.f.data.weights as any).vol_edge}% · Quality {(progress.f.data.weights as any).quality}% · Regime {(progress.f.data.weights as any).regime}% · Info Edge {(progress.f.data.weights as any).info_edge}%
+              </div>
+            )}
             <div style={{ maxHeight: 200, overflowY: 'auto' }}>
               <table className="w-full text-[10px]">
                 <thead><tr className="text-text-muted border-b border-border">

--- a/src/lib/convergence/pipeline.ts
+++ b/src/lib/convergence/pipeline.ts
@@ -423,6 +423,23 @@ export async function runPipeline(
   );
   const preFilteredScannerData = allScannerData.filter(t => preFilterCandidates.has(t.symbol));
   console.log(`[Pipeline] Step A2: Narrowed ${allScannerData.length} → ${preFilteredScannerData.length} by preScore (top ${preFilterTopN})`);
+  onProgress?.({ step: 'a2', label: 'Pre-Filter', data: {
+    input: allScannerData.length,
+    output: preFilterIncluded.length,
+    excluded: preFilterExcluded.length,
+    tickers: preFilterResults.map(r => ({
+      symbol: r.symbol,
+      pre_score: Math.round(r.preScore * 100),
+      iv_rank: r.ivRank,
+      liquidity: r.liquidityRating,
+      excluded: r.excluded,
+      reason: r.excluded
+        ? 'Liquidity < 2/5 — insufficient options activity'
+        : r.earningsWarning
+        ? `Warning: ${r.earningsWarning}`
+        : 'Passed — moved to hard filters',
+    })),
+  } });
 
   // ===== STEP B: Hard Filters =====
   console.log('[Pipeline] Step B: Applying hard filters...');
@@ -465,6 +482,17 @@ export async function runPipeline(
     survivors, undefined, finnhubPeersMap, scannerMap,
   );
   let textPeerGroups: Record<string, TextBasedPeerGroup> = {};
+  onProgress?.({ step: 'c', label: 'Peer Grouping', data: {
+    groups: survivors.map(s => {
+      const ps = peerStats[s.symbol];
+      return {
+        symbol: s.symbol,
+        peer_group: ps?.peer_group_name ?? 'Unknown',
+        peer_count: ps?.ticker_count ?? 0,
+        group_type: ps?.peer_group_type ?? 'unknown',
+      };
+    }),
+  } });
 
   // ===== STEP D: Pre-Score and Limit =====
   console.log('[Pipeline] Step D: Pre-scoring and limiting...');
@@ -803,7 +831,19 @@ export async function runPipeline(
 
   // Build ranked rows
   const rankedRows = buildRankedRows(scoredTickers);
-  onProgress?.({ step: 'f', label: '4-Gate Scoring', data: { scored: scoredTickers.length, rankings: rankedRows.map(r => ({ symbol: r.symbol, composite: r.composite, vol_edge: r.vol_edge, quality: r.quality, regime: r.regime, info_edge: r.info_edge })) } });
+  const _gwt = scoredTickers[0]?.scoring?.composite?.gate_weight_trace;
+  const _gw = _gwt?.gate_weights;
+  onProgress?.({ step: 'f', label: '4-Gate Scoring', data: {
+    scored: scoredTickers.length,
+    regime: _gwt?.regime_used ?? 'UNKNOWN',
+    weights: {
+      vol_edge: Math.round((_gw?.vol_edge ?? 0.25) * 100),
+      quality: Math.round((_gw?.quality ?? 0.25) * 100),
+      regime: Math.round((_gw?.regime ?? 0.25) * 100),
+      info_edge: Math.round((_gw?.info_edge ?? 0.25) * 100),
+    },
+    rankings: rankedRows.map(r => ({ symbol: r.symbol, composite: r.composite, vol_edge: r.vol_edge, quality: r.quality, regime: r.regime, info_edge: r.info_edge, selection_status: r.composite >= 50 ? 'eligible' : 'below_threshold' })),
+  } });
 
   // ===== STEP G: Rank and Diversify =====
   console.log('[Pipeline] Step G: Ranking and diversifying...');


### PR DESCRIPTION
…eights display

- pipeline.ts: Add Step A2 onProgress with pre-filter results (pre_score, iv_rank, liquidity, excluded, reason)
- pipeline.ts: Add Step C onProgress with peer grouping data (peer_group, peer_count, group_type)
- pipeline.ts: Update Step F onProgress with regime-dependent gate weights and selection_status
- UI: Add Step A2 section between Step A and Step B with scrollable pre-filter table
- UI: Update Step C expanded section with peer grouping table
- UI: Add regime weights display at top of Step F expanded section

https://claude.ai/code/session_01JnmQs9ZbzeVHRNiBigkKFi