### PR TITLE
fix: COA dropdown entity labels + cross-entity warning + admin entity…

### DIFF
--- a/src/app/api/admin/fix-entity-assignment/route.ts
+++ b/src/app/api/admin/fix-entity-assignment/route.ts
@@ -1,0 +1,248 @@
+import { randomUUID } from 'crypto';
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { ADMIN_USER_ID } from '@/lib/tiers';
+import { assertPeriodOpen, PeriodClosedError } from '@/lib/period-close-guard';
+
+function dollarsToCents(amount: number): bigint {
+  return BigInt(Math.round(amount * 100));
+}
+
+function updateBalance(entryType: string, accountBalanceType: string, amountCents: bigint): bigint {
+  return entryType === accountBalanceType ? amountCents : -amountCents;
+}
+
+/**
+ * POST /api/admin/fix-entity-assignment
+ *
+ * Moves committed Plaid transactions from one entity to another by:
+ * 1. Reversing the original journal entry on the old entity
+ * 2. Creating a new journal entry on the target entity
+ * 3. Updating the transaction's entity_id
+ *
+ * Admin-only endpoint.
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const user = await prisma.users.findFirst({
+      where: { email: { equals: userEmail, mode: 'insensitive' } },
+    });
+    if (!user) {
+      return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    }
+
+    // Admin-only
+    if (user.id !== ADMIN_USER_ID) {
+      return NextResponse.json({ error: 'Admin access required' }, { status: 403 });
+    }
+
+    const { transactionIds, targetEntityId, targetAccountCode } = await request.json();
+
+    if (!transactionIds?.length || !targetEntityId || !targetAccountCode) {
+      return NextResponse.json(
+        { error: 'Required: transactionIds, targetEntityId, targetAccountCode' },
+        { status: 400 }
+      );
+    }
+
+    // Verify target entity belongs to user
+    const targetEntity = await prisma.entities.findFirst({
+      where: { id: targetEntityId, userId: user.id },
+    });
+    if (!targetEntity) {
+      return NextResponse.json({ error: 'Target entity not found' }, { status: 404 });
+    }
+
+    // Verify target COA account exists
+    const targetCoaAccount = await prisma.chart_of_accounts.findUnique({
+      where: { userId_entity_id_code: { userId: user.id, entity_id: targetEntityId, code: targetAccountCode } },
+    });
+    if (!targetCoaAccount) {
+      return NextResponse.json(
+        { error: `Target COA account ${targetAccountCode} not found on entity ${targetEntityId}` },
+        { status: 404 }
+      );
+    }
+
+    // Verify transactions belong to user
+    const ownedTxns = await prisma.transactions.findMany({
+      where: { id: { in: transactionIds }, accounts: { userId: user.id } },
+      include: { accounts: true },
+    });
+    if (ownedTxns.length !== transactionIds.length) {
+      return NextResponse.json({ error: 'Some transactions not found or not owned' }, { status: 403 });
+    }
+
+    const batchId = randomUUID();
+    const results: { txnId: string; reversalId: string; newJeId: string }[] = [];
+    const errors: string[] = [];
+
+    for (const txn of ownedTxns) {
+      try {
+        await prisma.$transaction(async (tx) => {
+          // 1. Find the original journal entry
+          const original = await tx.journal_entries.findFirst({
+            where: {
+              source_type: 'plaid_txn',
+              source_id: txn.transactionId,
+              is_reversal: false,
+              reversed_by_entry_id: null,
+            },
+            include: {
+              ledger_entries: {
+                include: { account: { select: { id: true, balance_type: true, code: true, entity_id: true } } },
+              },
+            },
+          });
+
+          if (!original) {
+            throw new Error(`No committed journal entry found for txn ${txn.transactionId}`);
+          }
+
+          // 2. Period close check
+          const now = new Date();
+          await assertPeriodOpen(tx, user.id, original.entity_id, now);
+          await assertPeriodOpen(tx, user.id, targetEntityId, new Date(txn.date));
+
+          // 3. Create reversal for original
+          const reversalEntry = await tx.journal_entries.create({
+            data: {
+              userId: user.id,
+              entity_id: original.entity_id,
+              date: now,
+              description: `REVERSAL (entity fix): ${original.description}`,
+              source_type: 'reversal',
+              source_id: null,
+              status: 'posted',
+              is_reversal: true,
+              reverses_entry_id: original.id,
+              request_id: `${batchId}-rev-${txn.transactionId}`,
+              created_by: userEmail,
+            },
+          });
+
+          // Reverse ledger entries and COA balances
+          for (const entry of original.ledger_entries) {
+            const oppositeType = entry.entry_type === 'D' ? 'C' : 'D';
+
+            await tx.ledger_entries.create({
+              data: {
+                journal_entry_id: reversalEntry.id,
+                account_id: entry.account_id,
+                entry_type: oppositeType,
+                amount: entry.amount,
+                created_by: userEmail,
+              },
+            });
+
+            await tx.chart_of_accounts.update({
+              where: { id: entry.account.id },
+              data: {
+                settled_balance: { increment: updateBalance(oppositeType, entry.account.balance_type, entry.amount) },
+                version: { increment: 1 },
+              },
+            });
+          }
+
+          // Mark original as reversed
+          await tx.journal_entries.update({
+            where: { id: original.id },
+            data: { status: 'reversed', reversed_by_entry_id: reversalEntry.id },
+          });
+
+          // 4. Look up bank COA account for the target entity
+          const bankAccountCode = txn.accounts.accountCode;
+          let bankEntityId = targetEntityId;
+          if (txn.accounts.entityType) {
+            const bankEntity = await tx.entities.findFirst({
+              where: { userId: user.id, entity_type: txn.accounts.entityType },
+            });
+            if (bankEntity) bankEntityId = bankEntity.id;
+          }
+          const bankAccount = bankAccountCode
+            ? await tx.chart_of_accounts.findUnique({
+                where: { userId_entity_id_code: { userId: user.id, entity_id: bankEntityId, code: bankAccountCode } },
+              })
+            : null;
+
+          if (!bankAccount) {
+            throw new Error(`Bank COA account ${bankAccountCode} not found on entity ${bankEntityId}`);
+          }
+
+          // 5. Create new journal entry on target entity
+          const amountCents = dollarsToCents(Math.abs(txn.amount));
+          const isExpense = txn.amount > 0;
+          const debitAccountId = isExpense ? targetCoaAccount.id : bankAccount.id;
+          const creditAccountId = isExpense ? bankAccount.id : targetCoaAccount.id;
+          const debitBalanceType = isExpense ? targetCoaAccount.balance_type : bankAccount.balance_type;
+          const creditBalanceType = isExpense ? bankAccount.balance_type : targetCoaAccount.balance_type;
+
+          const newJe = await tx.journal_entries.create({
+            data: {
+              userId: user.id,
+              entity_id: targetEntityId,
+              date: new Date(txn.date),
+              description: txn.name,
+              source_type: 'plaid_txn',
+              source_id: txn.transactionId,
+              status: 'posted',
+              request_id: `${batchId}-new-${txn.transactionId}`,
+              created_by: userEmail,
+            },
+          });
+
+          await tx.ledger_entries.create({
+            data: { journal_entry_id: newJe.id, account_id: debitAccountId, entry_type: 'D', amount: amountCents, created_by: userEmail },
+          });
+          await tx.ledger_entries.create({
+            data: { journal_entry_id: newJe.id, account_id: creditAccountId, entry_type: 'C', amount: amountCents, created_by: userEmail },
+          });
+
+          await tx.chart_of_accounts.update({
+            where: { id: debitAccountId },
+            data: { settled_balance: { increment: updateBalance('D', debitBalanceType, amountCents) }, version: { increment: 1 } },
+          });
+          await tx.chart_of_accounts.update({
+            where: { id: creditAccountId },
+            data: { settled_balance: { increment: updateBalance('C', creditBalanceType, amountCents) }, version: { increment: 1 } },
+          });
+
+          // 6. Update transaction's entity_id and accountCode
+          await tx.transactions.update({
+            where: { id: txn.id },
+            data: { entity_id: targetEntityId, accountCode: targetAccountCode },
+          });
+
+          results.push({ txnId: txn.id, reversalId: reversalEntry.id, newJeId: newJe.id });
+        });
+      } catch (err) {
+        if (err instanceof PeriodClosedError) {
+          errors.push(`Txn ${txn.id}: ${err.message}`);
+          continue;
+        }
+        const msg = err instanceof Error ? err.message : 'Unknown error';
+        console.error(`Fix entity error for txn ${txn.id}:`, err);
+        errors.push(`Txn ${txn.id}: ${msg}`);
+      }
+    }
+
+    return NextResponse.json({
+      success: results.length > 0,
+      fixed: results.length,
+      errors,
+      results,
+    });
+  } catch (error) {
+    console.error('Fix entity assignment error:', error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/transactions/uncommit/route.ts
+++ b/src/app/api/transactions/uncommit/route.ts
@@ -38,7 +38,7 @@ export async function POST(request: Request) {
       );
     }
 
-    const requestId = randomUUID();
+    const batchId = randomUUID();
     const results = [];
     const errors = [];
 
@@ -66,7 +66,7 @@ export async function POST(request: Request) {
           userId: user.id,
           journalEntryId: originalEntry.id,
           transactionId: txn.transactionId,
-          requestId,
+          requestId: `${batchId}-${txn.transactionId}`,
           createdBy: userEmail,
         });
 

--- a/src/components/dashboard/SpendingTab.tsx
+++ b/src/components/dashboard/SpendingTab.tsx
@@ -7,6 +7,13 @@ import { Button } from '@/components/ui';
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
+const ENTITY_LABELS: Record<string, string> = {
+  personal: 'Personal',
+  sole_prop: 'Business',
+  business: 'Business',
+  trading: 'Trading',
+};
+
 export interface CoaOption {
   id: string;
   code: string;
@@ -1029,12 +1036,6 @@ export default function SpendingTab({ transactions, committedTransactions, coaOp
     localCoaOptions.forEach(o => map.set(o.code, o));
     return map;
   }, [localCoaOptions]);
-
-  const ENTITY_LABELS: Record<string, string> = {
-    personal: 'Personal',
-    sole_prop: 'Business',
-    trading: 'Trading',
-  };
 
   const coaGroupedByEntity = useMemo(() => {
     const g: Record<string, CoaOption[]> = {};

--- a/src/components/dashboard/SpendingTab.tsx
+++ b/src/components/dashboard/SpendingTab.tsx
@@ -910,8 +910,8 @@ function VirtualTable({
                     >
                       <option value="">{txn.predicted_coa_code ? `${txn.predicted_coa_code} - ${coaLookup.get(txn.predicted_coa_code)?.name || 'Unknown'}` : 'Select...'}</option>
                       {Object.entries(coaGroupedByEntity).map(([entity, opts]) => (
-                        <optgroup key={entity} label={entity || 'General'}>
-                          {opts.map(o => <option key={o.id} value={`${o.code}|${o.entity_id || ''}`}>{o.code} - {o.name}</option>)}
+                        <optgroup key={entity} label={ENTITY_LABELS[entity] || entity || 'General'}>
+                          {opts.map(o => <option key={o.id} value={`${o.code}|${o.entity_id || ''}`}>{o.code} - {o.name} ({ENTITY_LABELS[o.entity_type || ''] || o.entity_type || 'General'})</option>)}
                         </optgroup>
                       ))}
                       <option value="__NEW__">+ Add Category</option>
@@ -1030,6 +1030,12 @@ export default function SpendingTab({ transactions, committedTransactions, coaOp
     return map;
   }, [localCoaOptions]);
 
+  const ENTITY_LABELS: Record<string, string> = {
+    personal: 'Personal',
+    sole_prop: 'Business',
+    trading: 'Trading',
+  };
+
   const coaGroupedByEntity = useMemo(() => {
     const g: Record<string, CoaOption[]> = {};
     localCoaOptions.forEach(o => {
@@ -1039,6 +1045,47 @@ export default function SpendingTab({ transactions, committedTransactions, coaOp
     });
     return g;
   }, [localCoaOptions]);
+
+  // Determine the dominant entity type for selected pending transactions
+  const selectedEntityType = useMemo(() => {
+    if (selectedPending.size === 0) return null;
+    const types = transactions
+      .filter(t => selectedPending.has(t.id))
+      .map(t => t.entityType)
+      .filter(Boolean);
+    if (types.length === 0) return null;
+    // Return the most common entity type among selected
+    const counts: Record<string, number> = {};
+    types.forEach(t => { counts[t!] = (counts[t!] || 0) + 1; });
+    return Object.entries(counts).sort((a, b) => b[1] - a[1])[0][0];
+  }, [transactions, selectedPending]);
+
+  // Check if batch COA is cross-entity
+  const batchCrossEntity = useMemo(() => {
+    if (!batchCoa || !selectedEntityType) return null;
+    const [, coaEntityId] = batchCoa.split('|');
+    if (!coaEntityId) return null;
+    const coaOpt = localCoaOptions.find(o => o.entity_id === coaEntityId);
+    if (!coaOpt || !coaOpt.entity_type) return null;
+    if (coaOpt.entity_type !== selectedEntityType) {
+      return {
+        txnEntity: ENTITY_LABELS[selectedEntityType] || selectedEntityType,
+        coaEntity: ENTITY_LABELS[coaOpt.entity_type] || coaOpt.entity_type,
+      };
+    }
+    return null;
+  }, [batchCoa, selectedEntityType, localCoaOptions]);
+
+  // Sort entity groups: matching entity first
+  const sortedCoaGroups = useMemo(() => {
+    const entries = Object.entries(coaGroupedByEntity);
+    if (!selectedEntityType) return entries;
+    return entries.sort(([a], [b]) => {
+      if (a === selectedEntityType) return -1;
+      if (b === selectedEntityType) return 1;
+      return 0;
+    });
+  }, [coaGroupedByEntity, selectedEntityType]);
 
   // Unique values for filters
   const pendingMerchants = useMemo(() => {
@@ -1399,13 +1446,18 @@ export default function SpendingTab({ transactions, committedTransactions, coaOp
               className="flex-1 min-w-[200px] bg-brand-purple-hover text-white border-0 text-terminal-base font-mono px-2 py-1 rounded"
             >
               <option value="">Select COA...</option>
-              {Object.entries(coaGroupedByEntity).map(([entity, opts]) => (
-                <optgroup key={entity} label={entity || 'General'}>
-                  {opts.map(o => <option key={o.id} value={`${o.code}|${o.entity_id || ''}`}>{o.code} - {o.name}</option>)}
+              {sortedCoaGroups.map(([entity, opts]) => (
+                <optgroup key={entity} label={ENTITY_LABELS[entity] || entity || 'General'}>
+                  {opts.map(o => <option key={o.id} value={`${o.code}|${o.entity_id || ''}`}>{o.code} - {o.name} ({ENTITY_LABELS[o.entity_type || ''] || o.entity_type || 'General'})</option>)}
                 </optgroup>
               ))}
               <option value="__NEW__">+ Add Category</option>
             </select>
+            {batchCrossEntity && (
+              <span className="text-[11px] text-amber-300 font-mono">
+                ⚠ Cross-entity: txn is {batchCrossEntity.txnEntity} but COA is {batchCrossEntity.coaEntity}
+              </span>
+            )}
             <input
               type="text"
               placeholder="Sub-account"


### PR DESCRIPTION
… reassignment endpoint

Root cause: COA dropdown in SpendingTab showed all entities' accounts without labels, making it easy to accidentally assign a Personal transaction to a Trading COA account (both have code 3300).

SpendingTab changes:
- Add entity labels to every COA option: "3300 - Withdrawals (Personal)" instead of just "3300 - Withdrawals"
- Sort entity groups so matching entity appears first in batch dropdown
- Show amber cross-entity warning when selected COA entity differs from transaction's bank account entity
- Add ENTITY_LABELS map for human-readable names

Admin fix endpoint (POST /api/admin/fix-entity-assignment):
- Accepts { transactionIds, targetEntityId, targetAccountCode }
- For each transaction: reverses old JE, creates new JE on target entity, updates COA balances on both old and new entities, updates transaction entity_id — all in a single Prisma $transaction
- Admin-only (ADMIN_USER_ID check)
- Unique request_id per reversal and new entry

Spending uncommit fix (same bug as investment uncommit):
- Changed from single requestId for entire batch to per-transaction requestId (`${batchId}-${txn.transactionId}`) to avoid unique constraint violation on journal_entries.request_id

https://claude.ai/code/session_01VhnpMQwGJettRMvuPpSgNV