### PR TITLE
fix: investment commit pipeline - null COA assignment, unique request…

### DIFF
--- a/src/app/api/investment-transactions/assign-coa/route.ts
+++ b/src/app/api/investment-transactions/assign-coa/route.ts
@@ -15,7 +15,8 @@ export async function POST(request: Request) {
     });
     if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
 
-    const { transactionIds, accountCode, subAccount, strategy, tradeNum } = await request.json();
+    const body = await request.json();
+    const { transactionIds } = body;
 
     console.log('Investment transaction IDs received:', transactionIds);
 
@@ -27,16 +28,22 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: 'Forbidden: not all transactions belong to user' }, { status: 403 });
     }
 
+    // Only update fields that were explicitly provided in the request body
+    const updateData: Record<string, string | null> = {};
+    if ('accountCode' in body) updateData.accountCode = body.accountCode || null;
+    if ('subAccount' in body) updateData.subAccount = body.subAccount || null;
+    if ('strategy' in body) updateData.strategy = body.strategy || null;
+    if ('tradeNum' in body) updateData.tradeNum = body.tradeNum || null;
+
+    if (Object.keys(updateData).length === 0) {
+      return NextResponse.json({ error: 'No fields to update' }, { status: 400 });
+    }
+
     await prisma.investment_transactions.updateMany({
       where: {
         id: { in: ownedTxns.map(t => t.id) }
       },
-      data: {
-        accountCode: accountCode || null,
-        subAccount: subAccount || null,
-        strategy: strategy || null,
-        tradeNum: tradeNum || null
-      }
+      data: updateData
     });
 
     console.log('✓ Updated investment_transactions table');

--- a/src/app/api/investment-transactions/uncommit/route.ts
+++ b/src/app/api/investment-transactions/uncommit/route.ts
@@ -35,7 +35,7 @@ export async function POST(request: Request) {
     }
 
     const now = new Date();
-    const requestId = randomUUID();
+    const batchId = randomUUID();
     const reversalIds: string[] = [];
 
     await prisma.$transaction(async (tx) => {
@@ -108,7 +108,7 @@ export async function POST(request: Request) {
             status: 'posted',
             is_reversal: true,
             reverses_entry_id: original.id,
-            request_id: requestId,
+            request_id: `${batchId}-${original.id}`,
             created_by: userEmail,
           }
         });


### PR DESCRIPTION
…_id per transaction

Bug 1: assign-coa nulled ALL fields (accountCode, subAccount, strategy, tradeNum) even when only one field was sent. Now uses 'in' operator to check which fields were explicitly provided in the request body, only updating those. Sending { accountCode: null } now correctly clears just the COA assignment without touching strategy/tradeNum.

Bug 2: batch uncommit crashed with unique constraint violation on request_id. Root cause: migration 20260302000100 added a partial unique index on journal_entries.request_id (SOC2 IDEMP control). The uncommit flow generated ONE requestId (randomUUID) and reused it for ALL reversal journal entries in the batch. Fix: generate per-reversal request_id as `${batchId}-${originalJournalEntryId}` so each reversal gets a unique value while preserving batch traceability.

Bug 3 (commit): confirmed NOT a request_id issue. The position tracker service already generates a fresh randomUUID per createJournalEntry call. Batch commit P2002 errors are correctly caught as "already committed" at line 142.

https://claude.ai/code/session_01VhnpMQwGJettRMvuPpSgNV