### PR TITLE
Wire wash sales into Form 8949 generation + fix box coding

### DIFF
--- a/src/lib/tax-report-service.ts
+++ b/src/lib/tax-report-service.ts
@@ -1,4 +1,6 @@
 import { prisma } from '@/lib/prisma';
+import { detectWashSales } from './wash-sale-service';
+import type { WashSaleViolation } from './wash-sale-service';
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
@@ -25,11 +27,38 @@ export interface Form8949Entry {
   holdingDays: number;
   symbol: string;
   assetType: 'stock' | 'option';
-  // Form 8949 Box classification:
-  // A = basis reported to IRS (1099-B with basis)
-  // B = basis NOT reported to IRS (1099-B without basis)
-  // C = no 1099-B received
-  box: 'A' | 'B' | 'C';
+  // Form 8949 Box classification (IRS Pub 551):
+  //   Short-term:            Long-term:
+  //     A = basis reported     D = basis reported
+  //     B = basis NOT reported E = basis NOT reported
+  //     C = no 1099-B          F = no 1099-B
+  box: 'A' | 'B' | 'C' | 'D' | 'E' | 'F';
+  // Plain-English justification for the chosen box (for audit trail)
+  box_reasoning: string;
+}
+
+// Sources we trust to produce broker-reported basis (1099-B covered).
+// Anything else (manual entry, legacy imports) defaults to unreported.
+const BROKER_IMPORTED_SOURCES = new Set(['plaid', 'tastytrade', 'robinhood']);
+
+function determineBox(isLongTerm: boolean, source: string | null): Form8949Entry['box'] {
+  const normalized = source ? source.toLowerCase() : null;
+  const isBrokerImported = normalized !== null && BROKER_IMPORTED_SOURCES.has(normalized);
+  if (isLongTerm) return isBrokerImported ? 'D' : 'E';
+  return isBrokerImported ? 'A' : 'B';
+}
+
+function boxReasoning(isLongTerm: boolean, source: string | null): string {
+  const term = isLongTerm ? 'long-term' : 'short-term';
+  const normalized = source ? source.toLowerCase() : null;
+  const isBrokerImported = normalized !== null && BROKER_IMPORTED_SOURCES.has(normalized);
+  if (isBrokerImported) {
+    return `Broker-reported basis (source=${source}), ${term}`;
+  }
+  if (source) {
+    return `Unreported basis (source=${source}), ${term}`;
+  }
+  return `Unknown source (defaulting to unreported), ${term}`;
 }
 
 // ============================================
@@ -52,10 +81,10 @@ export interface ScheduleD {
     line1c: ScheduleDLine;  // Box C (no 1099-B)
     line7: ScheduleDLine;   // Total short-term
   };
-  partII: { // Long-term
-    line8a: ScheduleDLine;  // Box A
-    line8b: ScheduleDLine;  // Box B
-    line8c: ScheduleDLine;  // Box C
+  partII: { // Long-term (IRS Schedule D Part II uses Boxes D/E/F)
+    line8a: ScheduleDLine;  // Box D (basis reported to IRS)
+    line8b: ScheduleDLine;  // Box E (basis NOT reported)
+    line8c: ScheduleDLine;  // Box F (no 1099-B)
     line15: ScheduleDLine;  // Total long-term
   };
   line16: ScheduleDLine;    // Net: line 7 + line 15
@@ -78,21 +107,79 @@ export interface TaxReport {
     netGainOrLoss: number;
     washSaleCount: number;
     washSaleDisallowed: number;
+    // Count of wash-sale violations merged into 8949 entries in-memory
+    // but NOT yet persisted to the DB. Call POST /api/tax/wash-sales to persist.
+    washSalesApplied: number;
   };
+  // User-facing warnings (e.g., "N wash sale violations detected but not persisted")
+  warnings: string[];
   availableYears: number[];
 }
 
 /**
  * Generate Form 8949 entries for a given user and tax year.
+ *
+ * Backward-compatible signature: returns just the entries array. Internally
+ * delegates to generateForm8949WithMetadata so that wash-sale merging and
+ * box coding still run — callers that need the warning/count metadata
+ * should use generateForm8949WithMetadata directly.
  */
 export async function generateForm8949(
   userId: string,
   taxYear: number
 ): Promise<Form8949Entry[]> {
+  const { entries } = await generateForm8949WithMetadata(userId, taxYear);
+  return entries;
+}
+
+/**
+ * Full Form 8949 generation with metadata.
+ *
+ * Behavior:
+ *   1. Calls detectWashSales(userId) to find unapplied wash-sale violations.
+ *   2. Merges violations into 8949 entries IN MEMORY ONLY — does NOT write to
+ *      the DB. This is intentional: applyWashSaleAdjustments also mutates the
+ *      replacement stock_lot's cost_per_share + total_cost_basis (see
+ *      wash-sale-service.ts:wash-sale apply), which is destructive and can
+ *      double-adjust if run twice. Users who want to persist should POST to
+ *      /api/tax/wash-sales.
+ *   3. Determines IRS Box A/B/C/D/E/F per disposition from the transaction
+ *      source (broker-imported vs. manual/legacy) and holding period.
+ */
+export async function generateForm8949WithMetadata(
+  userId: string,
+  taxYear: number
+): Promise<{
+  entries: Form8949Entry[];
+  washSalesApplied: number;
+  warnings: string[];
+}> {
   const yearStart = new Date(`${taxYear}-01-01T00:00:00.000Z`);
   const yearEnd = new Date(`${taxYear + 1}-01-01T00:00:00.000Z`);
 
   const entries: Form8949Entry[] = [];
+  const warnings: string[] = [];
+
+  // ========== WASH SALE DETECTION (in-memory merge, non-destructive) ==========
+  //
+  // detectWashSales scans ALL of the user's losing dispositions against every
+  // purchase in the ±30-day window. We use it here to overlay the 'W' adjustment
+  // on 8949 entries whose DB row hasn't yet been marked is_wash_sale=true.
+  //
+  // We do NOT call applyWashSaleAdjustments because it also rewrites the
+  // replacement lot's cost_per_share / total_cost_basis. That would turn 8949
+  // generation into a destructive operation that double-adjusts on re-run.
+  const { violations: washViolations } = await detectWashSales(userId);
+
+  // One violation per dispositionId (wash-sale-service already dedupes with
+  // IRS first-in rule, but defensively take the first if duplicates leak).
+  const violationsByDispositionId = new Map<string, WashSaleViolation>();
+  for (const v of washViolations) {
+    if (!violationsByDispositionId.has(v.dispositionId)) {
+      violationsByDispositionId.set(v.dispositionId, v);
+    }
+  }
+  let washSalesMergedCount = 0;
 
   // ========== STOCK DISPOSITIONS ==========
   const stockDispositions = await prisma.lot_dispositions.findMany({
@@ -104,11 +191,49 @@ export async function generateForm8949(
     orderBy: { disposed_date: 'asc' }
   });
 
+  // Build stock-lot source map: lot.investment_txn_id → investment_transactions.accounts.source.
+  // Used to determine whether basis was broker-reported (Box A/D) vs. manual (Box B/E).
+  const stockLotTxnIds = Array.from(
+    new Set(stockDispositions.map(d => d.lot.investment_txn_id).filter(Boolean))
+  );
+  const stockLotTxns = stockLotTxnIds.length > 0
+    ? await prisma.investment_transactions.findMany({
+        where: { id: { in: stockLotTxnIds } },
+        select: { id: true, accounts: { select: { source: true } } },
+      })
+    : [];
+  const stockTxnSourceById = new Map<string, string | null>();
+  for (const t of stockLotTxns) {
+    stockTxnSourceById.set(t.id, t.accounts?.source ?? null);
+  }
+
   for (const disp of stockDispositions) {
-    const adjustmentAmount = disp.is_wash_sale ? disp.wash_sale_loss : 0;
+    const dbAdjustment = disp.is_wash_sale ? disp.wash_sale_loss : 0;
+    const pendingViolation = !disp.is_wash_sale
+      ? violationsByDispositionId.get(disp.id)
+      : undefined;
+
+    let adjustmentCode = '';
+    let adjustmentAmount = 0;
+    if (disp.is_wash_sale) {
+      adjustmentCode = 'W';
+      adjustmentAmount = dbAdjustment;
+    } else if (pendingViolation) {
+      adjustmentCode = 'W';
+      adjustmentAmount = pendingViolation.disallowedLoss;
+      washSalesMergedCount++;
+      console.log(
+        `[Form 8949] Merged unapplied wash sale: lot_id=${disp.lot_id}, symbol=${disp.lot.symbol}, disallowed_loss=$${adjustmentAmount.toFixed(2)} (in-memory only; POST /api/tax/wash-sales to persist)`
+      );
+    }
+
     // Form 8949 column (h): gain/loss = proceeds - cost + wash sale adjustment
     // Wash sale adjustment is positive (adds to cost basis, reducing the loss reported)
     const gainOrLoss = disp.total_proceeds - disp.cost_basis_disposed + adjustmentAmount;
+
+    const source = stockTxnSourceById.get(disp.lot.investment_txn_id) ?? null;
+    const box = determineBox(disp.is_long_term, source);
+    const reasoning = boxReasoning(disp.is_long_term, source);
 
     entries.push({
       description: `${disp.quantity_disposed} sh ${disp.lot.symbol}`,
@@ -116,15 +241,15 @@ export async function generateForm8949(
       dateSold: disp.disposed_date.toISOString().split('T')[0],
       proceeds: round2(disp.total_proceeds),
       costBasis: round2(disp.cost_basis_disposed),
-      adjustmentCode: disp.is_wash_sale ? 'W' : '',
+      adjustmentCode,
       adjustmentAmount: round2(adjustmentAmount),
       gainOrLoss: round2(gainOrLoss),
       isLongTerm: disp.is_long_term,
       holdingDays: disp.holding_period_days,
       symbol: disp.lot.symbol,
       assetType: 'stock',
-      // Default to Box A (basis reported to IRS via 1099-B) for broker-imported transactions
-      box: 'A'
+      box,
+      box_reasoning: reasoning,
     });
   }
 
@@ -163,10 +288,28 @@ export async function generateForm8949(
         // Use the pre-calculated realized_pl which correctly handles
         // LONG (proceeds - cost) vs SHORT (cost - proceeds) positions.
         // Recomputing as proceeds - costBasis is wrong for short positions.
-        const gainOrLoss = pos.realized_pl ?? (proceeds - costBasis);
+        const basePL = pos.realized_pl ?? (proceeds - costBasis);
+
+        // Check for option-side wash sale (wash-sale-service uses pos.id as dispositionId for options)
+        let adjustmentCode = '';
+        let adjustmentAmount = 0;
+        const optViolation = violationsByDispositionId.get(pos.id);
+        if (optViolation) {
+          adjustmentCode = 'W';
+          adjustmentAmount = optViolation.disallowedLoss;
+          washSalesMergedCount++;
+          console.log(
+            `[Form 8949] Merged unapplied wash sale: option_position_id=${pos.id}, symbol=${pos.symbol}, disallowed_loss=$${adjustmentAmount.toFixed(2)} (in-memory only; POST /api/tax/wash-sales to persist)`
+          );
+        }
+
+        const gainOrLoss = basePL + adjustmentAmount;
 
         // Build option description: "1 AAPL Jan 20 2025 $150 Call"
         const optDesc = buildOptionDescription(pos);
+
+        const box = determineBox(isLongTerm, pos.source);
+        const reasoning = boxReasoning(isLongTerm, pos.source);
 
         entries.push({
           description: optDesc,
@@ -174,14 +317,15 @@ export async function generateForm8949(
           dateSold: closeDate.toISOString().split('T')[0],
           proceeds: round2(proceeds),
           costBasis: round2(costBasis),
-          adjustmentCode: '',
-          adjustmentAmount: 0,
+          adjustmentCode,
+          adjustmentAmount: round2(adjustmentAmount),
           gainOrLoss: round2(gainOrLoss),
           isLongTerm,
           holdingDays,
           symbol: extractUnderlying(pos.symbol),
           assetType: 'option',
-          box: 'A'
+          box,
+          box_reasoning: reasoning,
         });
       }
     }
@@ -190,7 +334,14 @@ export async function generateForm8949(
   // Sort by date sold
   entries.sort((a, b) => a.dateSold.localeCompare(b.dateSold));
 
-  return entries;
+  if (washSalesMergedCount > 0) {
+    warnings.push(
+      `${washSalesMergedCount} wash sale violation(s) detected but not yet applied to DB. ` +
+      `Call POST /api/tax/wash-sales to persist the cost-basis adjustments.`
+    );
+  }
+
+  return { entries, washSalesApplied: washSalesMergedCount, warnings };
 }
 
 /**
@@ -200,12 +351,13 @@ export function generateScheduleD(entries: Form8949Entry[]): ScheduleD {
   const shortTerm = entries.filter(e => !e.isLongTerm);
   const longTerm = entries.filter(e => e.isLongTerm);
 
+  // IRS Form 8949: short-term uses Boxes A/B/C; long-term uses Boxes D/E/F.
   const stBoxA = shortTerm.filter(e => e.box === 'A');
   const stBoxB = shortTerm.filter(e => e.box === 'B');
   const stBoxC = shortTerm.filter(e => e.box === 'C');
-  const ltBoxA = longTerm.filter(e => e.box === 'A');
-  const ltBoxB = longTerm.filter(e => e.box === 'B');
-  const ltBoxC = longTerm.filter(e => e.box === 'C');
+  const ltBoxD = longTerm.filter(e => e.box === 'D');
+  const ltBoxE = longTerm.filter(e => e.box === 'E');
+  const ltBoxF = longTerm.filter(e => e.box === 'F');
 
   const sumLine = (items: Form8949Entry[], line: string, desc: string): ScheduleDLine => ({
     line,
@@ -228,9 +380,9 @@ export function generateScheduleD(entries: Form8949Entry[]): ScheduleD {
     gainOrLoss: round2(line1a.gainOrLoss + line1b.gainOrLoss + line1c.gainOrLoss),
   };
 
-  const line8a = sumLine(ltBoxA, '8a', 'Long-term from Form 8949 Box A');
-  const line8b = sumLine(ltBoxB, '8b', 'Long-term from Form 8949 Box B');
-  const line8c = sumLine(ltBoxC, '8c', 'Long-term from Form 8949 Box C');
+  const line8a = sumLine(ltBoxD, '8a', 'Long-term from Form 8949 Box D');
+  const line8b = sumLine(ltBoxE, '8b', 'Long-term from Form 8949 Box E');
+  const line8c = sumLine(ltBoxF, '8c', 'Long-term from Form 8949 Box F');
   const line15: ScheduleDLine = {
     line: '15',
     description: 'Net long-term capital gain or (loss)',
@@ -263,7 +415,7 @@ export async function generateTaxReport(
   userId: string,
   taxYear: number
 ): Promise<TaxReport> {
-  const entries = await generateForm8949(userId, taxYear);
+  const { entries, washSalesApplied, warnings } = await generateForm8949WithMetadata(userId, taxYear);
   const scheduleD = generateScheduleD(entries);
 
   const shortTerm = entries.filter(e => !e.isLongTerm);
@@ -331,7 +483,9 @@ export async function generateTaxReport(
       netGainOrLoss: scheduleD.line16.gainOrLoss,
       washSaleCount: washSales.length,
       washSaleDisallowed: round2(washSales.reduce((s, e) => s + e.adjustmentAmount, 0)),
+      washSalesApplied,
     },
+    warnings,
     availableYears: allYears
   };
 }


### PR DESCRIPTION
- Form 8949 now detects/merges wash sale violations before generating entries
- Box coding determined from source (broker-imported vs manual) and holding period
- Adds wash_sales_applied tracking and box_reasoning for audit trail

https://claude.ai/code/session_01K74AZxjnZcGZKEfMN9Lg3g