### PR TITLE
Swap trip type toggle and activity filter chips positions

### DIFF
--- a/src/app/budgets/trips/new/page.tsx
+++ b/src/app/budgets/trips/new/page.tsx
@@ -3,14 +3,8 @@
 import { useState, useEffect, Suspense } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { AppLayout } from '@/components/ui';
-import { TRAVEL_INTERESTS, ACTIVITY_GROUPS } from '@/lib/activities';
+import { TRAVEL_INTERESTS, ACTIVITY_GROUPS, INTEREST_CATEGORIES } from '@/lib/activities';
 import { ChevronDown } from 'lucide-react';
-
-const TRIP_TYPES = [
-  { value: 'personal', label: 'Personal' },
-  { value: 'business', label: 'Business' },
-  { value: 'mixed', label: 'Mixed' },
-];
 
 const BUDGET_OPTIONS = [
   { value: 'backpacker', label: '$0-50/night', hint: 'We\'d suggest $ venues' },
@@ -73,7 +67,7 @@ function NewTripForm() {
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
 
-  const [tripType, setTripType] = useState('personal');
+  const [selectedChips, setSelectedChips] = useState<string[]>([]);
   const [selectedActivities, setSelectedActivities] = useState<string[]>([]);
   const [budget, setBudget] = useState('midrange');
   const [vibes, setVibes] = useState<string[]>([]);
@@ -84,24 +78,20 @@ function NewTripForm() {
   // Track if we've already auto-created to prevent double submission
   const [hasSubmitted, setHasSubmitted] = useState(false);
 
-  // Read interests from URL params and auto-expand/select matching categories
+  // Sync interest categories from filter chips
   useEffect(() => {
-    const interests = searchParams.get('interests');
-    if (interests) {
-      const chipLabels = interests.split(',').map(c => c.trim());
-      const expanded = new Set<string>();
-      const activities = new Set<string>();
-      chipLabels.forEach(label => {
-        const mapped = INTEREST_TO_ACTIVITIES[label];
-        if (mapped) {
-          expanded.add(label);
-          mapped.forEach(a => activities.add(a));
-        }
-      });
-      if (expanded.size > 0) setExpandedCategories(expanded);
-      if (activities.size > 0) setSelectedActivities(Array.from(activities));
-    }
-  }, [searchParams]);
+    const expanded = new Set<string>();
+    const activities = new Set<string>();
+    selectedChips.forEach(label => {
+      const mapped = INTEREST_TO_ACTIVITIES[label];
+      if (mapped) {
+        expanded.add(label);
+        mapped.forEach(a => activities.add(a));
+      }
+    });
+    setExpandedCategories(expanded);
+    setSelectedActivities(Array.from(activities));
+  }, [selectedChips]);
 
   // Auto-create when search bar sets save=1 in URL params
   useEffect(() => {
@@ -113,10 +103,17 @@ function NewTripForm() {
   const name = searchParams.get('tripName') || '';
   const startDate = parseDate(searchParams.get('startDate'));
   const endDate = parseDate(searchParams.get('endDate'));
+  const tripType = searchParams.get('tripType') || 'personal';
   const destinations = searchParams.get('destinations')?.split(',').map(d => d.trim()).filter(Boolean) || [];
   const duration = startDate && endDate
     ? Math.round((new Date(endDate + 'T12:00:00').getTime() - new Date(startDate + 'T12:00:00').getTime()) / 86400000) + 1
     : 0;
+
+  const toggleChip = (chip: string) => {
+    setSelectedChips(prev =>
+      prev.includes(chip) ? prev.filter(c => c !== chip) : [...prev, chip]
+    );
+  };
 
   const toggleActivity = (val: string) => {
     setSelectedActivities(prev =>
@@ -238,16 +235,24 @@ function NewTripForm() {
           </div>
         )}
 
-        {/* Trip Type — simple inline toggle */}
-        <div className="flex items-center gap-2 mb-4">
-          {TRIP_TYPES.map(tt => (
-            <button key={tt.value} type="button" onClick={() => setTripType(tt.value)}
-              className={`px-4 py-2 text-xs font-medium rounded-full transition-colors ${
-                tripType === tt.value ? 'bg-brand-purple text-white' : 'bg-white text-gray-600 hover:bg-gray-50 border border-gray-200'
-              }`}>
-              {tt.label}
-            </button>
-          ))}
+        {/* Activity filter chips — toggle interest categories below */}
+        <div className="flex items-center gap-2 mb-4 overflow-x-auto pb-1 scrollbar-hide">
+          {INTEREST_CATEGORIES.map(chip => {
+            const active = selectedChips.includes(chip);
+            return (
+              <button
+                key={chip}
+                onClick={() => toggleChip(chip)}
+                className={`text-xs px-3 py-1.5 rounded-full border whitespace-nowrap transition-colors ${
+                  active
+                    ? 'bg-brand-purple text-white border-brand-purple'
+                    : 'bg-white text-gray-600 hover:bg-gray-50 border-gray-200'
+                }`}
+              >
+                {chip}
+              </button>
+            );
+          })}
         </div>
 
         {/* Travel Profile — Interests */}

--- a/src/components/trips/TripCreationBar.tsx
+++ b/src/components/trips/TripCreationBar.tsx
@@ -4,9 +4,12 @@ import { useState, useRef, useEffect, useCallback } from 'react';
 import { useRouter, usePathname, useSearchParams } from 'next/navigation';
 import { Plane, FileText, MapPin, Calendar, Users, X, Save } from 'lucide-react';
 import { searchDestinations, type Destination } from '@/lib/destinations';
-import { INTEREST_CATEGORIES } from '@/lib/activities';
 
-const FILTER_CHIPS = INTEREST_CATEGORIES;
+const TRIP_TYPES = [
+  { value: 'personal', label: 'Personal' },
+  { value: 'business', label: 'Business' },
+  { value: 'mixed', label: 'Mixed' },
+];
 
 function parseToDateInput(val: string): string | null {
   if (/^\d{4}-\d{2}-\d{2}$/.test(val)) return val;
@@ -29,7 +32,7 @@ export default function TripCreationBar() {
   const [barStartDate, setBarStartDate] = useState('');
   const [barEndDate, setBarEndDate] = useState('');
   const [barTravelers, setBarTravelers] = useState(2);
-  const [selectedChips, setSelectedChips] = useState<string[]>([]);
+  const [tripType, setTripType] = useState('personal');
 
   // Autocomplete state
   const [destQuery, setDestQuery] = useState('');
@@ -48,14 +51,14 @@ export default function TripCreationBar() {
     const sd = searchParams.get('startDate');
     const ed = searchParams.get('endDate');
     const travelers = searchParams.get('travelers');
-    const interests = searchParams.get('interests');
+    const tt = searchParams.get('tripType');
 
     if (tripName) setBarName(tripName);
     if (dests) setSelectedDestinations(dests.split(',').map(d => d.trim()).filter(Boolean));
     if (sd) { const p = parseToDateInput(sd); if (p) setBarStartDate(p); }
     if (ed) { const p = parseToDateInput(ed); if (p) setBarEndDate(p); }
     if (travelers) setBarTravelers(parseInt(travelers) || 2);
-    if (interests) setSelectedChips(interests.split(',').map(c => c.trim()).filter(Boolean));
+    if (tt) setTripType(tt);
     setDidInit(true);
   }, [isOnNewPage, searchParams, didInit]);
 
@@ -116,12 +119,6 @@ export default function TripCreationBar() {
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, [handleClickOutside]);
 
-  const toggleChip = (chip: string) => {
-    setSelectedChips(prev =>
-      prev.includes(chip) ? prev.filter(c => c !== chip) : [...prev, chip]
-    );
-  };
-
   const buildParams = () => {
     const params = new URLSearchParams();
     if (barName) params.set('tripName', barName);
@@ -129,7 +126,7 @@ export default function TripCreationBar() {
     if (barStartDate) params.set('startDate', barStartDate);
     if (barEndDate) params.set('endDate', barEndDate);
     if (barTravelers > 1) params.set('travelers', String(barTravelers));
-    if (selectedChips.length > 0) params.set('interests', selectedChips.join(','));
+    if (tripType !== 'personal') params.set('tripType', tripType);
     return params;
   };
 
@@ -264,24 +261,21 @@ export default function TripCreationBar() {
         </button>
       </div>
 
-      {/* Filter chips */}
-      <div className="flex items-center gap-2 overflow-x-auto pb-1 -mb-1 scrollbar-hide">
-        {FILTER_CHIPS.map(chip => {
-          const active = selectedChips.includes(chip);
-          return (
-            <button
-              key={chip}
-              onClick={() => toggleChip(chip)}
-              className={`text-xs px-3 py-1 rounded-full border whitespace-nowrap transition-colors ${
-                active
-                  ? 'bg-white/20 text-white border-white/60'
-                  : 'border-white/30 text-white/70 hover:bg-white/10 hover:text-white'
-              }`}
-            >
-              {chip}
-            </button>
-          );
-        })}
+      {/* Trip type toggle */}
+      <div className="flex items-center gap-2">
+        {TRIP_TYPES.map(tt => (
+          <button
+            key={tt.value}
+            onClick={() => setTripType(tt.value)}
+            className={`text-xs px-3 py-1 rounded-full border whitespace-nowrap transition-colors ${
+              tripType === tt.value
+                ? 'bg-white/20 text-white border-white/60'
+                : 'border-white/30 text-white/70 hover:bg-white/10 hover:text-white'
+            }`}
+          >
+            {tt.label}
+          </button>
+        ))}
       </div>
     </div>
   );


### PR DESCRIPTION
Header (TripCreationBar):
- Replace activity filter chips row with Personal/Business/Mixed pills
- Same styling as previous chips (rounded-full, white border on purple)
- tripType stored in state, passed as query param, pre-populated from URL
- Remove INTEREST_CATEGORIES import (no longer needed here)

Form page (new/page.tsx):
- Replace trip type toggle at top with activity filter chips row
- Chips use INTEREST_CATEGORIES, styled as rounded pills
- Selecting chips toggles interest categories in Travel Profile below
- tripType read from URL params (set by search bar) instead of local state
- Remove TRIP_TYPES constant (moved to search bar)

https://claude.ai/code/session_01ScpFQ9Q7hKRx4D6axZ8jfH