### PR TITLE
Remove redundant sections from trip creation page

### DIFF
--- a/src/app/budgets/trips/new/page.tsx
+++ b/src/app/budgets/trips/new/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useRef, Suspense } from 'react';
+import { useState, useEffect, Suspense } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { AppLayout } from '@/components/ui';
 import { TRAVEL_INTERESTS, ACTIVITY_GROUPS } from '@/lib/activities';
@@ -38,13 +38,20 @@ const PACE_OPTIONS = [
   { value: 'packed', label: 'Packed & Hustling' },
 ];
 
-// Map filter chip labels → activity values
 const INTEREST_TO_ACTIVITIES: Record<string, string[]> = Object.fromEntries(
   Object.entries(TRAVEL_INTERESTS).map(([category, items]) => [
     category,
     items.map(item => item.toLowerCase().replace(/[^a-z0-9]/g, '_')),
   ])
 );
+
+function parseDate(val: string | null): string {
+  if (!val) return '';
+  if (/^\d{4}-\d{2}-\d{2}$/.test(val)) return val;
+  const match = val.match(/^(\d{1,2})\/(\d{1,2})\/(\d{4})$/);
+  if (match) return `${match[3]}-${match[1].padStart(2, '0')}-${match[2].padStart(2, '0')}`;
+  return '';
+}
 
 export default function NewTripPage() {
   return (
@@ -66,18 +73,16 @@ function NewTripForm() {
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
 
-  // Trip type (not in search bar)
   const [tripType, setTripType] = useState('personal');
-
-  // Profile
   const [selectedActivities, setSelectedActivities] = useState<string[]>([]);
   const [budget, setBudget] = useState('midrange');
   const [vibes, setVibes] = useState<string[]>([]);
   const [pace, setPace] = useState('balanced');
-
-  // Track which interest categories are expanded
   const [expandedCategories, setExpandedCategories] = useState<Set<string>>(new Set());
   const [showAllCategories, setShowAllCategories] = useState(false);
+
+  // Track if we've already auto-created to prevent double submission
+  const [hasSubmitted, setHasSubmitted] = useState(false);
 
   // Read interests from URL params and auto-expand/select matching categories
   useEffect(() => {
@@ -98,26 +103,17 @@ function NewTripForm() {
     }
   }, [searchParams]);
 
-  // Read trip details from URL params (set by search bar)
-  const name = searchParams.get('tripName') || '';
-  const startDate = (() => {
-    const sd = searchParams.get('startDate');
-    if (!sd) return '';
-    if (/^\d{4}-\d{2}-\d{2}$/.test(sd)) return sd;
-    const match = sd.match(/^(\d{1,2})\/(\d{1,2})\/(\d{4})$/);
-    if (match) return `${match[3]}-${match[1].padStart(2, '0')}-${match[2].padStart(2, '0')}`;
-    return '';
-  })();
-  const endDate = (() => {
-    const ed = searchParams.get('endDate');
-    if (!ed) return '';
-    if (/^\d{4}-\d{2}-\d{2}$/.test(ed)) return ed;
-    const match = ed.match(/^(\d{1,2})\/(\d{1,2})\/(\d{4})$/);
-    if (match) return `${match[3]}-${match[1].padStart(2, '0')}-${match[2].padStart(2, '0')}`;
-    return '';
-  })();
-  const destinations = searchParams.get('destinations')?.split(',').map(d => d.trim()).filter(Boolean) || [];
+  // Auto-create when search bar sets save=1 in URL params
+  useEffect(() => {
+    if (searchParams.get('save') === '1' && !hasSubmitted && !saving) {
+      handleCreate();
+    }
+  }, [searchParams]);
 
+  const name = searchParams.get('tripName') || '';
+  const startDate = parseDate(searchParams.get('startDate'));
+  const endDate = parseDate(searchParams.get('endDate'));
+  const destinations = searchParams.get('destinations')?.split(',').map(d => d.trim()).filter(Boolean) || [];
   const duration = startDate && endDate
     ? Math.round((new Date(endDate + 'T12:00:00').getTime() - new Date(startDate + 'T12:00:00').getTime()) / 86400000) + 1
     : 0;
@@ -143,12 +139,11 @@ function NewTripForm() {
     });
   };
 
-  const canCreate = name.trim() && startDate && endDate && duration > 0;
-
   const handleCreate = async () => {
-    if (!canCreate) return;
+    if (!name.trim() || !startDate || !endDate || duration <= 0) return;
     setSaving(true);
     setError('');
+    setHasSubmitted(true);
 
     try {
       const tripRes = await fetch('/api/trips', {
@@ -194,7 +189,6 @@ function NewTripForm() {
         });
       }
 
-      // Save destinations — search resorts API for matching entries
       for (const destName of destinations) {
         try {
           const searchRes = await fetch('/api/resorts?activity=all');
@@ -212,21 +206,20 @@ function NewTripForm() {
             }
           }
         } catch {
-          // Resort not found — destination name is already set on the trip
+          // Destination name already set on trip
         }
       }
 
       router.push(`/budgets/trips/${tripId}`);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to create trip');
+      setHasSubmitted(false);
     } finally {
       setSaving(false);
     }
   };
 
   const budgetHint = BUDGET_OPTIONS.find(b => b.value === budget)?.hint;
-
-  // Categories to show: selected chips first (expanded), then unselected if user clicked "+ Add Category"
   const selectedCategoryGroups = ACTIVITY_GROUPS.filter(g => expandedCategories.has(g.label));
   const unselectedCategoryGroups = ACTIVITY_GROUPS.filter(g => !expandedCategories.has(g.label));
 
@@ -238,55 +231,80 @@ function NewTripForm() {
           <div className="bg-red-50 border border-red-200 text-brand-red px-4 py-3 mb-4 text-sm">{error}</div>
         )}
 
-        {/* Summary of what's in the search bar */}
-        {(name || destinations.length > 0 || startDate) && (
-          <div className="bg-white border border-gray-200 rounded-lg p-3 mb-3 flex flex-wrap items-center gap-3 text-xs text-gray-500">
-            {name && <span className="font-medium text-gray-900">{name}</span>}
-            {destinations.length > 0 && (
-              <span>{destinations.join(' → ')}</span>
-            )}
-            {startDate && endDate && (
-              <span>{new Date(startDate + 'T12:00:00').toLocaleDateString('en-US', { month: 'short', day: 'numeric' })} – {new Date(endDate + 'T12:00:00').toLocaleDateString('en-US', { month: 'short', day: 'numeric' })} · {duration} days</span>
-            )}
+        {saving && (
+          <div className="bg-brand-purple/5 border border-brand-purple/20 rounded-lg px-4 py-3 mb-4 flex items-center gap-3 text-sm text-brand-purple">
+            <div className="w-4 h-4 border-2 border-brand-purple border-t-transparent rounded-full animate-spin" />
+            Creating your trip...
           </div>
         )}
 
-        <div className="space-y-3">
+        {/* Trip Type — simple inline toggle */}
+        <div className="flex items-center gap-2 mb-4">
+          {TRIP_TYPES.map(tt => (
+            <button key={tt.value} type="button" onClick={() => setTripType(tt.value)}
+              className={`px-4 py-2 text-xs font-medium rounded-full transition-colors ${
+                tripType === tt.value ? 'bg-brand-purple text-white' : 'bg-white text-gray-600 hover:bg-gray-50 border border-gray-200'
+              }`}>
+              {tt.label}
+            </button>
+          ))}
+        </div>
 
-          {/* Trip Type */}
-          <div className="bg-white border border-gray-200 rounded-lg p-4">
-            <h2 className="text-sm font-semibold text-gray-700 border-b border-gray-200 pb-2 mb-3">Trip Type</h2>
-            <div className="flex gap-2">
-              {TRIP_TYPES.map(tt => (
-                <button key={tt.value} type="button" onClick={() => setTripType(tt.value)}
-                  className={`flex-1 px-3 py-2 text-xs font-medium rounded-lg transition-colors ${
-                    tripType === tt.value ? 'bg-brand-purple text-white' : 'bg-bg-row text-text-secondary hover:bg-border border border-gray-200'
-                  }`}>
-                  {tt.label}
-                </button>
+        {/* Travel Profile — Interests */}
+        <div className="bg-white border border-gray-200 rounded-lg p-4 mb-3">
+          <h2 className="text-sm font-semibold text-gray-700 border-b border-gray-200 pb-2 mb-3">
+            Your Travel Profile
+            {selectedActivities.length > 0 && (
+              <span className="ml-2 text-brand-purple font-normal text-xs">({selectedActivities.length} selected)</span>
+            )}
+          </h2>
+
+          {selectedCategoryGroups.length > 0 ? (
+            <div className="space-y-3">
+              {selectedCategoryGroups.map(group => (
+                <div key={group.label}>
+                  <button onClick={() => toggleCategory(group.label)}
+                    className="flex items-center gap-2 text-xs font-semibold text-gray-700 mb-1.5 hover:text-brand-purple">
+                    <ChevronDown className="w-3.5 h-3.5" />
+                    {group.label}
+                  </button>
+                  <div className="flex flex-wrap gap-1.5 pl-5">
+                    {group.activities.map(act => {
+                      const selected = selectedActivities.includes(act.value);
+                      return (
+                        <button key={act.value} type="button" onClick={() => toggleActivity(act.value)}
+                          className={`px-2.5 py-1 rounded text-xs font-medium transition-colors ${
+                            selected ? 'bg-brand-purple text-white' : 'bg-bg-row text-text-secondary hover:bg-border'
+                          }`}>
+                          {act.label}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
               ))}
             </div>
-          </div>
+          ) : (
+            <p className="text-xs text-gray-400 mb-3">Select interest categories using the filter chips in the search bar above, or add them below.</p>
+          )}
 
-          {/* Travel Profile — Interests */}
-          <div className="bg-white border border-gray-200 rounded-lg p-4">
-            <h2 className="text-sm font-semibold text-gray-700 border-b border-gray-200 pb-2 mb-3">
-              Your Interests
-              {selectedActivities.length > 0 && (
-                <span className="ml-2 text-brand-purple font-normal text-xs">({selectedActivities.length} selected)</span>
-              )}
-            </h2>
+          {!showAllCategories && unselectedCategoryGroups.length > 0 && (
+            <button onClick={() => setShowAllCategories(true)}
+              className="mt-3 text-xs text-brand-purple hover:underline font-medium">
+              + Add Category ({unselectedCategoryGroups.length} more)
+            </button>
+          )}
 
-            {/* Selected/expanded categories */}
-            {selectedCategoryGroups.length > 0 ? (
-              <div className="space-y-3">
-                {selectedCategoryGroups.map(group => (
-                  <div key={group.label}>
-                    <button onClick={() => toggleCategory(group.label)}
-                      className="flex items-center gap-2 text-xs font-semibold text-gray-700 mb-1.5 hover:text-brand-purple">
-                      <ChevronDown className="w-3.5 h-3.5" />
-                      {group.label}
-                    </button>
+          {showAllCategories && unselectedCategoryGroups.length > 0 && (
+            <div className="mt-3 pt-3 border-t border-gray-100 space-y-2">
+              {unselectedCategoryGroups.map(group => (
+                <div key={group.label}>
+                  <button onClick={() => toggleCategory(group.label)}
+                    className="flex items-center gap-2 text-xs font-medium text-gray-500 mb-1.5 hover:text-brand-purple">
+                    <ChevronDown className="w-3.5 h-3.5 -rotate-90" />
+                    {group.label}
+                  </button>
+                  {expandedCategories.has(group.label) && (
                     <div className="flex flex-wrap gap-1.5 pl-5">
                       {group.activities.map(act => {
                         const selected = selectedActivities.includes(act.value);
@@ -300,118 +318,67 @@ function NewTripForm() {
                         );
                       })}
                     </div>
-                  </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Preferences — Budget + Vibe + Pace */}
+        <div className="bg-white border border-gray-200 rounded-lg p-4">
+          <h2 className="text-sm font-semibold text-gray-700 border-b border-gray-200 pb-2 mb-3">Preferences</h2>
+          <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+            <div>
+              <h4 className="text-xs font-semibold text-text-secondary uppercase tracking-wider mb-2">Budget per Night</h4>
+              <div className="flex flex-wrap gap-1.5">
+                {BUDGET_OPTIONS.map(bo => (
+                  <button key={bo.value} type="button" onClick={() => setBudget(bo.value)}
+                    className={`px-2.5 py-1.5 rounded text-xs font-medium transition-colors ${
+                      budget === bo.value ? 'bg-brand-purple text-white' : 'bg-bg-row text-text-secondary hover:bg-border'
+                    }`}>
+                    {bo.label}
+                  </button>
                 ))}
               </div>
-            ) : (
-              <p className="text-xs text-gray-400 mb-3">Select interest categories using the filter chips in the search bar above, or add them below.</p>
-            )}
+              {budgetHint && <div className="text-xs text-text-muted mt-1.5">{budgetHint}</div>}
+            </div>
 
-            {/* Collapsed unselected categories */}
-            {!showAllCategories && unselectedCategoryGroups.length > 0 && (
-              <button onClick={() => setShowAllCategories(true)}
-                className="mt-3 text-xs text-brand-purple hover:underline font-medium">
-                + Add Category ({unselectedCategoryGroups.length} more)
-              </button>
-            )}
-
-            {showAllCategories && unselectedCategoryGroups.length > 0 && (
-              <div className="mt-3 pt-3 border-t border-gray-100 space-y-2">
-                {unselectedCategoryGroups.map(group => (
-                  <div key={group.label}>
-                    <button onClick={() => toggleCategory(group.label)}
-                      className="flex items-center gap-2 text-xs font-medium text-gray-500 mb-1.5 hover:text-brand-purple">
-                      <ChevronDown className="w-3.5 h-3.5 -rotate-90" />
-                      {group.label}
-                    </button>
-                    {expandedCategories.has(group.label) && (
-                      <div className="flex flex-wrap gap-1.5 pl-5">
-                        {group.activities.map(act => {
-                          const selected = selectedActivities.includes(act.value);
-                          return (
-                            <button key={act.value} type="button" onClick={() => toggleActivity(act.value)}
-                              className={`px-2.5 py-1 rounded text-xs font-medium transition-colors ${
-                                selected ? 'bg-brand-purple text-white' : 'bg-bg-row text-text-secondary hover:bg-border'
-                              }`}>
-                              {act.label}
-                            </button>
-                          );
-                        })}
-                      </div>
-                    )}
-                  </div>
-                ))}
-              </div>
-            )}
-          </div>
-
-          {/* Budget + Vibe + Pace */}
-          <div className="bg-white border border-gray-200 rounded-lg p-4">
-            <h2 className="text-sm font-semibold text-gray-700 border-b border-gray-200 pb-2 mb-3">Preferences</h2>
-            <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
-              <div>
-                <h4 className="text-xs font-semibold text-text-secondary uppercase tracking-wider mb-2">Budget per Night</h4>
-                <div className="flex flex-wrap gap-1.5">
-                  {BUDGET_OPTIONS.map(bo => (
-                    <button key={bo.value} type="button" onClick={() => setBudget(bo.value)}
+            <div>
+              <h4 className="text-xs font-semibold text-text-secondary uppercase tracking-wider mb-2">
+                Vibe <span className="font-normal text-text-muted">(up to 3)</span>
+              </h4>
+              <div className="flex flex-wrap gap-1.5">
+                {VIBE_OPTIONS.map(vo => {
+                  const selected = vibes.includes(vo.value);
+                  return (
+                    <button key={vo.value} type="button" onClick={() => toggleVibe(vo.value)}
                       className={`px-2.5 py-1.5 rounded text-xs font-medium transition-colors ${
-                        budget === bo.value ? 'bg-brand-purple text-white' : 'bg-bg-row text-text-secondary hover:bg-border'
+                        selected ? 'bg-brand-purple text-white' : 'bg-bg-row text-text-secondary hover:bg-border'
                       }`}>
-                      {bo.label}
+                      {vo.label}
                     </button>
-                  ))}
-                </div>
-                {budgetHint && <div className="text-xs text-text-muted mt-1.5">{budgetHint}</div>}
+                  );
+                })}
               </div>
+            </div>
 
-              <div>
-                <h4 className="text-xs font-semibold text-text-secondary uppercase tracking-wider mb-2">
-                  Vibe <span className="font-normal text-text-muted">(up to 3)</span>
-                </h4>
-                <div className="flex flex-wrap gap-1.5">
-                  {VIBE_OPTIONS.map(vo => {
-                    const selected = vibes.includes(vo.value);
-                    return (
-                      <button key={vo.value} type="button" onClick={() => toggleVibe(vo.value)}
-                        className={`px-2.5 py-1.5 rounded text-xs font-medium transition-colors ${
-                          selected ? 'bg-brand-purple text-white' : 'bg-bg-row text-text-secondary hover:bg-border'
-                        }`}>
-                        {vo.label}
-                      </button>
-                    );
-                  })}
-                </div>
-              </div>
-
-              <div>
-                <h4 className="text-xs font-semibold text-text-secondary uppercase tracking-wider mb-2">Pace</h4>
-                <div className="flex gap-2">
-                  {PACE_OPTIONS.map(po => (
-                    <button key={po.value} type="button" onClick={() => setPace(po.value)}
-                      className={`flex-1 px-3 py-2 rounded text-xs font-medium transition-colors ${
-                        pace === po.value ? 'bg-brand-purple text-white' : 'bg-bg-row text-text-secondary hover:bg-border'
-                      }`}>
-                      {po.label}
-                    </button>
-                  ))}
-                </div>
+            <div>
+              <h4 className="text-xs font-semibold text-text-secondary uppercase tracking-wider mb-2">Pace</h4>
+              <div className="flex gap-2">
+                {PACE_OPTIONS.map(po => (
+                  <button key={po.value} type="button" onClick={() => setPace(po.value)}
+                    className={`flex-1 px-3 py-2 rounded text-xs font-medium transition-colors ${
+                      pace === po.value ? 'bg-brand-purple text-white' : 'bg-bg-row text-text-secondary hover:bg-border'
+                    }`}>
+                    {po.label}
+                  </button>
+                ))}
               </div>
             </div>
           </div>
-
-          {/* Actions */}
-          <div className="flex items-center justify-end gap-3 pt-1">
-            <button type="button" onClick={() => router.back()}
-              className="text-gray-500 hover:text-gray-700 text-sm font-medium px-4 py-3 transition-colors">
-              Cancel
-            </button>
-            <button onClick={handleCreate} disabled={saving || !canCreate}
-              className="bg-brand-gold hover:bg-brand-gold-bright text-white font-semibold text-sm px-8 py-3 rounded-lg disabled:opacity-50 transition-colors">
-              {saving ? 'Saving...' : 'Save Trip'}
-            </button>
-          </div>
-
         </div>
+
       </div>
     </div>
   );

--- a/src/components/trips/TripCreationBar.tsx
+++ b/src/components/trips/TripCreationBar.tsx
@@ -137,8 +137,10 @@ export default function TripCreationBar() {
     const params = buildParams();
     const qs = params.toString() ? '?' + params.toString() : '';
     if (isOnNewPage) {
-      // Update URL params in-place so the form below picks up edits
-      router.replace(`/budgets/trips/new${qs}`, { scroll: false });
+      // Signal the form to save by adding save=1 param
+      params.set('save', '1');
+      const saveQs = params.toString() ? '?' + params.toString() : '';
+      router.replace(`/budgets/trips/new${saveQs}`, { scroll: false });
     } else {
       router.push(`/budgets/trips/new${qs}`);
     }


### PR DESCRIPTION
The search bar is now the single editor for trip name, destinations, dates, and travelers. The form page below only shows what the search bar doesn't handle.

Removed from form:
- Trip Details section (name, dates — all in search bar)
- Destinations section (chips are in search bar)
- Summary bar (redundant with search bar)
- Bottom Save/Cancel buttons (search bar Save handles creation)

Kept and restyled:
- Trip Type: simple inline pill toggle at top (not a card section)
- Travel Profile: interests with expandable categories
- Preferences: budget, vibe, pace in 3-column grid

Search bar Save flow:
- On /budgets/trips/new, clicking Save adds save=1 to URL params
- Form detects save=1 and auto-creates the trip via API
- Shows "Creating your trip..." spinner during submission

https://claude.ai/code/session_01ScpFQ9Q7hKRx4D6axZ8jfH