### PR TITLE
Fix: always show images - cache photos, verify full pipeline, placeho…

### DIFF
--- a/prisma/migrations/20260324130000_add_photos_to_places_cache/migration.sql
+++ b/prisma/migrations/20260324130000_add_photos_to_places_cache/migration.sql
@@ -1,0 +1,2 @@
+-- Add photos column to places_cache for storing photo references
+ALTER TABLE "places_cache" ADD COLUMN IF NOT EXISTS "photos" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1055,6 +1055,7 @@ model places_cache {
   priceLevel      Int?
   website         String?
   types           String?  // JSON array as string
+  photos          String?  @db.Text  // JSON array of photo references
   city            String
   country         String
   category        String   // coworking, lodging, etc.

--- a/src/components/trips/TripPlannerAI.tsx
+++ b/src/components/trips/TripPlannerAI.tsx
@@ -1011,7 +1011,12 @@ export default function TripPlannerAI({ tripId, city, country, activity, activit
                     const showPanel = commitCardKey === cardKey;
                     return (
                       <div key={`${rec.category}-${idx}`} className={`border rounded overflow-hidden ${committed ? 'border-emerald-400 bg-emerald-50/30' : 'border-border'}`}>
-                        {rec.photoUrl && <img src={rec.photoUrl} alt={rec.name} className="w-full h-40 object-cover" />}
+                        {rec.photoUrl ? (
+                          <img src={rec.photoUrl} alt={rec.name} className="w-full h-40 object-cover" onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; (e.target as HTMLImageElement).nextElementSibling?.classList.remove('hidden'); }} />
+                        ) : null}
+                        <div className={`w-full h-40 bg-gradient-to-br from-purple-100 to-indigo-100 flex items-center justify-center ${rec.photoUrl ? 'hidden' : ''}`}>
+                          <span className="text-4xl">{info.icon}</span>
+                        </div>
                         <div className="p-3 space-y-2">
                           <div className="flex items-start justify-between gap-2">
                             <div className="min-w-0">

--- a/src/lib/placesCache.ts
+++ b/src/lib/placesCache.ts
@@ -10,6 +10,7 @@ export interface CachedPlace {
   priceLevelDisplay: string | null;
   website: string | null;
   types: string[];
+  photos?: string[];
   city: string;
   country: string;
   category: string;
@@ -19,31 +20,41 @@ export interface CachedPlace {
 
 // Check cache first, return cached places for this city/country/category
 export async function getCachedPlaces(
-  city: string, 
-  country: string, 
+  city: string,
+  country: string,
   category: string
 ): Promise<CachedPlace[]> {
   try {
+    const apiKey = process.env.GOOGLE_PLACES_API_KEY;
     const cached = await prisma.places_cache.findMany({
       where: { city, country, category }
     });
-    
-    return cached.map(p => ({
-      placeId: p.placeId,
-      name: p.name,
-      address: p.address,
-      rating: p.rating,
-      reviewCount: p.reviewCount,
-      priceLevel: p.priceLevel,
-      priceLevelDisplay: p.priceLevel != null ? '$'.repeat(p.priceLevel) : null,
-      website: p.website,
-      types: p.types ? JSON.parse(p.types) : [],
-      city: p.city,
-      country: p.country,
-      category: p.category,
-      latitude: p.latitude,
-      longitude: p.longitude,
-    }));
+
+    return cached.map(p => {
+      // Reconstruct signed photo URLs from stored references
+      const photoRefs: string[] = p.photos ? JSON.parse(p.photos) : [];
+      const photos = apiKey && photoRefs.length > 0
+        ? photoRefs.map(ref => `https://maps.googleapis.com/maps/api/place/photo?maxwidth=400&photo_reference=${ref}&key=${apiKey}`)
+        : [];
+
+      return {
+        placeId: p.placeId,
+        name: p.name,
+        address: p.address,
+        rating: p.rating,
+        reviewCount: p.reviewCount,
+        priceLevel: p.priceLevel,
+        priceLevelDisplay: p.priceLevel != null ? '$'.repeat(p.priceLevel) : null,
+        website: p.website,
+        types: p.types ? JSON.parse(p.types) : [],
+        photos,
+        city: p.city,
+        country: p.country,
+        category: p.category,
+        latitude: p.latitude,
+        longitude: p.longitude,
+      };
+    });
   } catch (err) {
     console.error('[Cache] Error reading places cache:', err);
     return [];
@@ -51,14 +62,34 @@ export async function getCachedPlaces(
 }
 
 // Save places to cache
+// Extract photo references from photo URLs or raw photo objects.
+// Photos from Google come as signed URLs like:
+// https://maps.googleapis.com/maps/api/place/photo?...&photo_reference=REF&key=KEY
+// We store just the references so we can reconstruct URLs with a fresh key.
+function extractPhotoRefs(photos: any[] | undefined): string {
+  if (!photos || photos.length === 0) return '[]';
+  const refs: string[] = [];
+  for (const photo of photos) {
+    if (typeof photo === 'string') {
+      // Extract photo_reference param from signed URL
+      const match = photo.match(/photo_reference=([^&]+)/);
+      if (match) refs.push(match[1]);
+    } else if (photo?.photo_reference) {
+      refs.push(photo.photo_reference);
+    }
+  }
+  return JSON.stringify(refs);
+}
+
 export async function cachePlaces(
-  places: any[], 
-  city: string, 
-  country: string, 
+  places: any[],
+  city: string,
+  country: string,
   category: string
 ): Promise<void> {
   try {
     for (const p of places) {
+      const photoRefs = extractPhotoRefs(p.photos);
       await prisma.places_cache.upsert({
         where: { placeId: p.placeId },
         update: {
@@ -69,6 +100,7 @@ export async function cachePlaces(
           priceLevel: p.priceLevel,
           website: p.website || '',
           types: JSON.stringify(p.types || []),
+          photos: photoRefs,
           city,
           country,
           category,
@@ -85,6 +117,7 @@ export async function cachePlaces(
           priceLevel: p.priceLevel,
           website: p.website || '',
           types: JSON.stringify(p.types || []),
+          photos: photoRefs,
           city,
           country,
           category,
@@ -101,8 +134,8 @@ export async function cachePlaces(
 
 // Check if cache is fresh (less than 30 days old)
 export async function isCacheFresh(
-  city: string, 
-  country: string, 
+  city: string,
+  country: string,
   category: string,
   maxAgeDays: number = 30
 ): Promise<boolean> {
@@ -110,14 +143,18 @@ export async function isCacheFresh(
     const oldest = await prisma.places_cache.findFirst({
       where: { city, country, category },
       orderBy: { cachedAt: 'asc' },
-      select: { cachedAt: true }
+      select: { cachedAt: true, photos: true }
     });
-    
+
     if (!oldest) return false;
-    
+
+    // If cached entries have no photos stored, treat as stale to force re-fetch
+    // This ensures a one-time backfill of photos for pre-existing cache entries
+    if (!oldest.photos || oldest.photos === '[]') return false;
+
     const ageMs = Date.now() - oldest.cachedAt.getTime();
     const ageDays = ageMs / (1000 * 60 * 60 * 24);
-    
+
     return ageDays < maxAgeDays;
   } catch {
     return false;


### PR DESCRIPTION
…lder fallback

Root cause: places_cache stored no photo data. Cache hits returned places without photos, so photoUrl was undefined through the entire pipeline.

Fixes:
- Add photos column to places_cache (TEXT, stores JSON array of photo refs)
- cachePlaces() extracts photo_reference from signed Google URLs and stores just the references (refs don't expire, signed URLs do)
- getCachedPlaces() reconstructs signed URLs from stored refs at read time
- isCacheFresh() treats entries with no photos as stale, forcing a one-time re-fetch from Google to backfill photos for existing cache entries
- Card grid: show placeholder (gradient bg + category icon) when photoUrl is missing, with onError fallback if a photo URL fails to load

https://claude.ai/code/session_01GHNnihseAHoZFcnRMWjQMu