### PR TITLE
Flights render as duration blocks from takeoff to landing

### DIFF
--- a/src/app/api/trips/[id]/vendor-commit/route.ts
+++ b/src/app/api/trips/[id]/vendor-commit/route.ts
@@ -102,7 +102,7 @@ export async function POST(request: Request, { params }: { params: Promise<{ id:
     const trip = await prisma.trips.findFirst({ where: { id, userId: user.id } });
     if (!trip) return NextResponse.json({ error: 'Trip not found' }, { status: 404 });
 
-    const { optionType, optionId, startDate, endDate, startTime, endTime, notes, amount: requestAmount } = await request.json();
+    const { optionType, optionId, startDate, endDate, startTime, endTime, arriveDate, notes, amount: requestAmount } = await request.json();
 
     if (!optionType || !optionId || !startDate) {
       return NextResponse.json({ error: 'optionType, optionId, and startDate are required' }, { status: 400 });
@@ -171,6 +171,19 @@ export async function POST(request: Request, { params }: { params: Promise<{ id:
           },
         });
         itineraryEntries.push(entry);
+      } else if (optionType === 'flight') {
+        // Flights: single entry with departure date/time and arrival date/time
+        const dayNum = Math.round((start.getTime() - tripStart.getTime()) / (1000 * 60 * 60 * 24)) + 1;
+        const flightArriveDate = arriveDate ? new Date(arriveDate) : end;
+        const entry = await tx.trip_itinerary.create({
+          data: {
+            tripId: id, day: dayNum, homeDate: start, homeTime: startTime || null,
+            destDate: flightArriveDate, destTime: endTime || null,
+            category: optionType, vendor: details.title, cost: Math.round(details.amount * 100) / 100,
+            note: notes || null, vendorOptionId: optionId, vendorOptionType: optionType,
+          },
+        });
+        itineraryEntries.push(entry);
       } else {
         // Multi-day bookings (lodging, vehicles, etc.) — create entry per day
         const current = new Date(start);
@@ -182,7 +195,7 @@ export async function POST(request: Request, { params }: { params: Promise<{ id:
           const entry = await tx.trip_itinerary.create({
             data: {
               tripId: id, day: dayNum, homeDate: current, homeTime: startTime || null,
-              destDate: current, destTime: startTime || null,
+              destDate: current, destTime: endTime || null,
               category: optionType, vendor: details.title, cost: Math.round(dailyCost * 100) / 100,
               note: notes || null, vendorOptionId: optionId, vendorOptionType: optionType,
             },

--- a/src/app/budgets/trips/[id]/page.tsx
+++ b/src/app/budgets/trips/[id]/page.tsx
@@ -366,6 +366,7 @@ export default function TripDetailPage({ params }: { params: Promise<{ id: strin
     const flightEvents: CalendarEvent[] = flightItems.map((item: any) => {
       const cfg = TRIP_SOURCE_CONFIG['flight'];
       const dateStr = item.homeDate ? new Date(item.homeDate).toISOString().split('T')[0] : '';
+      const destDateStr = item.destDate ? new Date(item.destDate).toISOString().split('T')[0] : null;
       let title = `${cfg?.icon || ''} ${item.vendor || 'Flight'}`;
       if (item.homeTime) {
         title = `${formatTime12h(item.homeTime)} ${cfg?.icon || ''} ${item.vendor || 'Flight'}`;
@@ -376,7 +377,7 @@ export default function TripDetailPage({ params }: { params: Promise<{ id: strin
         title,
         icon: cfg?.icon || null,
         startDate: dateStr,
-        endDate: null,
+        endDate: destDateStr !== dateStr ? destDateStr : null,
         startTime: item.homeTime || null,
         endTime: item.destTime || null,
         budgetAmount: parseFloat(item.cost || 0),

--- a/src/components/trips/FlightPicker.tsx
+++ b/src/components/trips/FlightPicker.tsx
@@ -52,6 +52,7 @@ interface FlightLeg {
   manualPrice: string;
   manualDepartTime: string;
   manualArriveTime: string;
+  manualArriveDate: string;
 }
 
 interface Props {
@@ -97,6 +98,7 @@ export default function FlightPicker({
     manualPrice: '',
     manualDepartTime: '',
     manualArriveTime: '',
+    manualArriveDate: '',
     ...overrides,
   }), [originAirport, destinationAirport, departureDate, returnDate]);
 
@@ -239,7 +241,7 @@ export default function FlightPicker({
       currency: 'USD',
       outbound: {
         departure: { airport: leg.origin, localTime: leg.manualDepartTime || '', date: leg.departureDate },
-        arrival: { airport: leg.destination, localTime: leg.manualArriveTime || '', date: leg.departureDate },
+        arrival: { airport: leg.destination, localTime: leg.manualArriveTime || '', date: leg.manualArriveDate || leg.departureDate },
         duration: '',
         stops: 0,
         carriers: [leg.manualAirline || 'Manual Entry'],
@@ -254,7 +256,7 @@ export default function FlightPicker({
       isManual: true,
     };
 
-    updateLeg(legId, { selectedOffer: manualFlight, expanded: false, manualAirline: '', manualPrice: '', manualDepartTime: '', manualArriveTime: '' });
+    updateLeg(legId, { selectedOffer: manualFlight, expanded: false, manualAirline: '', manualPrice: '', manualDepartTime: '', manualArriveTime: '', manualArriveDate: '' });
   };
 
   // ── Commit via vendor-commit ──
@@ -272,9 +274,10 @@ export default function FlightPicker({
         : `${carrier} | ${title} | ${offer.outbound?.duration || ''} | ${formatStops(offer.outbound?.stops || 0)} | $${offer.price}`;
       const flightId = `flight-${leg.id}-${Date.now()}`;
 
-      // Extract departure/arrival times from offer
+      // Extract departure/arrival times and dates from offer
       const departTime = offer.outbound?.departure?.localTime || undefined;
       const arriveTime = offer.outbound?.arrival?.localTime || undefined;
+      const arriveDate = offer.outbound?.arrival?.date || undefined;
 
       const res = await fetch(`/api/trips/${tripId}/vendor-commit`, {
         method: 'POST',
@@ -288,6 +291,7 @@ export default function FlightPicker({
           notes: title,
           startTime: departTime,
           endTime: arriveTime,
+          arriveDate,
         }),
       });
 
@@ -467,9 +471,12 @@ export default function FlightPicker({
                           placeholder="Price" className="w-24 bg-white border border-border rounded px-2 py-1.5 text-xs" />
                       </div>
                       <input type="time" value={leg.manualDepartTime} onChange={e => updateLeg(leg.id, { manualDepartTime: e.target.value })}
-                        className="w-[100px] bg-white border border-border rounded px-2 py-1.5 text-xs" title="Departure time" />
+                        className="w-[100px] bg-white border border-border rounded px-2 py-1.5 text-xs" title="Departure time" placeholder="Depart" />
                       <input type="time" value={leg.manualArriveTime} onChange={e => updateLeg(leg.id, { manualArriveTime: e.target.value })}
-                        className="w-[100px] bg-white border border-border rounded px-2 py-1.5 text-xs" title="Arrival time" />
+                        className="w-[100px] bg-white border border-border rounded px-2 py-1.5 text-xs" title="Arrival time" placeholder="Arrive" />
+                      <input type="date" value={leg.manualArriveDate} onChange={e => updateLeg(leg.id, { manualArriveDate: e.target.value })}
+                        min={leg.departureDate}
+                        className="w-[130px] bg-white border border-border rounded px-2 py-1.5 text-xs" title="Arrival date (if next day)" />
                       <button onClick={() => submitManual(leg.id)} disabled={!leg.manualPrice}
                         className="px-3 py-1.5 bg-emerald-600 text-white text-xs rounded hover:bg-emerald-700 disabled:opacity-50">
                         Use This


### PR DESCRIPTION
FlightPicker:
- Add manualArriveDate field for next-day arrivals (date input)
- Pass arriveDate from offer.outbound.arrival.date to vendor-commit
- Manual entry: arrival date input with min=departureDate

vendor-commit API:
- Accept arriveDate field in request body
- Flight-specific branch: single itinerary entry with homeDate=departure, destDate=arriveDate, homeTime=departTime, destTime=arriveTime
- Non-flight multi-day entries unchanged (entry per day)
- Also fixed non-flight destTime to use endTime instead of startTime

Trip detail calendarEvents:
- Flight events now set endDate from destDate when it differs from homeDate, enabling multi-day event splitting in CalendarGrid
- A 14hr LAX→HND flight shows as departure block Sunday (4:38 AM to bottom) + arrival block Monday (top to 2:00 PM)

CalendarGrid getBlocksForDay already handles the splitting:
- Departure day: block from startTime to end of column, rounded-t
- Arrival day: block from top of column to endTime, rounded-b

https://claude.ai/code/session_01ScpFQ9Q7hKRx4D6axZ8jfH