### PR TITLE
Gate all paid tiers as Coming Soon site-wide

### DIFF
--- a/src/app/api/ai/cart-plan/route.ts
+++ b/src/app/api/ai/cart-plan/route.ts
@@ -85,7 +85,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'User not found' }, { status: 404 });
     }
 
-    const tierGate = requireTier(user.tier, 'ai');
+    const tierGate = requireTier(user.tier, 'ai', user.id);
     if (tierGate) return tierGate;
 
     const openai = new OpenAI({

--- a/src/app/api/ai/convergence-synthesis/route.ts
+++ b/src/app/api/ai/convergence-synthesis/route.ts
@@ -276,7 +276,7 @@ export async function POST(request: Request) {
     if (!user) {
       return NextResponse.json({ error: 'User not found' }, { status: 404 });
     }
-    const tierGate = requireTier(user.tier, 'ai');
+    const tierGate = requireTier(user.tier, 'ai', user.id);
     if (tierGate) return tierGate;
 
     const apiKey = process.env.ANTHROPIC_API_KEY;

--- a/src/app/api/ai/market-brief/route.ts
+++ b/src/app/api/ai/market-brief/route.ts
@@ -136,7 +136,7 @@ export async function POST(request: Request) {
     if (!user) {
       return NextResponse.json({ error: 'User not found' }, { status: 404 });
     }
-    const tierGate = requireTier(user.tier, 'ai');
+    const tierGate = requireTier(user.tier, 'ai', user.id);
     if (tierGate) return tierGate;
 
     const apiKey = process.env.ANTHROPIC_API_KEY;

--- a/src/app/api/ai/meal-plan/route.ts
+++ b/src/app/api/ai/meal-plan/route.ts
@@ -51,7 +51,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'User not found' }, { status: 404 });
     }
 
-    const tierGate = requireTier(user.tier, 'ai');
+    const tierGate = requireTier(user.tier, 'ai', user.id);
     if (tierGate) return tierGate;
 
     const openai = new OpenAI({

--- a/src/app/api/ai/meal-planner/route.ts
+++ b/src/app/api/ai/meal-planner/route.ts
@@ -82,7 +82,7 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: 'User not found' }, { status: 404 });
     }
 
-    const tierGate = requireTier(user.tier, 'ai');
+    const tierGate = requireTier(user.tier, 'ai', user.id);
     if (tierGate) return tierGate;
 
     const openai = new OpenAI({

--- a/src/app/api/ai/spending-insights/route.ts
+++ b/src/app/api/ai/spending-insights/route.ts
@@ -18,7 +18,7 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: 'User not found' }, { status: 404 });
     }
 
-    const tierGate = requireTier(user.tier, 'ai');
+    const tierGate = requireTier(user.tier, 'ai', user.id);
     if (tierGate) return tierGate;
 
     const openai = new OpenAI({

--- a/src/app/api/ai/strategy-analysis/route.ts
+++ b/src/app/api/ai/strategy-analysis/route.ts
@@ -112,7 +112,7 @@ export async function POST(request: Request) {
     if (!user) {
       return NextResponse.json({ error: 'User not found' }, { status: 404 });
     }
-    const tierGate = requireTier(user.tier, 'ai');
+    const tierGate = requireTier(user.tier, 'ai', user.id);
     if (tierGate) return tierGate;
 
     const apiKey = process.env.ANTHROPIC_API_KEY;

--- a/src/app/api/convergence/sentiment/route.ts
+++ b/src/app/api/convergence/sentiment/route.ts
@@ -18,7 +18,7 @@ export async function POST(req: Request) {
   if (!user) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
-  const tierGate = requireTier(user.tier, 'ai');
+  const tierGate = requireTier(user.tier, 'ai', user.id);
   if (tierGate) return tierGate;
 
   let body: { symbols?: unknown };

--- a/src/app/api/plaid/exchange-token/route.ts
+++ b/src/app/api/plaid/exchange-token/route.ts
@@ -21,7 +21,7 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: 'User not found' }, { status: 404 });
     }
 
-    const tierGate = requireTier(user.tier, 'plaid');
+    const tierGate = requireTier(user.tier, 'plaid', user.id);
     if (tierGate) return tierGate;
 
     const { publicToken } = await request.json();

--- a/src/app/api/plaid/items/route.ts
+++ b/src/app/api/plaid/items/route.ts
@@ -19,7 +19,7 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: 'User not found' }, { status: 404 });
     }
 
-    const tierGate = requireTier(user.tier, 'plaid');
+    const tierGate = requireTier(user.tier, 'plaid', user.id);
     if (tierGate) return tierGate;
 
     const items = await prisma.plaid_items.findMany({

--- a/src/app/api/plaid/link-token/route.ts
+++ b/src/app/api/plaid/link-token/route.ts
@@ -21,7 +21,7 @@ export async function POST() {
       return NextResponse.json({ error: 'User not found' }, { status: 404 });
     }
 
-    const tierGate = requireTier(user.tier, 'plaid');
+    const tierGate = requireTier(user.tier, 'plaid', user.id);
     if (tierGate) return tierGate;
 
     const configs = {

--- a/src/app/api/plaid/sync/route.ts
+++ b/src/app/api/plaid/sync/route.ts
@@ -37,7 +37,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'User not found' }, { status: 404 });
     }
 
-    const tierGate = requireTier(user.tier, 'plaid');
+    const tierGate = requireTier(user.tier, 'plaid', user.id);
     if (tierGate) return tierGate;
 
     const { itemId } = await request.json();

--- a/src/app/api/trips/[id]/ai-assistant/route.ts
+++ b/src/app/api/trips/[id]/ai-assistant/route.ts
@@ -84,7 +84,7 @@ export async function POST(
 
     const user = await prisma.users.findFirst({ where: { email: { equals: userEmail, mode: 'insensitive' } } });
     if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
-    const tierGate = requireTier(user.tier, 'tripAI');
+    const tierGate = requireTier(user.tier, 'tripAI', user.id);
     if (tierGate) return tierGate;
 
     const body = await request.json();

--- a/src/app/budgets/trips/[id]/page.tsx
+++ b/src/app/budgets/trips/[id]/page.tsx
@@ -9,6 +9,7 @@ import DestinationMap from '@/components/trips/DestinationMap';
 import TripPlannerAI from '@/components/trips/TripPlannerAI';
 import TripProfileCard from '@/components/trips/TripProfileCard';
 import CalendarGrid, { CalendarEvent, SourceConfig } from '@/components/shared/CalendarGrid';
+import { ADMIN_USER_ID } from '@/lib/tiers';
 import 'leaflet/dist/leaflet.css';
 
 const TRIP_SOURCE_CONFIG: Record<string, SourceConfig> = {
@@ -144,6 +145,7 @@ export default function TripDetailPage({ params }: { params: Promise<{ id: strin
   });
   const [savingExpense, setSavingExpense] = useState(false);
   const [userTier, setUserTier] = useState<string>('free');
+  const [currentUserId, setCurrentUserId] = useState<string>('');
   const [currentUserEmail, setCurrentUserEmail] = useState<string>('');
   const [showUpgradeModal, setShowUpgradeModal] = useState(false);
 
@@ -165,7 +167,7 @@ export default function TripDetailPage({ params }: { params: Promise<{ id: strin
 
   // Vendor commitment state (legacy — commit now handled inside TripPlannerAI)
 
-  useEffect(() => { loadTrip(); loadParticipants(); loadDestinations(); loadBudgetItems(); fetch("/api/auth/me").then(res => res.ok ? res.json() : null).then(data => { if (data?.user?.tier) setUserTier(data.user.tier); if (data?.user?.email) setCurrentUserEmail(data.user.email); }); }, [id]);
+  useEffect(() => { loadTrip(); loadParticipants(); loadDestinations(); loadBudgetItems(); fetch("/api/auth/me").then(res => res.ok ? res.json() : null).then(data => { if (data?.user?.tier) setUserTier(data.user.tier); if (data?.user?.email) setCurrentUserEmail(data.user.email); if (data?.user?.id) setCurrentUserId(data.user.id); }); }, [id]);
 
   // Derive origin airport from current user's participant record
   useEffect(() => {
@@ -804,7 +806,7 @@ export default function TripDetailPage({ params }: { params: Promise<{ id: strin
               {(() => {
                 const selectedDest = destinations.find((d: any) => d.resort?.name === trip.destination);
                 return (
-                  userTier === 'free' || userTier === 'pro' ? (
+                  (userTier === 'free' || userTier === 'pro') && currentUserId !== ADMIN_USER_ID ? (
                   <div className="text-center py-8">
                     <div className="text-sm font-medium text-text-primary mb-2">AI Trip Planner requires Pro+</div>
                     <div className="text-xs text-text-muted mb-4">Upgrade to Pro+ ($40/mo) to unlock AI-powered trip planning.</div>

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -6,6 +6,7 @@ import Script from 'next/script';
 import { AppLayout } from '@/components/ui';
 import type { LedgerMetrics, EngineMetrics } from '@/components/ui/AppLayout';
 import UpgradePrompt from '@/components/UpgradePrompt';
+import { ADMIN_USER_ID } from '@/lib/tiers';
 import SpendingTab from '@/components/dashboard/SpendingTab';
 import InvestmentsTab from '@/components/dashboard/InvestmentsTab';
 import GeneralLedger from '@/components/dashboard/GeneralLedger';
@@ -107,6 +108,7 @@ export default function Dashboard() {
   const [syncing, setSyncing] = useState(false);
   const [linkToken, setLinkToken] = useState<string | null>(null);
   const [userTier, setUserTier] = useState<string>('free');
+  const [currentUserId, setCurrentUserId] = useState<string>('');
   const [showUpgradeModal, setShowUpgradeModal] = useState(false);
   const [mappingTab, setMappingTab] = useState<'spending' | 'investments'>('spending');
   const [selectedYear, setSelectedYear] = useState(new Date().getFullYear());
@@ -165,7 +167,7 @@ export default function Dashboard() {
       const linkRes = await fetch("/api/plaid/link-token", { method: "POST", headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ entityId: 'personal' }) });
       if (linkRes.ok) { const linkData = await linkRes.json(); setLinkToken(linkData.link_token); }
       const meRes = await fetch('/api/auth/me');
-      if (meRes.ok) { const meData = await meRes.json(); setUserTier(meData.user?.tier || 'free'); }
+      if (meRes.ok) { const meData = await meRes.json(); setUserTier(meData.user?.tier || 'free'); if (meData.user?.id) setCurrentUserId(meData.user.id); }
     } catch (err) { console.error('Load error:', err); }
     finally { setLoading(false); }
   }, []);
@@ -321,7 +323,7 @@ export default function Dashboard() {
   }, [coaOptions]);
 
   const handleAddAccount = () => {
-    if (userTier === 'free') {
+    if (userTier === 'free' && currentUserId !== ADMIN_USER_ID) {
       setShowUpgradeModal(true);
       return;
     }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -356,7 +356,7 @@ export default function LandingPage() {
 
             {/* Pro */}
             <div className="border-2 border-brand-purple p-6 relative">
-              <div className="absolute -top-2.5 left-4 bg-brand-purple text-white text-[9px] px-2 py-0.5 uppercase tracking-wider">Popular</div>
+              <div className="absolute -top-2.5 left-4 bg-emerald-500 text-white text-[9px] px-2 py-0.5 uppercase tracking-wider">Coming Soon</div>
               <div className="text-xs font-medium text-text-primary mb-1">Pro</div>
               <div className="text-sm font-bold font-mono text-brand-purple mb-1">$20<span className="text-sm font-normal text-text-muted">/mo</span></div>
               <div className="text-[10px] text-text-muted mb-4">Everything in Free, plus</div>
@@ -382,14 +382,15 @@ export default function LandingPage() {
                   <span>Bank reconciliation + period close</span>
                 </div>
               </div>
-              <button onClick={() => { setLoginMode('login'); setLoginRedirect('/pricing'); setShowLogin(true); }}
-                className="mt-6 w-full px-4 py-2 text-xs bg-brand-purple text-white font-medium hover:bg-brand-purple-hover">
-                Subscribe
+              <button disabled
+                className="mt-6 w-full px-4 py-2 text-xs border border-border text-text-faint font-medium cursor-not-allowed">
+                Coming Soon
               </button>
             </div>
 
             {/* Pro+ */}
-            <div className="border border-border p-6">
+            <div className="border border-border p-6 relative">
+              <div className="absolute -top-2.5 left-4 bg-emerald-500 text-white text-[9px] px-2 py-0.5 uppercase tracking-wider">Coming Soon</div>
               <div className="text-xs font-medium text-text-primary mb-1">Pro+</div>
               <div className="text-sm font-bold font-mono text-brand-purple mb-1">$40<span className="text-sm font-normal text-text-muted">/mo</span></div>
               <div className="text-[10px] text-text-muted mb-4">Everything in Pro, plus</div>
@@ -415,9 +416,9 @@ export default function LandingPage() {
                   <span>Priority support</span>
                 </div>
               </div>
-              <button onClick={() => { setLoginMode('login'); setLoginRedirect('/pricing'); setShowLogin(true); }}
-                className="mt-6 w-full px-4 py-2 text-xs border border-border text-text-secondary font-medium hover:bg-bg-row">
-                Subscribe
+              <button disabled
+                className="mt-6 w-full px-4 py-2 text-xs border border-border text-text-faint font-medium cursor-not-allowed">
+                Coming Soon
               </button>
             </div>
 

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -18,7 +18,7 @@ const TIERS = [
       'Double-entry bookkeeping',
       'Hub command center',
     ],
-    cta: 'Current Plan',
+    cta: 'Get Started Free',
     highlight: false,
   },
   {
@@ -34,7 +34,7 @@ const TIERS = [
       'Wash sale tracking',
       'Bank reconciliation',
     ],
-    cta: 'Upgrade to Pro',
+    cta: 'Coming Soon',
     highlight: true,
   },
   {
@@ -50,7 +50,7 @@ const TIERS = [
       'Up to 25 linked accounts',
       'Priority support',
     ],
-    cta: 'Upgrade to Pro+',
+    cta: 'Coming Soon',
     highlight: false,
   },
   {
@@ -189,7 +189,7 @@ function PricingContent() {
                 Popular
               </div>
             )}
-            {t.tier === 'trader_pro' && (
+            {t.tier !== 'free' && (
               <div className="absolute -top-2.5 left-4 bg-emerald-500 text-white text-[9px] px-2 py-0.5 uppercase tracking-wider">
                 Coming Soon
               </div>
@@ -215,15 +215,11 @@ function PricingContent() {
             </div>
 
             <button
-              onClick={() => t.tier !== 'trader_pro' && handleUpgrade(t.tier)}
-              disabled={loading !== null || t.tier === 'trader_pro'}
+              onClick={() => t.tier === 'free' && handleUpgrade(t.tier)}
+              disabled={loading !== null || t.tier !== 'free'}
               className={`w-full px-4 py-2 text-xs font-medium ${
-                t.tier === 'trader_pro'
+                t.tier !== 'free'
                   ? 'bg-border text-text-muted cursor-not-allowed'
-                  : t.highlight
-                  ? 'bg-brand-purple text-white hover:bg-brand-purple-hover'
-                  : t.tier === 'free'
-                  ? 'border border-border text-text-secondary hover:bg-bg-row'
                   : 'border border-border text-text-secondary hover:bg-bg-row'
               }`}
             >

--- a/src/app/shopping/page.tsx
+++ b/src/app/shopping/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import { AppLayout } from '@/components/ui';
+import { ADMIN_USER_ID } from '@/lib/tiers';
 import MealPlannerForm, { MealPlan, Ingredient } from '@/components/shopping/MealPlannerForm';
 import MealPlanDashboard from '@/components/shopping/MealPlanDashboard';
 import CartPlannerForm, { CartPlan, CartItem, CartCategory } from '@/components/shopping/CartPlannerForm';
@@ -31,12 +32,13 @@ export default function ShoppingPage() {
   });
   const [activeCategory, setActiveCategory] = useState<PlannerCategory>('meals');
   const [userTier, setUserTier] = useState<string>('free');
+  const [currentUserId, setCurrentUserId] = useState<string>('');
   const [showUpgradeModal, setShowUpgradeModal] = useState(false);
   const [commitLoading, setCommitLoading] = useState(false);
 
   useEffect(() => {
     fetch('/api/auth/me').then(res => res.ok ? res.json() : null).then(data => {
-      if (data?.user?.tier) setUserTier(data.user.tier);
+      if (data?.user?.tier) setUserTier(data.user.tier); if (data?.user?.id) setCurrentUserId(data.user.id);
     }).finally(() => setLoading(false));
 
     const saved = localStorage.getItem(getMealPlanKey());
@@ -245,7 +247,7 @@ export default function ShoppingPage() {
                     onCommit={commitLoading ? undefined : () => handleCommit('meals')}
                   />
                 ) : (
-                  userTier === 'free' ? (
+                  userTier === 'free' && currentUserId !== ADMIN_USER_ID ? (
                     <div className="text-center py-8">
                       <div className="text-sm font-medium text-text-primary mb-2">AI Shopping Planner requires Pro+</div>
                       <div className="text-xs text-text-muted mb-4">Upgrade to Pro+ ($40/mo) to unlock AI-powered planning.</div>
@@ -270,7 +272,7 @@ export default function ShoppingPage() {
                     onCommit={commitLoading ? undefined : () => handleCommit(cat)}
                   />
                 ) : (
-                  userTier === 'free' ? (
+                  userTier === 'free' && currentUserId !== ADMIN_USER_ID ? (
                     <div className="text-center py-8">
                       <div className="text-sm font-medium text-text-primary mb-2">AI Shopping Planner requires Pro+</div>
                       <div className="text-xs text-text-muted mb-4">Upgrade to Pro+ ($40/mo) to unlock AI-powered planning.</div>

--- a/src/lib/auth-helpers.ts
+++ b/src/lib/auth-helpers.ts
@@ -38,8 +38,8 @@ export async function requireUser() {
  *   const gate = requireTier(user.tier, 'plaid');
  *   if (gate) return gate;
  */
-export function requireTier(tier: string | null | undefined, feature: keyof TierConfig): NextResponse | null {
-  if (!canAccess(tier, feature)) {
+export function requireTier(tier: string | null | undefined, feature: keyof TierConfig, userId?: string | null): NextResponse | null {
+  if (!canAccess(tier, feature, userId)) {
     return NextResponse.json(
       { error: 'Upgrade required', feature, message: `This feature requires a plan with ${feature} access.` },
       { status: 403 }

--- a/src/lib/tiers.ts
+++ b/src/lib/tiers.ts
@@ -4,7 +4,13 @@
  * Free:  Manual entry only. No Plaid, no AI.
  * Pro:   Plaid sync + all bookkeeping features.
  * Pro+:  Everything in Pro + AI insights + trip AI + trading analytics.
+ *
+ * NOTE: All paid tiers are currently gated as "Coming Soon" for public users.
+ * Only the admin user (ADMIN_USER_ID) has full access to all features.
  */
+
+// Admin bypass — this user retains full access to all features
+export const ADMIN_USER_ID = 'cmfi3rcrl0000zcj0ajbj4za5';
 
 export type Tier = 'free' | 'pro' | 'pro_plus';
 
@@ -57,7 +63,16 @@ export function getTierConfig(tier: string | null | undefined): TierConfig {
   return TIER_MAP[normalized] || TIER_MAP.free;
 }
 
-export function canAccess(tier: string | null | undefined, feature: keyof TierConfig): boolean {
+export function canAccess(tier: string | null | undefined, feature: keyof TierConfig, userId?: string | null): boolean {
+  // Admin bypass — full access to all features
+  if (userId === ADMIN_USER_ID) return true;
   const config = getTierConfig(tier);
   return !!config[feature];
+}
+
+/**
+ * Check if a user is the admin (full-access) user.
+ */
+export function isAdminUser(userId: string | null | undefined): boolean {
+  return userId === ADMIN_USER_ID;
 }


### PR DESCRIPTION
All paid subscription tiers (Pro, Pro+, Trader Pro) are now gated as "Coming Soon" with disabled subscribe buttons. Only the Free tier "Get Started Free" remains active. Users can create accounts and explore the app but cannot access paid APIs or subscribe.

Admin bypass (ADMIN_USER_ID in tiers.ts) retains full access to all features for Alex's account (cmfi3rcrl0000zcj0ajbj4za5).

Changes:
- tiers.ts: Add ADMIN_USER_ID constant, canAccess() accepts optional userId for admin bypass, add isAdminUser() helper
- auth-helpers.ts: requireTier() accepts optional userId, passes to canAccess()
- All 13 API routes with requireTier: pass user.id as third arg (plaid/*, ai/*, convergence/*, trips/ai-assistant)
- pricing/page.tsx: Pro and Pro+ buttons disabled with "Coming Soon" badge, matching Trader Pro's existing pattern
- page.tsx (landing): Pro and Pro+ subscribe buttons → disabled "Coming Soon", matching Trader Pro
- dashboard/page.tsx: Plaid "Add Account" checks admin bypass
- budgets/trips/[id]/page.tsx: AI Trip Planner checks admin bypass
- shopping/page.tsx: AI Shopping Planner checks admin bypass

https://claude.ai/code/session_01GHNnihseAHoZFcnRMWjQMu