### PR TITLE
Rework trip creation: onboarding flow + simplified dates + price leve…

### DIFF
--- a/src/app/api/trips/[id]/ai-assistant/route.ts
+++ b/src/app/api/trips/[id]/ai-assistant/route.ts
@@ -2,7 +2,7 @@ import { requireTier } from '@/lib/auth-helpers';
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { analyzeWithLiveSearch } from '@/lib/grokAgent';
-import { searchPlaces, searchPlacesMultiQuery, CATEGORY_SEARCHES } from '@/lib/placesSearch';
+import { searchPlaces, searchPlacesMultiQuery, CATEGORY_SEARCHES, formatPriceLevel } from '@/lib/placesSearch';
 import { getCachedPlaces, cachePlaces, isCacheFresh } from '@/lib/placesCache';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { ACTIVITY_SEARCH_EXPANSIONS, ACTIVITY_LABELS } from '@/lib/activities';
@@ -98,6 +98,7 @@ export async function POST(
       daysTravel,
       minRating = 4.0,
       minReviews = 50,
+      maxPriceLevel,
       category,
       profile
     } = body;
@@ -220,7 +221,12 @@ export async function POST(
       console.log(`[Grok AI] ${category}: Cached ${enriched.length} places`);
     }
 
-    const filtered = enriched.filter(p => p.rating >= minRating && p.reviewCount >= minReviews);
+    let filtered = enriched.filter(p => p.rating >= minRating && p.reviewCount >= minReviews);
+
+    // Apply price level filter — places without price data pass through (not excluded)
+    if (maxPriceLevel) {
+      filtered = filtered.filter(p => !p.priceLevel || p.priceLevel <= maxPriceLevel);
+    }
 
     const placesToAnalyze = filtered.slice(0, 20).map(p => ({
       name: p.name,
@@ -229,6 +235,8 @@ export async function POST(
       reviewCount: p.reviewCount,
       website: p.website || undefined,
       photoUrl: p.photos?.[0] || undefined,
+      priceLevel: p.priceLevel ?? null,
+      priceLevelDisplay: p.priceLevelDisplay || formatPriceLevel(p.priceLevel) || null,
       category
     }));
 

--- a/src/app/api/trips/[id]/route.ts
+++ b/src/app/api/trips/[id]/route.ts
@@ -180,11 +180,28 @@ export async function PATCH(
     }
 
     const body = await request.json();
-    const { destination } = body;
+    const { destination, startDate, endDate } = body;
+
+    const updateData: Record<string, any> = {};
+    if (destination !== undefined) updateData.destination = destination;
+    if (startDate !== undefined) {
+      updateData.startDate = startDate ? new Date(startDate + 'T12:00:00') : null;
+    }
+    if (endDate !== undefined) {
+      updateData.endDate = endDate ? new Date(endDate + 'T12:00:00') : null;
+    }
+    // Recalculate duration if both dates provided
+    if (startDate && endDate) {
+      const s = new Date(startDate + 'T12:00:00');
+      const e = new Date(endDate + 'T12:00:00');
+      updateData.daysTravel = Math.round((e.getTime() - s.getTime()) / 86400000) + 1;
+      updateData.month = s.getMonth() + 1;
+      updateData.year = s.getFullYear();
+    }
 
     const updatedTrip = await prisma.trips.update({
       where: { id },
-      data: { destination }
+      data: updateData
     });
 
     return NextResponse.json({ trip: updatedTrip });

--- a/src/app/api/trips/route.ts
+++ b/src/app/api/trips/route.ts
@@ -71,20 +71,39 @@ export async function POST(request: NextRequest) {
     }
 
     const body = await request.json();
-    const { 
-      name, 
-      destination, 
+    const {
+      name,
+      destination,
       activity,      // backward compat: single activity (deprecated)
       activities,    // NEW: array of activities
-      month, 
-      year, 
-      daysTravel, 
-      daysRiding, 
-      startDate 
+      month,
+      year,
+      daysTravel,
+      daysRiding,
+      startDate,
+      endDate,
+      tripType,
     } = body;
 
+    // Calculate duration and month/year from dates if provided
+    let computedMonth = month;
+    let computedYear = year;
+    let computedDaysTravel = daysTravel;
+
+    if (startDate) {
+      const start = new Date(startDate + 'T12:00:00');
+      computedMonth = computedMonth || (start.getMonth() + 1);
+      computedYear = computedYear || start.getFullYear();
+
+      if (endDate) {
+        const end = new Date(endDate + 'T12:00:00');
+        const diffMs = end.getTime() - start.getTime();
+        computedDaysTravel = Math.round(diffMs / 86400000) + 1;
+      }
+    }
+
     // Validate required fields
-    if (!name || !month || !year || !daysTravel) {
+    if (!name || !computedMonth || !computedYear || !computedDaysTravel) {
       return NextResponse.json({ error: 'Missing required fields' }, { status: 400 });
     }
 
@@ -96,6 +115,9 @@ export async function POST(request: NextRequest) {
     const tripInviteToken = randomBytes(16).toString('hex');
 
     // Create trip with owner as first participant
+    const parsedDays = typeof computedDaysTravel === 'number' ? computedDaysTravel : parseInt(computedDaysTravel);
+    const tripTypeValue = tripType === 'business' ? 'business' : tripType === 'mixed' ? 'mixed' : 'personal';
+
     const trip = await prisma.trips.create({
       data: {
         userId: user.id,
@@ -103,11 +125,13 @@ export async function POST(request: NextRequest) {
         destination: destination || null,
         activity: primaryActivity,            // backward compat: store primary activity
         activities: activityArray,            // NEW: store full array
-        month: parseInt(month),
-        year: parseInt(year),
-        daysTravel: parseInt(daysTravel),
-        daysRiding: daysRiding ? parseInt(daysRiding) : parseInt(daysTravel), // default to daysTravel
+        month: typeof computedMonth === 'number' ? computedMonth : parseInt(computedMonth),
+        year: typeof computedYear === 'number' ? computedYear : parseInt(computedYear),
+        daysTravel: parsedDays,
+        daysRiding: daysRiding ? parseInt(daysRiding) : parsedDays,
         startDate: startDate ? new Date(startDate + 'T12:00:00') : null,
+        endDate: endDate ? new Date(endDate + 'T12:00:00') : null,
+        tripType: tripTypeValue as any,
         inviteToken: tripInviteToken,
         participants: {
           create: {

--- a/src/app/budgets/trips/[id]/page.tsx
+++ b/src/app/budgets/trips/[id]/page.tsx
@@ -147,6 +147,22 @@ export default function TripDetailPage({ params }: { params: Promise<{ id: strin
   const [currentUserEmail, setCurrentUserEmail] = useState<string>('');
   const [showUpgradeModal, setShowUpgradeModal] = useState(false);
 
+  // Inline date editing
+  const [editingDates, setEditingDates] = useState(false);
+  const [editStartDate, setEditStartDate] = useState('');
+  const [editEndDate, setEditEndDate] = useState('');
+
+  const saveDates = async () => {
+    if (!editStartDate || !editEndDate) return;
+    try {
+      const res = await fetch(`/api/trips/${id}`, {
+        method: 'PATCH', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ startDate: editStartDate, endDate: editEndDate }),
+      });
+      if (res.ok) { loadTrip(); setEditingDates(false); }
+    } catch (err) { console.error('Failed to save dates:', err); }
+  };
+
   // Vendor commitment state (legacy — commit now handled inside TripPlannerAI)
 
   useEffect(() => { loadTrip(); loadParticipants(); loadDestinations(); loadBudgetItems(); fetch("/api/auth/me").then(res => res.ok ? res.json() : null).then(data => { if (data?.user?.tier) setUserTier(data.user.tier); if (data?.user?.email) setCurrentUserEmail(data.user.email); }); }, [id]);
@@ -291,13 +307,20 @@ export default function TripDetailPage({ params }: { params: Promise<{ id: strin
   };
 
   const tripDates = useMemo(() => {
-    if (!trip || !confirmedStartDay) return null;
-    const start = new Date(trip.year, trip.month - 1, confirmedStartDay);
-    const end = new Date(trip.year, trip.month - 1, confirmedStartDay + trip.daysTravel - 1);
-    return {
-      departure: start.toISOString().split("T")[0],
-      return: end.toISOString().split("T")[0],
-    };
+    if (!trip) return null;
+    // Prefer stored startDate/endDate, fall back to confirmedStartDay
+    if (trip.startDate && trip.endDate) {
+      return {
+        departure: new Date(trip.startDate).toISOString().split("T")[0],
+        return: new Date(trip.endDate).toISOString().split("T")[0],
+      };
+    }
+    if (confirmedStartDay) {
+      const start = new Date(trip.year, trip.month - 1, confirmedStartDay);
+      const end = new Date(trip.year, trip.month - 1, confirmedStartDay + trip.daysTravel - 1);
+      return { departure: start.toISOString().split("T")[0], return: end.toISOString().split("T")[0] };
+    }
+    return null;
   }, [trip, confirmedStartDay]);
 
   const dateWindows = useMemo(() => {
@@ -682,67 +705,61 @@ export default function TripDetailPage({ params }: { params: Promise<{ id: strin
             <div className="bg-white border border-border">
               <div className="bg-brand-purple text-white px-4 py-2 text-sm font-semibold flex items-center gap-2">
                 <span className="w-5 h-5 bg-white/20 flex items-center justify-center text-[10px] font-bold">1</span>
-                Date Selection
+                Dates
               </div>
               <div className="p-4">
-                <div className="text-xs text-text-muted mb-3">{MONTHS[trip.month]} {trip.year}</div>
-
-                {/* Mini Calendar */}
-                <div className="overflow-x-auto mb-4">
-                  <table className="w-full text-[10px]">
-                    <thead>
-                      <tr>
-                        <th className="text-left py-1 px-1 text-text-faint w-16 sticky left-0 bg-white">Person</th>
-                        {calendarDays.map(day => (
-                          <th key={day} className="text-center py-1 px-0.5 text-text-faint min-w-[20px]">{day}</th>
-                        ))}
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {confirmedParticipants.map(p => (
-                        <tr key={p.id} className="border-t border-border-light">
-                          <td className="py-1 px-1 text-text-secondary font-medium sticky left-0 bg-white text-[10px]">{p.firstName}</td>
-                          {calendarDays.map(day => {
-                            const blocked = (p.unavailableDays || []).includes(day);
-                            const inRange = confirmedStartDay && day >= confirmedStartDay && day < confirmedStartDay + trip.daysTravel;
-                            return (
-                              <td key={day} className="text-center py-0.5 px-0.5">
-                                <div className={`w-4 h-4 mx-auto flex items-center justify-center text-[8px] ${
-                                  blocked ? 'bg-red-100 text-brand-red' :
-                                  inRange ? 'bg-brand-purple text-white' :
-                                  'bg-emerald-100 text-emerald-600'
-                                }`}>
-                                  {blocked ? '×' : inRange ? '✓' : '·'}
-                                </div>
-                              </td>
-                            );
-                          })}
-                        </tr>
-                      ))}
-                    </tbody>
-                  </table>
-                </div>
-
-                {/* Date Windows */}
-                <div className="text-xs font-medium text-text-secondary mb-2">Valid {trip.daysTravel}-Day Windows:</div>
-                {dateWindows.length > 0 ? (
-                  <div className="flex flex-wrap gap-1">
-                    {dateWindows.map((w, idx) => (
-                      <button key={idx} onClick={() => setConfirmedStartDay(w.startDay)}
-                        className={`px-2 py-1 text-[10px] font-medium transition-all ${
-                          confirmedStartDay === w.startDay ? 'bg-brand-purple text-white' : 'bg-bg-row text-text-secondary hover:bg-border'
-                        }`}>
-                        {MONTHS[trip.month].slice(0, 3)} {w.startDay}–{w.endDay}
+                {editingDates ? (
+                  <div className="space-y-3">
+                    <div className="grid grid-cols-2 gap-4">
+                      <div>
+                        <label className="text-xs text-text-muted block mb-1">Start Date</label>
+                        <input type="date" value={editStartDate} onChange={e => setEditStartDate(e.target.value)}
+                          className="w-full px-3 py-2 border border-border text-sm focus:outline-none focus:border-brand-purple" />
+                      </div>
+                      <div>
+                        <label className="text-xs text-text-muted block mb-1">End Date</label>
+                        <input type="date" value={editEndDate} onChange={e => setEditEndDate(e.target.value)}
+                          min={editStartDate}
+                          className="w-full px-3 py-2 border border-border text-sm focus:outline-none focus:border-brand-purple" />
+                      </div>
+                    </div>
+                    <div className="flex gap-2">
+                      <button onClick={saveDates} disabled={!editStartDate || !editEndDate}
+                        className="px-4 py-1.5 bg-brand-purple text-white text-xs font-medium disabled:opacity-50">
+                        Save
                       </button>
-                    ))}
+                      <button onClick={() => setEditingDates(false)}
+                        className="px-4 py-1.5 border border-border text-text-secondary text-xs">
+                        Cancel
+                      </button>
+                    </div>
                   </div>
                 ) : (
-                  <p className="text-text-faint text-xs">{confirmedParticipants.length === 0 ? 'Waiting for RSVPs...' : 'No valid windows found.'}</p>
-                )}
-
-                {confirmedStartDay && (
-                  <div className="mt-3 p-2 bg-emerald-50 border border-emerald-200 text-emerald-700 text-xs">
-                    ✓ Selected: {MONTHS[trip.month]} {confirmedStartDay}–{confirmedStartDay + trip.daysTravel - 1}, {trip.year}
+                  <div className="flex items-center gap-6">
+                    <div>
+                      <div className="text-[10px] text-text-muted uppercase tracking-wider">Start</div>
+                      <div className="text-sm font-semibold text-text-primary">
+                        {trip.startDate ? new Date(trip.startDate).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' }) : 'Not set'}
+                      </div>
+                    </div>
+                    <span className="text-xl text-text-faint">→</span>
+                    <div>
+                      <div className="text-[10px] text-text-muted uppercase tracking-wider">End</div>
+                      <div className="text-sm font-semibold text-text-primary">
+                        {trip.endDate ? new Date(trip.endDate).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' }) : 'Not set'}
+                      </div>
+                    </div>
+                    <div>
+                      <div className="text-[10px] text-text-muted uppercase tracking-wider">Duration</div>
+                      <div className="text-sm font-semibold text-text-primary">{trip.daysTravel} days</div>
+                    </div>
+                    <button onClick={() => {
+                      setEditStartDate(trip.startDate ? new Date(trip.startDate).toISOString().split('T')[0] : '');
+                      setEditEndDate(trip.endDate ? new Date(trip.endDate).toISOString().split('T')[0] : '');
+                      setEditingDates(true);
+                    }} className="ml-auto text-xs text-brand-purple hover:underline font-medium">
+                      Edit Dates
+                    </button>
                   </div>
                 )}
               </div>

--- a/src/app/budgets/trips/new/page.tsx
+++ b/src/app/budgets/trips/new/page.tsx
@@ -1,49 +1,188 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import { AppLayout } from '@/components/ui';
+import { ACTIVITY_GROUPS, ACTIVITY_LABELS } from '@/lib/activities';
+
+const TRIP_TYPES = [
+  { value: 'personal', label: 'Personal' },
+  { value: 'business', label: 'Business' },
+  { value: 'mixed', label: 'Mixed' },
+];
+
+const BUDGET_OPTIONS = [
+  { value: 'backpacker', label: '$0-50/night', hint: 'We\'d suggest $ venues' },
+  { value: 'budget', label: '$50-100/night', hint: 'We\'d suggest $-$$ venues' },
+  { value: 'midrange', label: '$100-200/night', hint: 'We\'d suggest $$ venues' },
+  { value: 'comfort', label: '$200-350/night', hint: 'We\'d suggest $$-$$$ venues' },
+  { value: 'premium', label: '$350-500/night', hint: 'We\'d suggest $$$ venues' },
+  { value: 'luxury', label: '$500+/night', hint: 'All price levels' },
+];
+
+const VIBE_OPTIONS = [
+  { value: 'chill', label: 'Chill & Relaxed' },
+  { value: 'active', label: 'Adventurous' },
+  { value: 'social', label: 'Social & Party' },
+  { value: 'splurge', label: 'Luxe & Pampered' },
+  { value: 'spontaneous', label: 'Spontaneous' },
+  { value: 'offbeat', label: 'Off the Beaten Path' },
+  { value: 'touristy', label: 'Hit the Highlights' },
+  { value: 'local', label: 'Cultural & Immersive' },
+];
+
+const PACE_OPTIONS = [
+  { value: 'slow', label: 'Slow & Savoring' },
+  { value: 'balanced', label: 'Balanced' },
+  { value: 'packed', label: 'Packed & Hustling' },
+];
+
+interface Resort {
+  id: string;
+  name: string;
+  country: string;
+  state: string | null;
+  region: string;
+  nearestAirport: string | null;
+  bestMonths?: string | null;
+}
 
 export default function NewTripPage() {
   const router = useRouter();
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
-  const [created, setCreated] = useState<{ id: string; inviteUrl: string } | null>(null);
 
+  // Section 1: Trip Details
   const [name, setName] = useState('');
-  const [startDate, setStartDate] = useState(new Date().toISOString().split('T')[0]);
-  const [daysTravel, setDaysTravel] = useState(7);
-  const [tripType, setTripType] = useState<'personal' | 'business'>('personal');
+  const [startDate, setStartDate] = useState('');
+  const [endDate, setEndDate] = useState('');
+  const [tripType, setTripType] = useState('personal');
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setError('');
+  // Section 2: Profile
+  const [selectedActivities, setSelectedActivities] = useState<string[]>([]);
+  const [budget, setBudget] = useState('midrange');
+  const [vibes, setVibes] = useState<string[]>([]);
+  const [pace, setPace] = useState('balanced');
+
+  // Section 3: Destinations
+  const [searchQuery, setSearchQuery] = useState('');
+  const [searchResults, setSearchResults] = useState<Resort[]>([]);
+  const [selectedDestinations, setSelectedDestinations] = useState<Resort[]>([]);
+  const [searching, setSearching] = useState(false);
+
+  const duration = startDate && endDate
+    ? Math.round((new Date(endDate + 'T12:00:00').getTime() - new Date(startDate + 'T12:00:00').getTime()) / 86400000) + 1
+    : 0;
+
+  const toggleActivity = (val: string) => {
+    setSelectedActivities(prev =>
+      prev.includes(val) ? prev.filter(a => a !== val) : [...prev, val]
+    );
+  };
+
+  const toggleVibe = (val: string) => {
+    setVibes(prev =>
+      prev.includes(val) ? prev.filter(v => v !== val) : prev.length < 3 ? [...prev, val] : prev
+    );
+  };
+
+  const searchDestinations = useCallback(async (q: string) => {
+    setSearchQuery(q);
+    if (q.length < 2) { setSearchResults([]); return; }
+    setSearching(true);
+    try {
+      const res = await fetch('/api/resorts?activity=all');
+      if (res.ok) {
+        const data = await res.json();
+        const filtered = (data.resorts || []).filter((r: Resort) =>
+          r.name.toLowerCase().includes(q.toLowerCase()) ||
+          r.country.toLowerCase().includes(q.toLowerCase()) ||
+          r.region?.toLowerCase().includes(q.toLowerCase())
+        ).slice(0, 20);
+        setSearchResults(filtered);
+      }
+    } catch (err) {
+      console.error('Search failed:', err);
+    } finally {
+      setSearching(false);
+    }
+  }, []);
+
+  const addDestination = (resort: Resort) => {
+    if (!selectedDestinations.some(d => d.id === resort.id)) {
+      setSelectedDestinations(prev => [...prev, resort]);
+    }
+    setSearchQuery('');
+    setSearchResults([]);
+  };
+
+  const removeDestination = (id: string) => {
+    setSelectedDestinations(prev => prev.filter(d => d.id !== id));
+  };
+
+  const canCreate = name.trim() && startDate && endDate && duration > 0;
+
+  const handleCreate = async () => {
+    if (!canCreate) return;
     setSaving(true);
+    setError('');
 
     try {
-      const res = await fetch('/api/trips', {
+      // 1. Create trip
+      const tripRes = await fetch('/api/trips', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          name,
+          name: name.trim(),
+          startDate,
+          endDate,
           activity: 'all',
           month: new Date(startDate + 'T12:00:00').getMonth() + 1,
           year: new Date(startDate + 'T12:00:00').getFullYear(),
-          startDate,
-          daysTravel,
-          daysRiding: daysTravel,
+          daysTravel: duration,
+          daysRiding: duration,
           tripType,
-        })
+        }),
       });
 
-      if (!res.ok) {
-        const data = await res.json();
-        throw new Error(data.error || 'Failed to create trip');
+      if (!tripRes.ok) {
+        const d = await tripRes.json();
+        throw new Error(d.error || 'Failed to create trip');
       }
 
-      const { trip } = await res.json();
-      const inviteUrl = `${window.location.origin}/trips/rsvp?token=${trip.inviteToken}`;
-      setCreated({ id: trip.id, inviteUrl });
+      const { trip } = await tripRes.json();
+      const tripId = trip.id;
+      const ownerId = trip.participants?.[0]?.id;
+
+      // 2. Save organizer profile
+      if (ownerId && (selectedActivities.length > 0 || budget || vibes.length > 0 || pace)) {
+        await fetch(`/api/trips/${tripId}/participants`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            participantId: ownerId,
+            profile: {
+              activities: selectedActivities,
+              budget,
+              vibe: vibes,
+              pace,
+              tripType: tripType === 'business' ? 'remote_work' : 'adventure',
+            },
+          }),
+        });
+      }
+
+      // 3. Add destinations
+      for (const dest of selectedDestinations) {
+        await fetch(`/api/trips/${tripId}/destinations`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ resortId: dest.id }),
+        });
+      }
+
+      // Redirect to trip detail page
+      router.push(`/budgets/trips/${tripId}`);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to create trip');
     } finally {
@@ -51,68 +190,18 @@ export default function NewTripPage() {
     }
   };
 
-  const copyInviteLink = () => {
-    if (created?.inviteUrl) {
-      navigator.clipboard.writeText(created.inviteUrl);
-    }
-  };
-
-  // Success screen
-  if (created) {
-    return (
-      <AppLayout>
-        <div className="min-h-screen bg-bg-terminal">
-          <div className="p-4 lg:p-6 max-w-xl mx-auto">
-            <div className="bg-white border border-border">
-              <div className="bg-brand-purple text-white p-4 text-center">
-                <div className="text-terminal-lg font-semibold">Trip Created</div>
-              </div>
-              <div className="p-6 text-center">
-                <div className="text-4xl mb-4">✓</div>
-                <p className="text-text-secondary mb-6 text-sm">
-                  Share the invite link with your travelers. They'll add their names and blackout dates.
-                </p>
-
-                <div className="bg-bg-row p-3 mb-6">
-                  <label className="block text-[10px] text-text-muted uppercase tracking-wider mb-1">Invite Link</label>
-                  <div className="flex gap-2">
-                    <input type="text" value={created.inviteUrl} readOnly
-                      className="flex-1 px-3 py-2 border border-border text-xs font-mono bg-white" />
-                    <button onClick={copyInviteLink}
-                      className="px-4 py-2 bg-brand-purple text-white text-xs font-medium hover:bg-brand-purple-hover">
-                      Copy
-                    </button>
-                  </div>
-                </div>
-
-                <div className="flex gap-3 justify-center">
-                  <button onClick={() => router.push(`/budgets/trips/${created.id}`)}
-                    className="px-6 py-2 bg-brand-purple text-white text-xs font-medium hover:bg-brand-purple-hover">
-                    View Trip →
-                  </button>
-                  <button onClick={() => router.push('/budgets/trips')}
-                    className="px-6 py-2 border border-border text-text-secondary text-xs font-medium hover:bg-bg-row">
-                    All Trips
-                  </button>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </AppLayout>
-    );
-  }
+  const budgetHint = BUDGET_OPTIONS.find(b => b.value === budget)?.hint;
 
   return (
     <AppLayout>
       <div className="min-h-screen bg-bg-terminal">
-        <div className="p-4 lg:p-6 max-w-xl mx-auto">
+        <div className="p-4 lg:p-6 max-w-2xl mx-auto">
 
           {/* Header */}
           <div className="mb-4 bg-brand-purple text-white p-4 flex items-center justify-between">
             <div>
               <h1 className="text-terminal-lg font-semibold">New Trip</h1>
-              <p className="text-text-faint text-xs">Plan your next adventure</p>
+              <p className="text-text-faint text-xs">Set up your trip, your profile, and destinations all in one go</p>
             </div>
             <button onClick={() => router.push('/budgets/trips')} className="text-xs text-text-faint hover:text-white">
               ← Back
@@ -123,70 +212,212 @@ export default function NewTripPage() {
             <div className="bg-red-50 border border-red-200 text-brand-red px-4 py-3 mb-4 text-sm">{error}</div>
           )}
 
-          <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-4">
+
+            {/* ═══ Section 1: Trip Details ═══ */}
             <div className="bg-white border border-border">
-              <div className="bg-brand-purple-hover text-white px-4 py-2 text-xs font-semibold uppercase tracking-wider">
+              <div className="bg-brand-purple text-white px-4 py-2 text-sm font-semibold flex items-center gap-2">
+                <span className="w-5 h-5 bg-white/20 flex items-center justify-center text-[10px] font-bold">1</span>
                 Trip Details
               </div>
               <div className="p-4 space-y-4">
                 <div>
                   <label className="block text-xs font-medium text-text-secondary mb-1">Trip Name *</label>
-                  <input type="text" value={name} onChange={(e) => setName(e.target.value)}
-                    placeholder="e.g., Bali Surf Trip 2025"
+                  <input type="text" value={name} onChange={e => setName(e.target.value)}
+                    placeholder="e.g., Bali Surf Trip 2026"
                     className="w-full px-3 py-2 border border-border text-sm focus:outline-none focus:border-brand-purple"
                     required />
                 </div>
 
                 <div className="grid grid-cols-2 gap-4">
                   <div>
-                    <label className="block text-xs font-medium text-text-secondary mb-1">Start Date</label>
-                    <input type="date" value={startDate} onChange={(e) => setStartDate(e.target.value)}
+                    <label className="block text-xs font-medium text-text-secondary mb-1">Start Date *</label>
+                    <input type="date" value={startDate} onChange={e => setStartDate(e.target.value)}
                       min={new Date().toISOString().split('T')[0]}
                       className="w-full px-3 py-2 border border-border text-sm focus:outline-none focus:border-brand-purple" />
                   </div>
                   <div>
-                    <label className="block text-xs font-medium text-text-secondary mb-1">Duration (days)</label>
-                    <input type="number" min={1} max={90} value={daysTravel}
-                      onChange={(e) => setDaysTravel(parseInt(e.target.value) || 1)}
+                    <label className="block text-xs font-medium text-text-secondary mb-1">End Date *</label>
+                    <input type="date" value={endDate} onChange={e => setEndDate(e.target.value)}
+                      min={startDate || new Date().toISOString().split('T')[0]}
                       className="w-full px-3 py-2 border border-border text-sm focus:outline-none focus:border-brand-purple" />
                   </div>
                 </div>
 
+                {duration > 0 && (
+                  <div className="text-xs text-text-muted bg-bg-row px-3 py-2">
+                    Duration: <span className="font-semibold text-text-primary">{duration} days</span>
+                  </div>
+                )}
+
                 <div>
                   <label className="block text-xs font-medium text-text-secondary mb-1">Trip Type</label>
                   <div className="flex gap-2">
-                    <button type="button" onClick={() => setTripType('personal')}
-                      className={`flex-1 px-3 py-2 text-xs font-medium transition-colors ${tripType === 'personal' ? 'bg-brand-purple text-white' : 'bg-bg-row text-text-secondary hover:bg-border border border-border'}`}>
-                      Personal
-                    </button>
-                    <button type="button" onClick={() => setTripType('business')}
-                      className={`flex-1 px-3 py-2 text-xs font-medium transition-colors ${tripType === 'business' ? 'bg-brand-purple text-white' : 'bg-bg-row text-text-secondary hover:bg-border border border-border'}`}>
-                      Business
-                    </button>
+                    {TRIP_TYPES.map(tt => (
+                      <button key={tt.value} type="button" onClick={() => setTripType(tt.value)}
+                        className={`flex-1 px-3 py-2 text-xs font-medium transition-colors ${
+                          tripType === tt.value ? 'bg-brand-purple text-white' : 'bg-bg-row text-text-secondary hover:bg-border border border-border'
+                        }`}>
+                        {tt.label}
+                      </button>
+                    ))}
                   </div>
                 </div>
               </div>
             </div>
 
-            {/* Info Box */}
-            <div className="bg-brand-purple-wash border border-blue-200 p-4 text-xs text-blue-800">
-              <strong>How it works:</strong> After creating, you'll get a shareable invite link.
-              Send it to your crew — they'll add their names and mark blackout dates.
-              You'll pick destinations and activities on the trip page.
+            {/* ═══ Section 2: Your Travel Profile ═══ */}
+            <div className="bg-white border border-border">
+              <div className="bg-brand-purple text-white px-4 py-2 text-sm font-semibold flex items-center gap-2">
+                <span className="w-5 h-5 bg-white/20 flex items-center justify-center text-[10px] font-bold">2</span>
+                Your Travel Profile
+              </div>
+              <div className="p-4 space-y-5">
+
+                {/* Interests */}
+                <div>
+                  <h4 className="text-xs font-semibold text-text-secondary uppercase tracking-wider mb-2">
+                    Your Interests
+                    {selectedActivities.length > 0 && (
+                      <span className="ml-2 text-brand-purple font-normal normal-case">({selectedActivities.length} selected)</span>
+                    )}
+                  </h4>
+                  {ACTIVITY_GROUPS.map(group => (
+                    <div key={group.label} className="mb-3">
+                      <div className="text-[11px] font-medium text-text-muted mb-1">{group.label}</div>
+                      <div className="flex flex-wrap gap-1.5">
+                        {group.activities.map(act => {
+                          const selected = selectedActivities.includes(act.value);
+                          return (
+                            <button key={act.value} type="button" onClick={() => toggleActivity(act.value)}
+                              className={`px-2.5 py-1 rounded text-[11px] font-medium transition-colors ${
+                                selected ? 'bg-brand-purple text-white' : 'bg-bg-row text-text-secondary hover:bg-border'
+                              }`}>
+                              {act.label}
+                            </button>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+
+                {/* Budget */}
+                <div>
+                  <h4 className="text-xs font-semibold text-text-secondary uppercase tracking-wider mb-2">Budget per Night</h4>
+                  <div className="flex flex-wrap gap-1.5">
+                    {BUDGET_OPTIONS.map(bo => (
+                      <button key={bo.value} type="button" onClick={() => setBudget(bo.value)}
+                        className={`px-2.5 py-1.5 rounded text-xs font-medium transition-colors ${
+                          budget === bo.value ? 'bg-brand-purple text-white' : 'bg-bg-row text-text-secondary hover:bg-border'
+                        }`}>
+                        {bo.label}
+                      </button>
+                    ))}
+                  </div>
+                  {budgetHint && (
+                    <div className="text-[10px] text-text-muted mt-1.5">{budgetHint}</div>
+                  )}
+                </div>
+
+                {/* Vibe */}
+                <div>
+                  <h4 className="text-xs font-semibold text-text-secondary uppercase tracking-wider mb-2">
+                    Vibe <span className="font-normal text-text-muted">(up to 3)</span>
+                  </h4>
+                  <div className="flex flex-wrap gap-1.5">
+                    {VIBE_OPTIONS.map(vo => {
+                      const selected = vibes.includes(vo.value);
+                      return (
+                        <button key={vo.value} type="button" onClick={() => toggleVibe(vo.value)}
+                          className={`px-2.5 py-1.5 rounded text-xs font-medium transition-colors ${
+                            selected ? 'bg-brand-purple text-white' : 'bg-bg-row text-text-secondary hover:bg-border'
+                          }`}>
+                          {vo.label}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+
+                {/* Pace */}
+                <div>
+                  <h4 className="text-xs font-semibold text-text-secondary uppercase tracking-wider mb-2">Pace</h4>
+                  <div className="flex gap-2">
+                    {PACE_OPTIONS.map(po => (
+                      <button key={po.value} type="button" onClick={() => setPace(po.value)}
+                        className={`flex-1 px-3 py-2 rounded text-xs font-medium transition-colors ${
+                          pace === po.value ? 'bg-brand-purple text-white' : 'bg-bg-row text-text-secondary hover:bg-border'
+                        }`}>
+                        {po.label}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              </div>
             </div>
 
-            {/* Actions */}
+            {/* ═══ Section 3: Destinations ═══ */}
+            <div className="bg-white border border-border">
+              <div className="bg-brand-purple text-white px-4 py-2 text-sm font-semibold flex items-center gap-2">
+                <span className="w-5 h-5 bg-white/20 flex items-center justify-center text-[10px] font-bold">3</span>
+                Destinations
+                <span className="text-xs text-white/60 font-normal ml-auto">(optional — add later)</span>
+              </div>
+              <div className="p-4">
+                {/* Selected destinations */}
+                {selectedDestinations.length > 0 && (
+                  <div className="flex flex-wrap gap-2 mb-3">
+                    {selectedDestinations.map(d => (
+                      <div key={d.id} className="flex items-center gap-1.5 bg-brand-purple-wash border border-brand-purple/20 rounded-full px-3 py-1">
+                        <span className="text-xs text-text-primary">{d.name}</span>
+                        <span className="text-[10px] text-text-muted">{d.country}</span>
+                        {d.nearestAirport && <span className="text-[10px] font-mono text-text-faint">{d.nearestAirport}</span>}
+                        <button onClick={() => removeDestination(d.id)} className="text-text-faint hover:text-brand-red text-xs ml-1">×</button>
+                      </div>
+                    ))}
+                  </div>
+                )}
+
+                {/* Search */}
+                <input
+                  type="text"
+                  placeholder="Search destinations..."
+                  value={searchQuery}
+                  onChange={e => searchDestinations(e.target.value)}
+                  className="w-full px-3 py-2 border border-border text-sm focus:outline-none focus:border-brand-purple mb-2"
+                />
+                {searchResults.length > 0 && (
+                  <div className="max-h-48 overflow-y-auto border border-border rounded">
+                    {searchResults.map(r => (
+                      <button key={r.id} onClick={() => addDestination(r)}
+                        disabled={selectedDestinations.some(d => d.id === r.id)}
+                        className="w-full text-left px-3 py-2 text-xs hover:bg-bg-row flex justify-between items-center disabled:opacity-50 border-b border-border/50 last:border-0">
+                        <span>
+                          <span className="font-medium">{r.name}</span>
+                          <span className="text-text-muted ml-2">{r.state ? `${r.state}, ` : ''}{r.country}</span>
+                        </span>
+                        {r.nearestAirport && <span className="font-mono text-text-faint">{r.nearestAirport}</span>}
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
+            </div>
+
+            {/* ═══ Section 4: Create ═══ */}
             <div className="flex gap-3">
               <button type="button" onClick={() => router.back()}
                 className="flex-1 px-4 py-3 border border-border text-text-secondary text-xs font-medium hover:bg-bg-row">
                 Cancel
               </button>
-              <button type="submit" disabled={saving || !name}
-                className="flex-1 px-4 py-3 bg-brand-purple text-white text-xs font-medium hover:bg-brand-purple-hover disabled:opacity-50">
+              <button onClick={handleCreate} disabled={saving || !canCreate}
+                className="flex-1 px-4 py-3 bg-brand-purple text-white text-sm font-semibold hover:bg-brand-purple-hover disabled:opacity-50">
                 {saving ? 'Creating...' : 'Create Trip'}
               </button>
             </div>
-          </form>
+
+          </div>
         </div>
       </div>
     </AppLayout>

--- a/src/components/trips/TripPlannerAI.tsx
+++ b/src/components/trips/TripPlannerAI.tsx
@@ -10,6 +10,8 @@ interface GrokRecommendation {
   address: string;
   website: string | null;
   photoUrl: string | null;
+  priceLevel: number | null;
+  priceLevelDisplay: string | null;
   googleRating: number;
   reviewCount: number;
   sentimentScore: number;
@@ -251,6 +253,7 @@ export default function TripPlannerAI({ tripId, city, country, activity, activit
 
   const [minRating, setMinRating] = useState(4.0);
   const [minReviews, setMinReviews] = useState(50);
+  const [maxPriceLevel, setMaxPriceLevel] = useState(0); // 0 = any
 
   const [selections, setSelections] = useState<ScheduledSelection[]>([]);
   const [editingSelection, setEditingSelection] = useState<ScheduledSelection | null>(null);
@@ -366,7 +369,7 @@ export default function TripPlannerAI({ tripId, city, country, activity, activit
         const res = await fetch('/api/trips/' + tripId + '/ai-assistant', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ city, country, activities: tripActivities, activity, month, year, daysTravel, minRating, minReviews, category: cat, profile })
+          body: JSON.stringify({ city, country, activities: tripActivities, activity, month, year, daysTravel, minRating, minReviews, maxPriceLevel: maxPriceLevel || undefined, category: cat, profile })
         });
 
         // Guard against non-JSON responses (serverless timeout returns HTML)
@@ -667,6 +670,8 @@ export default function TripPlannerAI({ tripId, city, country, activity, activit
       address: customForm.notes || "Custom addition",
       website: customForm.url || null,
       photoUrl: customPreview?.image || null,
+      priceLevel: null,
+      priceLevelDisplay: null,
       googleRating: 0,
       reviewCount: 0,
       sentimentScore: 10,
@@ -835,6 +840,12 @@ export default function TripPlannerAI({ tripId, city, country, activity, activit
           <label className="text-xs text-text-muted font-medium block mb-1.5">📊 Min Reviews</label>
           <select value={minReviews} onChange={e => setMinReviews(+e.target.value)} className="border border-border rounded px-3 py-2.5 text-sm bg-white">
             <option value={10}>10+</option><option value={50}>50+</option><option value={100}>100+</option>
+          </select>
+        </div>
+        <div>
+          <label className="text-xs text-text-muted font-medium block mb-1.5">💰 Max Price</label>
+          <select value={maxPriceLevel} onChange={e => setMaxPriceLevel(+e.target.value)} className="border border-border rounded px-3 py-2.5 text-sm bg-white">
+            <option value={0}>Any</option><option value={1}>$</option><option value={2}>$$</option><option value={3}>$$$</option><option value={4}>$$$$</option>
           </select>
         </div>
         <Button onClick={analyzeDestination} loading={loading} disabled={!city} className="flex-1 py-3 text-base">
@@ -1018,6 +1029,17 @@ export default function TripPlannerAI({ tripId, city, country, activity, activit
                               <h4 className="font-semibold text-sm text-text-primary truncate">{rec.name}</h4>
                               <div className="text-xs text-text-muted flex items-center gap-2 mt-0.5">
                                 <span>{'*'.repeat(Math.round(rec.googleRating))} {rec.googleRating} ({rec.reviewCount})</span>
+                                {rec.priceLevelDisplay ? (
+                                  <span className={`px-1 py-0.5 rounded text-[9px] font-bold ${
+                                    rec.priceLevel === 1 ? 'bg-green-100 text-green-700' :
+                                    rec.priceLevel === 2 ? 'bg-blue-100 text-blue-700' :
+                                    rec.priceLevel === 3 ? 'bg-orange-100 text-orange-700' :
+                                    rec.priceLevel === 4 ? 'bg-red-100 text-red-700' :
+                                    'bg-gray-100 text-gray-500'
+                                  }`}>{rec.priceLevelDisplay}</span>
+                                ) : (
+                                  <span className="px-1 py-0.5 rounded text-[9px] bg-gray-100 text-gray-400">N/A</span>
+                                )}
                                 {rec.trending && <span title="Trending">🔥</span>}
                               </div>
                             </div>

--- a/src/lib/grokAgent.ts
+++ b/src/lib/grokAgent.ts
@@ -20,6 +20,8 @@ interface PlaceToAnalyze {
   category: string;
   website?: string;
   photoUrl?: string;
+  priceLevel?: number | null;
+  priceLevelDisplay?: string | null;
 }
 
 interface GrokAnalysis {
@@ -27,6 +29,8 @@ interface GrokAnalysis {
   address: string;
   website: string | null;
   photoUrl: string | null;
+  priceLevel: number | null;
+  priceLevelDisplay: string | null;
   googleRating: number;
   reviewCount: number;
   sentimentScore: number;
@@ -137,9 +141,10 @@ export async function analyzeWithLiveSearch(options: {
   const activityQuestions = buildActivityQuestions(activities);
 
   // Build the place list
-  const placeList = places.map((p, i) => 
-    `${i + 1}. ${p.name} | Rating: ${p.rating} (${p.reviewCount} reviews) | ${p.address}`
-  ).join('\n');
+  const placeList = places.map((p, i) => {
+    const price = p.priceLevelDisplay ? ` | Price: ${p.priceLevelDisplay}` : '';
+    return `${i + 1}. ${p.name} | Rating: ${p.rating} (${p.reviewCount} reviews)${price} | ${p.address}`;
+  }).join('\n');
 
   const vibeStr = profile.vibe || '';
   const paceStr = profile.pace || '';
@@ -188,7 +193,7 @@ Return ONLY a valid JSON array with this exact structure:
 IMPORTANT:
 - index: matches the place number (1-indexed)
 - sentimentScore: 1-10 based on X/web sentiment
-- fitScore: 1-10 how well it matches THIS traveler's activities and profile priorities
+- fitScore: 1-10 how well it matches THIS traveler's activities, profile priorities, and budget. Consider price level relative to the traveler's stated budget — a budget traveler should see higher fit scores for $ and $$ places.
 - valueRank: 1 to ${places.length} (1 = best for this traveler)
 - Include real evidence from your X/web searches in xEvidence
 - Return a DIVERSE set of recommendations — avoid clustering in one sub-category. If there are museums, temples, cooking classes, and adventure tours, include the best of each type rather than 20 similar options.
@@ -293,6 +298,8 @@ IMPORTANT:
         address: place.address,
         website: place.website || null,
         photoUrl: place.photoUrl || null,
+        priceLevel: place.priceLevel ?? null,
+        priceLevelDisplay: place.priceLevelDisplay || null,
         googleRating: place.rating,
         reviewCount: place.reviewCount,
         sentimentScore: rank.sentimentScore || 5,


### PR DESCRIPTION
…l pipeline

Trip creation page rewritten as single-page onboarding flow:
- Section 1: Trip name, start/end date pickers (duration auto-calculated), trip type selector (personal/business/mixed)
- Section 2: Travel profile — interests from 40 canonical activities, budget tier, vibe (up to 3), pace. Saved to organizer's participant record after creation.
- Section 3: Destination search and selection (reuses resorts API)
- Section 4: Create button fires 3 sequential API calls (trip, profile, destinations) then redirects to detail page

Trips API updated:
- POST accepts startDate + endDate, calculates duration automatically
- PATCH accepts startDate/endDate for inline editing, recalculates duration
- Backward compatible with old month/year/daysTravel-only clients

Trip detail page dates simplified:
- Replaced availability calendar + date window picker with simple start → end → duration display
- Inline date editing via "Edit Dates" button
- tripDates now derived from stored startDate/endDate first, falling back to confirmedStartDay for backward compat

Price level wired through full scanner pipeline:
- ai-assistant: priceLevel + priceLevelDisplay added to placesToAnalyze, maxPriceLevel filter (places without price data pass through)
- grokAgent: PlaceToAnalyze/GrokAnalysis interfaces include priceLevel, prompt shows price per place, fitScore considers budget alignment
- TripPlannerAI: price badge on cards ($=green, $$=blue, $$$=orange, $$$$=red, N/A=gray), Max Price dropdown in scanner controls

https://claude.ai/code/session_01GHNnihseAHoZFcnRMWjQMu