### PR TITLE
Compact hotel calendar: check-in/check-out blocks instead of full-day…

### DIFF
--- a/src/app/budgets/trips/[id]/page.tsx
+++ b/src/app/budgets/trips/[id]/page.tsx
@@ -451,16 +451,14 @@ export default function TripDetailPage({ params }: { params: Promise<{ id: strin
       const vendorName = first.vendor || 'Untitled';
       const title = `${cfg?.icon || ''} ${vendorName}`;
       const isLodging = source === 'lodging';
-      const checkInTime = first.homeTime || null;
-      const checkOutTime = first.destTime || null;
+      const checkInTime = first.homeTime || '15:00';
+      const checkOutTime = first.destTime || '11:00';
 
       if (isLodging && entries.length > 1) {
         // Multi-day lodging: check-in block + middle-day banners + check-out block
         const sortedEntries = [...entries].sort((a, b) =>
           new Date(a.homeDate).getTime() - new Date(b.homeDate).getTime()
         );
-        const firstDate = new Date(sortedEntries[0].homeDate).toISOString().split('T')[0];
-        const lastDate = new Date(sortedEntries[sortedEntries.length - 1].homeDate).toISOString().split('T')[0];
 
         for (let ei = 0; ei < sortedEntries.length; ei++) {
           const entry = sortedEntries[ei];
@@ -469,43 +467,43 @@ export default function TripDetailPage({ params }: { params: Promise<{ id: strin
           const isCheckOut = ei === sortedEntries.length - 1;
 
           if (isCheckIn) {
-            // Check-in day: timed block from check-in time to end of day
+            // Check-in day: compact afternoon block
             otherEvents.push({
               id: `${key}-checkin`,
               source,
-              title: `${cfg?.icon || ''} ${vendorName} (check-in)`,
+              title: `Check-in: ${vendorName}`,
               icon: cfg?.icon || null,
               startDate: dateStr,
               endDate: null,
-              startTime: checkInTime || '15:00',
-              endTime: '23:59',
+              startTime: checkInTime,
+              endTime: '23:00',
               budgetAmount: totalCost,
               _vendorOptionId: first.vendorOptionId,
               _vendorOptionType: first.vendorOptionType,
               _vendor: vendorName,
             } as any);
           } else if (isCheckOut) {
-            // Check-out day: timed block from start of day to check-out time
+            // Check-out day: compact morning block
             otherEvents.push({
               id: `${key}-checkout`,
               source,
-              title: `${cfg?.icon || ''} ${vendorName} (check-out)`,
+              title: `Check-out: ${vendorName}`,
               icon: cfg?.icon || null,
               startDate: dateStr,
               endDate: null,
-              startTime: '00:00',
-              endTime: checkOutTime || '11:00',
+              startTime: '07:00',
+              endTime: checkOutTime,
               budgetAmount: 0,
               _vendorOptionId: first.vendorOptionId,
               _vendorOptionType: first.vendorOptionType,
               _vendor: vendorName,
             } as any);
           } else {
-            // Middle days: all-day banner (no startTime = all-day row)
+            // Middle days: all-day banner (no startTime = slim bar in all-day row)
             otherEvents.push({
               id: `${key}-day-${ei}`,
               source,
-              title: `${cfg?.icon || ''} ${vendorName}`,
+              title: vendorName,
               icon: cfg?.icon || null,
               startDate: dateStr,
               endDate: null,
@@ -518,6 +516,23 @@ export default function TripDetailPage({ params }: { params: Promise<{ id: strin
             } as any);
           }
         }
+      } else if (isLodging && entries.length === 1) {
+        // Single-night lodging: check-in afternoon block only
+        const dateStr = first.homeDate ? new Date(first.homeDate).toISOString().split('T')[0] : '';
+        otherEvents.push({
+          id: `${key}-checkin`,
+          source,
+          title: `Check-in: ${vendorName}`,
+          icon: cfg?.icon || null,
+          startDate: dateStr,
+          endDate: null,
+          startTime: checkInTime,
+          endTime: '23:00',
+          budgetAmount: totalCost,
+          _vendorOptionId: first.vendorOptionId,
+          _vendorOptionType: first.vendorOptionType,
+          _vendor: vendorName,
+        } as any);
       } else {
         // Single-day events (or non-lodging multi-day): use time data if available
         const dateStr = first.homeDate ? new Date(first.homeDate).toISOString().split('T')[0] : '';


### PR DESCRIPTION
… spans

Multi-night lodging (entries.length > 1):
- Check-in day: compact timed block from check-in time (default 3 PM) to 11 PM. Title: "Check-in: [Hotel Name]". Shows total cost.
- Middle nights: all-day banner in the slim all-day row (no startTime). Title: hotel name only (no "check-in"/"check-out" prefix).
- Check-out day: compact timed block from 7 AM to check-out time (default 11 AM). Title: "Check-out: [Hotel Name]". No cost. Was starting at 00:00 which created a huge midnight-to-11AM block. Now starts at 07:00 for a compact morning block.

Single-night lodging (entries.length === 1):
- NEW: creates a check-in afternoon block instead of falling through to the generic handler (which created a full-day block when no homeTime was set).
- Compact afternoon block from check-in time to 11 PM.

Default times: check-in 3:00 PM, check-out 11:00 AM (applied when homeTime/destTime not set on the itinerary record).

Flights and activities unchanged — only lodging rendering affected.

https://claude.ai/code/session_01DgTeHT3M5SMmjDD54LzdRp