### PR TITLE
fix: critical - scope all COA queries by entity_id to prevent cross-e…

### DIFF
--- a/src/app/api/transactions/route.ts
+++ b/src/app/api/transactions/route.ts
@@ -24,6 +24,7 @@ export async function GET(request: Request) {
 
     const { searchParams } = new URL(request.url);
     const accountCode = searchParams.get('accountCode');
+    const entityId = searchParams.get('entityId');
 
     // Get transactions for accounts owned by this user
     const transactions = await prisma.transactions.findMany({
@@ -32,6 +33,7 @@ export async function GET(request: Request) {
           userId: user.id
         },
         ...(accountCode && { accountCode }),
+        ...(entityId && { entity_id: entityId }),
       },
       include: {
         accounts: {

--- a/src/components/bookkeeping/COAManagementTable.tsx
+++ b/src/components/bookkeeping/COAManagementTable.tsx
@@ -190,7 +190,7 @@ export default function COAManagementTable({ entityId, entityName, entityType }:
     setExpandedCode(code);
     setDrilldownLoading(true);
     try {
-      const res = await fetch(`/api/transactions?accountCode=${encodeURIComponent(code)}`);
+      const res = await fetch(`/api/transactions?accountCode=${encodeURIComponent(code)}&entityId=${encodeURIComponent(entityId)}`);
       if (res.ok) {
         const data = await res.json();
         setDrilldownTxns(data.transactions || []);


### PR DESCRIPTION
…ntity data leakage

When COA codes like 6200 exist in multiple entities (e.g. Personal "Travel & Vacation" and Business "Software & SaaS"), filtering by accountCode alone returns transactions from ALL entities.

Changes:
- GET /api/transactions: add entityId query param to filter transactions by entity_id alongside accountCode
- COAManagementTable drill-down: pass entityId (already available as prop) when fetching transactions for a COA code

The /api/ledger endpoint already supported entityId filtering and GeneralLedger.tsx already passed both params — no changes needed there.

https://claude.ai/code/session_01VhnpMQwGJettRMvuPpSgNV