### PR TITLE
Rewrite CPA Export: read from ledger instead of raw transactions

### DIFF
--- a/src/app/api/cpa-export/route.ts
+++ b/src/app/api/cpa-export/route.ts
@@ -1,0 +1,270 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { Prisma } from '@prisma/client';
+import { prisma } from '@/lib/prisma';
+import { getCurrentUser } from '@/lib/auth-helpers';
+
+// ═══════════════════════════════════════════════════════════════════
+// CPA Export API — Single source of truth for the 4 accountant reports.
+// All amounts are derived from the GENERAL LEDGER (journal_entries +
+// ledger_entries), NOT from raw Plaid transactions. Debit/credit is
+// taken from ledger_entries.entry_type ('D' or 'C'), NOT from amount sign.
+// ═══════════════════════════════════════════════════════════════════
+
+interface AccountAggregate {
+  accountId: string;
+  code: string;
+  name: string;
+  accountType: string;
+  balanceType: 'D' | 'C';
+  totalDebits: number;   // dollars
+  totalCredits: number;  // dollars
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const user = await getCurrentUser();
+    if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const { searchParams } = new URL(request.url);
+    const yearParam = searchParams.get('year');
+    const entityId = searchParams.get('entityId');
+
+    const year = yearParam ? parseInt(yearParam, 10) : new Date().getFullYear();
+    if (isNaN(year) || year < 2000 || year > 2100) {
+      return NextResponse.json({ error: 'Invalid year parameter' }, { status: 400 });
+    }
+
+    // Verify entity belongs to user (defense-in-depth; raw SQL filter is also applied)
+    if (entityId) {
+      const entity = await prisma.entities.findFirst({
+        where: { id: entityId, userId: user.id },
+      });
+      if (!entity) {
+        return NextResponse.json({ error: 'Entity not found' }, { status: 404 });
+      }
+    }
+
+    // Shared WHERE clause — user-scoped, reversals excluded (ASC 250), year-filtered,
+    // optionally entity-filtered. Same pattern as /api/trial-balance.
+    const conditions: Prisma.Sql[] = [
+      Prisma.sql`je."userId" = ${user.id}`,
+      Prisma.sql`je.is_reversal = false`,
+      Prisma.sql`je.reversed_by_entry_id IS NULL`,
+      Prisma.sql`EXTRACT(YEAR FROM je.date) = ${year}`,
+    ];
+    if (entityId) {
+      conditions.push(Prisma.sql`je.entity_id = ${entityId}`);
+    }
+    const whereClause = Prisma.join(conditions, ' AND ');
+
+    // ── Aggregate per-account debits/credits (cents) ──
+    const aggregateRows: Array<{
+      account_id: string;
+      code: string;
+      name: string;
+      account_type: string;
+      balance_type: string;
+      total_debits: string;
+      total_credits: string;
+    }> = await prisma.$queryRaw`
+      SELECT
+        coa.id as account_id,
+        coa.code,
+        coa.name,
+        coa.account_type,
+        coa.balance_type,
+        COALESCE(SUM(CASE WHEN le.entry_type = 'D' THEN le.amount ELSE 0 END), 0)::text as total_debits,
+        COALESCE(SUM(CASE WHEN le.entry_type = 'C' THEN le.amount ELSE 0 END), 0)::text as total_credits
+      FROM ledger_entries le
+      JOIN journal_entries je ON le.journal_entry_id = je.id
+      JOIN chart_of_accounts coa ON le.account_id = coa.id
+      WHERE ${whereClause}
+      GROUP BY coa.id, coa.code, coa.name, coa.account_type, coa.balance_type
+      ORDER BY coa.code
+    `;
+
+    const accounts: AccountAggregate[] = aggregateRows.map((r) => ({
+      accountId: r.account_id,
+      code: r.code,
+      name: r.name,
+      accountType: r.account_type,
+      balanceType: r.balance_type as 'D' | 'C',
+      totalDebits: Number(r.total_debits) / 100,
+      totalCredits: Number(r.total_credits) / 100,
+    }));
+
+    // ── General Ledger detail rows (chronological) ──
+    const detailRows: Array<{
+      date: Date;
+      journal_entry_id: string;
+      description: string;
+      code: string;
+      name: string;
+      account_type: string;
+      entry_type: string;
+      amount: string;
+      source_type: string;
+      source_id: string | null;
+    }> = await prisma.$queryRaw`
+      SELECT
+        je.date,
+        je.id AS journal_entry_id,
+        je.description,
+        je.source_type,
+        je.source_id,
+        coa.code,
+        coa.name,
+        coa.account_type,
+        le.entry_type,
+        le.amount::text as amount
+      FROM ledger_entries le
+      JOIN journal_entries je ON le.journal_entry_id = je.id
+      JOIN chart_of_accounts coa ON le.account_id = coa.id
+      WHERE ${whereClause}
+      ORDER BY je.date ASC, je.id ASC, le.entry_type DESC
+    `;
+
+    const generalLedger = detailRows.map((r) => ({
+      date: r.date.toISOString().split('T')[0],
+      journalEntryId: r.journal_entry_id,
+      description: r.description,
+      accountCode: r.code,
+      accountName: r.name,
+      accountType: r.account_type,
+      entryType: r.entry_type as 'D' | 'C',
+      amount: Number(r.amount) / 100,
+      sourceType: r.source_type,
+      sourceId: r.source_id,
+    }));
+
+    // ── Trial Balance ──
+    // For each account, place its absolute balance on its natural (normal) side.
+    // Negative normal balance → contra, swap to the opposite side.
+    const trialBalanceRows = accounts.map((a) => {
+      const normalBalance =
+        a.balanceType === 'D'
+          ? a.totalDebits - a.totalCredits
+          : a.totalCredits - a.totalDebits;
+      const abs = Math.abs(normalBalance);
+      const displaySide: 'debit' | 'credit' =
+        a.balanceType === 'D'
+          ? normalBalance >= 0
+            ? 'debit'
+            : 'credit'
+          : normalBalance >= 0
+            ? 'credit'
+            : 'debit';
+      return {
+        accountCode: a.code,
+        accountName: a.name,
+        accountType: a.accountType,
+        balanceType: a.balanceType,
+        totalDebits: a.totalDebits,
+        totalCredits: a.totalCredits,
+        debitBalance: displaySide === 'debit' ? abs : 0,
+        creditBalance: displaySide === 'credit' ? abs : 0,
+      };
+    });
+
+    const tbTotalDebits = round2(
+      trialBalanceRows.reduce((s, r) => s + r.debitBalance, 0)
+    );
+    const tbTotalCredits = round2(
+      trialBalanceRows.reduce((s, r) => s + r.creditBalance, 0)
+    );
+    const tbDifference = round2(tbTotalDebits - tbTotalCredits);
+
+    // ── Income Statement ──
+    const revenueAccounts = accounts.filter((a) => a.accountType === 'revenue');
+    const expenseAccounts = accounts.filter((a) => a.accountType === 'expense');
+
+    const revenueLines = revenueAccounts.map((a) => ({
+      accountCode: a.code,
+      accountName: a.name,
+      amount: round2(a.totalCredits - a.totalDebits), // revenue is credit-normal
+    }));
+    const expenseLines = expenseAccounts.map((a) => ({
+      accountCode: a.code,
+      accountName: a.name,
+      amount: round2(a.totalDebits - a.totalCredits), // expense is debit-normal
+    }));
+    const totalRevenue = round2(revenueLines.reduce((s, l) => s + l.amount, 0));
+    const totalExpenses = round2(expenseLines.reduce((s, l) => s + l.amount, 0));
+    const netIncome = round2(totalRevenue - totalExpenses);
+
+    // ── Balance Sheet ──
+    const assetAccounts = accounts.filter((a) => a.accountType === 'asset');
+    const liabilityAccounts = accounts.filter((a) => a.accountType === 'liability');
+    const equityAccounts = accounts.filter((a) => a.accountType === 'equity');
+
+    const assetLines = assetAccounts.map((a) => ({
+      accountCode: a.code,
+      accountName: a.name,
+      amount: round2(a.totalDebits - a.totalCredits), // asset is debit-normal
+    }));
+    const liabilityLines = liabilityAccounts.map((a) => ({
+      accountCode: a.code,
+      accountName: a.name,
+      amount: round2(a.totalCredits - a.totalDebits), // liability is credit-normal
+    }));
+    const equityLines = equityAccounts.map((a) => ({
+      accountCode: a.code,
+      accountName: a.name,
+      amount: round2(a.totalCredits - a.totalDebits), // equity is credit-normal
+    }));
+
+    const totalAssets = round2(assetLines.reduce((s, l) => s + l.amount, 0));
+    const totalLiabilities = round2(
+      liabilityLines.reduce((s, l) => s + l.amount, 0)
+    );
+    // Retained earnings for the period = net income (rolled into equity for the
+    // balance-sheet equation). This matches the traditional close-the-books flow.
+    const totalEquityExcludingRetained = round2(
+      equityLines.reduce((s, l) => s + l.amount, 0)
+    );
+    const totalEquity = round2(totalEquityExcludingRetained + netIncome);
+    const balanceSheetDifference = round2(
+      totalAssets - (totalLiabilities + totalEquity)
+    );
+
+    return NextResponse.json({
+      period: { year, entityId: entityId || null },
+      trialBalance: {
+        rows: trialBalanceRows,
+        totals: {
+          totalDebits: tbTotalDebits,
+          totalCredits: tbTotalCredits,
+          difference: tbDifference,
+          isBalanced: Math.abs(tbDifference) < 0.01,
+        },
+      },
+      incomeStatement: {
+        revenue: revenueLines,
+        expenses: expenseLines,
+        totals: { totalRevenue, totalExpenses, netIncome },
+      },
+      balanceSheet: {
+        assets: assetLines,
+        liabilities: liabilityLines,
+        equity: equityLines,
+        retainedEarnings: netIncome,
+        totals: {
+          totalAssets,
+          totalLiabilities,
+          totalEquity,
+          difference: balanceSheetDifference,
+          isBalanced: Math.abs(balanceSheetDifference) < 0.01,
+        },
+      },
+      generalLedger,
+    });
+  } catch (error) {
+    console.error('CPA export API error:', error);
+    const message = error instanceof Error ? error.message : 'Internal server error';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -699,7 +699,7 @@ export default function Dashboard() {
               <BookkeepingSection title="CPA Export" pipelineKey="EXP"
                 status="pending">
                 <div className="p-4">
-                  <CPAExport transactions={transactions} coaOptions={coaOptions} selectedYear={selectedYear} />
+                  <CPAExport year={selectedYear} entityId={defaultEntityId} />
                 </div>
               </BookkeepingSection>
 

--- a/src/components/dashboard/CPAExport.tsx
+++ b/src/components/dashboard/CPAExport.tsx
@@ -1,290 +1,455 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 
-interface Transaction {
-  id: string;
-  date: string;
-  name: string;
-  amount: number;
-  accountCode: string | null;
-  subAccount: string | null;
-}
-
-interface CoaOption {
-  id: string;
-  code: string;
-  name: string;
-  accountType: string;
-}
+// ═══════════════════════════════════════════════════════════════════
+// CPAExport — Generates accountant-ready CSV reports (Trial Balance,
+// Income Statement, Balance Sheet, General Ledger) from the GENERAL
+// LEDGER via /api/cpa-export. Debit/credit is taken from
+// ledger_entries.entry_type ('D'/'C'), NOT from Plaid amount sign.
+// ═══════════════════════════════════════════════════════════════════
 
 interface CPAExportProps {
-  transactions: Transaction[];
-  coaOptions: CoaOption[];
-  selectedYear: number;
+  year: number;
+  entityId?: string | null;
 }
 
-export default function CPAExport({ transactions, coaOptions, selectedYear }: CPAExportProps) {
+interface TrialBalanceRow {
+  accountCode: string;
+  accountName: string;
+  accountType: string;
+  balanceType: 'D' | 'C';
+  totalDebits: number;
+  totalCredits: number;
+  debitBalance: number;
+  creditBalance: number;
+}
+
+interface StatementLine {
+  accountCode: string;
+  accountName: string;
+  amount: number;
+}
+
+interface LedgerLine {
+  date: string;
+  journalEntryId: string;
+  description: string;
+  accountCode: string;
+  accountName: string;
+  accountType: string;
+  entryType: 'D' | 'C';
+  amount: number;
+  sourceType: string;
+  sourceId: string | null;
+}
+
+interface CPAExportData {
+  period: { year: number; entityId: string | null };
+  trialBalance: {
+    rows: TrialBalanceRow[];
+    totals: {
+      totalDebits: number;
+      totalCredits: number;
+      difference: number;
+      isBalanced: boolean;
+    };
+  };
+  incomeStatement: {
+    revenue: StatementLine[];
+    expenses: StatementLine[];
+    totals: { totalRevenue: number; totalExpenses: number; netIncome: number };
+  };
+  balanceSheet: {
+    assets: StatementLine[];
+    liabilities: StatementLine[];
+    equity: StatementLine[];
+    retainedEarnings: number;
+    totals: {
+      totalAssets: number;
+      totalLiabilities: number;
+      totalEquity: number;
+      difference: number;
+      isBalanced: boolean;
+    };
+  };
+  generalLedger: LedgerLine[];
+}
+
+// ─── CSV helpers ────────────────────────────────────────────────────
+
+function csvEscape(value: unknown): string {
+  const s = value == null ? '' : String(value);
+  if (s.includes(',') || s.includes('"') || s.includes('\n')) {
+    return `"${s.replace(/"/g, '""')}"`;
+  }
+  return s;
+}
+
+function rowsToCSV(rows: unknown[][]): string {
+  return rows.map((r) => r.map(csvEscape).join(',')).join('\n');
+}
+
+function downloadCSV(csv: string, filename: string) {
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+function fmtMoney(n: number): string {
+  return n.toFixed(2);
+}
+
+// ─── CSV generators (format data → CSV string) ──────────────────────
+
+function buildTrialBalanceCSV(data: CPAExportData): string {
+  const { trialBalance, period } = data;
+  const rows: unknown[][] = [
+    ['TRIAL BALANCE'],
+    [`For the Year Ended December 31, ${period.year}`],
+    period.entityId ? [`Entity: ${period.entityId}`] : [],
+    [],
+    ['Account Code', 'Account Name', 'Account Type', 'Debit Balance', 'Credit Balance'],
+  ];
+
+  for (const r of trialBalance.rows) {
+    rows.push([
+      r.accountCode,
+      r.accountName,
+      r.accountType,
+      r.debitBalance ? fmtMoney(r.debitBalance) : '',
+      r.creditBalance ? fmtMoney(r.creditBalance) : '',
+    ]);
+  }
+
+  rows.push([]);
+  rows.push([
+    '',
+    'TOTALS',
+    '',
+    fmtMoney(trialBalance.totals.totalDebits),
+    fmtMoney(trialBalance.totals.totalCredits),
+  ]);
+  rows.push([]);
+  rows.push([
+    '',
+    'VERIFICATION',
+    '',
+    `Difference: ${fmtMoney(trialBalance.totals.difference)}`,
+    trialBalance.totals.isBalanced ? 'BALANCED ✓' : 'OUT OF BALANCE ✗',
+  ]);
+
+  return rowsToCSV(rows);
+}
+
+function buildIncomeStatementCSV(data: CPAExportData): string {
+  const { incomeStatement, period } = data;
+  const rows: unknown[][] = [
+    ['INCOME STATEMENT'],
+    [`For the Year Ended December 31, ${period.year}`],
+    period.entityId ? [`Entity: ${period.entityId}`] : [],
+    [],
+    ['Account Code', 'Account Name', 'Amount'],
+    [],
+    ['', 'REVENUE', ''],
+  ];
+
+  for (const l of incomeStatement.revenue) {
+    rows.push([l.accountCode, l.accountName, fmtMoney(l.amount)]);
+  }
+  rows.push(['', 'Total Revenue', fmtMoney(incomeStatement.totals.totalRevenue)]);
+  rows.push([]);
+  rows.push(['', 'EXPENSES', '']);
+  for (const l of incomeStatement.expenses) {
+    rows.push([l.accountCode, l.accountName, fmtMoney(l.amount)]);
+  }
+  rows.push(['', 'Total Expenses', fmtMoney(incomeStatement.totals.totalExpenses)]);
+  rows.push([]);
+  rows.push(['', 'NET INCOME', fmtMoney(incomeStatement.totals.netIncome)]);
+
+  return rowsToCSV(rows);
+}
+
+function buildBalanceSheetCSV(data: CPAExportData): string {
+  const { balanceSheet, period } = data;
+  const rows: unknown[][] = [
+    ['BALANCE SHEET'],
+    [`As of December 31, ${period.year}`],
+    period.entityId ? [`Entity: ${period.entityId}`] : [],
+    [],
+    ['Account Code', 'Account Name', 'Amount'],
+    [],
+    ['', 'ASSETS', ''],
+  ];
+
+  for (const l of balanceSheet.assets) {
+    rows.push([l.accountCode, l.accountName, fmtMoney(l.amount)]);
+  }
+  rows.push(['', 'Total Assets', fmtMoney(balanceSheet.totals.totalAssets)]);
+  rows.push([]);
+
+  rows.push(['', 'LIABILITIES', '']);
+  for (const l of balanceSheet.liabilities) {
+    rows.push([l.accountCode, l.accountName, fmtMoney(l.amount)]);
+  }
+  rows.push(['', 'Total Liabilities', fmtMoney(balanceSheet.totals.totalLiabilities)]);
+  rows.push([]);
+
+  rows.push(['', 'EQUITY', '']);
+  for (const l of balanceSheet.equity) {
+    rows.push([l.accountCode, l.accountName, fmtMoney(l.amount)]);
+  }
+  rows.push(['', 'Retained Earnings (Net Income)', fmtMoney(balanceSheet.retainedEarnings)]);
+  rows.push(['', 'Total Equity', fmtMoney(balanceSheet.totals.totalEquity)]);
+  rows.push([]);
+
+  rows.push([
+    '',
+    'TOTAL LIABILITIES + EQUITY',
+    fmtMoney(
+      balanceSheet.totals.totalLiabilities + balanceSheet.totals.totalEquity
+    ),
+  ]);
+  rows.push([]);
+  rows.push([
+    '',
+    'VERIFICATION',
+    `Assets: ${fmtMoney(balanceSheet.totals.totalAssets)} | L+E: ${fmtMoney(
+      balanceSheet.totals.totalLiabilities + balanceSheet.totals.totalEquity
+    )} | Difference: ${fmtMoney(balanceSheet.totals.difference)}`,
+  ]);
+  rows.push([
+    '',
+    '',
+    balanceSheet.totals.isBalanced ? 'BALANCED ✓' : 'OUT OF BALANCE ✗',
+  ]);
+
+  return rowsToCSV(rows);
+}
+
+function buildGeneralLedgerCSV(data: CPAExportData): string {
+  const { generalLedger, period } = data;
+  const rows: unknown[][] = [
+    ['GENERAL LEDGER'],
+    [`For the Year ${period.year}`],
+    period.entityId ? [`Entity: ${period.entityId}`] : [],
+    [],
+    [
+      'Date',
+      'Journal Entry ID',
+      'Description',
+      'Account Code',
+      'Account Name',
+      'Debit',
+      'Credit',
+      'Source Type',
+      'Source ID',
+    ],
+  ];
+
+  let totalDebits = 0;
+  let totalCredits = 0;
+  for (const e of generalLedger) {
+    const debit = e.entryType === 'D' ? e.amount : 0;
+    const credit = e.entryType === 'C' ? e.amount : 0;
+    totalDebits += debit;
+    totalCredits += credit;
+    rows.push([
+      e.date,
+      e.journalEntryId,
+      e.description,
+      e.accountCode,
+      e.accountName,
+      debit ? fmtMoney(debit) : '',
+      credit ? fmtMoney(credit) : '',
+      e.sourceType,
+      e.sourceId || '',
+    ]);
+  }
+
+  rows.push([]);
+  rows.push([
+    '',
+    '',
+    '',
+    '',
+    'TOTALS',
+    fmtMoney(totalDebits),
+    fmtMoney(totalCredits),
+    '',
+    '',
+  ]);
+  rows.push([]);
+  rows.push([
+    '',
+    '',
+    '',
+    '',
+    'VERIFICATION',
+    `Difference: ${fmtMoney(totalDebits - totalCredits)}`,
+    Math.abs(totalDebits - totalCredits) < 0.01 ? 'BALANCED ✓' : 'OUT OF BALANCE ✗',
+    '',
+    '',
+  ]);
+
+  return rowsToCSV(rows);
+}
+
+// ─── Component ──────────────────────────────────────────────────────
+
+export default function CPAExport({ year, entityId }: CPAExportProps) {
+  const [data, setData] = useState<CPAExportData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
   const [exporting, setExporting] = useState<string | null>(null);
 
-  const getCoaName = (code: string) => coaOptions.find(c => c.code === code)?.name || code;
-  const getCoaType = (code: string) => coaOptions.find(c => c.code === code)?.accountType || '';
-
-  const yearTxns = transactions.filter(t => new Date(t.date).getFullYear() === selectedYear);
-
-  // Build account totals
-  const accountTotals: Record<string, number> = {};
-  yearTxns.forEach(t => {
-    if (t.accountCode) {
-      accountTotals[t.accountCode] = (accountTotals[t.accountCode] || 0) + t.amount;
+  const fetchData = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const qs = new URLSearchParams({ year: String(year) });
+      if (entityId) qs.set('entityId', entityId);
+      const res = await fetch(`/api/cpa-export?${qs.toString()}`);
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error || `HTTP ${res.status}`);
+      }
+      setData(await res.json());
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load CPA export data');
+    } finally {
+      setLoading(false);
     }
-  });
+  }, [year, entityId]);
 
-  const generateCSV = (data: string[][], filename: string) => {
-    const csv = data.map(row => row.map(cell => `"${String(cell).replace(/"/g, '""')}"`).join(',')).join('\n');
-    const blob = new Blob([csv], { type: 'text/csv' });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = filename;
-    a.click();
-    URL.revokeObjectURL(url);
-  };
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
 
   const exportTrialBalance = () => {
+    if (!data) return;
     setExporting('trial-balance');
-    
-    const rows: string[][] = [
-      ['TRIAL BALANCE'],
-      [`As of December 31, ${selectedYear}`],
-      [''],
-      ['Account Code', 'Account Name', 'Account Type', 'Debit', 'Credit']
-    ];
-
-    let totalDebits = 0;
-    let totalCredits = 0;
-
-    Object.entries(accountTotals)
-      .sort((a, b) => a[0].localeCompare(b[0]))
-      .forEach(([code, total]) => {
-        const debit = total > 0 ? total : 0;
-        const credit = total < 0 ? Math.abs(total) : 0;
-        totalDebits += debit;
-        totalCredits += credit;
-        rows.push([
-          code,
-          getCoaName(code),
-          getCoaType(code),
-          debit ? debit.toFixed(2) : '',
-          credit ? credit.toFixed(2) : ''
-        ]);
-      });
-
-    rows.push(['']);
-    rows.push(['', 'TOTALS', '', totalDebits.toFixed(2), totalCredits.toFixed(2)]);
-    rows.push(['']);
-    rows.push(['', 'Difference', '', (totalDebits - totalCredits).toFixed(2), '']);
-
-    generateCSV(rows, `trial-balance-${selectedYear}.csv`);
+    downloadCSV(buildTrialBalanceCSV(data), `trial-balance-${year}.csv`);
     setExporting(null);
   };
 
   const exportIncomeStatement = () => {
+    if (!data) return;
     setExporting('income-statement');
-
-    const rows: string[][] = [
-      ['INCOME STATEMENT'],
-      [`For the Year Ended December 31, ${selectedYear}`],
-      [''],
-      ['Account Code', 'Account Name', 'Amount']
-    ];
-
-    // Revenue
-    rows.push(['', 'REVENUE', '']);
-    let totalRevenue = 0;
-    Object.entries(accountTotals)
-      .filter(([code]) => getCoaType(code) === 'revenue')
-      .sort((a, b) => a[0].localeCompare(b[0]))
-      .forEach(([code, total]) => {
-        const amount = Math.abs(total);
-        totalRevenue += amount;
-        rows.push([code, getCoaName(code), amount.toFixed(2)]);
-      });
-    rows.push(['', 'Total Revenue', totalRevenue.toFixed(2)]);
-    rows.push(['']);
-
-    // Expenses
-    rows.push(['', 'EXPENSES', '']);
-    let totalExpenses = 0;
-    Object.entries(accountTotals)
-      .filter(([code]) => getCoaType(code) === 'expense')
-      .sort((a, b) => a[0].localeCompare(b[0]))
-      .forEach(([code, total]) => {
-        const amount = Math.abs(total);
-        totalExpenses += amount;
-        rows.push([code, getCoaName(code), amount.toFixed(2)]);
-      });
-    rows.push(['', 'Total Expenses', totalExpenses.toFixed(2)]);
-    rows.push(['']);
-
-    // Net Income
-    rows.push(['', 'NET INCOME', (totalRevenue - totalExpenses).toFixed(2)]);
-
-    generateCSV(rows, `income-statement-${selectedYear}.csv`);
+    downloadCSV(buildIncomeStatementCSV(data), `income-statement-${year}.csv`);
     setExporting(null);
   };
 
   const exportBalanceSheet = () => {
+    if (!data) return;
     setExporting('balance-sheet');
-
-    const rows: string[][] = [
-      ['BALANCE SHEET'],
-      [`As of December 31, ${selectedYear}`],
-      [''],
-      ['Account Code', 'Account Name', 'Amount']
-    ];
-
-    // Assets
-    rows.push(['', 'ASSETS', '']);
-    let totalAssets = 0;
-    Object.entries(accountTotals)
-      .filter(([code]) => getCoaType(code) === 'asset')
-      .sort((a, b) => a[0].localeCompare(b[0]))
-      .forEach(([code, total]) => {
-        const amount = Math.abs(total);
-        totalAssets += amount;
-        rows.push([code, getCoaName(code), amount.toFixed(2)]);
-      });
-    rows.push(['', 'Total Assets', totalAssets.toFixed(2)]);
-    rows.push(['']);
-
-    // Liabilities
-    rows.push(['', 'LIABILITIES', '']);
-    let totalLiabilities = 0;
-    Object.entries(accountTotals)
-      .filter(([code]) => getCoaType(code) === 'liability')
-      .sort((a, b) => a[0].localeCompare(b[0]))
-      .forEach(([code, total]) => {
-        const amount = Math.abs(total);
-        totalLiabilities += amount;
-        rows.push([code, getCoaName(code), amount.toFixed(2)]);
-      });
-    rows.push(['', 'Total Liabilities', totalLiabilities.toFixed(2)]);
-    rows.push(['']);
-
-    // Equity
-    rows.push(['', 'EQUITY', '']);
-    let totalEquity = 0;
-    Object.entries(accountTotals)
-      .filter(([code]) => getCoaType(code) === 'equity')
-      .sort((a, b) => a[0].localeCompare(b[0]))
-      .forEach(([code, total]) => {
-        const amount = Math.abs(total);
-        totalEquity += amount;
-        rows.push([code, getCoaName(code), amount.toFixed(2)]);
-      });
-    
-    // Add retained earnings (net income)
-    const totalRevenue = Object.entries(accountTotals)
-      .filter(([code]) => getCoaType(code) === 'revenue')
-      .reduce((sum, [, total]) => sum + Math.abs(total), 0);
-    const totalExpenses = Object.entries(accountTotals)
-      .filter(([code]) => getCoaType(code) === 'expense')
-      .reduce((sum, [, total]) => sum + Math.abs(total), 0);
-    const netIncome = totalRevenue - totalExpenses;
-    totalEquity += netIncome;
-    rows.push(['', 'Retained Earnings (Net Income)', netIncome.toFixed(2)]);
-    rows.push(['', 'Total Equity', totalEquity.toFixed(2)]);
-    rows.push(['']);
-
-    rows.push(['', 'TOTAL LIABILITIES + EQUITY', (totalLiabilities + totalEquity).toFixed(2)]);
-
-    generateCSV(rows, `balance-sheet-${selectedYear}.csv`);
+    downloadCSV(buildBalanceSheetCSV(data), `balance-sheet-${year}.csv`);
     setExporting(null);
   };
 
   const exportGeneralLedger = () => {
+    if (!data) return;
     setExporting('general-ledger');
-
-    const rows: string[][] = [
-      ['GENERAL LEDGER'],
-      [`For the Year ${selectedYear}`],
-      [''],
-      ['Date', 'Account Code', 'Account Name', 'Description', 'Vendor', 'Debit', 'Credit']
-    ];
-
-    yearTxns
-      .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime())
-      .forEach(t => {
-        const debit = t.amount > 0 ? t.amount : 0;
-        const credit = t.amount < 0 ? Math.abs(t.amount) : 0;
-        rows.push([
-          new Date(t.date).toLocaleDateString(),
-          t.accountCode || 'UNCATEGORIZED',
-          t.accountCode ? getCoaName(t.accountCode) : 'Uncategorized',
-          t.name,
-          t.subAccount || '',
-          debit ? debit.toFixed(2) : '',
-          credit ? credit.toFixed(2) : ''
-        ]);
-      });
-
-    generateCSV(rows, `general-ledger-${selectedYear}.csv`);
+    downloadCSV(buildGeneralLedgerCSV(data), `general-ledger-${year}.csv`);
     setExporting(null);
   };
 
   const exportAll = async () => {
+    if (!data) return;
     setExporting('all');
-    exportTrialBalance();
-    await new Promise(r => setTimeout(r, 500));
-    exportIncomeStatement();
-    await new Promise(r => setTimeout(r, 500));
-    exportBalanceSheet();
-    await new Promise(r => setTimeout(r, 500));
-    exportGeneralLedger();
+    downloadCSV(buildTrialBalanceCSV(data), `trial-balance-${year}.csv`);
+    await new Promise((r) => setTimeout(r, 400));
+    downloadCSV(buildIncomeStatementCSV(data), `income-statement-${year}.csv`);
+    await new Promise((r) => setTimeout(r, 400));
+    downloadCSV(buildBalanceSheetCSV(data), `balance-sheet-${year}.csv`);
+    await new Promise((r) => setTimeout(r, 400));
+    downloadCSV(buildGeneralLedgerCSV(data), `general-ledger-${year}.csv`);
     setExporting(null);
   };
 
-  const stats = {
-    accounts: Object.keys(accountTotals).length,
-    transactions: yearTxns.length,
-    uncategorized: yearTxns.filter(t => !t.accountCode).length
-  };
+  const stats = data
+    ? {
+        accounts: data.trialBalance.rows.length,
+        ledgerLines: data.generalLedger.length,
+        isBalanced: data.trialBalance.totals.isBalanced,
+        sheetBalanced: data.balanceSheet.totals.isBalanced,
+        netIncome: data.incomeStatement.totals.netIncome,
+      }
+    : null;
 
   return (
     <div className="bg-white overflow-hidden">
       <div className="px-3 py-2 border-b border-border flex items-center justify-between">
-        <span className="text-terminal-sm text-text-muted font-mono">Export financial reports for your accountant</span>
+        <span className="text-terminal-sm text-text-muted font-mono">
+          Export accountant-ready reports (sourced from the general ledger)
+        </span>
         <button
           onClick={exportAll}
-          disabled={exporting !== null}
+          disabled={exporting !== null || !data || loading}
           className="px-4 py-2 text-sm bg-brand-gold hover:bg-brand-gold-bright text-white font-semibold rounded-lg transition-colors disabled:opacity-50"
         >
           {exporting === 'all' ? 'Exporting...' : 'Export All'}
         </button>
       </div>
 
-      {/* Stats */}
+      {/* Status bar */}
       <div className="px-4 py-2 border-b border-border bg-bg-row flex items-center gap-6 text-sm">
-        <span className="text-text-secondary">Year: <strong>{selectedYear}</strong></span>
-        <span className="text-text-secondary">Accounts: <strong>{stats.accounts}</strong></span>
-        <span className="text-text-secondary">Transactions: <strong>{stats.transactions}</strong></span>
-        {stats.uncategorized > 0 && (
-          <span className="text-brand-red">⚠️ {stats.uncategorized} uncategorized</span>
+        <span className="text-text-secondary">
+          Year: <strong>{year}</strong>
+        </span>
+        {entityId && (
+          <span className="text-text-secondary">
+            Entity: <strong className="font-mono text-xs">{entityId}</strong>
+          </span>
+        )}
+        {loading && <span className="text-text-muted">Loading ledger...</span>}
+        {error && <span className="text-brand-red">Error: {error}</span>}
+        {stats && (
+          <>
+            <span className="text-text-secondary">
+              Accounts: <strong>{stats.accounts}</strong>
+            </span>
+            <span className="text-text-secondary">
+              Ledger lines: <strong>{stats.ledgerLines}</strong>
+            </span>
+            <span
+              className={
+                stats.isBalanced ? 'text-brand-green' : 'text-brand-red'
+              }
+            >
+              {stats.isBalanced ? 'Trial Balance ✓' : 'Trial Balance ✗'}
+            </span>
+            <span
+              className={
+                stats.sheetBalanced ? 'text-brand-green' : 'text-brand-red'
+              }
+            >
+              {stats.sheetBalanced ? 'Balance Sheet ✓' : 'Balance Sheet ✗'}
+            </span>
+            <span className="text-text-secondary">
+              Net Income: <strong>${fmtMoney(stats.netIncome)}</strong>
+            </span>
+          </>
         )}
       </div>
 
-      {/* Export Options */}
+      {/* Export options */}
       <div className="p-4 grid grid-cols-1 md:grid-cols-2 gap-4">
         <div className="border rounded p-4 hover:bg-bg-row">
           <div className="flex items-start justify-between">
             <div>
               <h4 className="font-medium">📊 Trial Balance</h4>
-              <p className="text-xs text-text-muted mt-1">Debits and credits by account - verifies books are balanced</p>
+              <p className="text-xs text-text-muted mt-1">
+                Per-account debit/credit balances from the ledger. Debits must equal credits.
+              </p>
             </div>
             <button
               onClick={exportTrialBalance}
-              disabled={exporting !== null}
+              disabled={exporting !== null || !data}
               className="px-3 py-1.5 border rounded text-sm hover:bg-bg-row disabled:opacity-50"
             >
               {exporting === 'trial-balance' ? '...' : 'Export CSV'}
@@ -296,11 +461,13 @@ export default function CPAExport({ transactions, coaOptions, selectedYear }: CP
           <div className="flex items-start justify-between">
             <div>
               <h4 className="font-medium">📈 Income Statement</h4>
-              <p className="text-xs text-text-muted mt-1">Revenue minus expenses = Net Income (P&L)</p>
+              <p className="text-xs text-text-muted mt-1">
+                Revenue minus expenses. Revenue nets credits − debits; expenses net debits − credits.
+              </p>
             </div>
             <button
               onClick={exportIncomeStatement}
-              disabled={exporting !== null}
+              disabled={exporting !== null || !data}
               className="px-3 py-1.5 border rounded text-sm hover:bg-bg-row disabled:opacity-50"
             >
               {exporting === 'income-statement' ? '...' : 'Export CSV'}
@@ -312,11 +479,13 @@ export default function CPAExport({ transactions, coaOptions, selectedYear }: CP
           <div className="flex items-start justify-between">
             <div>
               <h4 className="font-medium">📋 Balance Sheet</h4>
-              <p className="text-xs text-text-muted mt-1">Assets = Liabilities + Equity snapshot</p>
+              <p className="text-xs text-text-muted mt-1">
+                Assets = Liabilities + Equity. Retained earnings rolls net income into equity.
+              </p>
             </div>
             <button
               onClick={exportBalanceSheet}
-              disabled={exporting !== null}
+              disabled={exporting !== null || !data}
               className="px-3 py-1.5 border rounded text-sm hover:bg-bg-row disabled:opacity-50"
             >
               {exporting === 'balance-sheet' ? '...' : 'Export CSV'}
@@ -328,11 +497,13 @@ export default function CPAExport({ transactions, coaOptions, selectedYear }: CP
           <div className="flex items-start justify-between">
             <div>
               <h4 className="font-medium">📒 General Ledger</h4>
-              <p className="text-xs text-text-muted mt-1">Complete transaction detail by date</p>
+              <p className="text-xs text-text-muted mt-1">
+                Every posted ledger entry in chronological order. Full audit trail.
+              </p>
             </div>
             <button
               onClick={exportGeneralLedger}
-              disabled={exporting !== null}
+              disabled={exporting !== null || !data}
               className="px-3 py-1.5 border rounded text-sm hover:bg-bg-row disabled:opacity-50"
             >
               {exporting === 'general-ledger' ? '...' : 'Export CSV'}
@@ -343,7 +514,7 @@ export default function CPAExport({ transactions, coaOptions, selectedYear }: CP
 
       {/* Footer */}
       <div className="px-4 py-3 border-t bg-bg-row text-xs text-text-muted">
-        💡 Tip: Open CSV files in Excel or Google Sheets. Your CPA can import these directly into their tax software.
+        💡 Sourced from journal_entries + ledger_entries (reversals excluded). Open CSV files in Excel or Google Sheets.
       </div>
     </div>
   );


### PR DESCRIPTION
- Trial Balance, Income Statement, Balance Sheet, General Ledger all source from journal_entries + ledger_entries
- Debit/credit determined by entry_type field, not Plaid amount sign
- Adds verification totals (debits=credits proof, A=L+E proof)
- Creates /api/cpa-export endpoint for server-side ledger aggregation

https://claude.ai/code/session_01K74AZxjnZcGZKEfMN9Lg3g