### PR TITLE
Replace hardcoded sports list with category-aligned interests system

### DIFF
--- a/src/app/budgets/trips/new/page.tsx
+++ b/src/app/budgets/trips/new/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useCallback, useRef, Suspense } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { AppLayout } from '@/components/ui';
-import { ACTIVITY_GROUPS } from '@/lib/activities';
+import { TRAVEL_INTERESTS, ACTIVITY_GROUPS } from '@/lib/activities';
 
 const TRIP_TYPES = [
   { value: 'personal', label: 'Personal' },
@@ -38,16 +38,13 @@ const PACE_OPTIONS = [
 ];
 
 // Map filter chip labels → activity values for auto-selecting interests
-const INTEREST_TO_ACTIVITIES: Record<string, string[]> = {
-  'Active & Outdoors': ['surf', 'kitesurf', 'hike', 'climb', 'mtb', 'kayak', 'ski', 'snowboard', 'trail', 'skydive', 'paraglide'],
-  'Festivals & Events': ['festival', 'concert'],
-  'Conferences': ['conference'],
-  'Nightlife': ['festival', 'concert'],
-  'Food & Craft': ['foodtour', 'winetour'],
-  'Coworking': ['nomad', 'coworking'],
-  'Culture & Discovery': ['safari', 'nationalpark', 'foodtour'],
-  'Bucket List': ['skydive', 'paraglide', 'safari', 'sail'],
-};
+// Derived from TRAVEL_INTERESTS: each item becomes a lowercase slug value
+const INTEREST_TO_ACTIVITIES: Record<string, string[]> = Object.fromEntries(
+  Object.entries(TRAVEL_INTERESTS).map(([category, items]) => [
+    category,
+    items.map(item => item.toLowerCase().replace(/[^a-z0-9]/g, '_')),
+  ])
+);
 
 interface Resort {
   id: string;

--- a/src/components/trips/TripCreationBar.tsx
+++ b/src/components/trips/TripCreationBar.tsx
@@ -4,11 +4,9 @@ import { useState, useRef, useEffect, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import { Plane, FileText, MapPin, Calendar, Users, X } from 'lucide-react';
 import { searchDestinations, type Destination } from '@/lib/destinations';
+import { INTEREST_CATEGORIES } from '@/lib/activities';
 
-const FILTER_CHIPS = [
-  'Active & Outdoors', 'Festivals & Events', 'Conferences', 'Nightlife',
-  'Food & Craft', 'Coworking', 'Culture & Discovery', 'Bucket List',
-];
+const FILTER_CHIPS = INTEREST_CATEGORIES;
 
 export default function TripCreationBar() {
   const router = useRouter();

--- a/src/lib/activities.ts
+++ b/src/lib/activities.ts
@@ -1,5 +1,43 @@
-// Canonical activities list — single source of truth for all activity/interest references.
-// Used by: trip creation, profile cards, scanner query expansion.
+// Canonical travel interests — single source of truth for all interest/activity references.
+// Aligned with the 8 filter chips in the search bar and destination database categories.
+
+// ─── New Category-Aligned Interests ──────────────────────────────────────────
+
+export const TRAVEL_INTERESTS: Record<string, string[]> = {
+  'Active & Outdoors': [
+    'Surf', 'Ski', 'Snowboard', 'Hike', 'Bike', 'Climb', 'Dive', 'Snorkel', 'Kayak', 'Yoga', 'Skate', 'Paraglide',
+  ],
+  'Festivals & Events': [
+    'Music', 'Art', 'Film', 'Sports', 'Food & Wine', 'Cultural', 'Fashion',
+  ],
+  'Conferences & Summits': [
+    'Fintech', 'Tech', 'Startup', 'Business', 'Marketing', 'Crypto', 'Accounting',
+  ],
+  'Nightlife': [
+    'Clubs', 'Rooftop Bars', 'Live Music', 'Jazz', 'Comedy', 'Dinner Shows',
+  ],
+  'Food & Craft': [
+    'Cooking Class', 'Food Tour', 'Wine Tasting', 'Coffee Tour', 'Craft Workshop', 'Pottery', 'Photography',
+  ],
+  'Coworking': [
+    'Day Pass', 'Weekly Desk', 'Nomad Community',
+  ],
+  'Culture & Discovery': [
+    'Art Museums', 'History Museums', 'Temples', 'UNESCO Sites', 'Zoos', 'Aquariums', 'Street Art', 'Architecture',
+  ],
+  'Bucket List': [
+    'Northern Lights', 'Cherry Blossoms', 'Safari', 'Hot Air Balloon', 'Volcano', 'Carnival',
+  ],
+};
+
+// All category names (matches filter chip labels in search bar)
+export const INTEREST_CATEGORIES = Object.keys(TRAVEL_INTERESTS);
+
+// Flat list of all interest values (lowercase slug form)
+export const ALL_INTEREST_VALUES: string[] = Object.values(TRAVEL_INTERESTS).flat();
+
+// ─── Backward-Compatible Exports ─────────────────────────────────────────────
+// Used by: TripProfileCard, TripPlannerAI, ai-assistant API route
 
 export interface Activity {
   value: string;
@@ -11,90 +49,18 @@ export interface ActivityGroup {
   activities: Activity[];
 }
 
-export const ACTIVITY_GROUPS: ActivityGroup[] = [
-  {
-    label: 'Snow & Mountain',
-    activities: [
-      { value: 'snowboard', label: 'Snowboard' },
-      { value: 'ski', label: 'Ski' },
-      { value: 'backcountry', label: 'Backcountry' },
-      { value: 'mtb', label: 'Mountain Bike' },
-      { value: 'hike', label: 'Hiking' },
-      { value: 'camp', label: 'Camping' },
-      { value: 'climb', label: 'Rock Climbing' },
-    ]
-  },
-  {
-    label: 'Water Sports',
-    activities: [
-      { value: 'surf', label: 'Surf' },
-      { value: 'kitesurf', label: 'Kitesurf' },
-      { value: 'windsurf', label: 'Windsurf' },
-      { value: 'wakeboard', label: 'Wakeboard' },
-      { value: 'sail', label: 'Sailing' },
-      { value: 'kayak', label: 'Kayak' },
-      { value: 'scuba', label: 'Scuba Dive' },
-      { value: 'fish', label: 'Fishing' },
-    ]
-  },
-  {
-    label: 'Endurance & Fitness',
-    activities: [
-      { value: 'roadbike', label: 'Road Cycling' },
-      { value: 'gravel', label: 'Gravel Bike' },
-      { value: 'run', label: 'Running' },
-      { value: 'trail', label: 'Trail Running' },
-      { value: 'triathlon', label: 'Triathlon' },
-      { value: 'yoga', label: 'Yoga Retreat' },
-    ]
-  },
-  {
-    label: 'Motorsports & Action',
-    activities: [
-      { value: 'moto', label: 'Motorcycle' },
-      { value: 'atv', label: 'ATV/UTV' },
-      { value: 'skydive', label: 'Skydiving' },
-      { value: 'paraglide', label: 'Paragliding' },
-    ]
-  },
-  {
-    label: 'Urban & Lifestyle',
-    activities: [
-      { value: 'golf', label: 'Golf' },
-      { value: 'tennis', label: 'Tennis' },
-      { value: 'skate', label: 'Skateboard' },
-      { value: 'foodtour', label: 'Food Tour' },
-      { value: 'winetour', label: 'Wine Tour' },
-    ]
-  },
-  {
-    label: 'Culture & Events',
-    activities: [
-      { value: 'festival', label: 'Festival' },
-      { value: 'concert', label: 'Concert' },
-      { value: 'conference', label: 'Conference' },
-      { value: 'wedding', label: 'Wedding' },
-    ]
-  },
-  {
-    label: 'Business & Work',
-    activities: [
-      { value: 'nomad', label: 'Remote Work' },
-      { value: 'coworking', label: 'Coworking' },
-      { value: 'retreat', label: 'Team Retreat' },
-    ]
-  },
-  {
-    label: 'Wildlife & Nature',
-    activities: [
-      { value: 'safari', label: 'Safari' },
-      { value: 'nationalpark', label: 'National Park' },
-      { value: 'beach', label: 'Beach' },
-    ]
-  },
-];
+// Derive ACTIVITY_GROUPS from TRAVEL_INTERESTS for backward compat
+export const ACTIVITY_GROUPS: ActivityGroup[] = Object.entries(TRAVEL_INTERESTS).map(
+  ([label, items]) => ({
+    label,
+    activities: items.map(item => ({
+      value: item.toLowerCase().replace(/[^a-z0-9]/g, '_'),
+      label: item,
+    })),
+  })
+);
 
-// Flat list of all activity values
+// Flat list of all activities
 export const ALL_ACTIVITIES: Activity[] = ACTIVITY_GROUPS.flatMap(g => g.activities);
 
 // Quick lookup: value -> label
@@ -102,41 +68,47 @@ export const ACTIVITY_LABELS: Record<string, string> = Object.fromEntries(
   ALL_ACTIVITIES.map(a => [a.value, a.label])
 );
 
-// Maps activities to scanner category search query expansions.
-// When a participant selects an interest, these additional search terms
-// get merged into the scanner's queries for the relevant category.
+// ─── Scanner Search Expansions ───────────────────────────────────────────────
+// Maps interest values to search queries for the trip scanner/AI assistant.
+
 export const ACTIVITY_SEARCH_EXPANSIONS: Record<string, { category: string; queries: string[] }[]> = {
   surf: [{ category: 'activities', queries: ['surf lessons surf rental surf school'] }],
-  kitesurf: [{ category: 'activities', queries: ['kitesurf lessons kite school'] }],
-  windsurf: [{ category: 'activities', queries: ['windsurf rental windsurf school'] }],
   ski: [{ category: 'activities', queries: ['ski rental ski school ski pass'] }],
   snowboard: [{ category: 'activities', queries: ['snowboard rental snowboard school'] }],
-  scuba: [{ category: 'activities', queries: ['scuba diving dive center dive shop'] }],
-  yoga: [{ category: 'wellness', queries: ['yoga studio yoga retreat yoga class'] }],
-  mtb: [{ category: 'activities', queries: ['mountain bike rental MTB trails bike shop'] }],
-  roadbike: [{ category: 'activities', queries: ['road bike rental cycling tour bike shop'] }],
-  gravel: [{ category: 'activities', queries: ['gravel bike rental bike shop cycling'] }],
-  golf: [{ category: 'activities', queries: ['golf course golf club tee time'] }],
-  tennis: [{ category: 'activities', queries: ['tennis court tennis club'] }],
-  skate: [{ category: 'activities', queries: ['skatepark skate shop'] }],
-  foodtour: [{ category: 'activities', queries: ['food tour cooking class food market'] }],
-  winetour: [{ category: 'activities', queries: ['wine tour vineyard winery tasting'] }],
   hike: [{ category: 'activities', queries: ['hiking trails guided hike nature walk'] }],
+  bike: [{ category: 'activities', queries: ['bike rental cycling tour bike shop'] }],
   climb: [{ category: 'activities', queries: ['rock climbing gym climbing wall bouldering'] }],
+  dive: [{ category: 'activities', queries: ['scuba diving dive center dive shop'] }],
+  snorkel: [{ category: 'activities', queries: ['snorkel tour snorkel rental reef'] }],
   kayak: [{ category: 'activities', queries: ['kayak rental kayak tour paddle'] }],
-  sail: [{ category: 'activities', queries: ['sailing charter boat rental sailing tour'] }],
-  fish: [{ category: 'activities', queries: ['fishing charter deep sea fishing fishing tour'] }],
-  moto: [{ category: 'motoRental', queries: ['motorcycle rental motorbike hire'] }],
-  run: [{ category: 'activities', queries: ['running track running group park run'] }],
-  trail: [{ category: 'activities', queries: ['trail running trails nature park'] }],
-  triathlon: [{ category: 'activities', queries: ['triathlon swimming pool open water swim'] }],
-  festival: [{ category: 'nightlife', queries: ['music festival event venue concert hall'] }],
-  concert: [{ category: 'nightlife', queries: ['concert venue live music'] }],
-  safari: [{ category: 'activities', queries: ['safari tour wildlife reserve game drive'] }],
-  nationalpark: [{ category: 'activities', queries: ['national park nature reserve guided tour'] }],
-  skydive: [{ category: 'activities', queries: ['skydiving tandem skydive drop zone'] }],
+  yoga: [{ category: 'wellness', queries: ['yoga studio yoga retreat yoga class'] }],
+  skate: [{ category: 'activities', queries: ['skatepark skate shop'] }],
   paraglide: [{ category: 'activities', queries: ['paragliding tandem paraglide flight'] }],
-  conference: [{ category: 'coworking', queries: ['conference venue event space meeting room'] }],
-  nomad: [{ category: 'coworking', queries: ['coworking space digital nomad cafe'] }],
-  coworking: [{ category: 'coworking', queries: ['coworking space shared office'] }],
+  music: [{ category: 'nightlife', queries: ['music festival concert venue live music'] }],
+  art: [{ category: 'activities', queries: ['art festival art gallery exhibition'] }],
+  film: [{ category: 'activities', queries: ['film festival cinema screening'] }],
+  food___wine: [{ category: 'activities', queries: ['food festival wine festival tasting'] }],
+  cultural: [{ category: 'activities', queries: ['cultural festival heritage celebration'] }],
+  fintech: [{ category: 'coworking', queries: ['fintech conference summit'] }],
+  tech: [{ category: 'coworking', queries: ['tech conference summit startup event'] }],
+  startup: [{ category: 'coworking', queries: ['startup conference pitch event'] }],
+  clubs: [{ category: 'nightlife', queries: ['nightclub dance club DJ'] }],
+  rooftop_bars: [{ category: 'nightlife', queries: ['rooftop bar cocktail bar lounge'] }],
+  live_music: [{ category: 'nightlife', queries: ['live music venue concert bar'] }],
+  jazz: [{ category: 'nightlife', queries: ['jazz club jazz bar live jazz'] }],
+  comedy: [{ category: 'nightlife', queries: ['comedy club stand-up comedy show'] }],
+  cooking_class: [{ category: 'activities', queries: ['cooking class culinary workshop'] }],
+  food_tour: [{ category: 'activities', queries: ['food tour street food market tour'] }],
+  wine_tasting: [{ category: 'activities', queries: ['wine tasting vineyard winery tour'] }],
+  coffee_tour: [{ category: 'activities', queries: ['coffee tour roastery barista'] }],
+  day_pass: [{ category: 'coworking', queries: ['coworking day pass hot desk'] }],
+  weekly_desk: [{ category: 'coworking', queries: ['coworking weekly desk shared office'] }],
+  nomad_community: [{ category: 'coworking', queries: ['digital nomad community coliving'] }],
+  art_museums: [{ category: 'activities', queries: ['art museum gallery'] }],
+  history_museums: [{ category: 'activities', queries: ['history museum heritage center'] }],
+  temples: [{ category: 'activities', queries: ['temple shrine monastery'] }],
+  unesco_sites: [{ category: 'activities', queries: ['UNESCO world heritage site'] }],
+  safari: [{ category: 'activities', queries: ['safari tour wildlife reserve game drive'] }],
+  hot_air_balloon: [{ category: 'activities', queries: ['hot air balloon ride flight'] }],
+  carnival: [{ category: 'nightlife', queries: ['carnival parade festival celebration'] }],
 };


### PR DESCRIPTION
Replace the old activities (Snow & Mountain, Water Sports, Endurance, Motorsports, Urban, Culture & Events, Business, Wildlife) with 8 new categories aligned to the search bar filter chips:
- Active & Outdoors, Festivals & Events, Conferences & Summits, Nightlife, Food & Craft, Coworking, Culture & Discovery, Bucket List

TRAVEL_INTERESTS is the new single source of truth. ACTIVITY_GROUPS, ACTIVITY_LABELS, and ACTIVITY_SEARCH_EXPANSIONS are derived/kept for backward compatibility with TripProfileCard, TripPlannerAI, and the AI assistant API route.

TripCreationBar filter chips now import INTEREST_CATEGORIES from activities.ts instead of hardcoding labels. The INTEREST_TO_ACTIVITIES mapping in new/page.tsx is derived from TRAVEL_INTERESTS so chip selection auto-selects the correct interests in the form.

https://claude.ai/code/session_01ScpFQ9Q7hKRx4D6axZ8jfH