### PR TITLE
Fix hotel calendar: compact 2-hour blocks instead of 8-hour spans

### DIFF
--- a/src/app/budgets/trips/[id]/page.tsx
+++ b/src/app/budgets/trips/[id]/page.tsx
@@ -467,7 +467,10 @@ export default function TripDetailPage({ params }: { params: Promise<{ id: strin
           const isCheckOut = ei === sortedEntries.length - 1;
 
           if (isCheckIn) {
-            // Check-in day: compact afternoon block
+            // Check-in day: compact 2-hour block at check-in time
+            const ciTime = checkInTime;
+            const ciEndH = parseInt(ciTime.split(':')[0]) + 2;
+            const ciEnd = `${Math.min(ciEndH, 23).toString().padStart(2, '0')}:${ciTime.split(':')[1]}`;
             otherEvents.push({
               id: `${key}-checkin`,
               source,
@@ -475,15 +478,18 @@ export default function TripDetailPage({ params }: { params: Promise<{ id: strin
               icon: cfg?.icon || null,
               startDate: dateStr,
               endDate: null,
-              startTime: checkInTime,
-              endTime: '23:00',
+              startTime: ciTime,
+              endTime: ciEnd,
               budgetAmount: totalCost,
               _vendorOptionId: first.vendorOptionId,
               _vendorOptionType: first.vendorOptionType,
               _vendor: vendorName,
             } as any);
           } else if (isCheckOut) {
-            // Check-out day: compact morning block
+            // Check-out day: compact 2-hour block ending at check-out time
+            const coTime = checkOutTime;
+            const coStartH = Math.max(parseInt(coTime.split(':')[0]) - 2, 0);
+            const coStart = `${coStartH.toString().padStart(2, '0')}:${coTime.split(':')[1]}`;
             otherEvents.push({
               id: `${key}-checkout`,
               source,
@@ -491,8 +497,8 @@ export default function TripDetailPage({ params }: { params: Promise<{ id: strin
               icon: cfg?.icon || null,
               startDate: dateStr,
               endDate: null,
-              startTime: '07:00',
-              endTime: checkOutTime,
+              startTime: coStart,
+              endTime: coTime,
               budgetAmount: 0,
               _vendorOptionId: first.vendorOptionId,
               _vendorOptionType: first.vendorOptionType,
@@ -517,8 +523,11 @@ export default function TripDetailPage({ params }: { params: Promise<{ id: strin
           }
         }
       } else if (isLodging && entries.length === 1) {
-        // Single-night lodging: check-in afternoon block only
+        // Single-night lodging: compact 2-hour check-in block
         const dateStr = first.homeDate ? new Date(first.homeDate).toISOString().split('T')[0] : '';
+        const ciTime = checkInTime;
+        const ciEndH = parseInt(ciTime.split(':')[0]) + 2;
+        const ciEnd = `${Math.min(ciEndH, 23).toString().padStart(2, '0')}:${ciTime.split(':')[1]}`;
         otherEvents.push({
           id: `${key}-checkin`,
           source,
@@ -526,8 +535,8 @@ export default function TripDetailPage({ params }: { params: Promise<{ id: strin
           icon: cfg?.icon || null,
           startDate: dateStr,
           endDate: null,
-          startTime: checkInTime,
-          endTime: '23:00',
+          startTime: ciTime,
+          endTime: ciEnd,
           budgetAmount: totalCost,
           _vendorOptionId: first.vendorOptionId,
           _vendorOptionType: first.vendorOptionType,


### PR DESCRIPTION
ROOT CAUSE: The previous fix created correct check-in/check-out events with proper startTime/endTime, and the CalendarGrid did render them as timed blocks. But:
- Check-in: 3 PM to 11 PM = 8 hours = 320px tall block (not compact)
- Check-out: 7 AM to 11 AM = 4 hours = 160px tall block (not compact) At 40px/hour, these blocks consumed most of the day column — visually identical to "full day" blocks.

FIX: Check-in and check-out are now 2-hour compact blocks:
- Check-in: 3:00 PM to 5:00 PM (2 hours = 80px at 40px/hour)
- Check-out: 9:00 AM to 11:00 AM (2 hours = 80px)
- If custom times set: block spans from time to time+2h (check-in) or time-2h to time (check-out)
- Single-night lodging: same 2-hour check-in block

The 2-hour span is wide enough to show the hotel name + check-in/out label but small enough to not dominate the day column.

Middle-day banners remain as all-day slim bars (unchanged).

https://claude.ai/code/session_01DgTeHT3M5SMmjDD54LzdRp