### PR TITLE
feat: move COA table to top of entity pages with matching section header

### DIFF
--- a/src/app/trading/page.tsx
+++ b/src/app/trading/page.tsx
@@ -10,6 +10,7 @@ import DataObservatory from '@/components/data-observatory/DataObservatory';
 import type { ScannerFilters } from '@/lib/convergence/filter-types';
 import { DEFAULT_FILTERS, AVAILABLE_STRATEGIES } from '@/lib/convergence/filter-types';
 import COAManagementTable from '@/components/bookkeeping/COAManagementTable';
+import BookkeepingSection from '@/components/bookkeeping/BookkeepingSection';
 
 
 interface TradeSummary {
@@ -683,7 +684,27 @@ export default function TradingPage() {
     <AppLayout>
       <div className="min-h-screen bg-bg-terminal">
         <div className="p-4 lg:p-6 max-w-[1800px] mx-auto">
-          
+
+          {/* Chart of Accounts Management */}
+          {tradingEntityId && (
+            <div className="mb-4">
+              <BookkeepingSection
+                title="Chart of Accounts"
+                pipelineKey="COA"
+                subtitle="Trading"
+                status="complete"
+              >
+                <div className="p-3">
+                  <COAManagementTable
+                    entityId={tradingEntityId}
+                    entityName="Trading"
+                    entityType="trading"
+                  />
+                </div>
+              </BookkeepingSection>
+            </div>
+          )}
+
           {/* ── Purple Background Zone ── */}
           <div className="-mx-4 lg:-mx-6 -mt-4 lg:-mt-6 px-3 lg:px-6 py-3 pb-5 bg-brand-purple/95 backdrop-blur-sm sticky top-0 z-40">
             <div className="max-w-[1800px] mx-auto">
@@ -1148,17 +1169,6 @@ export default function TradingPage() {
               </button>
             </div>
           </div>
-        </div>
-      )}
-
-      {/* Chart of Accounts Management */}
-      {tradingEntityId && (
-        <div className="p-4 lg:p-6 max-w-[1800px] mx-auto">
-          <COAManagementTable
-            entityId={tradingEntityId}
-            entityName="Trading"
-            entityType="trading"
-          />
         </div>
       )}
 

--- a/src/components/dashboard/BudgetingPage.tsx
+++ b/src/components/dashboard/BudgetingPage.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react';
 import { AppLayout, Button, Badge } from '@/components/ui';
 import COAManagementTable from '@/components/bookkeeping/COAManagementTable';
+import BookkeepingSection from '@/components/bookkeeping/BookkeepingSection';
 
 interface Expense {
   id: string;
@@ -129,6 +130,24 @@ export default function BudgetingPage({ category, emoji, apiPath }: BudgetingPag
   return (
     <AppLayout>
       <div className="max-w-6xl mx-auto px-4 py-3 space-y-3">
+        {/* Chart of Accounts Management */}
+        {entityId && (
+          <BookkeepingSection
+            title="Chart of Accounts"
+            pipelineKey="COA"
+            subtitle={category}
+            status="complete"
+          >
+            <div className="p-3">
+              <COAManagementTable
+                entityId={entityId}
+                entityName={category}
+                entityType={category.toLowerCase()}
+              />
+            </div>
+          </BookkeepingSection>
+        )}
+
         {/* Budget Section */}
         <div className="rounded-lg overflow-hidden border border-gray-200/50 shadow-sm">
           <div className="bg-brand-purple/80 text-white px-4 py-2.5 text-sm font-semibold flex items-center justify-between">
@@ -275,25 +294,6 @@ export default function BudgetingPage({ category, emoji, apiPath }: BudgetingPag
           </div>
         </div>
 
-        {/* Chart of Accounts Management */}
-        {entityId && (
-          <div className="rounded-lg overflow-hidden border border-gray-200/50 shadow-sm">
-            <div className="bg-brand-purple/80 text-white px-4 py-2.5 text-sm font-semibold flex items-center justify-between">
-              <div className="flex items-center gap-2">
-                <span className="text-[9px] uppercase text-white/60 font-mono tracking-wider">COA</span>
-                <span>Chart of Accounts</span>
-              </div>
-              <span className="text-xs text-white/70">{category}</span>
-            </div>
-            <div className="bg-white p-3">
-              <COAManagementTable
-                entityId={entityId}
-                entityName={category}
-                entityType={category.toLowerCase()}
-              />
-            </div>
-          </div>
-        )}
       </div>
     </AppLayout>
   );


### PR DESCRIPTION
- Import BookkeepingSection into BudgetingPage and Trading page
- Wrap COAManagementTable in BookkeepingSection with pipelineKey="COA", matching the purple header bar pattern used across the bookkeeping UI
- Move COA section to render FIRST on Personal, Business, and Trading pages (was previously at the bottom)
- Replace the manually-constructed purple header in BudgetingPage with the reusable BookkeepingSection component

https://claude.ai/code/session_01VhnpMQwGJettRMvuPpSgNV