### PR TITLE
Unify destination system across search bar, creation, and detail pages

### DIFF
--- a/prisma/migrations/20260326000000_add_destination_name_fields/migration.sql
+++ b/prisma/migrations/20260326000000_add_destination_name_fields/migration.sql
@@ -1,0 +1,11 @@
+-- AlterTable: Add name-based destination fields to trip_destinations
+-- Allows destinations from the search bar (city names with coordinates)
+-- to be stored alongside resort-based destinations
+
+ALTER TABLE "trip_destinations" ADD COLUMN "name" VARCHAR(255);
+ALTER TABLE "trip_destinations" ADD COLUMN "country" VARCHAR(100);
+ALTER TABLE "trip_destinations" ADD COLUMN "latitude" DECIMAL(10, 7);
+ALTER TABLE "trip_destinations" ADD COLUMN "longitude" DECIMAL(10, 7);
+
+-- Make resortId nullable (name-based destinations don't have one)
+ALTER TABLE "trip_destinations" ALTER COLUMN "resortId" DROP NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -688,7 +688,11 @@ model ikon_resorts {
 model trip_destinations {
   id              String   @id @default(cuid())
   tripId          String
-  resortId        String
+  resortId        String?
+  name            String?  @db.VarChar(255)
+  country         String?  @db.VarChar(100)
+  latitude        Decimal? @db.Decimal(10, 7)
+  longitude       Decimal? @db.Decimal(10, 7)
   isSelected      Boolean  @default(true)
   estimatedTotal  Decimal? @db.Decimal(12, 2)
   createdAt       DateTime @default(now())

--- a/src/app/api/trips/[id]/destinations/route.ts
+++ b/src/app/api/trips/[id]/destinations/route.ts
@@ -215,7 +215,6 @@ export async function GET(
       return NextResponse.json({ error: 'User not found' }, { status: 404 });
     }
 
-    // Get trip to determine activity (verify ownership)
     const trip = await prisma.trips.findFirst({
       where: { id, userId: user.id },
       select: { activity: true }
@@ -230,15 +229,37 @@ export async function GET(
 
     const destinations = await prisma.trip_destinations.findMany({
       where: { tripId: id },
-    });
+    }) as any[];
 
-    const resortIds = destinations.map(d => d.resortId);
-    const resorts = await getDestinationData(table, resortIds);
+    // Separate resort-based and name-based destinations
+    const resortDests = destinations.filter((d: any) => d.resortId);
+    const nameDests = destinations.filter((d: any) => !d.resortId && d.name);
 
-    const enriched = destinations.map(d => ({
-      ...d,
-      resort: resorts.find((r: any) => r.id === d.resortId)
-    }));
+    const resortIds = resortDests.map(d => d.resortId!);
+    const resorts = resortIds.length > 0 ? await getDestinationData(table, resortIds) : [];
+
+    const enriched = [
+      // Resort-based destinations enriched with resort data
+      ...resortDests.map(d => ({
+        ...d,
+        resort: resorts.find((r: any) => r.id === d.resortId) || null,
+      })),
+      // Name-based destinations (from search bar) — synthesize resort shape
+      ...nameDests.map(d => ({
+        ...d,
+        resortId: d.id, // Use the destination record ID as a fallback
+        resort: {
+          id: d.id,
+          name: d.name,
+          country: d.country || '',
+          region: '',
+          state: null,
+          nearestAirport: null,
+          latitude: d.latitude ? Number(d.latitude) : null,
+          longitude: d.longitude ? Number(d.longitude) : null,
+        },
+      })),
+    ];
 
     return NextResponse.json({ destinations: enriched });
   } catch (error) {
@@ -248,6 +269,7 @@ export async function GET(
 }
 
 // POST add destination to trip
+// Accepts either: { resortId } for resort-based, or { name, country?, lat?, lng? } for name-based
 export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
@@ -266,13 +288,12 @@ export async function POST(
     }
 
     const body = await request.json();
-    const { resortId } = body;
+    const { resortId, name, country, lat, lng } = body;
 
-    if (!resortId) {
-      return NextResponse.json({ error: 'Missing resortId' }, { status: 400 });
+    if (!resortId && !name) {
+      return NextResponse.json({ error: 'Missing resortId or name' }, { status: 400 });
     }
 
-    // Get trip to determine activity (verify ownership)
     const trip = await prisma.trips.findFirst({
       where: { id, userId: user.id },
       select: { activity: true }
@@ -282,24 +303,53 @@ export async function POST(
       return NextResponse.json({ error: 'Trip not found' }, { status: 404 });
     }
 
-    const activity = trip?.activity || 'all';
-    const table = ACTIVITY_TABLE_MAP[activity] || 'all';
+    if (resortId) {
+      // Resort-based destination (legacy flow)
+      const activity = trip?.activity || 'all';
+      const table = ACTIVITY_TABLE_MAP[activity] || 'all';
 
-    const destination = await prisma.trip_destinations.upsert({
-      where: {
-        tripId_resortId: { tripId: id, resortId }
-      },
-      update: { isSelected: true },
-      create: {
-        tripId: id,
-        resortId,
-        isSelected: true
+      const destination = await prisma.trip_destinations.upsert({
+        where: { tripId_resortId: { tripId: id, resortId } },
+        update: { isSelected: true },
+        create: { tripId: id, resortId, isSelected: true },
+      });
+
+      const resort = await getSingleDestination(table, resortId);
+      return NextResponse.json({ destination: { ...destination, resort } }, { status: 201 });
+    } else {
+      // Name-based destination (from search bar / destinations.ts)
+      // Check if this destination name already exists for this trip
+      const existing = await (prisma.trip_destinations as any).findFirst({
+        where: { tripId: id, name: name },
+      });
+
+      if (existing) {
+        return NextResponse.json({
+          destination: {
+            ...existing,
+            resort: { id: existing.id, name: existing.name, country: existing.country || '', region: '', state: null, nearestAirport: null },
+          },
+        }, { status: 200 });
       }
-    });
 
-    const resort = await getSingleDestination(table, resortId);
+      const destination = await (prisma.trip_destinations as any).create({
+        data: {
+          tripId: id,
+          name,
+          country: country || null,
+          latitude: lat != null ? lat : null,
+          longitude: lng != null ? lng : null,
+          isSelected: true,
+        },
+      });
 
-    return NextResponse.json({ destination: { ...destination, resort } }, { status: 201 });
+      return NextResponse.json({
+        destination: {
+          ...destination,
+          resort: { id: destination.id, name, country: country || '', region: '', state: null, nearestAirport: null },
+        },
+      }, { status: 201 });
+    }
   } catch (error) {
     console.error('Add destination error:', error);
     return NextResponse.json({ error: 'Failed to add destination' }, { status: 500 });
@@ -330,17 +380,21 @@ export async function DELETE(
     }
 
     const body = await request.json();
-    const { resortId } = body;
+    const { resortId, destinationId } = body;
 
-    if (!resortId) {
-      return NextResponse.json({ error: 'Missing resortId' }, { status: 400 });
+    if (!resortId && !destinationId) {
+      return NextResponse.json({ error: 'Missing resortId or destinationId' }, { status: 400 });
     }
 
-    await prisma.trip_destinations.delete({
-      where: {
-        tripId_resortId: { tripId: id, resortId }
-      }
-    });
+    if (destinationId) {
+      // Delete by record ID (name-based destinations)
+      await prisma.trip_destinations.delete({ where: { id: destinationId } });
+    } else {
+      // Delete by compound key (resort-based destinations)
+      await prisma.trip_destinations.delete({
+        where: { tripId_resortId: { tripId: id, resortId } },
+      });
+    }
 
     return NextResponse.json({ success: true });
   } catch (error) {

--- a/src/app/budgets/trips/new/page.tsx
+++ b/src/app/budgets/trips/new/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, Suspense } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { AppLayout } from '@/components/ui';
 import { TRAVEL_INTERESTS, ACTIVITY_GROUPS, INTEREST_CATEGORIES } from '@/lib/activities';
+import { searchDestinations } from '@/lib/destinations';
 import { ChevronDown } from 'lucide-react';
 
 const BUDGET_OPTIONS = [
@@ -186,25 +187,23 @@ function NewTripForm() {
         });
       }
 
+      // Save destinations using name-based API with coordinates from destinations.ts
       for (const destName of destinations) {
-        try {
-          const searchRes = await fetch('/api/resorts?activity=all');
-          if (searchRes.ok) {
-            const data = await searchRes.json();
-            const match = (data.resorts || []).find((r: any) =>
-              r.name.toLowerCase() === destName.toLowerCase()
-            );
-            if (match) {
-              await fetch(`/api/trips/${tripId}/destinations`, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ resortId: match.id }),
-              });
-            }
-          }
-        } catch {
-          // Destination name already set on trip
-        }
+        // Look up coordinates from the static destinations database
+        const matches = searchDestinations(destName, 1);
+        const match = matches.find(d => d.type === 'city' && d.name.toLowerCase() === destName.toLowerCase())
+          || matches.find(d => d.type === 'city');
+
+        await fetch(`/api/trips/${tripId}/destinations`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            name: destName,
+            country: match?.country || null,
+            lat: match?.lat || null,
+            lng: match?.lng || null,
+          }),
+        });
       }
 
       router.push(`/budgets/trips/${tripId}`);

--- a/src/components/trips/DestinationSelector.tsx
+++ b/src/components/trips/DestinationSelector.tsx
@@ -156,12 +156,14 @@ export default function DestinationSelector({
     }
   };
 
-  const removeDestination = async (resortId: string) => {
+  const removeDestination = async (resortId: string, destinationId?: string) => {
     try {
+      // Use destinationId for name-based destinations, resortId for resort-based
+      const body = destinationId ? { destinationId } : { resortId };
       const res = await fetch(`/api/trips/${tripId}/destinations`, {
         method: 'DELETE',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ resortId })
+        body: JSON.stringify(body),
       });
       if (res.ok) {
         onDestinationsChange();
@@ -200,7 +202,7 @@ export default function DestinationSelector({
               {selectedDestinationId === d.resortId && ' ✓'}
             </span>
             <button
-              onClick={() => removeDestination(d.resortId)}
+              onClick={() => removeDestination(d.resortId, d.resortId === d.id ? d.id : undefined)}
               className={`text-xs ${selectedDestinationId === d.resortId ? 'text-white/70 hover:text-white' : 'text-text-faint hover:text-brand-red'}`}
             >
               ✕

--- a/src/components/trips/TripCreationBar.tsx
+++ b/src/components/trips/TripCreationBar.tsx
@@ -26,6 +26,10 @@ export default function TripCreationBar() {
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const isOnNewPage = pathname === '/budgets/trips/new';
+  const tripDetailMatch = pathname?.match(/^\/budgets\/trips\/([^/]+)$/);
+  const isOnDetailPage = !!(tripDetailMatch && tripDetailMatch[1] !== 'new');
+  const detailTripId = tripDetailMatch?.[1] || null;
+  const mode: 'landing' | 'new' | 'detail' = isOnNewPage ? 'new' : isOnDetailPage ? 'detail' : 'landing';
 
   const [barName, setBarName] = useState('');
   const [selectedDestinations, setSelectedDestinations] = useState<string[]>([]);
@@ -42,6 +46,35 @@ export default function TripCreationBar() {
   const dropdownRef = useRef<HTMLDivElement>(null);
   const destInputRef = useRef<HTMLInputElement>(null);
   const [didInit, setDidInit] = useState(false);
+
+  // Pre-populate from trip data on detail page
+  useEffect(() => {
+    if (!isOnDetailPage || !detailTripId || didInit) return;
+    (async () => {
+      try {
+        const res = await fetch(`/api/trips/${detailTripId}`);
+        if (!res.ok) return;
+        const data = await res.json();
+        const trip = data.trip;
+        if (trip.name) setBarName(trip.name);
+        if (trip.startDate) setBarStartDate(trip.startDate.split('T')[0]);
+        if (trip.endDate) setBarEndDate(trip.endDate.split('T')[0]);
+        if (trip.participants) setBarTravelers(trip.participants.length || 2);
+        // Load destinations
+        const destRes = await fetch(`/api/trips/${detailTripId}/destinations`);
+        if (destRes.ok) {
+          const destData = await destRes.json();
+          const names = (destData.destinations || [])
+            .map((d: any) => d.name || d.resort?.name)
+            .filter(Boolean);
+          if (names.length > 0) setSelectedDestinations(names);
+        } else if (trip.destination) {
+          setSelectedDestinations([trip.destination]);
+        }
+        setDidInit(true);
+      } catch { /* ignore */ }
+    })();
+  }, [isOnDetailPage, detailTripId, didInit]);
 
   // Pre-populate from URL params on /new page
   useEffect(() => {
@@ -130,11 +163,35 @@ export default function TripCreationBar() {
     return params;
   };
 
-  const handleButtonClick = () => {
+  const [updating, setUpdating] = useState(false);
+
+  const handleButtonClick = async () => {
     const params = buildParams();
     const qs = params.toString() ? '?' + params.toString() : '';
-    if (isOnNewPage) {
-      // Signal the form to save by adding save=1 param
+
+    if (mode === 'detail' && detailTripId) {
+      // PATCH the existing trip
+      setUpdating(true);
+      try {
+        const duration = barStartDate && barEndDate
+          ? Math.round((new Date(barEndDate + 'T12:00:00').getTime() - new Date(barStartDate + 'T12:00:00').getTime()) / 86400000) + 1
+          : undefined;
+        await fetch(`/api/trips/${detailTripId}`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            name: barName || undefined,
+            destination: selectedDestinations[0] || undefined,
+            startDate: barStartDate || undefined,
+            endDate: barEndDate || undefined,
+            daysTravel: duration,
+            tripType: tripType !== 'personal' ? tripType : undefined,
+          }),
+        });
+        router.refresh();
+      } catch { /* ignore */ }
+      finally { setUpdating(false); }
+    } else if (mode === 'new') {
       params.set('save', '1');
       const saveQs = params.toString() ? '?' + params.toString() : '';
       router.replace(`/budgets/trips/new${saveQs}`, { scroll: false });
@@ -245,18 +302,15 @@ export default function TripCreationBar() {
         {/* Section 5: Button */}
         <button
           onClick={handleButtonClick}
-          className="flex items-center justify-center gap-2 px-6 py-3 bg-brand-gold hover:bg-brand-gold-bright text-white font-semibold text-sm transition-colors whitespace-nowrap rounded-b-xl lg:rounded-b-none lg:rounded-r-xl"
+          disabled={updating}
+          className="flex items-center justify-center gap-2 px-6 py-3 bg-brand-gold hover:bg-brand-gold-bright text-white font-semibold text-sm transition-colors whitespace-nowrap rounded-b-xl lg:rounded-b-none lg:rounded-r-xl disabled:opacity-50"
         >
-          {isOnNewPage ? (
-            <>
-              <Save className="w-4 h-4" />
-              Save
-            </>
+          {mode === 'detail' ? (
+            <>{updating ? 'Updating...' : <><Save className="w-4 h-4" /> Update</>}</>
+          ) : mode === 'new' ? (
+            <><Save className="w-4 h-4" /> Save</>
           ) : (
-            <>
-              <Plane className="w-4 h-4" />
-              Create Trip
-            </>
+            <><Plane className="w-4 h-4" /> Create Trip</>
           )}
         </button>
       </div>


### PR DESCRIPTION
Schema: Add name, country, latitude, longitude to trip_destinations. Make resortId nullable. Migration adds columns and drops NOT NULL. Destinations can now be stored as either resort-based (resortId) or name-based (name + country + lat/lng from destinations.ts).

API (destinations route):
- POST accepts { name, country, lat, lng } for name-based destinations in addition to { resortId } for resort-based
- GET separates resort-based and name-based, synthesizes resort shape for name-based so DestinationSelector renders both types uniformly
- DELETE accepts destinationId for name-based or resortId for resort-based

Trip creation (new/page.tsx):
- Look up each destination name in destinations.ts for coordinates
- Send { name, country, lat, lng } to the API instead of searching the resorts API for a matching resort by name

TripCreationBar — three modes:
- Landing (/budgets/trips): empty, "Create Trip" button
- New (/budgets/trips/new): populated from URL params, "Save" button
- Detail (/budgets/trips/[id]): fetches trip data + destinations, populates search bar, "Update" button that PATCHes the trip

DestinationSelector:
- removeDestination accepts optional destinationId for name-based
- Pills render correctly for both destination types

https://claude.ai/code/session_01ScpFQ9Q7hKRx4D6axZ8jfH