### PR TITLE
Unify search bar with trip creation — no duplicate fields

### DIFF
--- a/src/app/budgets/trips/new/page.tsx
+++ b/src/app/budgets/trips/new/page.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { useState, useEffect, useCallback, useRef, Suspense } from 'react';
+import { useState, useEffect, useRef, Suspense } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { AppLayout } from '@/components/ui';
 import { TRAVEL_INTERESTS, ACTIVITY_GROUPS } from '@/lib/activities';
+import { ChevronDown } from 'lucide-react';
 
 const TRIP_TYPES = [
   { value: 'personal', label: 'Personal' },
@@ -37,24 +38,13 @@ const PACE_OPTIONS = [
   { value: 'packed', label: 'Packed & Hustling' },
 ];
 
-// Map filter chip labels → activity values for auto-selecting interests
-// Derived from TRAVEL_INTERESTS: each item becomes a lowercase slug value
+// Map filter chip labels → activity values
 const INTEREST_TO_ACTIVITIES: Record<string, string[]> = Object.fromEntries(
   Object.entries(TRAVEL_INTERESTS).map(([category, items]) => [
     category,
     items.map(item => item.toLowerCase().replace(/[^a-z0-9]/g, '_')),
   ])
 );
-
-interface Resort {
-  id: string;
-  name: string;
-  country: string;
-  state: string | null;
-  region: string;
-  nearestAirport: string | null;
-  bestMonths?: string | null;
-}
 
 export default function NewTripPage() {
   return (
@@ -75,85 +65,58 @@ function NewTripForm() {
   const searchParams = useSearchParams();
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
-  const profileRef = useRef<HTMLDivElement>(null);
-  const [didAutoScroll, setDidAutoScroll] = useState(false);
 
-  // Section 1: Trip Details
-  const [name, setName] = useState('');
-  const [startDate, setStartDate] = useState('');
-  const [endDate, setEndDate] = useState('');
+  // Trip type (not in search bar)
   const [tripType, setTripType] = useState('personal');
 
-  // Section 2: Profile
+  // Profile
   const [selectedActivities, setSelectedActivities] = useState<string[]>([]);
   const [budget, setBudget] = useState('midrange');
   const [vibes, setVibes] = useState<string[]>([]);
   const [pace, setPace] = useState('balanced');
 
-  // Section 3: Destinations
-  const [searchQuery, setSearchQuery] = useState('');
-  const [searchResults, setSearchResults] = useState<Resort[]>([]);
-  const [selectedDestinations, setSelectedDestinations] = useState<Resort[]>([]);
-  const [searching, setSearching] = useState(false);
+  // Track which interest categories are expanded
+  const [expandedCategories, setExpandedCategories] = useState<Set<string>>(new Set());
+  const [showAllCategories, setShowAllCategories] = useState(false);
 
-  // Auto-populate from query params
+  // Read interests from URL params and auto-expand/select matching categories
   useEffect(() => {
-    const tripName = searchParams.get('tripName');
-    const sd = searchParams.get('startDate');
-    const ed = searchParams.get('endDate');
-    const travelers = searchParams.get('travelers');
     const interests = searchParams.get('interests');
-    const destinations = searchParams.get('destinations');
-
-    if (tripName) setName(tripName);
-
-    if (sd) {
-      // Handle both YYYY-MM-DD and MM/DD/YYYY formats
-      const parsed = parseToDateInput(sd);
-      if (parsed) setStartDate(parsed);
-    }
-    if (ed) {
-      const parsed = parseToDateInput(ed);
-      if (parsed) setEndDate(parsed);
-    }
-
-    // Map interest filter chips to activity toggles
     if (interests) {
-      const chipLabels = interests.split(',');
+      const chipLabels = interests.split(',').map(c => c.trim());
+      const expanded = new Set<string>();
       const activities = new Set<string>();
       chipLabels.forEach(label => {
-        const mapped = INTEREST_TO_ACTIVITIES[label.trim()];
-        if (mapped) mapped.forEach(a => activities.add(a));
+        const mapped = INTEREST_TO_ACTIVITIES[label];
+        if (mapped) {
+          expanded.add(label);
+          mapped.forEach(a => activities.add(a));
+        }
       });
+      if (expanded.size > 0) setExpandedCategories(expanded);
       if (activities.size > 0) setSelectedActivities(Array.from(activities));
-    }
-
-    // Pre-fill destinations as simple name entries (search will be needed for full resort data)
-    if (destinations) {
-      const destNames = destinations.split(',').map(d => d.trim()).filter(Boolean);
-      const fakeResorts: Resort[] = destNames.map((n, i) => ({
-        id: `param-${i}`,
-        name: n,
-        country: '',
-        state: null,
-        region: '',
-        nearestAirport: null,
-      }));
-      setSelectedDestinations(fakeResorts);
     }
   }, [searchParams]);
 
-  // Auto-scroll past pre-filled details to Travel Profile
-  useEffect(() => {
-    if (didAutoScroll) return;
-    const hasPreFilled = searchParams.get('tripName') && searchParams.get('startDate');
-    if (hasPreFilled && profileRef.current) {
-      setTimeout(() => {
-        profileRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
-      }, 100);
-      setDidAutoScroll(true);
-    }
-  }, [searchParams, didAutoScroll]);
+  // Read trip details from URL params (set by search bar)
+  const name = searchParams.get('tripName') || '';
+  const startDate = (() => {
+    const sd = searchParams.get('startDate');
+    if (!sd) return '';
+    if (/^\d{4}-\d{2}-\d{2}$/.test(sd)) return sd;
+    const match = sd.match(/^(\d{1,2})\/(\d{1,2})\/(\d{4})$/);
+    if (match) return `${match[3]}-${match[1].padStart(2, '0')}-${match[2].padStart(2, '0')}`;
+    return '';
+  })();
+  const endDate = (() => {
+    const ed = searchParams.get('endDate');
+    if (!ed) return '';
+    if (/^\d{4}-\d{2}-\d{2}$/.test(ed)) return ed;
+    const match = ed.match(/^(\d{1,2})\/(\d{1,2})\/(\d{4})$/);
+    if (match) return `${match[3]}-${match[1].padStart(2, '0')}-${match[2].padStart(2, '0')}`;
+    return '';
+  })();
+  const destinations = searchParams.get('destinations')?.split(',').map(d => d.trim()).filter(Boolean) || [];
 
   const duration = startDate && endDate
     ? Math.round((new Date(endDate + 'T12:00:00').getTime() - new Date(startDate + 'T12:00:00').getTime()) / 86400000) + 1
@@ -171,38 +134,13 @@ function NewTripForm() {
     );
   };
 
-  const searchDestinationsApi = useCallback(async (q: string) => {
-    setSearchQuery(q);
-    if (q.length < 2) { setSearchResults([]); return; }
-    setSearching(true);
-    try {
-      const res = await fetch('/api/resorts?activity=all');
-      if (res.ok) {
-        const data = await res.json();
-        const filtered = (data.resorts || []).filter((r: Resort) =>
-          r.name.toLowerCase().includes(q.toLowerCase()) ||
-          r.country.toLowerCase().includes(q.toLowerCase()) ||
-          r.region?.toLowerCase().includes(q.toLowerCase())
-        ).slice(0, 20);
-        setSearchResults(filtered);
-      }
-    } catch (err) {
-      console.error('Search failed:', err);
-    } finally {
-      setSearching(false);
-    }
-  }, []);
-
-  const addDestination = (resort: Resort) => {
-    if (!selectedDestinations.some(d => d.id === resort.id)) {
-      setSelectedDestinations(prev => [...prev, resort]);
-    }
-    setSearchQuery('');
-    setSearchResults([]);
-  };
-
-  const removeDestination = (id: string) => {
-    setSelectedDestinations(prev => prev.filter(d => d.id !== id));
+  const toggleCategory = (label: string) => {
+    setExpandedCategories(prev => {
+      const next = new Set(prev);
+      if (next.has(label)) next.delete(label);
+      else next.add(label);
+      return next;
+    });
   };
 
   const canCreate = name.trim() && startDate && endDate && duration > 0;
@@ -218,7 +156,7 @@ function NewTripForm() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           name: name.trim(),
-          destination: selectedDestinations.length > 0 ? selectedDestinations[0].name : undefined,
+          destination: destinations.length > 0 ? destinations[0] : undefined,
           startDate,
           endDate,
           activity: 'all',
@@ -256,35 +194,25 @@ function NewTripForm() {
         });
       }
 
-      // Save destinations — resolve placeholder entries by searching the resorts API
-      for (const dest of selectedDestinations) {
-        if (!dest.id.startsWith('param-')) {
-          // Real resort ID — save directly
-          await fetch(`/api/trips/${tripId}/destinations`, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ resortId: dest.id }),
-          });
-        } else {
-          // Placeholder from query params — search for a matching resort by name
-          try {
-            const searchRes = await fetch('/api/resorts?activity=all');
-            if (searchRes.ok) {
-              const data = await searchRes.json();
-              const match = (data.resorts || []).find((r: Resort) =>
-                r.name.toLowerCase() === dest.name.toLowerCase()
-              );
-              if (match) {
-                await fetch(`/api/trips/${tripId}/destinations`, {
-                  method: 'POST',
-                  headers: { 'Content-Type': 'application/json' },
-                  body: JSON.stringify({ resortId: match.id }),
-                });
-              }
+      // Save destinations — search resorts API for matching entries
+      for (const destName of destinations) {
+        try {
+          const searchRes = await fetch('/api/resorts?activity=all');
+          if (searchRes.ok) {
+            const data = await searchRes.json();
+            const match = (data.resorts || []).find((r: any) =>
+              r.name.toLowerCase() === destName.toLowerCase()
+            );
+            if (match) {
+              await fetch(`/api/trips/${tripId}/destinations`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ resortId: match.id }),
+              });
             }
-          } catch {
-            // Resort not found — destination name is already set on the trip
           }
+        } catch {
+          // Resort not found — destination name is already set on the trip
         }
       }
 
@@ -298,226 +226,193 @@ function NewTripForm() {
 
   const budgetHint = BUDGET_OPTIONS.find(b => b.value === budget)?.hint;
 
+  // Categories to show: selected chips first (expanded), then unselected if user clicked "+ Add Category"
+  const selectedCategoryGroups = ACTIVITY_GROUPS.filter(g => expandedCategories.has(g.label));
+  const unselectedCategoryGroups = ACTIVITY_GROUPS.filter(g => !expandedCategories.has(g.label));
+
   return (
-      <div className="min-h-screen bg-bg-terminal">
-        <div className="p-4 lg:p-6 max-w-[1800px] mx-auto">
+    <div className="min-h-screen bg-bg-terminal">
+      <div className="p-4 lg:p-6 max-w-[1800px] mx-auto">
 
-          {error && (
-            <div className="bg-red-50 border border-red-200 text-brand-red px-4 py-3 mb-4 text-sm">{error}</div>
-          )}
+        {error && (
+          <div className="bg-red-50 border border-red-200 text-brand-red px-4 py-3 mb-4 text-sm">{error}</div>
+        )}
 
-          <div className="space-y-3">
+        {/* Summary of what's in the search bar */}
+        {(name || destinations.length > 0 || startDate) && (
+          <div className="bg-white border border-gray-200 rounded-lg p-3 mb-3 flex flex-wrap items-center gap-3 text-xs text-gray-500">
+            {name && <span className="font-medium text-gray-900">{name}</span>}
+            {destinations.length > 0 && (
+              <span>{destinations.join(' → ')}</span>
+            )}
+            {startDate && endDate && (
+              <span>{new Date(startDate + 'T12:00:00').toLocaleDateString('en-US', { month: 'short', day: 'numeric' })} – {new Date(endDate + 'T12:00:00').toLocaleDateString('en-US', { month: 'short', day: 'numeric' })} · {duration} days</span>
+            )}
+          </div>
+        )}
 
-            {/* ═══ Section 1: Trip Details ═══ */}
-            <div className="bg-white border border-border p-4">
-              <h2 className="text-sm font-semibold text-gray-700 border-b border-gray-200 pb-2 mb-4">Trip Details</h2>
-              <div className="space-y-3">
-                <div>
-                  <label className="block text-xs font-medium text-text-secondary mb-1">Trip Name *</label>
-                  <input type="text" value={name} onChange={e => setName(e.target.value)}
-                    placeholder="e.g., Bali Surf Trip 2026"
-                    className="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:border-brand-purple"
-                    required />
-                </div>
+        <div className="space-y-3">
 
-                <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
-                  <div>
-                    <label className="block text-xs font-medium text-text-secondary mb-1">Start Date *</label>
-                    <input type="date" value={startDate} onChange={e => setStartDate(e.target.value)}
-                      min={new Date().toISOString().split('T')[0]}
-                      className="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:border-brand-purple" />
-                  </div>
-                  <div>
-                    <label className="block text-xs font-medium text-text-secondary mb-1">End Date *</label>
-                    <input type="date" value={endDate} onChange={e => setEndDate(e.target.value)}
-                      min={startDate || new Date().toISOString().split('T')[0]}
-                      className="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:border-brand-purple" />
-                  </div>
-                  <div>
-                    <label className="block text-xs font-medium text-text-secondary mb-1">Trip Type</label>
-                    <div className="flex gap-1">
-                      {TRIP_TYPES.map(tt => (
-                        <button key={tt.value} type="button" onClick={() => setTripType(tt.value)}
-                          className={`flex-1 px-2 py-2 text-xs font-medium rounded-lg transition-colors ${
-                            tripType === tt.value ? 'bg-brand-purple text-white' : 'bg-bg-row text-text-secondary hover:bg-border border border-gray-200'
-                          }`}>
-                          {tt.label}
-                        </button>
-                      ))}
-                    </div>
-                  </div>
-                  {duration > 0 && (
-                    <div className="flex items-end">
-                      <div className="text-xs text-text-muted bg-bg-row px-3 py-2 rounded-lg w-full text-center">
-                        <span className="font-semibold text-text-primary">{duration} days</span>
-                      </div>
-                    </div>
-                  )}
-                </div>
-              </div>
+          {/* Trip Type */}
+          <div className="bg-white border border-gray-200 rounded-lg p-4">
+            <h2 className="text-sm font-semibold text-gray-700 border-b border-gray-200 pb-2 mb-3">Trip Type</h2>
+            <div className="flex gap-2">
+              {TRIP_TYPES.map(tt => (
+                <button key={tt.value} type="button" onClick={() => setTripType(tt.value)}
+                  className={`flex-1 px-3 py-2 text-xs font-medium rounded-lg transition-colors ${
+                    tripType === tt.value ? 'bg-brand-purple text-white' : 'bg-bg-row text-text-secondary hover:bg-border border border-gray-200'
+                  }`}>
+                  {tt.label}
+                </button>
+              ))}
             </div>
+          </div>
 
-            {/* ═══ Section 2: Your Travel Profile ═══ */}
-            <div className="bg-white border border-border p-4" ref={profileRef}>
-              <h2 className="text-sm font-semibold text-gray-700 border-b border-gray-200 pb-2 mb-4">
-                Your Travel Profile
-                {selectedActivities.length > 0 && (
-                  <span className="ml-2 text-brand-purple font-normal text-xs">({selectedActivities.length} selected)</span>
-                )}
-              </h2>
-              <div className="space-y-4">
+          {/* Travel Profile — Interests */}
+          <div className="bg-white border border-gray-200 rounded-lg p-4">
+            <h2 className="text-sm font-semibold text-gray-700 border-b border-gray-200 pb-2 mb-3">
+              Your Interests
+              {selectedActivities.length > 0 && (
+                <span className="ml-2 text-brand-purple font-normal text-xs">({selectedActivities.length} selected)</span>
+              )}
+            </h2>
 
-                {/* Interests */}
-                <div>
-                  <h4 className="text-xs font-semibold text-text-secondary uppercase tracking-wider mb-2">Your Interests</h4>
-                  <div className="space-y-2">
-                    {ACTIVITY_GROUPS.map(group => (
-                      <div key={group.label}>
-                        <div className="text-[11px] font-medium text-text-muted mb-1">{group.label}</div>
-                        <div className="flex flex-wrap gap-1.5">
-                          {group.activities.map(act => {
-                            const selected = selectedActivities.includes(act.value);
-                            return (
-                              <button key={act.value} type="button" onClick={() => toggleActivity(act.value)}
-                                className={`px-2.5 py-1 rounded text-[11px] font-medium transition-colors ${
-                                  selected ? 'bg-brand-purple text-white' : 'bg-bg-row text-text-secondary hover:bg-border'
-                                }`}>
-                                {act.label}
-                              </button>
-                            );
-                          })}
-                        </div>
-                      </div>
-                    ))}
-                  </div>
-                </div>
-
-                {/* Budget + Vibe + Pace in a tighter grid */}
-                <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
-                  <div>
-                    <h4 className="text-xs font-semibold text-text-secondary uppercase tracking-wider mb-2">Budget per Night</h4>
-                    <div className="flex flex-wrap gap-1.5">
-                      {BUDGET_OPTIONS.map(bo => (
-                        <button key={bo.value} type="button" onClick={() => setBudget(bo.value)}
-                          className={`px-2.5 py-1.5 rounded text-xs font-medium transition-colors ${
-                            budget === bo.value ? 'bg-brand-purple text-white' : 'bg-bg-row text-text-secondary hover:bg-border'
-                          }`}>
-                          {bo.label}
-                        </button>
-                      ))}
-                    </div>
-                    {budgetHint && <div className="text-[10px] text-text-muted mt-1.5">{budgetHint}</div>}
-                  </div>
-
-                  <div>
-                    <h4 className="text-xs font-semibold text-text-secondary uppercase tracking-wider mb-2">
-                      Vibe <span className="font-normal text-text-muted">(up to 3)</span>
-                    </h4>
-                    <div className="flex flex-wrap gap-1.5">
-                      {VIBE_OPTIONS.map(vo => {
-                        const selected = vibes.includes(vo.value);
+            {/* Selected/expanded categories */}
+            {selectedCategoryGroups.length > 0 ? (
+              <div className="space-y-3">
+                {selectedCategoryGroups.map(group => (
+                  <div key={group.label}>
+                    <button onClick={() => toggleCategory(group.label)}
+                      className="flex items-center gap-2 text-xs font-semibold text-gray-700 mb-1.5 hover:text-brand-purple">
+                      <ChevronDown className="w-3.5 h-3.5" />
+                      {group.label}
+                    </button>
+                    <div className="flex flex-wrap gap-1.5 pl-5">
+                      {group.activities.map(act => {
+                        const selected = selectedActivities.includes(act.value);
                         return (
-                          <button key={vo.value} type="button" onClick={() => toggleVibe(vo.value)}
-                            className={`px-2.5 py-1.5 rounded text-xs font-medium transition-colors ${
+                          <button key={act.value} type="button" onClick={() => toggleActivity(act.value)}
+                            className={`px-2.5 py-1 rounded text-xs font-medium transition-colors ${
                               selected ? 'bg-brand-purple text-white' : 'bg-bg-row text-text-secondary hover:bg-border'
                             }`}>
-                            {vo.label}
+                            {act.label}
                           </button>
                         );
                       })}
                     </div>
                   </div>
-
-                  <div>
-                    <h4 className="text-xs font-semibold text-text-secondary uppercase tracking-wider mb-2">Pace</h4>
-                    <div className="flex gap-2">
-                      {PACE_OPTIONS.map(po => (
-                        <button key={po.value} type="button" onClick={() => setPace(po.value)}
-                          className={`flex-1 px-3 py-2 rounded text-xs font-medium transition-colors ${
-                            pace === po.value ? 'bg-brand-purple text-white' : 'bg-bg-row text-text-secondary hover:bg-border'
-                          }`}>
-                          {po.label}
-                        </button>
-                      ))}
-                    </div>
-                  </div>
-                </div>
+                ))}
               </div>
-            </div>
+            ) : (
+              <p className="text-xs text-gray-400 mb-3">Select interest categories using the filter chips in the search bar above, or add them below.</p>
+            )}
 
-            {/* ═══ Section 3: Destinations ═══ */}
-            <div className="bg-white border border-border p-4">
-              <h2 className="text-sm font-semibold text-gray-700 border-b border-gray-200 pb-2 mb-4">
-                Destinations
-                <span className="text-xs text-text-muted font-normal ml-2">(optional — add later)</span>
-              </h2>
+            {/* Collapsed unselected categories */}
+            {!showAllCategories && unselectedCategoryGroups.length > 0 && (
+              <button onClick={() => setShowAllCategories(true)}
+                className="mt-3 text-xs text-brand-purple hover:underline font-medium">
+                + Add Category ({unselectedCategoryGroups.length} more)
+              </button>
+            )}
 
-              {/* Selected destinations */}
-              {selectedDestinations.length > 0 && (
-                <div className="flex flex-wrap gap-2 mb-3">
-                  {selectedDestinations.map(d => (
-                    <div key={d.id} className="flex items-center gap-1.5 bg-brand-purple/10 border border-brand-purple/20 rounded-full px-3 py-1">
-                      <span className="text-xs text-text-primary">{d.name}</span>
-                      {d.country && <span className="text-[10px] text-text-muted">{d.country}</span>}
-                      {d.nearestAirport && <span className="text-[10px] font-mono text-text-faint">{d.nearestAirport}</span>}
-                      <button onClick={() => removeDestination(d.id)} className="text-text-faint hover:text-brand-red text-xs ml-1">×</button>
-                    </div>
-                  ))}
-                </div>
-              )}
+            {showAllCategories && unselectedCategoryGroups.length > 0 && (
+              <div className="mt-3 pt-3 border-t border-gray-100 space-y-2">
+                {unselectedCategoryGroups.map(group => (
+                  <div key={group.label}>
+                    <button onClick={() => toggleCategory(group.label)}
+                      className="flex items-center gap-2 text-xs font-medium text-gray-500 mb-1.5 hover:text-brand-purple">
+                      <ChevronDown className="w-3.5 h-3.5 -rotate-90" />
+                      {group.label}
+                    </button>
+                    {expandedCategories.has(group.label) && (
+                      <div className="flex flex-wrap gap-1.5 pl-5">
+                        {group.activities.map(act => {
+                          const selected = selectedActivities.includes(act.value);
+                          return (
+                            <button key={act.value} type="button" onClick={() => toggleActivity(act.value)}
+                              className={`px-2.5 py-1 rounded text-xs font-medium transition-colors ${
+                                selected ? 'bg-brand-purple text-white' : 'bg-bg-row text-text-secondary hover:bg-border'
+                              }`}>
+                              {act.label}
+                            </button>
+                          );
+                        })}
+                      </div>
+                    )}
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
 
-              {/* Search */}
-              <input
-                type="text"
-                placeholder="Search destinations..."
-                value={searchQuery}
-                onChange={e => searchDestinationsApi(e.target.value)}
-                className="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:border-brand-purple mb-2"
-              />
-              {searchResults.length > 0 && (
-                <div className="max-h-48 overflow-y-auto border border-gray-200 rounded-lg">
-                  {searchResults.map(r => (
-                    <button key={r.id} onClick={() => addDestination(r)}
-                      disabled={selectedDestinations.some(d => d.id === r.id)}
-                      className="w-full text-left px-3 py-2 text-xs hover:bg-bg-row flex justify-between items-center disabled:opacity-50 border-b border-border/50 last:border-0">
-                      <span>
-                        <span className="font-medium">{r.name}</span>
-                        <span className="text-text-muted ml-2">{r.state ? `${r.state}, ` : ''}{r.country}</span>
-                      </span>
-                      {r.nearestAirport && <span className="font-mono text-text-faint">{r.nearestAirport}</span>}
+          {/* Budget + Vibe + Pace */}
+          <div className="bg-white border border-gray-200 rounded-lg p-4">
+            <h2 className="text-sm font-semibold text-gray-700 border-b border-gray-200 pb-2 mb-3">Preferences</h2>
+            <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+              <div>
+                <h4 className="text-xs font-semibold text-text-secondary uppercase tracking-wider mb-2">Budget per Night</h4>
+                <div className="flex flex-wrap gap-1.5">
+                  {BUDGET_OPTIONS.map(bo => (
+                    <button key={bo.value} type="button" onClick={() => setBudget(bo.value)}
+                      className={`px-2.5 py-1.5 rounded text-xs font-medium transition-colors ${
+                        budget === bo.value ? 'bg-brand-purple text-white' : 'bg-bg-row text-text-secondary hover:bg-border'
+                      }`}>
+                      {bo.label}
                     </button>
                   ))}
                 </div>
-              )}
-            </div>
+                {budgetHint && <div className="text-xs text-text-muted mt-1.5">{budgetHint}</div>}
+              </div>
 
-            {/* ═══ Actions ═══ */}
-            <div className="flex items-center justify-end gap-3 pt-1">
-              <button type="button" onClick={() => router.back()}
-                className="text-gray-500 hover:text-gray-700 text-sm font-medium px-4 py-3 transition-colors">
-                Cancel
-              </button>
-              <button onClick={handleCreate} disabled={saving || !canCreate}
-                className="bg-brand-gold hover:bg-brand-gold-bright text-white font-semibold text-sm px-8 py-3 rounded-lg disabled:opacity-50 transition-colors">
-                {saving ? 'Creating...' : 'Create Trip'}
-              </button>
-            </div>
+              <div>
+                <h4 className="text-xs font-semibold text-text-secondary uppercase tracking-wider mb-2">
+                  Vibe <span className="font-normal text-text-muted">(up to 3)</span>
+                </h4>
+                <div className="flex flex-wrap gap-1.5">
+                  {VIBE_OPTIONS.map(vo => {
+                    const selected = vibes.includes(vo.value);
+                    return (
+                      <button key={vo.value} type="button" onClick={() => toggleVibe(vo.value)}
+                        className={`px-2.5 py-1.5 rounded text-xs font-medium transition-colors ${
+                          selected ? 'bg-brand-purple text-white' : 'bg-bg-row text-text-secondary hover:bg-border'
+                        }`}>
+                        {vo.label}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
 
+              <div>
+                <h4 className="text-xs font-semibold text-text-secondary uppercase tracking-wider mb-2">Pace</h4>
+                <div className="flex gap-2">
+                  {PACE_OPTIONS.map(po => (
+                    <button key={po.value} type="button" onClick={() => setPace(po.value)}
+                      className={`flex-1 px-3 py-2 rounded text-xs font-medium transition-colors ${
+                        pace === po.value ? 'bg-brand-purple text-white' : 'bg-bg-row text-text-secondary hover:bg-border'
+                      }`}>
+                      {po.label}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            </div>
           </div>
+
+          {/* Actions */}
+          <div className="flex items-center justify-end gap-3 pt-1">
+            <button type="button" onClick={() => router.back()}
+              className="text-gray-500 hover:text-gray-700 text-sm font-medium px-4 py-3 transition-colors">
+              Cancel
+            </button>
+            <button onClick={handleCreate} disabled={saving || !canCreate}
+              className="bg-brand-gold hover:bg-brand-gold-bright text-white font-semibold text-sm px-8 py-3 rounded-lg disabled:opacity-50 transition-colors">
+              {saving ? 'Saving...' : 'Save Trip'}
+            </button>
+          </div>
+
         </div>
       </div>
+    </div>
   );
-}
-
-/** Parse date string (YYYY-MM-DD or MM/DD/YYYY) to YYYY-MM-DD for date inputs */
-function parseToDateInput(val: string): string | null {
-  // Already YYYY-MM-DD
-  if (/^\d{4}-\d{2}-\d{2}$/.test(val)) return val;
-  // MM/DD/YYYY
-  const match = val.match(/^(\d{1,2})\/(\d{1,2})\/(\d{4})$/);
-  if (match) {
-    const [, m, d, y] = match;
-    return `${y}-${m.padStart(2, '0')}-${d.padStart(2, '0')}`;
-  }
-  return null;
 }

--- a/src/components/trips/TripCreationBar.tsx
+++ b/src/components/trips/TripCreationBar.tsx
@@ -1,15 +1,29 @@
 'use client';
 
 import { useState, useRef, useEffect, useCallback } from 'react';
-import { useRouter } from 'next/navigation';
-import { Plane, FileText, MapPin, Calendar, Users, X } from 'lucide-react';
+import { useRouter, usePathname, useSearchParams } from 'next/navigation';
+import { Plane, FileText, MapPin, Calendar, Users, X, Save } from 'lucide-react';
 import { searchDestinations, type Destination } from '@/lib/destinations';
 import { INTEREST_CATEGORIES } from '@/lib/activities';
 
 const FILTER_CHIPS = INTEREST_CATEGORIES;
 
+function parseToDateInput(val: string): string | null {
+  if (/^\d{4}-\d{2}-\d{2}$/.test(val)) return val;
+  const match = val.match(/^(\d{1,2})\/(\d{1,2})\/(\d{4})$/);
+  if (match) {
+    const [, m, d, y] = match;
+    return `${y}-${m.padStart(2, '0')}-${d.padStart(2, '0')}`;
+  }
+  return null;
+}
+
 export default function TripCreationBar() {
   const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const isOnNewPage = pathname === '/budgets/trips/new';
+
   const [barName, setBarName] = useState('');
   const [selectedDestinations, setSelectedDestinations] = useState<string[]>([]);
   const [barStartDate, setBarStartDate] = useState('');
@@ -24,6 +38,26 @@ export default function TripCreationBar() {
   const [highlightIdx, setHighlightIdx] = useState(-1);
   const dropdownRef = useRef<HTMLDivElement>(null);
   const destInputRef = useRef<HTMLInputElement>(null);
+  const [didInit, setDidInit] = useState(false);
+
+  // Pre-populate from URL params on /new page
+  useEffect(() => {
+    if (!isOnNewPage || didInit) return;
+    const tripName = searchParams.get('tripName');
+    const dests = searchParams.get('destinations');
+    const sd = searchParams.get('startDate');
+    const ed = searchParams.get('endDate');
+    const travelers = searchParams.get('travelers');
+    const interests = searchParams.get('interests');
+
+    if (tripName) setBarName(tripName);
+    if (dests) setSelectedDestinations(dests.split(',').map(d => d.trim()).filter(Boolean));
+    if (sd) { const p = parseToDateInput(sd); if (p) setBarStartDate(p); }
+    if (ed) { const p = parseToDateInput(ed); if (p) setBarEndDate(p); }
+    if (travelers) setBarTravelers(parseInt(travelers) || 2);
+    if (interests) setSelectedChips(interests.split(',').map(c => c.trim()).filter(Boolean));
+    setDidInit(true);
+  }, [isOnNewPage, searchParams, didInit]);
 
   const handleDestChange = (val: string) => {
     setDestQuery(val);
@@ -52,7 +86,6 @@ export default function TripCreationBar() {
   };
 
   const handleDestKeyDown = (e: React.KeyboardEvent) => {
-    // Backspace on empty input removes last chip
     if (e.key === 'Backspace' && destQuery === '' && selectedDestinations.length > 0) {
       setSelectedDestinations(prev => prev.slice(0, -1));
       return;
@@ -72,7 +105,6 @@ export default function TripCreationBar() {
     }
   };
 
-  // Close dropdown on outside click
   const handleClickOutside = useCallback((e: MouseEvent) => {
     if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
       setShowDropdown(false);
@@ -90,7 +122,7 @@ export default function TripCreationBar() {
     );
   };
 
-  const handleCreateFromBar = () => {
+  const buildParams = () => {
     const params = new URLSearchParams();
     if (barName) params.set('tripName', barName);
     if (selectedDestinations.length > 0) params.set('destinations', selectedDestinations.join(','));
@@ -98,7 +130,18 @@ export default function TripCreationBar() {
     if (barEndDate) params.set('endDate', barEndDate);
     if (barTravelers > 1) params.set('travelers', String(barTravelers));
     if (selectedChips.length > 0) params.set('interests', selectedChips.join(','));
-    router.push(`/budgets/trips/new${params.toString() ? '?' + params.toString() : ''}`);
+    return params;
+  };
+
+  const handleButtonClick = () => {
+    const params = buildParams();
+    const qs = params.toString() ? '?' + params.toString() : '';
+    if (isOnNewPage) {
+      // Update URL params in-place so the form below picks up edits
+      router.replace(`/budgets/trips/new${qs}`, { scroll: false });
+    } else {
+      router.push(`/budgets/trips/new${qs}`);
+    }
   };
 
   return (
@@ -147,7 +190,6 @@ export default function TripCreationBar() {
               className="flex-1 min-w-[60px] border-0 outline-none bg-transparent text-sm text-text-primary placeholder:text-gray-400 py-1"
             />
           </div>
-          {/* Autocomplete dropdown */}
           {showDropdown && (
             <div className="absolute top-full left-0 right-0 mt-1 bg-white rounded-lg shadow-lg border border-gray-200 z-50 max-h-[280px] overflow-y-auto">
               {destResults.map((dest, idx) => (
@@ -201,13 +243,22 @@ export default function TripCreationBar() {
           </select>
         </div>
 
-        {/* Section 5: Create button */}
+        {/* Section 5: Button */}
         <button
-          onClick={handleCreateFromBar}
+          onClick={handleButtonClick}
           className="flex items-center justify-center gap-2 px-6 py-3 bg-brand-gold hover:bg-brand-gold-bright text-white font-semibold text-sm transition-colors whitespace-nowrap rounded-b-xl lg:rounded-b-none lg:rounded-r-xl"
         >
-          <Plane className="w-4 h-4" />
-          Create Trip
+          {isOnNewPage ? (
+            <>
+              <Save className="w-4 h-4" />
+              Save
+            </>
+          ) : (
+            <>
+              <Plane className="w-4 h-4" />
+              Create Trip
+            </>
+          )}
         </button>
       </div>
 

--- a/src/components/ui/AppLayout.tsx
+++ b/src/components/ui/AppLayout.tsx
@@ -2,7 +2,7 @@
 
 import { useRouter, usePathname } from 'next/navigation';
 import { useSession, signOut } from 'next-auth/react';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, Suspense } from 'react';
 import Link from 'next/link';
 import { BookOpen, User, Briefcase, Plane, TrendingUp, LayoutGrid, Menu, X } from 'lucide-react';
 import TripCreationBar from '@/components/trips/TripCreationBar';
@@ -228,7 +228,7 @@ export default function AppLayout({ children, ledgerMetrics, engineMetrics, onOp
         {showTravelSearch && (
           <div className="bg-brand-purple/80 border-t border-white/[.06]">
             <div className="max-w-[1800px] mx-auto px-6 py-4">
-              <TripCreationBar />
+              <Suspense><TripCreationBar /></Suspense>
             </div>
           </div>
         )}


### PR DESCRIPTION
Part 1: Search bar stays populated on /budgets/trips/new
- Read URL params (tripName, destinations, startDate, endDate, travelers, interests) and pre-populate all fields on mount
- Button changes from "Create Trip" to "Save" with Save icon
- Clicking Save on /new updates URL params in-place (router.replace) so the form below picks up any edits
- Wrapped in Suspense in AppLayout for useSearchParams

Part 2: Form only shows Travel Profile
- Removed duplicate Trip Name, Start/End Date, Travelers inputs
- Removed Destinations section (all handled by search bar chips)
- Trip details shown as compact summary bar from URL params
- Interest categories: only selected chip categories are expanded, unselected hidden behind "+ Add Category" button
- Each category is collapsible with chevron toggle
- Keep Trip Type, Budget, Vibe, Pace
- Button says "Save Trip" instead of "Create Trip"

Part 3: Unified destination flow
- Form reads destinations from URL params (set by search bar)
- Creates trip with first destination as primary
- Searches resorts API for matching entries to save

https://claude.ai/code/session_01ScpFQ9Q7hKRx4D6axZ8jfH