### PR TITLE
Add time data to flights and display on calendar

### DIFF
--- a/src/app/budgets/trips/[id]/page.tsx
+++ b/src/app/budgets/trips/[id]/page.tsx
@@ -100,6 +100,15 @@ interface DateWindow {
 }
 
 const MONTHS = ['', 'January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
+
+function formatTime12h(time: string): string {
+  if (!time) return '';
+  const [h, m] = time.split(':').map(Number);
+  if (isNaN(h)) return time;
+  const ampm = h >= 12 ? 'PM' : 'AM';
+  const h12 = h % 12 || 12;
+  return `${h12}:${String(m).padStart(2, '0')} ${ampm}`;
+}
 const WEEKDAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
 
 const CATEGORIES = [
@@ -359,10 +368,18 @@ export default function TripDetailPage({ params }: { params: Promise<{ id: strin
       const cfg = TRIP_SOURCE_CONFIG[source];
       const totalCost = entries.reduce((s: number, e: any) => s + parseFloat(e.cost || 0), 0);
       const dateStr = first.homeDate ? new Date(first.homeDate).toISOString().split('T')[0] : '';
+
+      // Build title with time for flights
+      let title = `${cfg?.icon || ''} ${first.vendor || 'Untitled'}`;
+      if (source === 'flight' && first.homeTime) {
+        const timeStr = formatTime12h(first.homeTime);
+        title = `${timeStr} ${cfg?.icon || ''} ${first.vendor || 'Untitled'}`;
+      }
+
       return {
         id: key,
         source,
-        title: `${cfg?.icon || ''} ${first.vendor || 'Untitled'}`,
+        title,
         icon: cfg?.icon || null,
         startDate: dateStr,
         endDate: entries.length > 1 && entries[entries.length - 1].homeDate
@@ -374,6 +391,8 @@ export default function TripDetailPage({ params }: { params: Promise<{ id: strin
         _vendorOptionType: first.vendorOptionType,
         _vendor: first.vendor,
         _note: first.note,
+        _homeTime: first.homeTime,
+        _destTime: first.destTime,
       } as CalendarEvent & Record<string, any>;
     });
   }, [trip]);
@@ -537,6 +556,7 @@ export default function TripDetailPage({ params }: { params: Promise<{ id: strin
                             {TRIP_SOURCE_CONFIG[clickedEvent.source]?.label || clickedEvent.source}
                             {clickedEvent.startDate && <span className="ml-2">{clickedEvent.startDate}</span>}
                             {clickedEvent.endDate && clickedEvent.endDate !== clickedEvent.startDate && <span> — {clickedEvent.endDate}</span>}
+                            {clickedEvent._destTime && <span className="ml-2">arr {formatTime12h(clickedEvent._destTime)}</span>}
                           </div>
                           {(clickedEvent.budgetAmount || 0) > 0 && (
                             <div className="text-sm font-semibold text-emerald-700 mt-1">{fmt(clickedEvent.budgetAmount || 0)}</div>

--- a/src/components/trips/FlightPicker.tsx
+++ b/src/components/trips/FlightPicker.tsx
@@ -50,6 +50,8 @@ interface FlightLeg {
   // Manual entry fields
   manualAirline: string;
   manualPrice: string;
+  manualDepartTime: string;
+  manualArriveTime: string;
 }
 
 interface Props {
@@ -93,6 +95,8 @@ export default function FlightPicker({
     expanded: true,
     manualAirline: '',
     manualPrice: '',
+    manualDepartTime: '',
+    manualArriveTime: '',
     ...overrides,
   }), [originAirport, destinationAirport, departureDate, returnDate]);
 
@@ -234,8 +238,8 @@ export default function FlightPicker({
       price: parseFloat(leg.manualPrice),
       currency: 'USD',
       outbound: {
-        departure: { airport: leg.origin, localTime: '', date: leg.departureDate },
-        arrival: { airport: leg.destination, localTime: '', date: leg.departureDate },
+        departure: { airport: leg.origin, localTime: leg.manualDepartTime || '', date: leg.departureDate },
+        arrival: { airport: leg.destination, localTime: leg.manualArriveTime || '', date: leg.departureDate },
         duration: '',
         stops: 0,
         carriers: [leg.manualAirline || 'Manual Entry'],
@@ -250,7 +254,7 @@ export default function FlightPicker({
       isManual: true,
     };
 
-    updateLeg(legId, { selectedOffer: manualFlight, expanded: false, manualAirline: '', manualPrice: '' });
+    updateLeg(legId, { selectedOffer: manualFlight, expanded: false, manualAirline: '', manualPrice: '', manualDepartTime: '', manualArriveTime: '' });
   };
 
   // ── Commit via vendor-commit ──
@@ -268,6 +272,10 @@ export default function FlightPicker({
         : `${carrier} | ${title} | ${offer.outbound?.duration || ''} | ${formatStops(offer.outbound?.stops || 0)} | $${offer.price}`;
       const flightId = `flight-${leg.id}-${Date.now()}`;
 
+      // Extract departure/arrival times from offer
+      const departTime = offer.outbound?.departure?.localTime || undefined;
+      const arriveTime = offer.outbound?.arrival?.localTime || undefined;
+
       const res = await fetch(`/api/trips/${tripId}/vendor-commit`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -278,6 +286,8 @@ export default function FlightPicker({
           endDate: leg.tripType === 'roundtrip' && leg.returnDate ? leg.returnDate : leg.departureDate,
           amount: offer.price,
           notes: title,
+          startTime: departTime,
+          endTime: arriveTime,
         }),
       });
 
@@ -448,14 +458,18 @@ export default function FlightPicker({
                         <a href="https://www.kayak.com/flights" target="_blank" rel="noopener noreferrer" className="text-[10px] text-brand-purple">Kayak ↗</a>
                       </div>
                     </div>
-                    <div className="flex items-center gap-2">
+                    <div className="flex items-center gap-2 flex-wrap">
                       <input type="text" value={leg.manualAirline} onChange={e => updateLeg(leg.id, { manualAirline: e.target.value })}
-                        placeholder="Airline" className="flex-1 bg-white border border-border rounded px-2 py-1.5 text-xs" />
+                        placeholder="Airline" className="flex-1 min-w-[100px] bg-white border border-border rounded px-2 py-1.5 text-xs" />
                       <div className="flex items-center gap-1">
                         <span className="text-xs text-text-muted">$</span>
                         <input type="number" value={leg.manualPrice} onChange={e => updateLeg(leg.id, { manualPrice: e.target.value })}
                           placeholder="Price" className="w-24 bg-white border border-border rounded px-2 py-1.5 text-xs" />
                       </div>
+                      <input type="time" value={leg.manualDepartTime} onChange={e => updateLeg(leg.id, { manualDepartTime: e.target.value })}
+                        className="w-[100px] bg-white border border-border rounded px-2 py-1.5 text-xs" title="Departure time" />
+                      <input type="time" value={leg.manualArriveTime} onChange={e => updateLeg(leg.id, { manualArriveTime: e.target.value })}
+                        className="w-[100px] bg-white border border-border rounded px-2 py-1.5 text-xs" title="Arrival time" />
                       <button onClick={() => submitManual(leg.id)} disabled={!leg.manualPrice}
                         className="px-3 py-1.5 bg-emerald-600 text-white text-xs rounded hover:bg-emerald-700 disabled:opacity-50">
                         Use This


### PR DESCRIPTION
FlightPicker manual entry:
- Add departure time and arrival time inputs (type="time") to the manual flight entry form, alongside airline and price
- Times stored in FlightLeg as manualDepartTime/manualArriveTime
- submitManual populates outbound.departure.localTime and outbound.arrival.localTime on the FlightOffer

Flight commit:
- commitLeg extracts departure/arrival times from the selected offer (whether from Duffel search results or manual entry)
- Passes startTime and endTime to the vendor-commit API
- The API already stores these as homeTime/destTime in trip_itinerary

Calendar display:
- Calendar event titles now show departure time for flights: "6:35 AM ✈ HND → HKT" instead of just "✈ HND → HKT"
- formatTime12h helper converts 24h time strings to 12h AM/PM format
- Event detail popover shows arrival time: "arr 10:15 AM"

https://claude.ai/code/session_01ScpFQ9Q7hKRx4D6axZ8jfH