### PR TITLE
feat: COA drill-down with transaction reassignment, hide zero balance…

### DIFF
--- a/src/app/api/transactions/route.ts
+++ b/src/app/api/transactions/route.ts
@@ -3,10 +3,10 @@ import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { ensureBookkeepingInitialized } from '@/lib/ensure-bookkeeping';
 
-export async function GET() {
+export async function GET(request: Request) {
   try {
     const userEmail = await getVerifiedEmail();
-    
+
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
@@ -22,12 +22,16 @@ export async function GET() {
 
     await ensureBookkeepingInitialized(user);
 
+    const { searchParams } = new URL(request.url);
+    const accountCode = searchParams.get('accountCode');
+
     // Get transactions for accounts owned by this user
     const transactions = await prisma.transactions.findMany({
       where: {
         accounts: {
           userId: user.id
-        }
+        },
+        ...(accountCode && { accountCode }),
       },
       include: {
         accounts: {

--- a/src/components/bookkeeping/COAManagementTable.tsx
+++ b/src/components/bookkeeping/COAManagementTable.tsx
@@ -20,6 +20,15 @@ interface COAAccount {
   entityType: string;
 }
 
+interface DrilldownTxn {
+  id: string;
+  date: string;
+  merchantName: string | null;
+  name: string;
+  amount: number;
+  accountCode: string | null;
+}
+
 const ACCOUNT_TYPE_ORDER = ['asset', 'liability', 'equity', 'revenue', 'expense'];
 const ACCOUNT_TYPE_LABELS: Record<string, string> = {
   asset: 'Assets',
@@ -39,10 +48,20 @@ function formatCurrency(cents: string | number): string {
   return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(val / 100);
 }
 
+function formatAmount(dollars: number): string {
+  return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(Math.abs(dollars));
+}
+
+function formatDate(d: string): string {
+  return new Date(d).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+}
+
 export default function COAManagementTable({ entityId, entityName, entityType }: COAManagementTableProps) {
   const [accounts, setAccounts] = useState<COAAccount[]>([]);
+  const [allCoaOptions, setAllCoaOptions] = useState<COAAccount[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [showZeroBalances, setShowZeroBalances] = useState(false);
 
   // Inline edit state
   const [editingId, setEditingId] = useState<string | null>(null);
@@ -55,6 +74,12 @@ export default function COAManagementTable({ entityId, entityName, entityType }:
   const [addForm, setAddForm] = useState({ code: '', name: '', accountType: 'expense' });
   const [addSaving, setAddSaving] = useState(false);
   const [addError, setAddError] = useState<string | null>(null);
+
+  // Drill-down state
+  const [expandedCode, setExpandedCode] = useState<string | null>(null);
+  const [drilldownTxns, setDrilldownTxns] = useState<DrilldownTxn[]>([]);
+  const [drilldownLoading, setDrilldownLoading] = useState(false);
+  const [reassigning, setReassigning] = useState<string | null>(null);
 
   const fetchAccounts = useCallback(async () => {
     try {
@@ -70,10 +95,25 @@ export default function COAManagementTable({ entityId, entityName, entityType }:
     }
   }, [entityId]);
 
-  useEffect(() => { fetchAccounts(); }, [fetchAccounts]);
+  // Fetch all COA options for reassignment dropdown
+  const fetchAllCoa = useCallback(async () => {
+    try {
+      const res = await fetch(`/api/chart-of-accounts?entity_id=${entityId}`);
+      if (res.ok) {
+        const data = await res.json();
+        setAllCoaOptions(data.accounts || []);
+      }
+    } catch (err) { /* silent */ }
+  }, [entityId]);
+
+  useEffect(() => { fetchAccounts(); fetchAllCoa(); }, [fetchAccounts, fetchAllCoa]);
+
+  const nonZeroAccounts = accounts.filter(a => parseInt(a.settledBalance, 10) !== 0);
+  const zeroCount = accounts.length - nonZeroAccounts.length;
+  const displayAccounts = showZeroBalances ? accounts : nonZeroAccounts;
 
   const grouped = ACCOUNT_TYPE_ORDER.reduce<Record<string, COAAccount[]>>((acc, type) => {
-    const items = accounts.filter(a => a.accountType === type);
+    const items = displayAccounts.filter(a => a.accountType === type);
     if (items.length > 0) acc[type] = items;
     return acc;
   }, {});
@@ -133,11 +173,47 @@ export default function COAManagementTable({ entityId, entityName, entityType }:
       setShowAddForm(false);
       setAddForm({ code: '', name: '', accountType: 'expense' });
       await fetchAccounts();
+      await fetchAllCoa();
     } catch (err: any) {
       setAddError(err.message);
     } finally {
       setAddSaving(false);
     }
+  };
+
+  const toggleDrilldown = async (code: string) => {
+    if (expandedCode === code) {
+      setExpandedCode(null);
+      setDrilldownTxns([]);
+      return;
+    }
+    setExpandedCode(code);
+    setDrilldownLoading(true);
+    try {
+      const res = await fetch(`/api/transactions?accountCode=${encodeURIComponent(code)}`);
+      if (res.ok) {
+        const data = await res.json();
+        setDrilldownTxns(data.transactions || []);
+      }
+    } catch (err) { /* silent */ }
+    finally { setDrilldownLoading(false); }
+  };
+
+  const reassignTransaction = async (txnId: string, newCode: string) => {
+    setReassigning(txnId);
+    try {
+      const res = await fetch('/api/transactions/assign-coa', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ transactionIds: [txnId], accountCode: newCode }),
+      });
+      if (res.ok) {
+        // Refresh drilldown and balances
+        if (expandedCode) await toggleDrilldown(expandedCode);
+        await fetchAccounts();
+      }
+    } catch (err) { /* silent */ }
+    finally { setReassigning(null); }
   };
 
   const balanceColor = (type: string) => {
@@ -163,14 +239,7 @@ export default function COAManagementTable({ entityId, entityName, entityType }:
   }
 
   return (
-    <div className="space-y-1">
-      <div className="flex items-center justify-between mb-3">
-        <div>
-          <h3 className="text-sm font-semibold text-text-primary">Chart of Accounts</h3>
-          <p className="text-xs text-text-muted">{entityName} — {accounts.length} accounts</p>
-        </div>
-      </div>
-
+    <div className="space-y-2">
       <div className="border border-gray-200/50 rounded-lg overflow-hidden">
         <table className="w-full text-sm">
           <thead>
@@ -178,27 +247,43 @@ export default function COAManagementTable({ entityId, entityName, entityType }:
               <th className="text-left px-3 py-2 text-xs font-semibold text-text-secondary">Code</th>
               <th className="text-left px-3 py-2 text-xs font-semibold text-text-secondary">Account Name</th>
               <th className="text-right px-3 py-2 text-xs font-semibold text-text-secondary">Balance</th>
-              <th className="text-right px-3 py-2 text-xs font-semibold text-text-secondary w-[140px]">Actions</th>
+              <th className="text-right px-3 py-2 text-xs font-semibold text-text-secondary w-[100px]">Actions</th>
             </tr>
           </thead>
           <tbody>
-            {Object.entries(grouped).map(([type, items]) => (
-              <GroupRows
-                key={type}
-                type={type}
-                items={items}
-                editingId={editingId}
-                editForm={editForm}
-                editSaving={editSaving}
-                editError={editError}
-                balanceColor={balanceColor}
-                onEditFormChange={setEditForm}
-                onStartEdit={startEdit}
-                onCancelEdit={cancelEdit}
-                onSaveEdit={saveEdit}
-              />
-            ))}
-            {accounts.length === 0 && (
+            {Object.entries(grouped).map(([type, items]) =>
+              items.map((account, i) => {
+                const isEditing = editingId === account.id;
+                const isFirst = i === 0;
+                const isExpanded = expandedCode === account.code;
+                return (
+                  <GroupedRow
+                    key={account.id}
+                    account={account}
+                    isFirst={isFirst}
+                    type={type}
+                    isEditing={isEditing}
+                    isExpanded={isExpanded}
+                    editForm={editForm}
+                    editSaving={editSaving}
+                    editError={editError}
+                    balanceColor={balanceColor}
+                    rowIndex={i}
+                    drilldownLoading={drilldownLoading}
+                    drilldownTxns={drilldownTxns}
+                    allCoaOptions={allCoaOptions}
+                    reassigning={reassigning}
+                    onEditFormChange={setEditForm}
+                    onStartEdit={startEdit}
+                    onCancelEdit={cancelEdit}
+                    onSaveEdit={saveEdit}
+                    onToggleDrilldown={toggleDrilldown}
+                    onReassign={reassignTransaction}
+                  />
+                );
+              })
+            )}
+            {displayAccounts.length === 0 && (
               <tr>
                 <td colSpan={4} className="text-center py-6 text-xs text-text-muted">
                   No accounts found for this entity. Add one below.
@@ -208,6 +293,18 @@ export default function COAManagementTable({ entityId, entityName, entityType }:
           </tbody>
         </table>
       </div>
+
+      {/* Zero balance toggle */}
+      {zeroCount > 0 && (
+        <button
+          onClick={() => setShowZeroBalances(v => !v)}
+          className="text-[11px] text-text-muted hover:text-brand-purple-deep"
+        >
+          {showZeroBalances
+            ? `Hide ${zeroCount} account${zeroCount !== 1 ? 's' : ''} with $0 balance`
+            : `${zeroCount} account${zeroCount !== 1 ? 's' : ''} with $0 balance hidden — show`}
+        </button>
+      )}
 
       {/* Add Account Form */}
       {showAddForm ? (
@@ -275,120 +372,183 @@ export default function COAManagementTable({ entityId, entityName, entityType }:
           + Add Account
         </button>
       )}
-
-      {/* Reassignment guidance */}
-      <div className="mt-3 px-3 py-2 bg-amber-50 border border-amber-200/50 rounded text-[11px] text-amber-800">
-        <span className="font-semibold">Reassign transactions?</span>{' '}
-        To move transactions to a different COA, go to the Categorize section — switch to the Committed tab, find the transactions, uncommit them, then reassign and recommit.
-      </div>
     </div>
   );
 }
 
-// Sub-component for grouped rows
-function GroupRows({
+// Individual row with optional group header and drill-down
+function GroupedRow({
+  account,
+  isFirst,
   type,
-  items,
-  editingId,
+  isEditing,
+  isExpanded,
   editForm,
   editSaving,
   editError,
   balanceColor,
+  rowIndex,
+  drilldownLoading,
+  drilldownTxns,
+  allCoaOptions,
+  reassigning,
   onEditFormChange,
   onStartEdit,
   onCancelEdit,
   onSaveEdit,
+  onToggleDrilldown,
+  onReassign,
 }: {
+  account: COAAccount;
+  isFirst: boolean;
   type: string;
-  items: COAAccount[];
-  editingId: string | null;
+  isEditing: boolean;
+  isExpanded: boolean;
   editForm: { code: string; name: string };
   editSaving: boolean;
   editError: string | null;
   balanceColor: (type: string) => string;
+  rowIndex: number;
+  drilldownLoading: boolean;
+  drilldownTxns: DrilldownTxn[];
+  allCoaOptions: COAAccount[];
+  reassigning: string | null;
   onEditFormChange: (f: { code: string; name: string }) => void;
   onStartEdit: (account: COAAccount) => void;
   onCancelEdit: () => void;
   onSaveEdit: (id: string) => void;
+  onToggleDrilldown: (code: string) => void;
+  onReassign: (txnId: string, newCode: string) => void;
 }) {
   return (
     <>
-      <tr className="bg-bg-row">
-        <td colSpan={4} className="px-3 py-1.5">
-          <span className="text-[10px] uppercase text-text-muted font-semibold tracking-wider">
-            {ACCOUNT_TYPE_LABELS[type] || type}
-          </span>
+      {/* Group header */}
+      {isFirst && (
+        <tr className="bg-bg-row">
+          <td colSpan={4} className="px-3 py-1.5">
+            <span className="text-[10px] uppercase text-text-muted font-semibold tracking-wider">
+              {ACCOUNT_TYPE_LABELS[type] || type}
+            </span>
+          </td>
+        </tr>
+      )}
+      {/* Account row */}
+      <tr className={rowIndex % 2 === 0 ? 'bg-white' : 'bg-bg-row/50'}>
+        <td className="px-3 py-2 font-mono text-xs">
+          {isEditing ? (
+            <div>
+              <input
+                type="text"
+                value={editForm.code}
+                onChange={e => onEditFormChange({ ...editForm, code: e.target.value })}
+                className="w-20 px-1.5 py-1 text-xs border border-gray-200 rounded focus:outline-none focus:ring-1 focus:ring-brand-purple-deep font-mono"
+              />
+              <div className="text-[9px] text-amber-600 mt-0.5">Changing codes affects categorization mappings</div>
+            </div>
+          ) : (
+            account.code
+          )}
+        </td>
+        <td className="px-3 py-2 text-xs text-text-primary">
+          {isEditing ? (
+            <input
+              type="text"
+              value={editForm.name}
+              onChange={e => onEditFormChange({ ...editForm, name: e.target.value })}
+              className="w-full px-1.5 py-1 text-xs border border-gray-200 rounded focus:outline-none focus:ring-1 focus:ring-brand-purple-deep"
+            />
+          ) : (
+            account.name
+          )}
+        </td>
+        <td className={`px-3 py-2 text-right font-mono font-semibold text-xs ${balanceColor(account.accountType)}`}>
+          <button
+            onClick={() => onToggleDrilldown(account.code)}
+            className="cursor-pointer hover:underline hover:text-brand-purple-deep transition-colors"
+            title="Click to view transactions"
+          >
+            {formatCurrency(account.settledBalance)}
+          </button>
+        </td>
+        <td className="px-3 py-2 text-right">
+          {isEditing ? (
+            <div className="flex items-center justify-end gap-1.5">
+              {editError && <span className="text-[10px] text-red-500 mr-1">{editError}</span>}
+              <button
+                onClick={() => onSaveEdit(account.id)}
+                disabled={editSaving}
+                className="px-2 py-1 text-[10px] font-semibold bg-emerald-500 text-white rounded hover:bg-emerald-600 disabled:opacity-50"
+              >
+                {editSaving ? '...' : 'Save'}
+              </button>
+              <button
+                onClick={onCancelEdit}
+                className="px-2 py-1 text-[10px] font-medium border border-gray-200 text-text-secondary rounded hover:bg-bg-row"
+              >
+                Cancel
+              </button>
+            </div>
+          ) : (
+            <button
+              onClick={() => onStartEdit(account)}
+              className="px-2 py-1 text-[10px] font-medium border border-gray-200 text-text-secondary rounded hover:bg-bg-row"
+            >
+              Edit
+            </button>
+          )}
         </td>
       </tr>
-      {items.map((account, i) => {
-        const isEditing = editingId === account.id;
-        return (
-          <tr key={account.id} className={i % 2 === 0 ? 'bg-white' : 'bg-bg-row/50'}>
-            <td className="px-3 py-2 font-mono text-xs">
-              {isEditing ? (
-                <div>
-                  <input
-                    type="text"
-                    value={editForm.code}
-                    onChange={e => onEditFormChange({ ...editForm, code: e.target.value })}
-                    className="w-20 px-1.5 py-1 text-xs border border-gray-200 rounded focus:outline-none focus:ring-1 focus:ring-brand-purple-deep font-mono"
-                  />
-                  <div className="text-[9px] text-amber-600 mt-0.5">Changing codes affects categorization mappings</div>
+      {/* Drill-down panel */}
+      {isExpanded && (
+        <tr>
+          <td colSpan={4} className="p-0">
+            <div className="bg-brand-purple/5 border-l-4 border-brand-purple px-4 py-3">
+              {drilldownLoading ? (
+                <div className="flex items-center gap-2 py-2">
+                  <div className="w-4 h-4 border-2 border-brand-purple border-t-transparent rounded-full animate-spin" />
+                  <span className="text-xs text-text-muted">Loading transactions...</span>
                 </div>
+              ) : drilldownTxns.length === 0 ? (
+                <div className="text-xs text-text-muted py-2">No transactions assigned to this account.</div>
               ) : (
-                account.code
+                <table className="w-full text-xs">
+                  <thead>
+                    <tr className="text-text-muted">
+                      <th className="text-left pb-1.5 font-medium">Date</th>
+                      <th className="text-left pb-1.5 font-medium">Merchant</th>
+                      <th className="text-left pb-1.5 font-medium">Description</th>
+                      <th className="text-right pb-1.5 font-medium">Amount</th>
+                      <th className="text-right pb-1.5 font-medium w-[180px]">Reassign COA</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {drilldownTxns.map(txn => (
+                      <tr key={txn.id} className="border-t border-gray-200/50">
+                        <td className="py-1.5 font-mono text-text-secondary">{formatDate(txn.date)}</td>
+                        <td className="py-1.5 text-text-primary">{txn.merchantName || '\u2014'}</td>
+                        <td className="py-1.5 text-text-muted truncate max-w-[200px]">{txn.name}</td>
+                        <td className="py-1.5 text-right font-mono font-semibold">{formatAmount(txn.amount)}</td>
+                        <td className="py-1.5 text-right">
+                          <select
+                            value={txn.accountCode || ''}
+                            disabled={reassigning === txn.id}
+                            onChange={e => { if (e.target.value && e.target.value !== txn.accountCode) onReassign(txn.id, e.target.value); }}
+                            className="text-[10px] border border-gray-200 rounded px-1.5 py-0.5 bg-white focus:outline-none focus:ring-1 focus:ring-brand-purple-deep disabled:opacity-50 max-w-[170px]"
+                          >
+                            {allCoaOptions.map(opt => (
+                              <option key={opt.id} value={opt.code}>{opt.code} - {opt.name}</option>
+                            ))}
+                          </select>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
               )}
-            </td>
-            <td className="px-3 py-2 text-xs text-text-primary">
-              {isEditing ? (
-                <input
-                  type="text"
-                  value={editForm.name}
-                  onChange={e => onEditFormChange({ ...editForm, name: e.target.value })}
-                  className="w-full px-1.5 py-1 text-xs border border-gray-200 rounded focus:outline-none focus:ring-1 focus:ring-brand-purple-deep"
-                />
-              ) : (
-                account.name
-              )}
-            </td>
-            <td className={`px-3 py-2 text-right font-mono font-semibold text-xs ${balanceColor(account.accountType)}`}>
-              {formatCurrency(account.settledBalance)}
-            </td>
-            <td className="px-3 py-2 text-right">
-              {isEditing ? (
-                <div className="flex items-center justify-end gap-1.5">
-                  {editError && <span className="text-[10px] text-red-500 mr-1">{editError}</span>}
-                  <button
-                    onClick={() => onSaveEdit(account.id)}
-                    disabled={editSaving}
-                    className="px-2 py-1 text-[10px] font-semibold bg-emerald-500 text-white rounded hover:bg-emerald-600 disabled:opacity-50"
-                  >
-                    {editSaving ? '...' : 'Save'}
-                  </button>
-                  <button
-                    onClick={onCancelEdit}
-                    className="px-2 py-1 text-[10px] font-medium border border-gray-200 text-text-secondary rounded hover:bg-bg-row"
-                  >
-                    Cancel
-                  </button>
-                </div>
-              ) : (
-                <div className="flex items-center justify-end gap-1.5">
-                  <button
-                    onClick={() => onStartEdit(account)}
-                    className="px-2 py-1 text-[10px] font-medium border border-gray-200 text-text-secondary rounded hover:bg-bg-row"
-                  >
-                    Edit
-                  </button>
-                  <span className="px-2 py-1 text-[10px] font-medium text-text-muted">
-                    View Txns
-                  </span>
-                </div>
-              )}
-            </td>
-          </tr>
-        );
-      })}
+            </div>
+          </td>
+        </tr>
+      )}
     </>
   );
 }

--- a/src/components/dashboard/BudgetingPage.tsx
+++ b/src/components/dashboard/BudgetingPage.tsx
@@ -129,155 +129,170 @@ export default function BudgetingPage({ category, emoji, apiPath }: BudgetingPag
   return (
     <AppLayout>
       <div className="max-w-6xl mx-auto px-4 py-3 space-y-3">
-        {/* Header + inline metrics */}
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-3">
-            <span className="text-terminal-lg font-mono font-semibold text-text-primary">{emoji} {category.toUpperCase()}</span>
-            <span className="text-terminal-xs text-text-faint font-mono">
-              {draft.length} draft · {committed.length} committed · Total: {fmt(totalCommitted)}
-            </span>
-          </div>
-          <Button size="sm" onClick={() => setShowForm(!showForm)}>+ ADD</Button>
-        </div>
-
-        {/* Add Form */}
-        {showForm && (
-          <div className="border border-border rounded bg-white p-3">
-            <form onSubmit={handleSubmit} className="space-y-2">
-              <div className="grid grid-cols-2 gap-2">
-                <input
-                  className="border border-border rounded px-2 py-1 text-terminal-base font-mono bg-white focus:border-brand-purple outline-none"
-                  placeholder="Expense name"
-                  value={form.name}
-                  onChange={e => setForm({ ...form, name: e.target.value })}
-                  required
-                />
-                <select
-                  className="border border-border rounded px-2 py-1 text-terminal-base font-mono bg-white focus:border-brand-purple outline-none"
-                  value={form.coa_code}
-                  onChange={e => setForm({ ...form, coa_code: e.target.value })}
-                  required
-                >
-                  {coaAccounts.length === 0 && <option value="">No accounts found</option>}
-                  {coaAccounts.map(o => <option key={o.code} value={o.code}>{o.code} - {o.name}</option>)}
-                </select>
-              </div>
-              <div className="grid grid-cols-3 gap-2">
-                <input
-                  className="border border-border rounded px-2 py-1 text-terminal-base font-mono bg-white focus:border-brand-purple outline-none"
-                  type="number"
-                  step="0.01"
-                  placeholder="Amount $"
-                  value={form.amount}
-                  onChange={e => setForm({ ...form, amount: e.target.value })}
-                  required
-                />
-                <select
-                  className="border border-border rounded px-2 py-1 text-terminal-base font-mono bg-white focus:border-brand-purple outline-none"
-                  value={form.cadence}
-                  onChange={e => setForm({ ...form, cadence: e.target.value })}
-                >
-                  {CADENCE_OPTIONS.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
-                </select>
-                <input
-                  className="border border-border rounded px-2 py-1 text-terminal-base font-mono bg-white focus:border-brand-purple outline-none"
-                  type="date"
-                  value={form.target_date}
-                  onChange={e => setForm({ ...form, target_date: e.target.value })}
-                  required
-                />
-              </div>
-              <div className="flex justify-end gap-2">
-                <Button type="button" variant="ghost" size="sm" onClick={() => setShowForm(false)}>Cancel</Button>
-                <Button type="submit" size="sm" disabled={!form.coa_code}>Save</Button>
-              </div>
-            </form>
-          </div>
-        )}
-
-        {/* No COA Warning */}
-        {coaAccounts.length === 0 && (
-          <div className="bg-amber-50 border border-brand-amber/30 rounded px-3 py-2 flex items-start gap-2">
-            <span className="text-terminal-base">⚠️</span>
-            <div>
-              <span className="text-terminal-sm font-semibold text-brand-amber">No {category} Accounts Found</span>
-              <p className="text-terminal-xs text-text-muted mt-0.5">
-                Create Chart of Accounts entries to track {category.toLowerCase()} expenses. Go to Chart of Accounts to add them.
-              </p>
+        {/* Budget Section */}
+        <div className="rounded-lg overflow-hidden border border-gray-200/50 shadow-sm">
+          <div className="bg-brand-purple/80 text-white px-4 py-2.5 text-sm font-semibold flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <span className="text-[9px] uppercase text-white/60 font-mono tracking-wider">{category.slice(0, 4).toUpperCase()}</span>
+              <span>{emoji} {category}</span>
+            </div>
+            <div className="flex items-center gap-3">
+              <span className="text-xs text-white/70">
+                {draft.length} draft · {committed.length} committed · Total: {fmt(totalCommitted)}
+              </span>
+              <Button size="sm" onClick={() => setShowForm(!showForm)}>+ ADD</Button>
             </div>
           </div>
-        )}
+          <div className="bg-white">
+            {/* Add Form */}
+            {showForm && (
+              <div className="border-b border-gray-200/50 p-3">
+                <form onSubmit={handleSubmit} className="space-y-2">
+                  <div className="grid grid-cols-2 gap-2">
+                    <input
+                      className="border border-border rounded px-2 py-1 text-terminal-base font-mono bg-white focus:border-brand-purple outline-none"
+                      placeholder="Expense name"
+                      value={form.name}
+                      onChange={e => setForm({ ...form, name: e.target.value })}
+                      required
+                    />
+                    <select
+                      className="border border-border rounded px-2 py-1 text-terminal-base font-mono bg-white focus:border-brand-purple outline-none"
+                      value={form.coa_code}
+                      onChange={e => setForm({ ...form, coa_code: e.target.value })}
+                      required
+                    >
+                      {coaAccounts.length === 0 && <option value="">No accounts found</option>}
+                      {coaAccounts.map(o => <option key={o.code} value={o.code}>{o.code} - {o.name}</option>)}
+                    </select>
+                  </div>
+                  <div className="grid grid-cols-3 gap-2">
+                    <input
+                      className="border border-border rounded px-2 py-1 text-terminal-base font-mono bg-white focus:border-brand-purple outline-none"
+                      type="number"
+                      step="0.01"
+                      placeholder="Amount $"
+                      value={form.amount}
+                      onChange={e => setForm({ ...form, amount: e.target.value })}
+                      required
+                    />
+                    <select
+                      className="border border-border rounded px-2 py-1 text-terminal-base font-mono bg-white focus:border-brand-purple outline-none"
+                      value={form.cadence}
+                      onChange={e => setForm({ ...form, cadence: e.target.value })}
+                    >
+                      {CADENCE_OPTIONS.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
+                    </select>
+                    <input
+                      className="border border-border rounded px-2 py-1 text-terminal-base font-mono bg-white focus:border-brand-purple outline-none"
+                      type="date"
+                      value={form.target_date}
+                      onChange={e => setForm({ ...form, target_date: e.target.value })}
+                      required
+                    />
+                  </div>
+                  <div className="flex justify-end gap-2">
+                    <Button type="button" variant="ghost" size="sm" onClick={() => setShowForm(false)}>Cancel</Button>
+                    <Button type="submit" size="sm" disabled={!form.coa_code}>Save</Button>
+                  </div>
+                </form>
+              </div>
+            )}
 
-        {/* Table */}
-        {expenses.length > 0 && (
-          <div className="border border-border rounded overflow-hidden">
-            <table className="w-full text-terminal-base border-collapse">
-              <thead className="bg-brand-purple text-white">
-                <tr>
-                  <th className="px-2 py-1 text-left text-terminal-xs font-semibold uppercase tracking-widest font-mono text-white/70">NAME</th>
-                  <th className="px-2 py-1 text-left text-terminal-xs font-semibold uppercase tracking-widest font-mono text-white/70 w-20">COA</th>
-                  <th className="px-2 py-1 text-left text-terminal-xs font-semibold uppercase tracking-widest font-mono text-white/70 w-20">CADENCE</th>
-                  <th className="px-2 py-1 text-left text-terminal-xs font-semibold uppercase tracking-widest font-mono text-white/70 w-20">DATE</th>
-                  <th className="px-2 py-1 text-right text-terminal-xs font-semibold uppercase tracking-widest font-mono text-white/70 w-24">AMOUNT</th>
-                  <th className="px-2 py-1 text-center text-terminal-xs font-semibold uppercase tracking-widest font-mono text-white/70 w-20">STATUS</th>
-                  <th className="px-2 py-1 text-right text-terminal-xs font-semibold uppercase tracking-widest font-mono text-white/70 w-28">ACTIONS</th>
-                </tr>
-              </thead>
-              <tbody>
-                {draft.map((e, i) => (
-                  <tr key={e.id} className={`${i % 2 === 0 ? 'bg-white' : 'bg-bg-row'} border-b border-border-light hover:bg-brand-purple-deep/[.05]`}>
-                    <td className="px-2 py-1 text-text-primary font-medium">{e.name}</td>
-                    <td className="px-2 py-1 text-text-muted font-mono">{e.coa_code}</td>
-                    <td className="px-2 py-1 text-text-secondary">{CADENCE_OPTIONS.find(c => c.value === e.cadence)?.label || e.cadence}</td>
-                    <td className="px-2 py-1 text-text-muted font-mono">{fmtDate(e.target_date)}</td>
-                    <td className="px-2 py-1 text-right font-mono font-semibold">{fmt(e.amount)}</td>
-                    <td className="px-2 py-1 text-center"><Badge variant="warning" size="sm">Draft</Badge></td>
-                    <td className="px-2 py-1 text-right">
-                      <span className="flex items-center justify-end gap-1">
-                        <Button size="sm" onClick={() => handleAction(e.id, 'commit')} disabled={actionLoading === e.id}>
-                          {actionLoading === e.id ? '...' : 'Commit'}
+            {/* No COA Warning */}
+            {coaAccounts.length === 0 && (
+              <div className="bg-amber-50 border-b border-brand-amber/30 px-3 py-2 flex items-start gap-2">
+                <span className="text-terminal-base">⚠️</span>
+                <div>
+                  <span className="text-terminal-sm font-semibold text-brand-amber">No {category} Accounts Found</span>
+                  <p className="text-terminal-xs text-text-muted mt-0.5">
+                    Create Chart of Accounts entries to track {category.toLowerCase()} expenses. Go to Chart of Accounts to add them.
+                  </p>
+                </div>
+              </div>
+            )}
+
+            {/* Budget Entries Table */}
+            {expenses.length > 0 && (
+              <table className="w-full text-terminal-base border-collapse">
+                <thead className="bg-gray-50">
+                  <tr>
+                    <th className="px-2 py-1.5 text-left text-terminal-xs font-semibold uppercase tracking-widest font-mono text-text-secondary">NAME</th>
+                    <th className="px-2 py-1.5 text-left text-terminal-xs font-semibold uppercase tracking-widest font-mono text-text-secondary w-20">COA</th>
+                    <th className="px-2 py-1.5 text-left text-terminal-xs font-semibold uppercase tracking-widest font-mono text-text-secondary w-20">CADENCE</th>
+                    <th className="px-2 py-1.5 text-left text-terminal-xs font-semibold uppercase tracking-widest font-mono text-text-secondary w-20">DATE</th>
+                    <th className="px-2 py-1.5 text-right text-terminal-xs font-semibold uppercase tracking-widest font-mono text-text-secondary w-24">AMOUNT</th>
+                    <th className="px-2 py-1.5 text-center text-terminal-xs font-semibold uppercase tracking-widest font-mono text-text-secondary w-20">STATUS</th>
+                    <th className="px-2 py-1.5 text-right text-terminal-xs font-semibold uppercase tracking-widest font-mono text-text-secondary w-28">ACTIONS</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {draft.map((e, i) => (
+                    <tr key={e.id} className={`${i % 2 === 0 ? 'bg-white' : 'bg-bg-row'} border-b border-border-light hover:bg-brand-purple-deep/[.05]`}>
+                      <td className="px-2 py-1 text-text-primary font-medium">{e.name}</td>
+                      <td className="px-2 py-1 text-text-muted font-mono">{e.coa_code}</td>
+                      <td className="px-2 py-1 text-text-secondary">{CADENCE_OPTIONS.find(c => c.value === e.cadence)?.label || e.cadence}</td>
+                      <td className="px-2 py-1 text-text-muted font-mono">{fmtDate(e.target_date)}</td>
+                      <td className="px-2 py-1 text-right font-mono font-semibold">{fmt(e.amount)}</td>
+                      <td className="px-2 py-1 text-center"><Badge variant="warning" size="sm">Draft</Badge></td>
+                      <td className="px-2 py-1 text-right">
+                        <span className="flex items-center justify-end gap-1">
+                          <Button size="sm" onClick={() => handleAction(e.id, 'commit')} disabled={actionLoading === e.id}>
+                            {actionLoading === e.id ? '...' : 'Commit'}
+                          </Button>
+                          <button className="text-brand-red text-terminal-sm hover:text-brand-red px-1" onClick={() => handleDelete(e.id)}>×</button>
+                        </span>
+                      </td>
+                    </tr>
+                  ))}
+                  {committed.map((e, i) => (
+                    <tr key={e.id} className={`${(draft.length + i) % 2 === 0 ? 'bg-white' : 'bg-bg-row'} border-b border-border-light hover:bg-brand-purple-deep/[.05]`}>
+                      <td className="px-2 py-1 text-text-primary font-medium">{e.name}</td>
+                      <td className="px-2 py-1 text-text-muted font-mono">{e.coa_code}</td>
+                      <td className="px-2 py-1 text-text-secondary">{CADENCE_OPTIONS.find(c => c.value === e.cadence)?.label || e.cadence}</td>
+                      <td className="px-2 py-1 text-text-muted font-mono">{fmtDate(e.target_date)}</td>
+                      <td className="px-2 py-1 text-right font-mono font-semibold text-brand-green">{fmt(e.amount)}</td>
+                      <td className="px-2 py-1 text-center"><Badge variant="success" size="sm">Active</Badge></td>
+                      <td className="px-2 py-1 text-right">
+                        <Button size="sm" variant="secondary" onClick={() => handleAction(e.id, 'uncommit')} disabled={actionLoading === e.id}>
+                          {actionLoading === e.id ? '...' : 'Undo'}
                         </Button>
-                        <button className="text-brand-red text-terminal-sm hover:text-brand-red px-1" onClick={() => handleDelete(e.id)}>×</button>
-                      </span>
-                    </td>
-                  </tr>
-                ))}
-                {committed.map((e, i) => (
-                  <tr key={e.id} className={`${(draft.length + i) % 2 === 0 ? 'bg-white' : 'bg-bg-row'} border-b border-border-light hover:bg-brand-purple-deep/[.05]`}>
-                    <td className="px-2 py-1 text-text-primary font-medium">{e.name}</td>
-                    <td className="px-2 py-1 text-text-muted font-mono">{e.coa_code}</td>
-                    <td className="px-2 py-1 text-text-secondary">{CADENCE_OPTIONS.find(c => c.value === e.cadence)?.label || e.cadence}</td>
-                    <td className="px-2 py-1 text-text-muted font-mono">{fmtDate(e.target_date)}</td>
-                    <td className="px-2 py-1 text-right font-mono font-semibold text-brand-green">{fmt(e.amount)}</td>
-                    <td className="px-2 py-1 text-center"><Badge variant="success" size="sm">Active</Badge></td>
-                    <td className="px-2 py-1 text-right">
-                      <Button size="sm" variant="secondary" onClick={() => handleAction(e.id, 'uncommit')} disabled={actionLoading === e.id}>
-                        {actionLoading === e.id ? '...' : 'Undo'}
-                      </Button>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
 
-        {/* Empty State */}
-        {expenses.length === 0 && coaAccounts.length > 0 && (
-          <div className="border border-border rounded bg-white px-4 py-6 text-center">
-            <span className="text-terminal-lg">{emoji}</span>
-            <p className="text-terminal-sm text-text-muted mt-1 font-mono">No {category.toLowerCase()} expenses yet</p>
-            <p className="text-terminal-xs text-text-faint mt-0.5">Click "+ ADD" to create your first entry</p>
+            {/* Empty State */}
+            {expenses.length === 0 && coaAccounts.length > 0 && (
+              <div className="px-4 py-6 text-center">
+                <span className="text-terminal-lg">{emoji}</span>
+                <p className="text-terminal-sm text-text-muted mt-1 font-mono">No {category.toLowerCase()} expenses yet</p>
+                <p className="text-terminal-xs text-text-faint mt-0.5">Click "+ ADD" to create your first entry</p>
+              </div>
+            )}
           </div>
-        )}
+        </div>
 
         {/* Chart of Accounts Management */}
         {entityId && (
-          <COAManagementTable
-            entityId={entityId}
-            entityName={category}
-            entityType={category.toLowerCase()}
-          />
+          <div className="rounded-lg overflow-hidden border border-gray-200/50 shadow-sm">
+            <div className="bg-brand-purple/80 text-white px-4 py-2.5 text-sm font-semibold flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <span className="text-[9px] uppercase text-white/60 font-mono tracking-wider">COA</span>
+                <span>Chart of Accounts</span>
+              </div>
+              <span className="text-xs text-white/70">{category}</span>
+            </div>
+            <div className="bg-white p-3">
+              <COAManagementTable
+                entityId={entityId}
+                entityName={category}
+                entityType={category.toLowerCase()}
+              />
+            </div>
+          </div>
         )}
       </div>
     </AppLayout>


### PR DESCRIPTION
…s, fix header styling

- Add accountCode query param filtering to GET /api/transactions
- COAManagementTable: remove View Txns column, hide $0 balance accounts with toggle to show/hide, make balances clickable to expand inline drill-down panel showing transactions with COA reassignment dropdown
- Drill-down panel fetches transactions by accountCode, shows date/merchant/ description/amount, and allows reassigning via /api/transactions/assign-coa
- BudgetingPage: wrap budget section and COA section in BookkeepingSection-style purple headers (bg-brand-purple/80 with rounded-lg shadow-sm pattern)

https://claude.ai/code/session_01VhnpMQwGJettRMvuPpSgNV