### PR TITLE
Fix: brunch_coffee items grouped under Dining section

### DIFF
--- a/src/app/budgets/trips/[id]/page.tsx
+++ b/src/app/budgets/trips/[id]/page.tsx
@@ -574,7 +574,7 @@ export default function TripDetailPage({ params }: { params: Promise<{ id: strin
             {/* ── Map + Committed Rows ── */}
             {(() => {
               const itinerary = trip.itinerary || [];
-              const DINING_CATEGORIES = new Set(['dinner', 'brunchCoffee', 'meals', 'meals_dining', 'food']);
+              const DINING_CATEGORIES = new Set(['dinner', 'brunch_coffee', 'brunchCoffee', 'meals', 'meals_dining', 'food', 'business_meals', 'coffee', 'restaurant', 'dining', 'cafe']);
               const EXCLUDE_FROM_ACTIVITIES = new Set(['flight', 'lodging', 'dinner', 'brunchCoffee', 'meals', 'meals_dining', 'food', 'business_meals']);
 
               const resolvedItems = itinerary.map((item: any) => {


### PR DESCRIPTION
DINING_CATEGORIES Set was missing 'brunch_coffee' (underscore format). It had 'brunchCoffee' (camelCase) but the scanner saves categories as COA keys with underscores. Same root cause as the budget category fix.

Added to DINING_CATEGORIES: brunch_coffee, business_meals, coffee, restaurant, dining, cafe. Kept brunchCoffee for backward compat.

https://claude.ai/code/session_01DgTeHT3M5SMmjDD54LzdRp