### PR TITLE
feat: COA management table with inline edit, add account, entity filt…

### DIFF
--- a/src/app/api/chart-of-accounts/[id]/route.ts
+++ b/src/app/api/chart-of-accounts/[id]/route.ts
@@ -1,0 +1,99 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
+
+export async function PUT(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const user = await prisma.users.findFirst({
+      where: { email: { equals: userEmail, mode: 'insensitive' } },
+    });
+    if (!user) {
+      return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    }
+
+    const { id } = await params;
+    const body = await request.json();
+    const { name, accountType, balanceType, code } = body;
+
+    // Verify account exists and belongs to user
+    const existing = await prisma.chart_of_accounts.findFirst({
+      where: { id, userId: user.id },
+    });
+    if (!existing) {
+      return NextResponse.json({ error: 'Account not found' }, { status: 404 });
+    }
+
+    // If code is changing, check uniqueness within entity
+    if (code && code !== existing.code) {
+      const duplicate = await prisma.chart_of_accounts.findFirst({
+        where: { userId: user.id, entity_id: existing.entity_id, code, id: { not: id } },
+      });
+      if (duplicate) {
+        return NextResponse.json(
+          { error: `Account code "${code}" already exists for this entity` },
+          { status: 409 }
+        );
+      }
+    }
+
+    const BALANCE_TYPE_MAP: Record<string, string> = {
+      asset: 'D', expense: 'D', liability: 'C', equity: 'C', revenue: 'C',
+    };
+
+    const updateData: Record<string, any> = {};
+    if (name !== undefined) updateData.name = name;
+    if (code !== undefined) updateData.code = code;
+    if (accountType !== undefined) {
+      const normalized = accountType.toLowerCase();
+      const bt = BALANCE_TYPE_MAP[normalized];
+      if (!bt) {
+        return NextResponse.json(
+          { error: 'Invalid accountType. Must be asset, liability, equity, revenue, or expense' },
+          { status: 400 }
+        );
+      }
+      updateData.account_type = normalized;
+      updateData.balance_type = bt;
+    }
+    if (balanceType !== undefined && !accountType) {
+      updateData.balance_type = balanceType;
+    }
+
+    if (Object.keys(updateData).length === 0) {
+      return NextResponse.json({ error: 'No fields to update' }, { status: 400 });
+    }
+
+    const updated = await prisma.chart_of_accounts.update({
+      where: { id },
+      data: updateData,
+    });
+
+    return NextResponse.json({
+      success: true,
+      account: {
+        id: updated.id,
+        code: updated.code,
+        name: updated.name,
+        accountType: updated.account_type,
+        balanceType: updated.balance_type,
+        settledBalance: Number(updated.settled_balance),
+        pendingBalance: Number(updated.pending_balance),
+        entity_id: updated.entity_id,
+        entity_type: updated.entity_type,
+        version: Number(updated.version),
+        is_archived: updated.is_archived,
+      },
+    });
+  } catch (error) {
+    console.error('COA update error:', error);
+    return NextResponse.json({ error: 'Failed to update account' }, { status: 500 });
+  }
+}

--- a/src/app/api/chart-of-accounts/balances/route.ts
+++ b/src/app/api/chart-of-accounts/balances/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 
-export async function GET() {
+export async function GET(request: Request) {
   try {
     const userEmail = await getVerifiedEmail();
     if (!userEmail) {
@@ -16,19 +16,29 @@ export async function GET() {
       return NextResponse.json({ error: 'User not found' }, { status: 404 });
     }
 
+    const { searchParams } = new URL(request.url);
+    const entityId = searchParams.get('entityId');
+
     // SECURITY: Scoped to user's COA only
     const accounts = await prisma.chart_of_accounts.findMany({
-      where: { userId: user.id, is_archived: false },
+      where: {
+        userId: user.id,
+        is_archived: false,
+        ...(entityId && { entity_id: entityId }),
+      },
       orderBy: { code: 'asc' }
     });
 
     return NextResponse.json({
       accounts: accounts.map(acc => ({
+        id: acc.id,
         code: acc.code,
         name: acc.name,
         accountType: acc.account_type,
         balanceType: acc.balance_type,
         settledBalance: acc.settled_balance.toString(),
+        pendingBalance: acc.pending_balance.toString(),
+        entityId: acc.entity_id,
         entityType: acc.entity_type
       }))
     });

--- a/src/app/trading/page.tsx
+++ b/src/app/trading/page.tsx
@@ -9,6 +9,7 @@ import TradeLabPanel from '@/components/trading/TradeLabPanel';
 import DataObservatory from '@/components/data-observatory/DataObservatory';
 import type { ScannerFilters } from '@/lib/convergence/filter-types';
 import { DEFAULT_FILTERS, AVAILABLE_STRATEGIES } from '@/lib/convergence/filter-types';
+import COAManagementTable from '@/components/bookkeeping/COAManagementTable';
 
 
 interface TradeSummary {
@@ -186,6 +187,21 @@ export default function TradingPage() {
   const [ttGreeksLoading, setTtGreeksLoading] = useState(false);
   const [ttGreeksFetched, setTtGreeksFetched] = useState<Set<number>>(new Set());
   const [ttShowAllStrikes, setTtShowAllStrikes] = useState(false);
+  const [tradingEntityId, setTradingEntityId] = useState<string | null>(null);
+
+  // Load trading entity for COA management
+  useEffect(() => {
+    (async () => {
+      try {
+        const res = await fetch('/api/entities');
+        if (res.ok) {
+          const data = await res.json();
+          const entity = (data.entities || []).find((e: any) => e.entity_type === 'trading');
+          if (entity) setTradingEntityId(entity.id);
+        }
+      } catch (err) { console.error('Failed to load entity:', err); }
+    })();
+  }, []);
 
   // Check Tastytrade connection status on load
   useEffect(() => {
@@ -1132,6 +1148,17 @@ export default function TradingPage() {
               </button>
             </div>
           </div>
+        </div>
+      )}
+
+      {/* Chart of Accounts Management */}
+      {tradingEntityId && (
+        <div className="p-4 lg:p-6 max-w-[1800px] mx-auto">
+          <COAManagementTable
+            entityId={tradingEntityId}
+            entityName="Trading"
+            entityType="trading"
+          />
         </div>
       )}
 

--- a/src/components/bookkeeping/COAManagementTable.tsx
+++ b/src/components/bookkeeping/COAManagementTable.tsx
@@ -1,0 +1,394 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+
+interface COAManagementTableProps {
+  entityId: string;
+  entityName: string;
+  entityType: string;
+}
+
+interface COAAccount {
+  id: string;
+  code: string;
+  name: string;
+  accountType: string;
+  balanceType: string;
+  settledBalance: string;
+  pendingBalance: string;
+  entityId: string;
+  entityType: string;
+}
+
+const ACCOUNT_TYPE_ORDER = ['asset', 'liability', 'equity', 'revenue', 'expense'];
+const ACCOUNT_TYPE_LABELS: Record<string, string> = {
+  asset: 'Assets',
+  liability: 'Liabilities',
+  equity: 'Equity',
+  revenue: 'Revenue',
+  expense: 'Expenses',
+};
+
+const BALANCE_TYPE_MAP: Record<string, string> = {
+  asset: 'D', expense: 'D', liability: 'C', equity: 'C', revenue: 'C',
+};
+
+function formatCurrency(cents: string | number): string {
+  const val = typeof cents === 'string' ? parseInt(cents, 10) : cents;
+  if (isNaN(val)) return '$0.00';
+  return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(val / 100);
+}
+
+export default function COAManagementTable({ entityId, entityName, entityType }: COAManagementTableProps) {
+  const [accounts, setAccounts] = useState<COAAccount[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Inline edit state
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editForm, setEditForm] = useState({ code: '', name: '' });
+  const [editSaving, setEditSaving] = useState(false);
+  const [editError, setEditError] = useState<string | null>(null);
+
+  // Add new account state
+  const [showAddForm, setShowAddForm] = useState(false);
+  const [addForm, setAddForm] = useState({ code: '', name: '', accountType: 'expense' });
+  const [addSaving, setAddSaving] = useState(false);
+  const [addError, setAddError] = useState<string | null>(null);
+
+  const fetchAccounts = useCallback(async () => {
+    try {
+      setError(null);
+      const res = await fetch(`/api/chart-of-accounts/balances?entityId=${entityId}`);
+      if (!res.ok) throw new Error('Failed to fetch accounts');
+      const data = await res.json();
+      setAccounts(data.accounts || []);
+    } catch (err: any) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  }, [entityId]);
+
+  useEffect(() => { fetchAccounts(); }, [fetchAccounts]);
+
+  const grouped = ACCOUNT_TYPE_ORDER.reduce<Record<string, COAAccount[]>>((acc, type) => {
+    const items = accounts.filter(a => a.accountType === type);
+    if (items.length > 0) acc[type] = items;
+    return acc;
+  }, {});
+
+  const startEdit = (account: COAAccount) => {
+    setEditingId(account.id);
+    setEditForm({ code: account.code, name: account.name });
+    setEditError(null);
+  };
+
+  const cancelEdit = () => {
+    setEditingId(null);
+    setEditError(null);
+  };
+
+  const saveEdit = async (id: string) => {
+    setEditSaving(true);
+    setEditError(null);
+    try {
+      const res = await fetch(`/api/chart-of-accounts/${id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ code: editForm.code, name: editForm.name }),
+      });
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.error || 'Failed to update');
+      }
+      setEditingId(null);
+      await fetchAccounts();
+    } catch (err: any) {
+      setEditError(err.message);
+    } finally {
+      setEditSaving(false);
+    }
+  };
+
+  const addAccount = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setAddSaving(true);
+    setAddError(null);
+    try {
+      const res = await fetch('/api/chart-of-accounts', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          code: addForm.code,
+          name: addForm.name,
+          accountType: addForm.accountType,
+          entityId,
+        }),
+      });
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.error || 'Failed to create account');
+      }
+      setShowAddForm(false);
+      setAddForm({ code: '', name: '', accountType: 'expense' });
+      await fetchAccounts();
+    } catch (err: any) {
+      setAddError(err.message);
+    } finally {
+      setAddSaving(false);
+    }
+  };
+
+  const balanceColor = (type: string) => {
+    if (type === 'asset' || type === 'revenue') return 'text-emerald-600';
+    if (type === 'liability' || type === 'expense') return 'text-red-600';
+    return 'text-text-primary';
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-8">
+        <div className="w-5 h-5 border-2 border-brand-purple-deep border-t-transparent rounded-full animate-spin" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="text-center py-8 text-sm text-red-500">
+        Failed to load chart of accounts: {error}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center justify-between mb-3">
+        <div>
+          <h3 className="text-sm font-semibold text-text-primary">Chart of Accounts</h3>
+          <p className="text-xs text-text-muted">{entityName} — {accounts.length} accounts</p>
+        </div>
+      </div>
+
+      <div className="border border-gray-200/50 rounded-lg overflow-hidden">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="bg-gray-50">
+              <th className="text-left px-3 py-2 text-xs font-semibold text-text-secondary">Code</th>
+              <th className="text-left px-3 py-2 text-xs font-semibold text-text-secondary">Account Name</th>
+              <th className="text-right px-3 py-2 text-xs font-semibold text-text-secondary">Balance</th>
+              <th className="text-right px-3 py-2 text-xs font-semibold text-text-secondary w-[140px]">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {Object.entries(grouped).map(([type, items]) => (
+              <GroupRows
+                key={type}
+                type={type}
+                items={items}
+                editingId={editingId}
+                editForm={editForm}
+                editSaving={editSaving}
+                editError={editError}
+                balanceColor={balanceColor}
+                onEditFormChange={setEditForm}
+                onStartEdit={startEdit}
+                onCancelEdit={cancelEdit}
+                onSaveEdit={saveEdit}
+              />
+            ))}
+            {accounts.length === 0 && (
+              <tr>
+                <td colSpan={4} className="text-center py-6 text-xs text-text-muted">
+                  No accounts found for this entity. Add one below.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Add Account Form */}
+      {showAddForm ? (
+        <form onSubmit={addAccount} className="border border-gray-200/50 rounded-lg p-3 bg-white space-y-3">
+          <div className="text-xs font-semibold text-text-primary mb-1">New Account</div>
+          <div className="grid grid-cols-3 gap-2">
+            <div>
+              <label className="text-[10px] text-text-muted uppercase tracking-wider block mb-1">Code</label>
+              <input
+                type="text"
+                value={addForm.code}
+                onChange={e => setAddForm(f => ({ ...f, code: e.target.value }))}
+                className="w-full px-2 py-1.5 text-xs border border-gray-200 rounded focus:outline-none focus:ring-1 focus:ring-brand-purple-deep"
+                placeholder="e.g. 5030"
+                required
+              />
+            </div>
+            <div>
+              <label className="text-[10px] text-text-muted uppercase tracking-wider block mb-1">Name</label>
+              <input
+                type="text"
+                value={addForm.name}
+                onChange={e => setAddForm(f => ({ ...f, name: e.target.value }))}
+                className="w-full px-2 py-1.5 text-xs border border-gray-200 rounded focus:outline-none focus:ring-1 focus:ring-brand-purple-deep"
+                placeholder="e.g. Office Supplies"
+                required
+              />
+            </div>
+            <div>
+              <label className="text-[10px] text-text-muted uppercase tracking-wider block mb-1">Type</label>
+              <select
+                value={addForm.accountType}
+                onChange={e => setAddForm(f => ({ ...f, accountType: e.target.value }))}
+                className="w-full px-2 py-1.5 text-xs border border-gray-200 rounded focus:outline-none focus:ring-1 focus:ring-brand-purple-deep"
+              >
+                {ACCOUNT_TYPE_ORDER.map(t => (
+                  <option key={t} value={t}>{ACCOUNT_TYPE_LABELS[t]} ({BALANCE_TYPE_MAP[t] === 'D' ? 'Debit' : 'Credit'})</option>
+                ))}
+              </select>
+            </div>
+          </div>
+          {addError && <div className="text-xs text-red-500">{addError}</div>}
+          <div className="flex gap-2">
+            <button
+              type="submit"
+              disabled={addSaving}
+              className="px-3 py-1.5 text-xs font-semibold bg-brand-gold text-white rounded hover:bg-brand-gold/90 disabled:opacity-50"
+            >
+              {addSaving ? 'Saving...' : 'Save Account'}
+            </button>
+            <button
+              type="button"
+              onClick={() => { setShowAddForm(false); setAddError(null); }}
+              className="px-3 py-1.5 text-xs font-medium border border-gray-200 text-text-secondary rounded hover:bg-bg-row"
+            >
+              Cancel
+            </button>
+          </div>
+        </form>
+      ) : (
+        <button
+          onClick={() => setShowAddForm(true)}
+          className="px-3 py-1.5 text-xs font-semibold bg-brand-gold text-white rounded hover:bg-brand-gold/90"
+        >
+          + Add Account
+        </button>
+      )}
+
+      {/* Reassignment guidance */}
+      <div className="mt-3 px-3 py-2 bg-amber-50 border border-amber-200/50 rounded text-[11px] text-amber-800">
+        <span className="font-semibold">Reassign transactions?</span>{' '}
+        To move transactions to a different COA, go to the Categorize section — switch to the Committed tab, find the transactions, uncommit them, then reassign and recommit.
+      </div>
+    </div>
+  );
+}
+
+// Sub-component for grouped rows
+function GroupRows({
+  type,
+  items,
+  editingId,
+  editForm,
+  editSaving,
+  editError,
+  balanceColor,
+  onEditFormChange,
+  onStartEdit,
+  onCancelEdit,
+  onSaveEdit,
+}: {
+  type: string;
+  items: COAAccount[];
+  editingId: string | null;
+  editForm: { code: string; name: string };
+  editSaving: boolean;
+  editError: string | null;
+  balanceColor: (type: string) => string;
+  onEditFormChange: (f: { code: string; name: string }) => void;
+  onStartEdit: (account: COAAccount) => void;
+  onCancelEdit: () => void;
+  onSaveEdit: (id: string) => void;
+}) {
+  return (
+    <>
+      <tr className="bg-bg-row">
+        <td colSpan={4} className="px-3 py-1.5">
+          <span className="text-[10px] uppercase text-text-muted font-semibold tracking-wider">
+            {ACCOUNT_TYPE_LABELS[type] || type}
+          </span>
+        </td>
+      </tr>
+      {items.map((account, i) => {
+        const isEditing = editingId === account.id;
+        return (
+          <tr key={account.id} className={i % 2 === 0 ? 'bg-white' : 'bg-bg-row/50'}>
+            <td className="px-3 py-2 font-mono text-xs">
+              {isEditing ? (
+                <div>
+                  <input
+                    type="text"
+                    value={editForm.code}
+                    onChange={e => onEditFormChange({ ...editForm, code: e.target.value })}
+                    className="w-20 px-1.5 py-1 text-xs border border-gray-200 rounded focus:outline-none focus:ring-1 focus:ring-brand-purple-deep font-mono"
+                  />
+                  <div className="text-[9px] text-amber-600 mt-0.5">Changing codes affects categorization mappings</div>
+                </div>
+              ) : (
+                account.code
+              )}
+            </td>
+            <td className="px-3 py-2 text-xs text-text-primary">
+              {isEditing ? (
+                <input
+                  type="text"
+                  value={editForm.name}
+                  onChange={e => onEditFormChange({ ...editForm, name: e.target.value })}
+                  className="w-full px-1.5 py-1 text-xs border border-gray-200 rounded focus:outline-none focus:ring-1 focus:ring-brand-purple-deep"
+                />
+              ) : (
+                account.name
+              )}
+            </td>
+            <td className={`px-3 py-2 text-right font-mono font-semibold text-xs ${balanceColor(account.accountType)}`}>
+              {formatCurrency(account.settledBalance)}
+            </td>
+            <td className="px-3 py-2 text-right">
+              {isEditing ? (
+                <div className="flex items-center justify-end gap-1.5">
+                  {editError && <span className="text-[10px] text-red-500 mr-1">{editError}</span>}
+                  <button
+                    onClick={() => onSaveEdit(account.id)}
+                    disabled={editSaving}
+                    className="px-2 py-1 text-[10px] font-semibold bg-emerald-500 text-white rounded hover:bg-emerald-600 disabled:opacity-50"
+                  >
+                    {editSaving ? '...' : 'Save'}
+                  </button>
+                  <button
+                    onClick={onCancelEdit}
+                    className="px-2 py-1 text-[10px] font-medium border border-gray-200 text-text-secondary rounded hover:bg-bg-row"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              ) : (
+                <div className="flex items-center justify-end gap-1.5">
+                  <button
+                    onClick={() => onStartEdit(account)}
+                    className="px-2 py-1 text-[10px] font-medium border border-gray-200 text-text-secondary rounded hover:bg-bg-row"
+                  >
+                    Edit
+                  </button>
+                  <span className="px-2 py-1 text-[10px] font-medium text-text-muted">
+                    View Txns
+                  </span>
+                </div>
+              )}
+            </td>
+          </tr>
+        );
+      })}
+    </>
+  );
+}

--- a/src/components/dashboard/BudgetingPage.tsx
+++ b/src/components/dashboard/BudgetingPage.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import { AppLayout, Button, Badge } from '@/components/ui';
+import COAManagementTable from '@/components/bookkeeping/COAManagementTable';
 
 interface Expense {
   id: string;
@@ -40,8 +41,21 @@ export default function BudgetingPage({ category, emoji, apiPath }: BudgetingPag
   const [showForm, setShowForm] = useState(false);
   const [form, setForm] = useState({ name: '', coa_code: '', amount: '', cadence: 'monthly', target_date: new Date().toISOString().split('T')[0] });
   const [actionLoading, setActionLoading] = useState<string | null>(null);
+  const [entityId, setEntityId] = useState<string | null>(null);
 
-  useEffect(() => { loadExpenses(); }, []);
+  useEffect(() => { loadExpenses(); loadEntity(); }, []);
+
+  const loadEntity = async () => {
+    try {
+      const res = await fetch('/api/entities');
+      if (res.ok) {
+        const data = await res.json();
+        const entityType = category.toLowerCase();
+        const entity = (data.entities || []).find((e: any) => e.entity_type === entityType);
+        if (entity) setEntityId(entity.id);
+      }
+    } catch (err) { console.error('Failed to load entity:', err); }
+  };
 
   const loadExpenses = async () => {
     try {
@@ -252,6 +266,15 @@ export default function BudgetingPage({ category, emoji, apiPath }: BudgetingPag
             <p className="text-terminal-sm text-text-muted mt-1 font-mono">No {category.toLowerCase()} expenses yet</p>
             <p className="text-terminal-xs text-text-faint mt-0.5">Click "+ ADD" to create your first entry</p>
           </div>
+        )}
+
+        {/* Chart of Accounts Management */}
+        {entityId && (
+          <COAManagementTable
+            entityId={entityId}
+            entityName={category}
+            entityType={category.toLowerCase()}
+          />
         )}
       </div>
     </AppLayout>


### PR DESCRIPTION
…ering

- Add PUT /api/chart-of-accounts/[id] endpoint for updating accounts (name, code, accountType) with ownership validation and code uniqueness checks
- Add entityId query param filtering to /api/chart-of-accounts/balances
- Create COAManagementTable component with:
  - Accounts grouped by type (assets, liabilities, equity, revenue, expenses)
  - Inline edit mode for account name and code with save/cancel
  - Add new account form with type dropdown and auto-set balance type
  - Transaction reassignment guidance (uncommit/reassign/recommit pattern)
- Wire COAManagementTable into Personal and Business pages (via BudgetingPage) and Trading page, each fetching their entity ID from /api/entities

https://claude.ai/code/session_01VhnpMQwGJettRMvuPpSgNV