### PR TITLE
feat: replace universe dropdown with 9 standard indices — S&P 500, Na…

### DIFF
--- a/src/components/convergence/ConvergenceIntelligence.tsx
+++ b/src/components/convergence/ConvergenceIntelligence.tsx
@@ -1390,7 +1390,7 @@ function FilteredResultsSection({
 
 export default function ConvergenceIntelligence() {
   // Batch scan state
-  const [universe, setUniverse] = useState('popular');
+  const [universe, setUniverse] = useState('sp500');
   const [scanning, setScanning] = useState(false);
   const [batchData, setBatchData] = useState<BatchResponse | null>(null);
   const [batchError, setBatchError] = useState<string | null>(null);
@@ -1652,23 +1652,15 @@ export default function ConvergenceIntelligence() {
               disabled={scanning || enriching}
               className="bg-brand-purple-deep text-white text-xs font-mono px-2 py-1 border border-white/10 rounded focus:outline-none focus:ring-1 focus:ring-brand-gold disabled:opacity-50"
             >
-              <optgroup label="Indices">
-                <option value="popular">Popular (50)</option>
-                <option value="megacap">Mega Cap (30)</option>
-                <option value="nasdaq100">Nasdaq 100</option>
-                <option value="dow30">Dow Jones (30)</option>
-                <option value="sp500">S&amp;P 500</option>
-              </optgroup>
-              <optgroup label="ETFs">
-                <option value="etfs">ETFs (25)</option>
-              </optgroup>
-              <optgroup label="Sectors">
-                <option value="tech">Tech</option>
-                <option value="finance">Finance</option>
-                <option value="energy">Energy</option>
-                <option value="healthcare">Healthcare</option>
-                <option value="retail">Retail Favorites</option>
-              </optgroup>
+              <option value="sp500">S&amp;P 500</option>
+              <option value="nasdaq100">Nasdaq 100</option>
+              <option value="russell2000">Russell 2000</option>
+              <option value="sp400">S&amp;P 400 MidCap</option>
+              <option value="dow30">Dow Jones (30)</option>
+              <option value="sp600">S&amp;P 600 SmallCap</option>
+              <option value="wilshire5000">Wilshire 5000</option>
+              <option value="msciusa">MSCI USA</option>
+              <option value="russell1000">Russell 1000</option>
             </select>
             <button
               onClick={scanMarket}

--- a/src/lib/convergence/pipeline.ts
+++ b/src/lib/convergence/pipeline.ts
@@ -124,53 +124,6 @@ export interface PipelineResult {
 
 // ===== SYMBOL UNIVERSE (same lists as scanner/route.ts) =====
 
-const POPULAR_SYMBOLS = [
-  'SPY','QQQ','IWM','AAPL','MSFT','GOOGL','AMZN','TSLA','NVDA','META',
-  'AMD','NFLX','JPM','BAC','GS','XOM','CVX','PFE','JNJ','UNH',
-  'DIS','BA','COST','HD','LOW','CRM','ORCL','ADBE','INTC','MU',
-  'COIN','MARA','SQ','SHOP','SNAP','PLTR','SOFI','RIVN','LCID','NIO',
-  'ARM','SMCI','AVGO','MRVL','PANW','CRWD','NET','DKNG','ABNB','UBER',
-];
-
-const MEGA_CAP = [
-  'AAPL','MSFT','NVDA','GOOGL','AMZN','META','TSLA','BRK.B','AVGO','LLY',
-  'JPM','V','WMT','MA','UNH','XOM','COST','HD','PG','JNJ',
-  'ORCL','BAC','NFLX','ABBV','CRM','AMD','CVX','MRK','KO','PEP',
-];
-
-const ETFS = [
-  'SPY','QQQ','IWM','DIA','XLF','XLE','XLK','XLV','XLI','XLP',
-  'XLU','XLB','XLRE','XLC','GDX','GDXJ','SLV','GLD','TLT','HYG',
-  'EEM','EFA','ARKK','VXX','KWEB',
-];
-
-const SECTOR_TECH = [
-  'AAPL','MSFT','NVDA','GOOGL','META','AMD','AVGO','CRM','ORCL','ADBE',
-  'INTC','MU','QCOM','TXN','AMAT','LRCX','KLAC','SNPS','CDNS','NOW',
-  'PANW','CRWD','NET','DDOG','ZS',
-];
-
-const SECTOR_FINANCE = [
-  'JPM','BAC','GS','MS','WFC','C','BLK','SCHW','AXP','USB',
-  'PNC','TFC','COF','ICE','CME','SPGI','MCO','MSCI','FIS','PYPL',
-  'SQ','COIN','SOFI','HOOD','AFRM',
-];
-
-const SECTOR_ENERGY = [
-  'XOM','CVX','COP','EOG','SLB','MPC','PSX','VLO','OXY','PXD',
-  'DVN','HES','FANG','HAL','BKR','KMI','WMB','OKE','TRGP','ET',
-];
-
-const SECTOR_HEALTHCARE = [
-  'UNH','JNJ','LLY','PFE','ABBV','MRK','TMO','ABT','DHR','BMY',
-  'AMGN','GILD','VRTX','REGN','ISRG','MDT','SYK','BDX','ZTS','CI',
-];
-
-const RETAIL_FAVORITES = [
-  'GME','AMC','PLTR','SOFI','RIVN','LCID','NIO','MARA','COIN','HOOD',
-  'BBBY','WISH','CLOV','BB','DKNG','RBLX','SNAP','PINS','ABNB','UBER',
-];
-
 const DOW_30 = [
   'AAPL','AMGN','AMZN','AXP','BA','CAT','CRM','CSCO','CVX','DIS',
   'GS','HD','HON','IBM','JNJ','JPM','KO','MCD','MMM','MRK',
@@ -242,11 +195,16 @@ const SP500 = [
   'XYZ','YUM','ZBH','ZBRA','ZTS',
 ];
 
+const RUSSELL_2000: string[] = []; // TODO: source from iShares IWM holdings
+const SP400: string[] = []; // TODO: source from iShares IJH holdings
+const SP600: string[] = []; // TODO: source from iShares IJR holdings
+const WILSHIRE_5000: string[] = []; // TODO: source from iShares ITOT holdings
+const MSCI_USA: string[] = []; // TODO: source from iShares ITOT holdings
+const RUSSELL_1000: string[] = []; // TODO: source from iShares IWB holdings
+
 function getAllSymbols(): string[] {
   return [...new Set([
-    ...POPULAR_SYMBOLS, ...MEGA_CAP, ...ETFS, ...SECTOR_TECH,
-    ...SECTOR_FINANCE, ...SECTOR_ENERGY, ...SECTOR_HEALTHCARE,
-    ...RETAIL_FAVORITES, ...DOW_30, ...NASDAQ_100, ...SP500,
+    ...SP500, ...NASDAQ_100, ...DOW_30,
   ])];
 }
 
@@ -337,18 +295,16 @@ function parseMarketMetrics(items: Record<string, unknown>[]): TTScannerData[] {
 
 function getUniverseSymbols(universe?: string): string[] {
   switch (universe) {
-    case 'popular': return [...POPULAR_SYMBOLS];
-    case 'megacap': return [...MEGA_CAP];
-    case 'nasdaq100': return [...NASDAQ_100];
-    case 'dow30': return [...DOW_30];
     case 'sp500': return [...SP500];
-    case 'etfs': return [...ETFS];
-    case 'tech': return [...SECTOR_TECH];
-    case 'finance': return [...SECTOR_FINANCE];
-    case 'energy': return [...SECTOR_ENERGY];
-    case 'healthcare': return [...SECTOR_HEALTHCARE];
-    case 'retail': return [...RETAIL_FAVORITES];
-    default: return getAllSymbols();
+    case 'nasdaq100': return [...NASDAQ_100];
+    case 'russell2000': return [...RUSSELL_2000];
+    case 'sp400': return [...SP400];
+    case 'dow30': return [...DOW_30];
+    case 'sp600': return [...SP600];
+    case 'wilshire5000': return [...WILSHIRE_5000];
+    case 'msciusa': return [...MSCI_USA];
+    case 'russell1000': return [...RUSSELL_1000];
+    default: return [...SP500];
   }
 }
 


### PR DESCRIPTION
…sdaq 100, Russell 2000, S&P 400, Dow 30, S&P 600, Wilshire 5000, MSCI USA, Russell 1000

- Remove POPULAR_SYMBOLS, MEGA_CAP, ETFS, SECTOR_TECH, SECTOR_FINANCE, SECTOR_ENERGY, SECTOR_HEALTHCARE, RETAIL_FAVORITES from pipeline.ts
- Add RUSSELL_2000, SP400, SP600, WILSHIRE_5000, MSCI_USA, RUSSELL_1000 as empty arrays with TODO comments
- Update getUniverseSymbols to map all 9 index values, default to SP500
- Update getAllSymbols to union SP500 + NASDAQ_100 + DOW_30
- Replace dropdown optgroups with flat list of 9 standard indices
- Change default universe from 'popular' to 'sp500'

https://claude.ai/code/session_01JnmQs9ZbzeVHRNiBigkKFi