### PR TITLE
Reorder trip detail page and restyle to match header design

### DIFF
--- a/src/app/budgets/trips/[id]/page.tsx
+++ b/src/app/budgets/trips/[id]/page.tsx
@@ -452,32 +452,32 @@ export default function TripDetailPage({ params }: { params: Promise<{ id: strin
     <AppLayout>
       <div className="min-h-screen bg-bg-terminal">
         <div className="p-4 lg:p-6 max-w-[1800px] mx-auto">
-          
+
           {/* Header */}
-          <div className="mb-4 bg-brand-purple text-white p-4">
+          <div className="mb-4 bg-white rounded-lg border border-gray-200 p-4">
             <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4">
               <div>
                 <div className="flex items-center gap-2 mb-1">
-                  <button onClick={() => router.push('/budgets/trips')} className="text-text-faint hover:text-white text-xs">
+                  <button onClick={() => router.push('/budgets/trips')} className="text-gray-400 hover:text-gray-700 text-xs">
                     ← Trips
                   </button>
-                  <span className={`px-2 py-0.5 text-[10px] ${trip.committedAt ? 'bg-emerald-500' : 'bg-amber-500'}`}>
-                    {trip.committedAt ? 'COMMITTED' : 'PLANNING'}
+                  <span className={`px-2 py-0.5 text-xs rounded ${trip.committedAt ? 'bg-emerald-100 text-emerald-700' : 'bg-amber-100 text-amber-700'}`}>
+                    {trip.committedAt ? 'Committed' : 'Planning'}
                   </span>
                 </div>
-                <h1 className="text-terminal-lg font-semibold tracking-tight">{trip.name}</h1>
-                <p className="text-text-faint text-xs font-mono">
+                <h1 className="text-lg font-semibold text-gray-900">{trip.name}</h1>
+                <p className="text-gray-500 text-sm">
                   {trip.destination || 'Destination TBD'} · {MONTHS[trip.month]} {trip.year} · {trip.daysTravel} days
                 </p>
               </div>
               <div className="flex items-center gap-3">
                 <div className="text-right">
-                  <div className="text-sm font-bold font-mono">{fmt(totalBudget || totalExpenses)}</div>
-                  <div className="text-[10px] text-text-faint">total budget</div>
+                  <div className="text-sm font-bold text-gray-900">{fmt(totalBudget || totalExpenses)}</div>
+                  <div className="text-xs text-gray-500">total budget</div>
                 </div>
                 {trip.inviteToken && (
                   <button onClick={copyInviteLink}
-                    className="px-3 py-2 text-xs bg-white/10 hover:bg-white/20">
+                    className="px-3 py-2 text-xs bg-brand-gold hover:bg-brand-gold-bright text-white rounded-lg font-medium">
                     {copiedLink ? '✓ Copied' : 'Copy Invite'}
                   </button>
                 )}
@@ -487,104 +487,226 @@ export default function TripDetailPage({ params }: { params: Promise<{ id: strin
 
           {/* Quick Stats */}
           <div className="grid grid-cols-2 lg:grid-cols-5 gap-3 mb-4">
-            <div className="bg-white border border-border p-3">
-              <div className="text-[10px] text-text-muted uppercase tracking-wider">Crew</div>
-              <div className="text-sm font-bold font-mono text-text-primary">{confirmedParticipants.length}</div>
-              <div className="text-[10px] text-text-faint">{participants.length} invited</div>
-            </div>
-            <div className="bg-white border border-border p-3">
-              <div className="text-[10px] text-text-muted uppercase tracking-wider">Days</div>
-              <div className="text-sm font-bold font-mono text-text-primary">{trip.daysTravel}</div>
-            </div>
-            <div className="bg-white border border-border p-3">
-              <div className="text-[10px] text-text-muted uppercase tracking-wider">Expenses</div>
-              <div className="text-sm font-bold font-mono text-text-primary">{trip.expenses.length}</div>
-            </div>
-            <div className="bg-white border border-border p-3">
-              <div className="text-[10px] text-text-muted uppercase tracking-wider">Budget</div>
-              <div className="text-sm font-bold font-mono text-emerald-700">{fmt(totalBudget || totalExpenses)}</div>
-            </div>
-            <div className="bg-white border border-border p-3">
-              <div className="text-[10px] text-text-muted uppercase tracking-wider">Per Person</div>
-              <div className="text-sm font-bold font-mono text-text-primary">
-                {confirmedParticipants.length > 0 ? fmt((totalBudget || totalExpenses) / confirmedParticipants.length) : '—'}
+            {[
+              { label: 'Crew', value: String(confirmedParticipants.length), sub: `${participants.length} invited` },
+              { label: 'Days', value: String(trip.daysTravel) },
+              { label: 'Expenses', value: String(trip.expenses.length) },
+              { label: 'Budget', value: fmt(totalBudget || totalExpenses), color: 'text-emerald-700' },
+              { label: 'Per Person', value: confirmedParticipants.length > 0 ? fmt((totalBudget || totalExpenses) / confirmedParticipants.length) : '—' },
+            ].map(stat => (
+              <div key={stat.label} className="bg-white rounded-lg border border-gray-200 p-3">
+                <div className="text-xs text-gray-500 uppercase tracking-wider">{stat.label}</div>
+                <div className={`text-sm font-bold ${stat.color || 'text-gray-900'}`}>{stat.value}</div>
+                {stat.sub && <div className="text-xs text-gray-400">{stat.sub}</div>}
               </div>
-            </div>
+            ))}
           </div>
 
-          {/* Trip Profiles — each participant fills out their travel preferences */}
-          <div className="bg-white rounded-lg border border-border p-4 mb-4">
-            <div className="flex justify-between items-center mb-3">
-              <h3 className="font-semibold text-sm text-text-primary">Trip Profiles</h3>
-              <span className="text-xs text-text-muted">
-                {participants.filter(p => !!p.profileTripType).length} of {participants.length} profiles complete
-              </span>
-            </div>
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-              {participants.map(p => (
-                <TripProfileCard
-                  key={p.id}
-                  participant={p}
-                  isCurrentUser={p.email.toLowerCase() === currentUserEmail.toLowerCase()}
-                  tripId={id}
-                  onProfileSaved={() => { loadParticipants(); }}
-                />
-              ))}
-            </div>
-          </div>
-
-          {/* ═══════════════════════════════════════════════════════════ */}
-          {/* SCOREBOARD — Itinerary + Crew (reference while planning)  */}
-          {/* ═══════════════════════════════════════════════════════════ */}
           <div className="space-y-4">
 
-            {/* ── Itinerary (scoreboard — fills up as you commit vendors) ── */}
-            <div className="bg-white border border-border">
-              <div className="bg-brand-purple text-white px-4 py-2 text-sm font-semibold flex items-center justify-between">
-                <span>Itinerary</span>
+            {/* ── Crew & Profiles ── */}
+            <div className="bg-white rounded-lg border border-gray-200 p-4">
+              <div className="flex justify-between items-center border-b border-gray-200 pb-2 mb-4">
+                <h2 className="text-sm font-semibold text-gray-700">Crew ({participants.length})</h2>
+                <span className="text-xs text-gray-500">
+                  {participants.filter(p => !!p.profileTripType).length} of {participants.length} profiles complete
+                </span>
+              </div>
+              <div className="overflow-x-auto mb-4">
+                <table className="w-full text-xs">
+                  <thead className="border-b border-gray-200">
+                    <tr>
+                      <th className="px-3 py-2 text-left font-medium text-gray-500">Name</th>
+                      <th className="px-3 py-2 text-left font-medium text-gray-500">Email</th>
+                      <th className="px-3 py-2 text-center font-medium text-gray-500">Status</th>
+                      <th className="px-3 py-2 text-center font-medium text-gray-500">Role</th>
+                      <th className="px-3 py-2 text-center font-medium text-gray-500">Blackout Days</th>
+                      <th className="px-3 py-2 text-center font-medium text-gray-500"></th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-gray-100">
+                    {participants.map(p => (
+                      <tr key={p.id} className="hover:bg-gray-50">
+                        <td className="px-3 py-3">
+                          <div className="flex items-center gap-2">
+                            <div className={`w-7 h-7 rounded-full flex items-center justify-center text-xs font-bold text-white ${
+                              p.rsvpStatus === 'confirmed' ? 'bg-emerald-500' : p.rsvpStatus === 'declined' ? 'bg-red-500' : 'bg-amber-500'
+                            }`}>
+                              {p.firstName[0]}
+                            </div>
+                            <span className="font-medium text-gray-900">{p.firstName} {p.lastName}</span>
+                          </div>
+                        </td>
+                        <td className="px-3 py-3 text-gray-500">{p.email}</td>
+                        <td className="px-3 py-3 text-center">
+                          <span className={`px-2 py-0.5 text-xs rounded ${
+                            p.rsvpStatus === 'confirmed' ? 'bg-emerald-100 text-emerald-700' :
+                            p.rsvpStatus === 'declined' ? 'bg-red-100 text-red-700' :
+                            'bg-amber-100 text-amber-700'
+                          }`}>
+                            {p.rsvpStatus}
+                          </span>
+                        </td>
+                        <td className="px-3 py-3 text-center">
+                          {p.isOwner && <span className="px-2 py-0.5 bg-brand-purple/10 text-brand-purple text-xs rounded">Organizer</span>}
+                        </td>
+                        <td className="px-3 py-3 text-center text-gray-400">
+                          {(p.unavailableDays || []).length > 0 ? (p.unavailableDays || []).join(', ') : '—'}
+                        </td>
+                        <td className="px-3 py-3 text-center">
+                          {!p.isOwner && (
+                            <button onClick={() => removeParticipant(p.id, p.firstName)}
+                              className="text-gray-400 hover:text-red-500">×</button>
+                          )}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+              {/* Inline profiles */}
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                {participants.map(p => (
+                  <TripProfileCard
+                    key={p.id}
+                    participant={p}
+                    isCurrentUser={p.email.toLowerCase() === currentUserEmail.toLowerCase()}
+                    tripId={id}
+                    onProfileSaved={() => { loadParticipants(); }}
+                  />
+                ))}
+              </div>
+            </div>
+
+            {/* ── Dates ── */}
+            <div className="bg-white rounded-lg border border-gray-200 p-4">
+              <h2 className="text-sm font-semibold text-gray-700 border-b border-gray-200 pb-2 mb-4">Dates</h2>
+              {editingDates ? (
+                <div className="space-y-3">
+                  <div className="grid grid-cols-2 gap-4">
+                    <div>
+                      <label className="text-xs text-gray-500 block mb-1">Start Date</label>
+                      <input type="date" value={editStartDate} onChange={e => setEditStartDate(e.target.value)}
+                        className="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:border-brand-purple" />
+                    </div>
+                    <div>
+                      <label className="text-xs text-gray-500 block mb-1">End Date</label>
+                      <input type="date" value={editEndDate} onChange={e => setEditEndDate(e.target.value)}
+                        min={editStartDate}
+                        className="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:border-brand-purple" />
+                    </div>
+                  </div>
+                  <div className="flex gap-2">
+                    <button onClick={saveDates} disabled={!editStartDate || !editEndDate}
+                      className="px-4 py-1.5 bg-brand-gold text-white text-xs font-medium rounded-lg disabled:opacity-50">
+                      Save
+                    </button>
+                    <button onClick={() => setEditingDates(false)}
+                      className="px-4 py-1.5 text-gray-500 hover:text-gray-700 text-xs">
+                      Cancel
+                    </button>
+                  </div>
+                </div>
+              ) : (
+                <div className="flex items-center gap-6">
+                  <div>
+                    <div className="text-xs text-gray-500 uppercase tracking-wider">Start</div>
+                    <div className="text-sm font-semibold text-gray-900">
+                      {trip.startDate ? new Date(trip.startDate).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' }) : 'Not set'}
+                    </div>
+                  </div>
+                  <span className="text-xl text-gray-300">→</span>
+                  <div>
+                    <div className="text-xs text-gray-500 uppercase tracking-wider">End</div>
+                    <div className="text-sm font-semibold text-gray-900">
+                      {trip.endDate ? new Date(trip.endDate).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' }) : 'Not set'}
+                    </div>
+                  </div>
+                  <div>
+                    <div className="text-xs text-gray-500 uppercase tracking-wider">Duration</div>
+                    <div className="text-sm font-semibold text-gray-900">{trip.daysTravel} days</div>
+                  </div>
+                  <button onClick={() => {
+                    setEditStartDate(trip.startDate ? new Date(trip.startDate).toISOString().split('T')[0] : '');
+                    setEditEndDate(trip.endDate ? new Date(trip.endDate).toISOString().split('T')[0] : '');
+                    setEditingDates(true);
+                  }} className="ml-auto text-xs text-brand-purple hover:underline font-medium">
+                    Edit Dates
+                  </button>
+                </div>
+              )}
+            </div>
+
+            {/* ── Destinations ── */}
+            <div className="bg-white rounded-lg border border-gray-200 p-4">
+              <h2 className="text-sm font-semibold text-gray-700 border-b border-gray-200 pb-2 mb-4">Destinations</h2>
+              <DestinationSelector
+                activity={trip.activity}
+                tripId={id}
+                selectedDestinations={destinations}
+                onDestinationsChange={loadDestinations}
+                selectedDestinationId={destinations.find((d: any) => d.resort?.name === trip.destination)?.resortId}
+                onSelectDestination={selectDestination}
+              />
+              {destinations.length > 0 && (
+                <div className="mt-6">
+                  <div className="text-xs font-medium text-gray-500 mb-3 uppercase tracking-wider">Location Map</div>
+                  <DestinationMap
+                    destinations={destinations}
+                    selectedName={trip.destination}
+                    onDestinationClick={(resortId: string, name: string) => selectDestination(resortId, name)}
+                  />
+                </div>
+              )}
+            </div>
+
+            {/* ── Itinerary Calendar ── */}
+            <div className="bg-white rounded-lg border border-gray-200">
+              <div className="p-4 border-b border-gray-200 flex items-center justify-between">
+                <h2 className="text-sm font-semibold text-gray-700">Itinerary</h2>
                 <button onClick={() => setShowExpenseForm(!showExpenseForm)}
-                  className="px-3 py-1 text-xs bg-white/10 hover:bg-white/20">
+                  className="px-3 py-1.5 text-xs bg-brand-gold hover:bg-brand-gold-bright text-white rounded-lg font-medium">
                   {showExpenseForm ? 'Cancel' : '+ Add Expense'}
                 </button>
               </div>
 
               {/* Inline Add Expense Form */}
               {showExpenseForm && (
-                <form onSubmit={handleAddExpense} className="p-4 bg-bg-row border-b border-border">
+                <form onSubmit={handleAddExpense} className="p-4 bg-gray-50 border-b border-gray-200">
                   <div className="grid grid-cols-2 md:grid-cols-4 gap-2 mb-2">
                     <select value={expenseForm.paidById} onChange={(e) => setExpenseForm({ ...expenseForm, paidById: e.target.value })}
-                      className="bg-white border border-border px-2 py-1.5 text-xs" required>
+                      className="bg-white border border-gray-200 rounded-lg px-2 py-1.5 text-xs" required>
                       <option value="">Paid by...</option>
                       {confirmedParticipants.map(p => <option key={p.id} value={p.id}>{p.firstName}</option>)}
                     </select>
                     <select value={expenseForm.category} onChange={(e) => setExpenseForm({ ...expenseForm, category: e.target.value })}
-                      className="bg-white border border-border px-2 py-1.5 text-xs">
+                      className="bg-white border border-gray-200 rounded-lg px-2 py-1.5 text-xs">
                       {CATEGORIES.map(c => <option key={c.value} value={c.value}>{c.label}</option>)}
                     </select>
                     <input type="text" placeholder="Vendor *" value={expenseForm.vendor} onChange={(e) => setExpenseForm({ ...expenseForm, vendor: e.target.value })}
-                      className="bg-white border border-border px-2 py-1.5 text-xs" required />
+                      className="bg-white border border-gray-200 rounded-lg px-2 py-1.5 text-xs" required />
                     <input type="number" step="0.01" placeholder="Amount *" value={expenseForm.amount} onChange={(e) => setExpenseForm({ ...expenseForm, amount: e.target.value })}
-                      className="bg-white border border-border px-2 py-1.5 text-xs" required />
+                      className="bg-white border border-gray-200 rounded-lg px-2 py-1.5 text-xs" required />
                   </div>
                   <div className="grid grid-cols-2 md:grid-cols-4 gap-2 mb-2">
                     <input type="number" min="1" max={trip.daysTravel} placeholder="Day #" value={expenseForm.day} onChange={(e) => setExpenseForm({ ...expenseForm, day: e.target.value })}
-                      className="bg-white border border-border px-2 py-1.5 text-xs" />
+                      className="bg-white border border-gray-200 rounded-lg px-2 py-1.5 text-xs" />
                     <input type="date" value={expenseForm.date} onChange={(e) => setExpenseForm({ ...expenseForm, date: e.target.value })}
-                      className="bg-white border border-border px-2 py-1.5 text-xs" />
+                      className="bg-white border border-gray-200 rounded-lg px-2 py-1.5 text-xs" />
                     <input type="text" placeholder="Description" value={expenseForm.description} onChange={(e) => setExpenseForm({ ...expenseForm, description: e.target.value })}
-                      className="bg-white border border-border px-2 py-1.5 text-xs col-span-2" />
+                      className="bg-white border border-gray-200 rounded-lg px-2 py-1.5 text-xs col-span-2" />
                   </div>
                   <div className="flex items-center gap-2 mb-2">
-                    <span className="text-xs text-text-muted">Split:</span>
+                    <span className="text-xs text-gray-500">Split:</span>
                     {confirmedParticipants.map(p => (
                       <button key={p.id} type="button" onClick={() => toggleSplitWith(p.id)}
-                        className={`px-2 py-1 text-[10px] font-medium ${expenseForm.splitWith.includes(p.id) ? 'bg-brand-purple text-white' : 'bg-border text-text-secondary'}`}>
+                        className={`px-2 py-1 text-xs font-medium rounded ${expenseForm.splitWith.includes(p.id) ? 'bg-brand-purple text-white' : 'bg-gray-100 text-gray-600'}`}>
                         {p.firstName}
                       </button>
                     ))}
                   </div>
                   <button type="submit" disabled={savingExpense}
-                    className="px-4 py-2 bg-brand-purple text-white text-xs font-medium disabled:opacity-50">
+                    className="px-4 py-2 bg-brand-gold text-white text-xs font-medium rounded-lg disabled:opacity-50">
                     {savingExpense ? '...' : 'Add'}
                   </button>
                 </form>
@@ -596,9 +718,9 @@ export default function TripDetailPage({ params }: { params: Promise<{ id: strin
                     events={calendarEvents}
                     sourceConfig={TRIP_SOURCE_CONFIG}
                     defaultView="week"
-                    anchorDate={tripDates?.departure || trip.startDate || undefined}
-                    highlightStart={tripDates?.departure || trip.startDate || undefined}
-                    highlightEnd={tripDates?.return || trip.endDate || undefined}
+                    anchorDate={tripDates?.departure || trip.startDate?.split('T')[0] || undefined}
+                    highlightStart={tripDates?.departure || trip.startDate?.split('T')[0] || undefined}
+                    highlightEnd={tripDates?.return || trip.endDate?.split('T')[0] || undefined}
                     onEventClick={(event) => setClickedEvent(event as any)}
                     showBudgetTotals={true}
                     showCategoryLegend={true}
@@ -606,211 +728,51 @@ export default function TripDetailPage({ params }: { params: Promise<{ id: strin
                   />
                   {/* Event detail popover */}
                   {clickedEvent && (
-                    <div className="mt-3 p-3 bg-white border border-border rounded shadow-md">
+                    <div className="mt-3 p-3 bg-white border border-gray-200 rounded-lg shadow-md">
                       <div className="flex items-center justify-between">
                         <div>
-                          <div className="text-sm font-medium text-text-primary">{clickedEvent.title}</div>
-                          <div className="text-xs text-text-muted mt-0.5">
+                          <div className="text-sm font-medium text-gray-900">{clickedEvent.title}</div>
+                          <div className="text-xs text-gray-500 mt-0.5">
                             {TRIP_SOURCE_CONFIG[clickedEvent.source]?.label || clickedEvent.source}
                             {clickedEvent.startDate && <span className="ml-2">{clickedEvent.startDate}</span>}
                             {clickedEvent.endDate && clickedEvent.endDate !== clickedEvent.startDate && <span> — {clickedEvent.endDate}</span>}
                           </div>
                           {(clickedEvent.budgetAmount || 0) > 0 && (
-                            <div className="text-sm font-mono font-semibold text-emerald-700 mt-1">{fmt(clickedEvent.budgetAmount || 0)}</div>
+                            <div className="text-sm font-semibold text-emerald-700 mt-1">{fmt(clickedEvent.budgetAmount || 0)}</div>
                           )}
                         </div>
                         <div className="flex items-center gap-2">
                           {clickedEvent._vendorOptionId && (
                             <button onClick={handleUncommitEvent} disabled={uncommitting}
-                              className="px-3 py-1.5 text-xs text-red-600 hover:bg-red-50 border border-red-200 rounded disabled:opacity-50">
+                              className="px-3 py-1.5 text-xs text-red-600 hover:bg-red-50 border border-red-200 rounded-lg disabled:opacity-50">
                               {uncommitting ? '...' : 'Uncommit'}
                             </button>
                           )}
-                          <button onClick={() => setClickedEvent(null)} className="px-2 py-1.5 text-xs text-text-muted hover:bg-bg-row rounded">Close</button>
+                          <button onClick={() => setClickedEvent(null)} className="px-2 py-1.5 text-xs text-gray-400 hover:bg-gray-50 rounded-lg">Close</button>
                         </div>
                       </div>
                     </div>
                   )}
                 </div>
               ) : (
-                <div className="p-8 text-center text-text-faint">
+                <div className="p-8 text-center text-gray-400">
                   <p className="text-sm mb-2">Commit vendors to see itinerary calendar</p>
                   <p className="text-xs">Select dates and destination first, then commit lodging, flights, etc.</p>
                 </div>
               )}
             </div>
 
-            {/* ── Crew ── */}
-            <div className="bg-white border border-border">
-              <div className="bg-brand-purple text-white px-4 py-2 text-sm font-semibold">
-                Crew ({participants.length})
-              </div>
-              <div className="overflow-x-auto">
-                <table className="w-full text-xs">
-                  <thead className="bg-brand-purple-hover text-white">
-                    <tr>
-                      <th className="px-3 py-2 text-left font-medium">Name</th>
-                      <th className="px-3 py-2 text-left font-medium">Email</th>
-                      <th className="px-3 py-2 text-center font-medium">Status</th>
-                      <th className="px-3 py-2 text-center font-medium">Role</th>
-                      <th className="px-3 py-2 text-center font-medium">Blackout Days</th>
-                      <th className="px-3 py-2 text-center font-medium"></th>
-                    </tr>
-                  </thead>
-                  <tbody className="divide-y divide-border">
-                    {participants.map(p => (
-                      <tr key={p.id} className="hover:bg-bg-row">
-                        <td className="px-3 py-3">
-                          <div className="flex items-center gap-2">
-                            <div className={`w-7 h-7 rounded-full flex items-center justify-center text-[10px] font-bold text-white ${
-                              p.rsvpStatus === 'confirmed' ? 'bg-emerald-500' : p.rsvpStatus === 'declined' ? 'bg-red-500' : 'bg-amber-500'
-                            }`}>
-                              {p.firstName[0]}
-                            </div>
-                            <span className="font-medium text-text-primary">{p.firstName} {p.lastName}</span>
-                          </div>
-                        </td>
-                        <td className="px-3 py-3 text-text-secondary font-mono">{p.email}</td>
-                        <td className="px-3 py-3 text-center">
-                          <span className={`px-2 py-0.5 text-[10px] ${
-                            p.rsvpStatus === 'confirmed' ? 'bg-emerald-100 text-emerald-700' :
-                            p.rsvpStatus === 'declined' ? 'bg-red-100 text-brand-red' :
-                            'bg-amber-100 text-amber-700'
-                          }`}>
-                            {p.rsvpStatus}
-                          </span>
-                        </td>
-                        <td className="px-3 py-3 text-center">
-                          {p.isOwner && <span className="px-2 py-0.5 bg-brand-purple-wash text-brand-purple text-[10px]">Organizer</span>}
-                        </td>
-                        <td className="px-3 py-3 text-center text-text-muted">
-                          {(p.unavailableDays || []).length > 0 ? (p.unavailableDays || []).join(', ') : '—'}
-                        </td>
-                        <td className="px-3 py-3 text-center">
-                          {!p.isOwner && (
-                            <button onClick={() => removeParticipant(p.id, p.firstName)}
-                              className="text-text-faint hover:text-brand-red">×</button>
-                          )}
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-            </div>
-
-            {/* ═══════════════════════════════════════════════════════════ */}
-            {/* PLANNING FLOW — Steps 1 through 6                         */}
-            {/* ═══════════════════════════════════════════════════════════ */}
-
-            {/* ── Step 1: Dates ── */}
-            <div className="bg-white border border-border">
-              <div className="bg-brand-purple text-white px-4 py-2 text-sm font-semibold flex items-center gap-2">
-                <span className="w-5 h-5 bg-white/20 flex items-center justify-center text-[10px] font-bold">1</span>
-                Dates
-              </div>
-              <div className="p-4">
-                {editingDates ? (
-                  <div className="space-y-3">
-                    <div className="grid grid-cols-2 gap-4">
-                      <div>
-                        <label className="text-xs text-text-muted block mb-1">Start Date</label>
-                        <input type="date" value={editStartDate} onChange={e => setEditStartDate(e.target.value)}
-                          className="w-full px-3 py-2 border border-border text-sm focus:outline-none focus:border-brand-purple" />
-                      </div>
-                      <div>
-                        <label className="text-xs text-text-muted block mb-1">End Date</label>
-                        <input type="date" value={editEndDate} onChange={e => setEditEndDate(e.target.value)}
-                          min={editStartDate}
-                          className="w-full px-3 py-2 border border-border text-sm focus:outline-none focus:border-brand-purple" />
-                      </div>
-                    </div>
-                    <div className="flex gap-2">
-                      <button onClick={saveDates} disabled={!editStartDate || !editEndDate}
-                        className="px-4 py-1.5 bg-brand-purple text-white text-xs font-medium disabled:opacity-50">
-                        Save
-                      </button>
-                      <button onClick={() => setEditingDates(false)}
-                        className="px-4 py-1.5 border border-border text-text-secondary text-xs">
-                        Cancel
-                      </button>
-                    </div>
-                  </div>
-                ) : (
-                  <div className="flex items-center gap-6">
-                    <div>
-                      <div className="text-[10px] text-text-muted uppercase tracking-wider">Start</div>
-                      <div className="text-sm font-semibold text-text-primary">
-                        {trip.startDate ? new Date(trip.startDate).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' }) : 'Not set'}
-                      </div>
-                    </div>
-                    <span className="text-xl text-text-faint">→</span>
-                    <div>
-                      <div className="text-[10px] text-text-muted uppercase tracking-wider">End</div>
-                      <div className="text-sm font-semibold text-text-primary">
-                        {trip.endDate ? new Date(trip.endDate).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' }) : 'Not set'}
-                      </div>
-                    </div>
-                    <div>
-                      <div className="text-[10px] text-text-muted uppercase tracking-wider">Duration</div>
-                      <div className="text-sm font-semibold text-text-primary">{trip.daysTravel} days</div>
-                    </div>
-                    <button onClick={() => {
-                      setEditStartDate(trip.startDate ? new Date(trip.startDate).toISOString().split('T')[0] : '');
-                      setEditEndDate(trip.endDate ? new Date(trip.endDate).toISOString().split('T')[0] : '');
-                      setEditingDates(true);
-                    }} className="ml-auto text-xs text-brand-purple hover:underline font-medium">
-                      Edit Dates
-                    </button>
-                  </div>
-                )}
-              </div>
-            </div>
-
-            {/* ── Step 2: Destinations ── */}
-            <div className="bg-white border border-border">
-              <div className="bg-brand-purple text-white px-4 py-2 text-sm font-semibold flex items-center gap-2">
-                <span className="w-5 h-5 bg-white/20 flex items-center justify-center text-[10px] font-bold">2</span>
-                Destinations
-              </div>
-              <div className="p-4">
-                <DestinationSelector
-                  activity={trip.activity}
-                  tripId={id}
-                  selectedDestinations={destinations}
-                  onDestinationsChange={loadDestinations}
-                  selectedDestinationId={destinations.find((d: any) => d.resort?.name === trip.destination)?.resortId}
-                  onSelectDestination={selectDestination}
-                />
-
-                {destinations.length > 0 && (
-                  <div className="mt-6">
-                    <div className="text-xs font-medium text-text-muted mb-3 uppercase tracking-wider">Location Map</div>
-                    <DestinationMap
-                      destinations={destinations}
-                      selectedName={trip.destination}
-                      onDestinationClick={(resortId: string, name: string) => selectDestination(resortId, name)}
-                    />
-                  </div>
-                )}
-              </div>
-            </div>
-
-            {/* ── Step 3: Trip Planner & Budget ── */}
-            <div className="bg-white border border-border">
-              <div className="bg-brand-purple text-white px-4 py-2 text-sm font-semibold flex items-center gap-2">
-                <span className="w-5 h-5 bg-white/20 flex items-center justify-center text-[10px] font-bold">3</span>
-                Trip Planner &amp; Budget
-              </div>
-              <div className="p-4">
+            {/* ── Trip Planner & Budget ── */}
+            <div className="bg-white rounded-lg border border-gray-200 p-4">
+              <h2 className="text-sm font-semibold text-gray-700 border-b border-gray-200 pb-2 mb-4">Trip Planner &amp; Budget</h2>
               {(() => {
                 const selectedDest = destinations.find((d: any) => d.resort?.name === trip.destination);
                 return (
                   (userTier === 'free' || userTier === 'pro') && currentUserId !== ADMIN_USER_ID ? (
                   <div className="text-center py-8">
-                    <div className="text-sm font-medium text-text-primary mb-2">AI Trip Planner requires Pro+</div>
-                    <div className="text-xs text-text-muted mb-4">Upgrade to Pro+ ($40/mo) to unlock AI-powered trip planning.</div>
-                    <button onClick={() => setShowUpgradeModal(true)} className="px-6 py-2 text-xs bg-brand-purple text-white font-medium hover:bg-brand-purple-hover">View Plans</button>
+                    <div className="text-sm font-medium text-gray-900 mb-2">AI Trip Planner requires Pro+</div>
+                    <div className="text-xs text-gray-500 mb-4">Upgrade to Pro+ ($40/mo) to unlock AI-powered trip planning.</div>
+                    <button onClick={() => setShowUpgradeModal(true)} className="px-6 py-2 text-xs bg-brand-gold text-white font-medium rounded-lg hover:bg-brand-gold-bright">View Plans</button>
                   </div>
                 ) : (
                   <TripPlannerAI
@@ -845,107 +807,91 @@ export default function TripDetailPage({ params }: { params: Promise<{ id: strin
                 )
               );
               })()}
-              </div>
             </div>
 
-            {/* ── Step 4: Flights ── */}
+            {/* ── Flights ── */}
             {tripDates && trip.destination && (
-              <div className="bg-white border border-border">
-                <div className="bg-brand-purple text-white px-4 py-2 text-sm font-semibold flex items-center gap-2">
-                  <span className="w-5 h-5 bg-white/20 flex items-center justify-center text-[10px] font-bold">4</span>
-                  Flights
-                </div>
-                <div className="p-4">
-                  <FlightPicker
-                    tripId={id}
-                    destinationName={trip.destination}
-                    destinationAirport={destinationAirport}
-                    originAirport={originAirport}
-                    departureDate={tripDates.departure}
-                    returnDate={tripDates.return}
-                    passengers={confirmedParticipants.length || 1}
-                    onCommitted={() => { loadTrip(); loadBudgetItems(); }}
-                  />
-                </div>
+              <div className="bg-white rounded-lg border border-gray-200 p-4">
+                <h2 className="text-sm font-semibold text-gray-700 border-b border-gray-200 pb-2 mb-4">Flights</h2>
+                <FlightPicker
+                  tripId={id}
+                  destinationName={trip.destination}
+                  destinationAirport={destinationAirport}
+                  originAirport={originAirport}
+                  departureDate={tripDates.departure}
+                  returnDate={tripDates.return}
+                  passengers={confirmedParticipants.length || 1}
+                  onCommitted={() => { loadTrip(); loadBudgetItems(); }}
+                />
               </div>
             )}
 
-            {/* ── Step 5: Commit Trip ── */}
-            <div className="bg-white border border-border">
-              <div className="bg-brand-purple text-white px-4 py-2 text-sm font-semibold flex items-center gap-2">
-                <span className="w-5 h-5 bg-white/20 flex items-center justify-center text-[10px] font-bold">5</span>
-                Commit to Calendar
-              </div>
-              <div className="p-4">
-                {trip.committedAt ? (
-                  <div className="text-center">
-                    <div className="text-3xl mb-2">✓</div>
-                    <div className="text-sm font-semibold text-emerald-700 mb-1">Trip Committed</div>
-                    <div className="text-xs text-text-muted mb-4">
-                      {new Date(trip.startDate!).toLocaleDateString()} - {new Date(trip.endDate!).toLocaleDateString()}
-                    </div>
-                    <button onClick={uncommitTrip} disabled={committing}
-                      className="px-4 py-2 text-xs border border-border text-text-secondary hover:bg-bg-row">
-                      {committing ? '...' : 'Uncommit'}
-                    </button>
+            {/* ── Commit to Calendar ── */}
+            <div className="bg-white rounded-lg border border-gray-200 p-4">
+              <h2 className="text-sm font-semibold text-gray-700 border-b border-gray-200 pb-2 mb-4">Commit to Calendar</h2>
+              {trip.committedAt ? (
+                <div className="text-center py-4">
+                  <div className="text-sm font-semibold text-emerald-700 mb-1">Trip Committed</div>
+                  <div className="text-xs text-gray-500 mb-4">
+                    {new Date(trip.startDate!).toLocaleDateString()} - {new Date(trip.endDate!).toLocaleDateString()}
                   </div>
-                ) : (
-                  <div>
-                    <div className="grid grid-cols-3 gap-2 mb-4">
-                      <div className={`p-3 text-center border ${confirmedStartDay ? 'border-emerald-500 bg-emerald-50' : 'border-border'}`}>
-                        <div className="text-terminal-lg mb-1">{confirmedStartDay ? '✓' : '—'}</div>
-                        <div className="text-[10px] text-text-muted">Dates</div>
-                      </div>
-                      <div className={`p-3 text-center border ${trip.destination ? 'border-emerald-500 bg-emerald-50' : 'border-border'}`}>
-                        <div className="text-terminal-lg mb-1">{trip.destination ? '✓' : '—'}</div>
-                        <div className="text-[10px] text-text-muted">Destination</div>
-                      </div>
-                      <div className={`p-3 text-center border ${committedBudgetItems.length > 0 ? 'border-emerald-500 bg-emerald-50' : 'border-border'}`}>
-                        <div className="text-terminal-lg mb-1">{committedBudgetItems.length > 0 ? '✓' : '—'}</div>
-                        <div className="text-[10px] text-text-muted">Budget</div>
-                      </div>
+                  <button onClick={uncommitTrip} disabled={committing}
+                    className="px-4 py-2 text-xs text-gray-500 hover:text-gray-700 border border-gray-200 rounded-lg">
+                    {committing ? '...' : 'Uncommit'}
+                  </button>
+                </div>
+              ) : (
+                <div>
+                  <div className="grid grid-cols-3 gap-2 mb-4">
+                    <div className={`p-3 text-center rounded-lg border ${confirmedStartDay ? 'border-emerald-400 bg-emerald-50' : 'border-gray-200'}`}>
+                      <div className="text-lg mb-1">{confirmedStartDay ? '✓' : '—'}</div>
+                      <div className="text-xs text-gray-500">Dates</div>
                     </div>
-                    <button onClick={commitTrip} disabled={!confirmedStartDay || !trip.destination || committing}
-                      className="w-full px-4 py-3 bg-brand-purple text-white text-sm font-medium hover:bg-brand-purple-hover disabled:opacity-50">
-                      {committing ? 'Committing...' : 'Commit Trip'}
-                    </button>
+                    <div className={`p-3 text-center rounded-lg border ${trip.destination ? 'border-emerald-400 bg-emerald-50' : 'border-gray-200'}`}>
+                      <div className="text-lg mb-1">{trip.destination ? '✓' : '—'}</div>
+                      <div className="text-xs text-gray-500">Destination</div>
+                    </div>
+                    <div className={`p-3 text-center rounded-lg border ${committedBudgetItems.length > 0 ? 'border-emerald-400 bg-emerald-50' : 'border-gray-200'}`}>
+                      <div className="text-lg mb-1">{committedBudgetItems.length > 0 ? '✓' : '—'}</div>
+                      <div className="text-xs text-gray-500">Budget</div>
+                    </div>
                   </div>
-                )}
-              </div>
+                  <button onClick={commitTrip} disabled={!confirmedStartDay || !trip.destination || committing}
+                    className="w-full px-4 py-3 bg-brand-gold text-white text-sm font-semibold rounded-lg hover:bg-brand-gold-bright disabled:opacity-50">
+                    {committing ? 'Committing...' : 'Commit Trip'}
+                  </button>
+                </div>
+              )}
             </div>
-
-            {/* ═══════════════════════════════════════════════════════════ */}
-            {/* OUTPUT / REFERENCE SECTIONS                               */}
-            {/* ═══════════════════════════════════════════════════════════ */}
 
             {/* ── Budget Summary ── */}
             {committedBudgetItems.length > 0 && (
-              <div className="bg-white border border-border">
-                <div className="bg-brand-purple-hover text-white px-4 py-2 text-xs font-semibold uppercase tracking-wider">
-                  Committed Budget
+              <div className="bg-white rounded-lg border border-gray-200">
+                <div className="p-4 border-b border-gray-200">
+                  <h2 className="text-sm font-semibold text-gray-700">Committed Budget</h2>
                 </div>
                 <div className="overflow-x-auto">
                   <table className="w-full text-xs">
-                    <thead className="bg-bg-row">
+                    <thead className="bg-gray-50">
                       <tr>
-                        <th className="px-3 py-2 text-left font-medium">Item</th>
-                        <th className="px-3 py-2 text-left font-medium">Category</th>
-                        <th className="px-3 py-2 text-right font-medium">Amount</th>
+                        <th className="px-3 py-2 text-left font-medium text-gray-500">Item</th>
+                        <th className="px-3 py-2 text-left font-medium text-gray-500">Category</th>
+                        <th className="px-3 py-2 text-right font-medium text-gray-500">Amount</th>
                       </tr>
                     </thead>
-                    <tbody className="divide-y divide-border">
+                    <tbody className="divide-y divide-gray-100">
                       {committedBudgetItems.map((item, idx) => (
-                        <tr key={idx} className="hover:bg-bg-row">
-                          <td className="px-3 py-2 font-medium">{item.description || item.category}</td>
-                          <td className="px-3 py-2 text-text-secondary">{item.category}</td>
-                          <td className="px-3 py-2 text-right font-mono font-semibold text-emerald-700">{fmt(item.amount)}</td>
+                        <tr key={idx} className="hover:bg-gray-50">
+                          <td className="px-3 py-2 font-medium text-gray-900">{item.description || item.category}</td>
+                          <td className="px-3 py-2 text-gray-500">{item.category}</td>
+                          <td className="px-3 py-2 text-right font-semibold text-emerald-700">{fmt(item.amount)}</td>
                         </tr>
                       ))}
                     </tbody>
-                    <tfoot className="bg-bg-row border-t border-border">
+                    <tfoot className="bg-gray-50 border-t border-gray-200">
                       <tr>
-                        <td colSpan={2} className="px-3 py-2 font-semibold">Total</td>
-                        <td className="px-3 py-2 text-right font-mono font-bold text-emerald-700">{fmt(totalBudget)}</td>
+                        <td colSpan={2} className="px-3 py-2 font-semibold text-gray-900">Total</td>
+                        <td className="px-3 py-2 text-right font-bold text-emerald-700">{fmt(totalBudget)}</td>
                       </tr>
                     </tfoot>
                   </table>
@@ -955,30 +901,28 @@ export default function TripDetailPage({ params }: { params: Promise<{ id: strin
 
             {/* ── Settlement Matrix ── */}
             {confirmedParticipants.length > 1 && (
-              <div className="bg-white border border-border">
-                <div className="bg-brand-purple-hover text-white px-4 py-2 text-xs font-semibold uppercase tracking-wider">
-                  Settlement Matrix
-                </div>
-                <div className="p-4 overflow-x-auto">
+              <div className="bg-white rounded-lg border border-gray-200 p-4">
+                <h2 className="text-sm font-semibold text-gray-700 border-b border-gray-200 pb-2 mb-4">Settlement Matrix</h2>
+                <div className="overflow-x-auto">
                   <table className="text-xs">
                     <thead>
                       <tr>
-                        <th className="text-left py-2 px-2 text-text-muted font-medium">Owes →</th>
+                        <th className="text-left py-2 px-2 text-gray-500 font-medium">Owes →</th>
                         {confirmedParticipants.map(p => (
-                          <th key={p.id} className="text-center py-2 px-3 text-text-muted font-medium">{p.firstName}</th>
+                          <th key={p.id} className="text-center py-2 px-3 text-gray-500 font-medium">{p.firstName}</th>
                         ))}
                       </tr>
                     </thead>
                     <tbody>
                       {confirmedParticipants.map(p => (
-                        <tr key={p.id} className="border-t border-border-light">
-                          <td className="py-2 px-2 font-medium text-text-primary">{p.firstName}</td>
+                        <tr key={p.id} className="border-t border-gray-100">
+                          <td className="py-2 px-2 font-medium text-gray-900">{p.firstName}</td>
                           {confirmedParticipants.map(other => (
                             <td key={other.id} className="text-center py-2 px-3">
                               {p.id === other.id ? (
-                                <span className="text-text-faint">—</span>
+                                <span className="text-gray-300">—</span>
                               ) : (
-                                <span className={(settlementMatrix[p.id]?.[other.id] || 0) > 0 ? 'text-brand-red font-semibold' : 'text-text-faint'}>
+                                <span className={(settlementMatrix[p.id]?.[other.id] || 0) > 0 ? 'text-red-600 font-semibold' : 'text-gray-300'}>
                                   {(settlementMatrix[p.id]?.[other.id] || 0) > 0 ? fmt(settlementMatrix[p.id][other.id]) : '$0'}
                                 </span>
                               )}


### PR DESCRIPTION
Section reorder:
- Header → Quick Stats → Crew & Profiles (merged) → Dates → Destinations → Itinerary Calendar → Trip Planner → Flights → Commit → Budget → Settlement

Styling overhaul:
- Replace all purple section header bars with clean dividers (text-sm font-semibold text-gray-700 border-b border-gray-200)
- All cards: bg-white rounded-lg border border-gray-200
- Remove font-mono, text-[10px], text-[9px] terminal styling
- Primary actions: bg-brand-gold text-white rounded-lg
- Status badges: rounded pills with semantic colors
- Form inputs: border-gray-200 rounded-lg
- Table headers: border-b instead of purple backgrounds

Crew & Profiles merged: crew table + profile cards in one section
Calendar fix: anchorDate passes trip startDate with T split for clean YYYY-MM-DD

https://claude.ai/code/session_01ScpFQ9Q7hKRx4D6axZ8jfH