### PR TITLE
feat: trade-to-ledger pipeline - commit closed trades as journal entries

### DIFF
--- a/src/app/api/trading/commit-to-ledger/route.ts
+++ b/src/app/api/trading/commit-to-ledger/route.ts
@@ -1,0 +1,215 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { assertPeriodOpen, PeriodClosedError } from '@/lib/period-close-guard';
+
+function dollarsToCents(amount: number): bigint {
+  return BigInt(Math.round(amount * 100));
+}
+
+function updateBalance(entryType: string, accountBalanceType: string, amountCents: bigint): bigint {
+  return entryType === accountBalanceType ? amountCents : -amountCents;
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const user = await prisma.users.findFirst({
+      where: { email: { equals: userEmail, mode: 'insensitive' } },
+    });
+    if (!user) {
+      return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    }
+
+    const { tradeNums } = await request.json();
+    if (!tradeNums || !Array.isArray(tradeNums) || tradeNums.length === 0) {
+      return NextResponse.json({ error: 'tradeNums array required' }, { status: 400 });
+    }
+
+    // Resolve Trading entity
+    const tradingEntity = await prisma.entities.findFirst({
+      where: { userId: user.id, entity_type: 'trading' },
+    });
+    if (!tradingEntity) {
+      return NextResponse.json({ error: 'No Trading entity found for user' }, { status: 400 });
+    }
+    const entityId = tradingEntity.id;
+
+    // Look up COA accounts: T-1010 (Trading Cash), T-4100 (Trading Gains), T-5100 (Trading Losses)
+    const [cashAccount, gainsAccount, lossesAccount] = await Promise.all([
+      prisma.chart_of_accounts.findUnique({
+        where: { userId_entity_id_code: { userId: user.id, entity_id: entityId, code: 'T-1010' } },
+      }),
+      prisma.chart_of_accounts.findUnique({
+        where: { userId_entity_id_code: { userId: user.id, entity_id: entityId, code: 'T-4100' } },
+      }),
+      prisma.chart_of_accounts.findUnique({
+        where: { userId_entity_id_code: { userId: user.id, entity_id: entityId, code: 'T-5100' } },
+      }),
+    ]);
+
+    if (!cashAccount || !gainsAccount || !lossesAccount) {
+      const missing = [];
+      if (!cashAccount) missing.push('T-1010');
+      if (!gainsAccount) missing.push('T-4100');
+      if (!lossesAccount) missing.push('T-5100');
+      return NextResponse.json(
+        { error: `Missing Trading COA accounts: ${missing.join(', ')}. Initialize bookkeeping first.` },
+        { status: 400 }
+      );
+    }
+
+    let committed = 0;
+    let skipped = 0;
+    const errors: string[] = [];
+
+    for (const tradeNum of tradeNums) {
+      try {
+        // Idempotency: check if already committed
+        const existing = await prisma.journal_entries.findFirst({
+          where: { userId: user.id, source_type: 'trading_position', source_id: tradeNum },
+        });
+        if (existing) {
+          skipped++;
+          continue;
+        }
+
+        // Fetch all closed positions for this trade
+        // Security: verify ownership through investment_transactions → accounts → userId
+        const positions = await prisma.trading_positions.findMany({
+          where: { trade_num: tradeNum, status: 'CLOSED' },
+        });
+
+        if (positions.length === 0) {
+          errors.push(`Trade #${tradeNum}: no closed positions found`);
+          continue;
+        }
+
+        // Verify ownership: check that open_investment_txn_id belongs to user
+        const txnIds = positions.map(p => p.open_investment_txn_id);
+        const ownedTxns = await prisma.investment_transactions.findMany({
+          where: { id: { in: txnIds }, accounts: { userId: user.id } },
+          select: { id: true },
+        });
+        if (ownedTxns.length === 0) {
+          errors.push(`Trade #${tradeNum}: positions do not belong to this user`);
+          continue;
+        }
+
+        // Sum realized P&L across all legs
+        const netPL = positions.reduce((sum, p) => sum + (p.realized_pl ?? 0), 0);
+
+        // Skip zero P&L trades
+        if (Math.abs(netPL) < 0.005) {
+          skipped++;
+          continue;
+        }
+
+        // Get close date (latest across legs)
+        const closeDate = positions.reduce<Date | null>((latest, p) => {
+          if (!p.close_date) return latest;
+          if (!latest || p.close_date > latest) return p.close_date;
+          return latest;
+        }, null) || new Date();
+
+        // Build description from first position
+        const symbol = positions[0].symbol;
+        const strategy = positions[0].strategy || 'unknown';
+        const plLabel = netPL > 0 ? 'WIN' : 'LOSS';
+        const description = `${symbol} ${strategy} - Trade #${tradeNum} - ${plLabel}`;
+
+        const amountCents = dollarsToCents(Math.abs(netPL));
+        const isWin = netPL > 0;
+
+        // WIN: DR T-1010 (Cash), CR T-4100 (Gains)
+        // LOSS: DR T-5100 (Losses), CR T-1010 (Cash)
+        const debitAccount = isWin ? cashAccount : lossesAccount;
+        const creditAccount = isWin ? gainsAccount : cashAccount;
+
+        // Period close enforcement
+        await assertPeriodOpen(prisma, user.id, entityId, closeDate);
+
+        // Create JE + ledger entries + update balances in a single transaction
+        await prisma.$transaction(async (tx) => {
+          const journalEntry = await tx.journal_entries.create({
+            data: {
+              userId: user.id,
+              entity_id: entityId,
+              date: closeDate,
+              description,
+              source_type: 'trading_position',
+              source_id: tradeNum,
+              status: 'posted',
+              created_by: userEmail,
+            },
+          });
+
+          // Debit ledger entry
+          await tx.ledger_entries.create({
+            data: {
+              journal_entry_id: journalEntry.id,
+              account_id: debitAccount.id,
+              entry_type: 'D',
+              amount: amountCents,
+              created_by: userEmail,
+            },
+          });
+
+          // Credit ledger entry
+          await tx.ledger_entries.create({
+            data: {
+              journal_entry_id: journalEntry.id,
+              account_id: creditAccount.id,
+              entry_type: 'C',
+              amount: amountCents,
+              created_by: userEmail,
+            },
+          });
+
+          // Update settled_balance on debit account
+          await tx.chart_of_accounts.update({
+            where: { id: debitAccount.id },
+            data: {
+              settled_balance: { increment: updateBalance('D', debitAccount.balance_type, amountCents) },
+              version: { increment: 1 },
+            },
+          });
+
+          // Update settled_balance on credit account
+          await tx.chart_of_accounts.update({
+            where: { id: creditAccount.id },
+            data: {
+              settled_balance: { increment: updateBalance('C', creditAccount.balance_type, amountCents) },
+              version: { increment: 1 },
+            },
+          });
+        });
+
+        committed++;
+      } catch (err) {
+        if (err instanceof PeriodClosedError) {
+          errors.push(`Trade #${tradeNum}: ${err.message}`);
+          continue;
+        }
+        const message = err instanceof Error ? err.message : 'Unknown error';
+        // Handle duplicate JE (unique constraint)
+        if (message.includes('Unique constraint') || message.includes('unique constraint')) {
+          skipped++;
+          continue;
+        }
+        console.error(`Error committing trade #${tradeNum}:`, err);
+        errors.push(`Trade #${tradeNum}: ${message}`);
+      }
+    }
+
+    return NextResponse.json({ committed, skipped, errors });
+  } catch (error) {
+    console.error('Trade commit API error:', error);
+    const message = error instanceof Error ? error.message : 'Internal server error';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/trading/page.tsx
+++ b/src/app/trading/page.tsx
@@ -93,7 +93,12 @@ export default function TradingPage() {
   const [tradesData, setTradesData] = useState<TradesData | null>(null);
   const [journalEntries, setJournalEntries] = useState<JournalEntry[]>([]);
   const [loading, setLoading] = useState(true);
-  
+
+  // Trade-to-ledger commit state
+  const [committedTradeNums, setCommittedTradeNums] = useState<Set<string>>(new Set());
+  const [commitLoading, setCommitLoading] = useState(false);
+  const [commitResult, setCommitResult] = useState<{ committed: number; skipped: number; errors: string[] } | null>(null);
+
   // Date range filter
   const [dateFrom, setDateFrom] = useState<string>('');
   const [dateTo, setDateTo] = useState<string>('');
@@ -396,6 +401,22 @@ export default function TradingPage() {
 
   const fmtCurrency = (n: number) => n.toLocaleString('en-US', { style: 'currency', currency: 'USD' });
 
+  // Fetch committed trade nums from journal entries
+  const loadCommittedTrades = useCallback(async () => {
+    try {
+      const res = await fetch('/api/journal-transactions?source_type=trading_position');
+      if (res.ok) {
+        const data = await res.json();
+        const nums = new Set<string>(
+          (data.entries || [])
+            .filter((e: any) => e.source_type === 'trading_position' && e.source_id)
+            .map((e: any) => e.source_id)
+        );
+        setCommittedTradeNums(nums);
+      }
+    } catch { /* ignore */ }
+  }, []);
+
   useEffect(() => {
     Promise.all([
       fetch('/api/trading/trades').then(res => res.json()),
@@ -409,7 +430,8 @@ export default function TradingPage() {
       })
       .catch(console.error)
       .finally(() => setLoading(false));
-  }, []);
+    loadCommittedTrades();
+  }, [loadCommittedTrades]);
 
   // Filtered trades based on date range
   const filteredTrades = useMemo(() => {
@@ -563,6 +585,43 @@ export default function TradingPage() {
       details: data.trades.map(t => `${t.underlying} | ${t.strategy.replace(/-/g, ' ').replace(/\b\w/g, c => c.toUpperCase())}`),
     }));
   }, [plByDate]);
+
+  // Uncommitted closed trades (for ledger commit)
+  const uncommittedTrades = useMemo(() => {
+    if (!tradesData?.trades) return [];
+    return tradesData.trades.filter(t =>
+      t.status === 'CLOSED' &&
+      t.tradeNum &&
+      Math.abs(t.realizedPL) >= 0.01 &&
+      !committedTradeNums.has(t.tradeNum)
+    );
+  }, [tradesData, committedTradeNums]);
+
+  const commitTradesToLedger = async () => {
+    if (uncommittedTrades.length === 0) return;
+    setCommitLoading(true);
+    setCommitResult(null);
+    try {
+      const tradeNums = [...new Set(uncommittedTrades.map(t => t.tradeNum!))];
+      const res = await fetch('/api/trading/commit-to-ledger', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ tradeNums }),
+      });
+      if (res.ok) {
+        const result = await res.json();
+        setCommitResult(result);
+        await loadCommittedTrades();
+      } else {
+        const data = await res.json().catch(() => ({}));
+        setCommitResult({ committed: 0, skipped: 0, errors: [data.error || 'Failed to commit'] });
+      }
+    } catch (err) {
+      setCommitResult({ committed: 0, skipped: 0, errors: ['Network error'] });
+    } finally {
+      setCommitLoading(false);
+    }
+  };
 
   const PL_SOURCE_CONFIG: Record<string, SourceConfig> = {
     win: { label: 'Win', icon: '', bg: 'bg-emerald-50', dot: 'bg-emerald-500', badge: 'bg-emerald-500' },
@@ -871,6 +930,39 @@ export default function TradingPage() {
                     entityName="Trading"
                     entityType="trading"
                   />
+                </div>
+              </div>
+            )}
+
+            {/* Commit Trades to Ledger */}
+            {uncommittedTrades.length > 0 && (
+              <div className="overflow-hidden border-x border-b border-gray-200/50">
+                <div className="bg-brand-purple/80 text-white px-4 py-2.5 text-sm font-semibold">Commit Trades to Ledger</div>
+                <div className="bg-white px-4 py-3 flex items-center justify-between">
+                  <div>
+                    <span className="text-sm text-text-primary font-medium">
+                      {uncommittedTrades.length} closed trade{uncommittedTrades.length !== 1 ? 's' : ''} not yet in ledger
+                    </span>
+                    <span className="text-xs text-text-muted ml-2">
+                      (Net P&L: {fmtCurrency(uncommittedTrades.reduce((s, t) => s + t.realizedPL, 0))})
+                    </span>
+                  </div>
+                  <div className="flex items-center gap-3">
+                    {commitResult && (
+                      <span className={`text-xs ${commitResult.errors.length > 0 ? 'text-red-500' : 'text-emerald-600'}`}>
+                        {commitResult.committed > 0 && `${commitResult.committed} committed`}
+                        {commitResult.skipped > 0 && ` · ${commitResult.skipped} skipped`}
+                        {commitResult.errors.length > 0 && ` · ${commitResult.errors.length} error${commitResult.errors.length !== 1 ? 's' : ''}`}
+                      </span>
+                    )}
+                    <button
+                      onClick={commitTradesToLedger}
+                      disabled={commitLoading}
+                      className="px-4 py-1.5 text-xs font-semibold bg-brand-gold text-white rounded hover:bg-brand-gold/90 disabled:opacity-50"
+                    >
+                      {commitLoading ? 'Committing...' : 'Commit to Ledger'}
+                    </button>
+                  </div>
                 </div>
               </div>
             )}


### PR DESCRIPTION
Add POST /api/trading/commit-to-ledger endpoint that converts closed trading positions into double-entry journal entries:

- Accepts { tradeNums: string[] } array of trade numbers
- For each closed trade, sums realized P&L across all position legs
- WIN (P&L > 0): DR T-1010 Trading Cash, CR T-4100 Trading Gains
- LOSS (P&L < 0): DR T-5100 Trading Losses, CR T-1010 Trading Cash
- Creates journal_entries with source_type="trading_position", source_id=tradeNum for idempotency
- Updates chart_of_accounts settled_balance for both accounts
- Respects period close enforcement via assertPeriodOpen
- Verifies user ownership through investment_transactions → accounts
- Skips zero P&L trades and already-committed trades

Add "Commit Trades to Ledger" section on Trading page:
- Shows count of uncommitted closed trades with net P&L
- Gold "Commit to Ledger" button (matches site style)
- Fetches committed trade nums from journal-transactions API
- Shows result summary after commit (committed/skipped/errors)

https://claude.ai/code/session_01VhnpMQwGJettRMvuPpSgNV