### PR TITLE
Fix tax year default to 2025, fix Box B coding for broker trades, fix…

### DIFF
--- a/src/components/tax-filing/TaxFilingWizard.tsx
+++ b/src/components/tax-filing/TaxFilingWizard.tsx
@@ -116,11 +116,34 @@ const DEFAULT_LIFE_EVENTS: LifeEvents = {
   hasRental: false,
 };
 
+// Default to the return the user is currently filing.
+// IRS deadline is April 15; automatic extension runs to October 15.
+// Before Oct 15, people are still filing the PRIOR calendar year.
+// On/after Oct 15, filing season is over — start planning the CURRENT year.
+function defaultTaxYear(): number {
+  const now = new Date();
+  const year = now.getUTCFullYear();
+  const month = now.getUTCMonth() + 1;
+  const day = now.getUTCDate();
+  if (month < 10 || (month === 10 && day < 15)) {
+    return year - 1;
+  }
+  return year;
+}
+
+// Years offered in the selector: current, prior 2, and next. Users filing
+// early are usually in prior-year mode; offering next year supports
+// forward-planning scenarios.
+function availableTaxYears(): number[] {
+  const current = new Date().getUTCFullYear();
+  return [current + 1, current, current - 1, current - 2];
+}
+
 export default function TaxFilingWizard() {
   const [state, setState] = useState<WizardState>({
     currentStep: 0,
     completedSteps: new Set<number>(),
-    taxYear: new Date().getFullYear(),
+    taxYear: defaultTaxYear(),
     lifeEvents: DEFAULT_LIFE_EVENTS,
     autoDetected: {},
   });
@@ -271,12 +294,39 @@ export default function TaxFilingWizard() {
     <AppLayout>
       <div className="px-4 py-6 max-w-5xl mx-auto">
         {/* Header */}
-        <div className="mb-6">
-          <h1 className="text-2xl font-semibold text-gray-900">File your taxes</h1>
-          <p className="text-sm text-gray-500 mt-1">
-            Tax year {state.taxYear} · Step {state.currentStep + 1} of {STEPS.length} ·{' '}
-            {step.label}
-          </p>
+        <div className="mb-6 flex items-start justify-between gap-4">
+          <div>
+            <h1 className="text-2xl font-semibold text-gray-900">File your taxes</h1>
+            <p className="text-sm text-gray-500 mt-1">
+              Tax year {state.taxYear} · Step {state.currentStep + 1} of {STEPS.length} ·{' '}
+              {step.label}
+            </p>
+          </div>
+          <div className="shrink-0">
+            <label
+              htmlFor="wizard-tax-year"
+              className="block text-[10px] font-semibold text-gray-500 uppercase tracking-wider mb-1 text-right"
+            >
+              Tax year
+            </label>
+            <select
+              id="wizard-tax-year"
+              value={state.taxYear}
+              onChange={(e) =>
+                setState((prev) => ({
+                  ...prev,
+                  taxYear: parseInt(e.target.value, 10),
+                }))
+              }
+              className="px-3 py-1.5 text-sm font-mono font-semibold border border-gray-300 rounded focus:outline-none focus:ring-1 focus:ring-blue-500 bg-white"
+            >
+              {availableTaxYears().map((y) => (
+                <option key={y} value={y}>
+                  {y}
+                </option>
+              ))}
+            </select>
+          </div>
         </div>
 
         {/* Progress bar */}

--- a/src/components/tax-filing/steps/TradingStep.tsx
+++ b/src/components/tax-filing/steps/TradingStep.tsx
@@ -287,14 +287,19 @@ export default function TradingStep({
   const lossCount = allEntries.filter((e) => e.gainOrLoss < 0).length;
   const winRate =
     allEntries.length > 0 ? (winCount / allEntries.length) * 100 : 0;
-  const largestGain = allEntries.reduce(
-    (m, e) => (e.gainOrLoss > m ? e.gainOrLoss : m),
-    0
-  );
-  const largestLoss = allEntries.reduce(
-    (m, e) => (e.gainOrLoss < m ? e.gainOrLoss : m),
-    0
-  );
+  // Use filter + reduce so the result is only defined when real gains/losses
+  // exist. Previous version seeded the accumulator with 0, which masked the
+  // absence of any gains or losses as "$0.00" in the UI.
+  const gainEntries = allEntries.filter((e) => e.gainOrLoss > 0);
+  const lossEntries = allEntries.filter((e) => e.gainOrLoss < 0);
+  const largestGain =
+    gainEntries.length > 0
+      ? gainEntries.reduce((m, e) => Math.max(m, e.gainOrLoss), -Infinity)
+      : 0;
+  const largestLoss =
+    lossEntries.length > 0
+      ? lossEntries.reduce((m, e) => Math.min(m, e.gainOrLoss), Infinity)
+      : 0;
 
   const hasWashSaleWarning =
     (summary.washSalesApplied ?? 0) > 0 ||
@@ -709,13 +714,13 @@ export default function TradingStep({
             />
             <Metric
               label="Largest gain"
-              value={fmtMoney(largestGain)}
-              valueClass="text-emerald-700"
+              value={winCount > 0 ? fmtMoney(largestGain) : '—'}
+              valueClass={winCount > 0 ? 'text-emerald-700' : 'text-gray-400'}
             />
             <Metric
               label="Largest loss"
-              value={fmtMoney(largestLoss)}
-              valueClass="text-red-600"
+              value={lossCount > 0 ? fmtMoney(largestLoss) : '—'}
+              valueClass={lossCount > 0 ? 'text-red-600' : 'text-gray-400'}
             />
             <Metric
               label="Total proceeds"

--- a/src/lib/tax-report-service.ts
+++ b/src/lib/tax-report-service.ts
@@ -38,8 +38,21 @@ export interface Form8949Entry {
 }
 
 // Sources we trust to produce broker-reported basis (1099-B covered).
-// Anything else (manual entry, legacy imports) defaults to unreported.
-const BROKER_IMPORTED_SOURCES = new Set(['plaid', 'tastytrade', 'robinhood']);
+//
+// 'legacy' is included because every trading_positions row in this app was
+// either broker-imported (via Plaid/TastyTrade/Robinhood) or manually
+// entered with an explicit source tag. Rows with source='legacy' came from
+// the initial schema where source defaulted to 'legacy' — they are in
+// practice broker-imported (1099-B basis is reported). The preferred
+// disambiguation is via investment_transactions.accounts.source, which is
+// resolved per-position below; `legacy` acts as a safety net when that
+// lookup returns null.
+const BROKER_IMPORTED_SOURCES = new Set([
+  'plaid',
+  'tastytrade',
+  'robinhood',
+  'legacy',
+]);
 
 function determineBox(isLongTerm: boolean, source: string | null): Form8949Entry['box'] {
   const normalized = source ? source.toLowerCase() : null;
@@ -277,6 +290,26 @@ export async function generateForm8949WithMetadata(
         orderBy: { close_date: 'asc' }
       });
 
+      // Build the option-position source map: prefer the source on the
+      // opening investment_transaction's linked account (e.g., 'plaid')
+      // over trading_positions.source (which defaults to 'legacy' and
+      // therefore mis-classifies broker-imported trades as Box B). This is
+      // the root-cause fix for Bug 3 (32 TastyTrade/Plaid positions showing
+      // as Box B instead of Box A).
+      const openTxnIds = Array.from(
+        new Set(closedOptions.map((p) => p.open_investment_txn_id).filter(Boolean))
+      );
+      const openTxnRows = openTxnIds.length > 0
+        ? await prisma.investment_transactions.findMany({
+            where: { id: { in: openTxnIds } },
+            select: { id: true, accounts: { select: { source: true } } },
+          })
+        : [];
+      const openTxnSourceById = new Map<string, string | null>();
+      for (const t of openTxnRows) {
+        openTxnSourceById.set(t.id, t.accounts?.source ?? null);
+      }
+
       for (const pos of closedOptions) {
         const closeDate = pos.close_date!;
         const holdingDays = Math.floor(
@@ -308,8 +341,12 @@ export async function generateForm8949WithMetadata(
         // Build option description: "1 AAPL Jan 20 2025 $150 Call"
         const optDesc = buildOptionDescription(pos);
 
-        const box = determineBox(isLongTerm, pos.source);
-        const reasoning = boxReasoning(isLongTerm, pos.source);
+        // Prefer the opening account's source (authoritative) over the
+        // position's own source field (which commonly defaults to 'legacy').
+        const effectiveSource =
+          openTxnSourceById.get(pos.open_investment_txn_id) ?? pos.source;
+        const box = determineBox(isLongTerm, effectiveSource);
+        const reasoning = boxReasoning(isLongTerm, effectiveSource);
 
         entries.push({
           description: optDesc,


### PR DESCRIPTION
… largest loss display

- Tax year defaults to prior year when filing (2025 for current season)
- Year selector added to wizard header
- Box coding recognizes legacy source as broker-imported
- Largest loss computation fixed in TradingStep

https://claude.ai/code/session_01K74AZxjnZcGZKEfMN9Lg3g