### PR TITLE
Fix: exclude dining items from Activities section

### DIFF
--- a/src/app/budgets/trips/[id]/page.tsx
+++ b/src/app/budgets/trips/[id]/page.tsx
@@ -575,7 +575,7 @@ export default function TripDetailPage({ params }: { params: Promise<{ id: strin
             {(() => {
               const itinerary = trip.itinerary || [];
               const DINING_CATEGORIES = new Set(['dinner', 'brunch_coffee', 'brunchCoffee', 'meals', 'meals_dining', 'food', 'business_meals', 'coffee', 'restaurant', 'dining', 'cafe']);
-              const EXCLUDE_FROM_ACTIVITIES = new Set(['flight', 'lodging', 'dinner', 'brunchCoffee', 'meals', 'meals_dining', 'food', 'business_meals']);
+              const EXCLUDE_FROM_ACTIVITIES = new Set(['flight', 'lodging', 'dinner', 'brunch_coffee', 'brunchCoffee', 'meals', 'meals_dining', 'food', 'business_meals', 'coffee', 'restaurant', 'dining', 'cafe']);
 
               const resolvedItems = itinerary.map((item: any) => {
                 const optInfo = item.vendorOptionId ? vendorOptions[item.vendorOptionId] : null;


### PR DESCRIPTION
EXCLUDE_FROM_ACTIVITIES Set was missing 'brunch_coffee' (underscore format) — same camelCase vs underscore bug. Added brunch_coffee and all dining-related values to match DINING_CATEGORIES exactly.

https://claude.ai/code/session_01DgTeHT3M5SMmjDD54LzdRp