### PR TITLE
feat: bookkeeping foundation components - section wrapper, cockpit ba…

### DIFF
--- a/src/components/bookkeeping/BookkeepingCockpitBar.tsx
+++ b/src/components/bookkeeping/BookkeepingCockpitBar.tsx
@@ -1,0 +1,123 @@
+'use client';
+
+export interface BookkeepingCockpitBarProps {
+  connectedAccounts: number;
+  uncategorized: number;
+  uncommitted: number;
+  journalEntryCount: number;
+  trialBalanceStatus: 'balanced' | 'unbalanced' | 'unknown';
+  periodStatus: 'open' | 'closed';
+  onSync: () => void;
+  syncing: boolean;
+}
+
+export default function BookkeepingCockpitBar({
+  connectedAccounts,
+  uncategorized,
+  uncommitted,
+  journalEntryCount,
+  trialBalanceStatus,
+  periodStatus,
+  onSync,
+  syncing,
+}: BookkeepingCockpitBarProps) {
+  const tbLabel = trialBalanceStatus === 'balanced' ? 'Balanced' : trialBalanceStatus === 'unbalanced' ? 'Unbalanced' : '—';
+  const tbColor = trialBalanceStatus === 'balanced' ? 'text-emerald-300' : trialBalanceStatus === 'unbalanced' ? 'text-red-300' : 'text-white';
+  const periodLabel = periodStatus === 'open' ? 'Open' : 'Closed';
+  const periodColor = periodStatus === 'open' ? 'text-emerald-300' : 'text-white';
+
+  return (
+    <div className="-mx-4 lg:-mx-6 -mt-4 lg:-mt-6 px-3 lg:px-6 py-3 pb-5 bg-brand-purple/95 backdrop-blur-sm sticky top-0 z-40">
+      <div className="max-w-[1800px] mx-auto">
+
+        {/* ROW 1 — Identity + Sync */}
+        <div className="bg-white border-2 border-brand-gold/60 rounded-xl shadow-md flex flex-col lg:flex-row">
+          {/* Zone 1: Identity */}
+          <div className="px-4 py-3 lg:w-[160px] lg:flex-shrink-0 lg:border-r border-b lg:border-b-0 border-gray-200">
+            <div className="text-sm font-bold text-text-primary">Bookkeeping</div>
+            <div className="flex items-center gap-1.5 mt-1">
+              {connectedAccounts > 0 ? (
+                <><div className="w-2 h-2 bg-emerald-500 rounded-full" /><span className="text-xs text-emerald-600">{connectedAccounts} linked</span></>
+              ) : (
+                <><div className="w-2 h-2 bg-gray-400 rounded-full" /><span className="text-xs text-text-muted">No accounts</span></>
+              )}
+            </div>
+          </div>
+
+          {/* Zone 2: Pipeline status summary */}
+          <div className="px-4 py-2.5 lg:flex-1 lg:border-r border-b lg:border-b-0 border-gray-200 min-w-0">
+            <div className="flex flex-wrap items-center gap-3 text-xs text-text-secondary">
+              {uncategorized > 0 && (
+                <span className="flex items-center gap-1">
+                  <span className="w-2 h-2 rounded-full bg-amber-400" />
+                  {uncategorized} uncategorized
+                </span>
+              )}
+              {uncommitted > 0 && (
+                <span className="flex items-center gap-1">
+                  <span className="w-2 h-2 rounded-full bg-amber-400" />
+                  {uncommitted} uncommitted
+                </span>
+              )}
+              {uncategorized === 0 && uncommitted === 0 && (
+                <span className="flex items-center gap-1">
+                  <span className="w-2 h-2 rounded-full bg-emerald-500" />
+                  All transactions processed
+                </span>
+              )}
+            </div>
+          </div>
+
+          {/* Zone 3: Sync button */}
+          <button
+            onClick={onSync}
+            disabled={syncing}
+            className="flex items-center justify-center px-5 min-w-[80px] bg-brand-gold hover:bg-brand-gold-bright text-white font-bold text-base transition-colors whitespace-nowrap lg:rounded-r-xl shrink-0 disabled:opacity-50 py-3 lg:py-0"
+          >
+            {syncing ? (
+              <span className="flex items-center gap-2">
+                <span className="w-3.5 h-3.5 border-2 border-white border-t-transparent rounded-full animate-spin" />
+                Syncing
+              </span>
+            ) : (
+              'Sync'
+            )}
+          </button>
+        </div>
+
+        {/* ROW 2 — 6 Metrics Bar */}
+        <div className="bg-brand-purple/90 rounded-lg mt-2 px-3 py-2">
+          <div className="flex items-center">
+            <div className="flex-1 grid grid-cols-6 text-center min-w-0">
+              <div className="px-2 border-r border-white/10 min-w-0">
+                <div className="text-[9px] text-white/60 uppercase">Accts</div>
+                <div className="text-sm font-bold font-mono text-white truncate">{connectedAccounts}</div>
+              </div>
+              <div className="px-2 border-r border-white/10 min-w-0">
+                <div className="text-[9px] text-white/60 uppercase">Uncat</div>
+                <div className={`text-sm font-bold font-mono truncate ${uncategorized > 0 ? 'text-amber-300' : 'text-emerald-300'}`}>{uncategorized}</div>
+              </div>
+              <div className="px-2 border-r border-white/10 min-w-0">
+                <div className="text-[9px] text-white/60 uppercase">Uncommit</div>
+                <div className={`text-sm font-bold font-mono truncate ${uncommitted > 0 ? 'text-amber-300' : 'text-emerald-300'}`}>{uncommitted}</div>
+              </div>
+              <div className="px-2 border-r border-white/10 min-w-0">
+                <div className="text-[9px] text-white/60 uppercase">JE</div>
+                <div className="text-sm font-bold font-mono text-white truncate">{journalEntryCount}</div>
+              </div>
+              <div className="px-2 border-r border-white/10 min-w-0">
+                <div className="text-[9px] text-white/60 uppercase">TB</div>
+                <div className={`text-sm font-bold font-mono truncate ${tbColor}`}>{tbLabel}</div>
+              </div>
+              <div className="px-2 min-w-0">
+                <div className="text-[9px] text-white/60 uppercase">Period</div>
+                <div className={`text-sm font-bold font-mono truncate ${periodColor}`}>{periodLabel}</div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+      </div>
+    </div>
+  );
+}

--- a/src/components/bookkeeping/BookkeepingSection.tsx
+++ b/src/components/bookkeeping/BookkeepingSection.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { ReactNode } from 'react';
+
+interface BookkeepingSectionProps {
+  title: string;
+  pipelineKey: string;
+  subtitle?: string;
+  status?: 'complete' | 'action-needed' | 'error' | 'pending';
+  children: ReactNode;
+}
+
+const STATUS_DOT: Record<string, string> = {
+  complete: 'bg-emerald-400',
+  'action-needed': 'bg-amber-400',
+  error: 'bg-red-400',
+  pending: 'bg-gray-400',
+};
+
+export default function BookkeepingSection({
+  title,
+  pipelineKey,
+  subtitle,
+  status,
+  children,
+}: BookkeepingSectionProps) {
+  return (
+    <div className="overflow-hidden border-x border-b border-gray-200/50">
+      <div className="bg-brand-purple/80 text-white px-4 py-2.5 text-sm font-semibold flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <span className="text-[9px] uppercase text-white/60 font-mono tracking-wider">{pipelineKey}</span>
+          <span>{title}</span>
+        </div>
+        {(subtitle || status) && (
+          <div className="flex items-center gap-2">
+            {subtitle && <span className="text-xs text-white/70">{subtitle}</span>}
+            {status && <div className={`w-2 h-2 rounded-full ${STATUS_DOT[status]}`} />}
+          </div>
+        )}
+      </div>
+      <div className="bg-white">
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/components/bookkeeping/TrialBalanceSection.tsx
+++ b/src/components/bookkeeping/TrialBalanceSection.tsx
@@ -1,0 +1,142 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import BookkeepingSection from './BookkeepingSection';
+
+interface TrialBalanceAccount {
+  accountCode: string;
+  accountName: string;
+  accountType: string;
+  balanceType: string;
+  entityId: string;
+  entityName: string;
+  totalDebits: number;
+  totalCredits: number;
+  netBalance: number;
+  normalBalance: number;
+  displaySide: 'debit' | 'credit';
+}
+
+interface TrialBalanceTotals {
+  totalDebits: number;
+  totalCredits: number;
+  imbalance: number;
+  isBalanced: boolean;
+}
+
+interface TrialBalanceData {
+  asOfDate: string | null;
+  startDate: string | null;
+  entityId: string | null;
+  accounts: TrialBalanceAccount[];
+  totals: TrialBalanceTotals;
+}
+
+const fmtCents = (cents: number) => {
+  const abs = Math.abs(cents);
+  const dollars = abs / 100;
+  const formatted = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', minimumFractionDigits: 2 }).format(dollars);
+  return cents < 0 ? `(${formatted})` : formatted;
+};
+
+export default function TrialBalanceSection() {
+  const [data, setData] = useState<TrialBalanceData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const res = await fetch('/api/trial-balance');
+        if (!res.ok) throw new Error('Failed to load trial balance');
+        const json = await res.json();
+        setData(json);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to load');
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, []);
+
+  const status = data?.totals.isBalanced ? 'complete' : data ? 'error' : 'pending';
+  const subtitle = data
+    ? `${data.accounts.length} accounts · ${data.totals.isBalanced ? 'Balanced' : 'UNBALANCED'}`
+    : undefined;
+
+  return (
+    <BookkeepingSection title="Trial Balance" pipelineKey="TB" subtitle={subtitle} status={status}>
+      {loading ? (
+        <div className="p-8 text-center">
+          <div className="w-5 h-5 border-2 border-brand-purple border-t-transparent rounded-full animate-spin mx-auto" />
+        </div>
+      ) : error ? (
+        <div className="p-6 text-center text-brand-red text-sm">{error}</div>
+      ) : data && data.accounts.length === 0 ? (
+        <div className="p-8 text-center text-text-muted text-sm">
+          No ledger entries found. Commit transactions to generate a trial balance.
+        </div>
+      ) : data ? (
+        <div className="p-4">
+          {/* Balance status banner */}
+          {data.totals.isBalanced ? (
+            <div className="mb-4 px-4 py-2.5 bg-green-50 border border-green-200 rounded-lg flex items-center gap-2">
+              <div className="w-2.5 h-2.5 rounded-full bg-emerald-500" />
+              <span className="text-sm font-semibold text-emerald-700">Balanced</span>
+              <span className="text-xs text-emerald-600 ml-1">Debits equal credits</span>
+            </div>
+          ) : (
+            <div className="mb-4 px-4 py-2.5 bg-red-50 border border-red-200 rounded-lg flex items-center gap-2">
+              <div className="w-2.5 h-2.5 rounded-full bg-red-500" />
+              <span className="text-sm font-semibold text-red-700">Unbalanced</span>
+              <span className="text-xs text-red-600 ml-1">Imbalance: {fmtCents(data.totals.imbalance)}</span>
+            </div>
+          )}
+
+          {/* Table */}
+          <div className="overflow-x-auto">
+            <table className="w-full text-xs">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-3 py-2 text-left font-medium text-text-secondary">Account Code</th>
+                  <th className="px-3 py-2 text-left font-medium text-text-secondary">Account Name</th>
+                  <th className="px-3 py-2 text-left font-medium text-text-secondary">Type</th>
+                  <th className="px-3 py-2 text-left font-medium text-text-secondary">Entity</th>
+                  <th className="px-3 py-2 text-right font-medium text-text-secondary">Debit</th>
+                  <th className="px-3 py-2 text-right font-medium text-text-secondary">Credit</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border">
+                {data.accounts.map((acct, idx) => {
+                  const absBalance = Math.abs(acct.normalBalance);
+                  return (
+                    <tr key={`${acct.accountCode}-${acct.entityId}`} className={idx % 2 === 1 ? 'bg-bg-row' : ''}>
+                      <td className="px-3 py-2 font-mono text-text-secondary">{acct.accountCode}</td>
+                      <td className="px-3 py-2 text-text-primary">{acct.accountName}</td>
+                      <td className="px-3 py-2 text-text-muted capitalize">{acct.accountType}</td>
+                      <td className="px-3 py-2 text-text-muted">{acct.entityName}</td>
+                      <td className="px-3 py-2 text-right font-mono text-text-primary">
+                        {acct.displaySide === 'debit' ? fmtCents(absBalance) : ''}
+                      </td>
+                      <td className="px-3 py-2 text-right font-mono text-text-primary">
+                        {acct.displaySide === 'credit' ? fmtCents(absBalance) : ''}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+              <tfoot className="bg-gray-50 border-t-2 border-border">
+                <tr className="font-semibold">
+                  <td colSpan={4} className="px-3 py-2 text-text-primary">Totals</td>
+                  <td className="px-3 py-2 text-right font-mono text-text-primary">{fmtCents(data.totals.totalDebits)}</td>
+                  <td className="px-3 py-2 text-right font-mono text-text-primary">{fmtCents(data.totals.totalCredits)}</td>
+                </tr>
+              </tfoot>
+            </table>
+          </div>
+        </div>
+      ) : null}
+    </BookkeepingSection>
+  );
+}


### PR DESCRIPTION
…r, trial balance

BookkeepingSection.tsx:
- Reusable section wrapper matching trading page pattern exactly
- Props: title, pipelineKey (SRC/CAT/JE/LDG/etc), subtitle, status
- Header: bg-brand-purple/80, pipeline key badge + title left, subtitle + status dot right
- Wrapper: overflow-hidden border-x border-b border-gray-200/50

BookkeepingCockpitBar.tsx:
- Sticky top bar mirroring trading page scanner bar structure
- Outer: bg-brand-purple/95 sticky top-0 z-40 with gold-bordered scanner bar
- Identity zone + pipeline status summary + gold Sync button
- 6-metric bar: ACCTS, UNCAT, UNCOMMIT, JE, TB, PERIOD
- Metric style: text-[9px] text-white/60 uppercase labels, text-sm font-bold font-mono values
- Props-driven (no internal fetching) for parent page data flow

TrialBalanceSection.tsx:
- New UI for existing /api/trial-balance endpoint (was the only section without UI)
- Balance status banner: green "Balanced" or red "Unbalanced" with imbalance amount
- Table: Account Code, Account Name, Type, Entity, Debit, Credit
- Alternating rows (bg-bg-row), font-mono for amounts, currency formatting from cents
- All field names match exact API response shape from trial-balance/route.ts

https://claude.ai/code/session_01HNCMRgS9WiGgVibV2tH7eZ