### PR TITLE
feat: add brain dump intake layer — bullet points to AI-structured pl…

### DIFF
--- a/prisma/migrations/20260422200000_upgrade_missions_bamf_fields/migration.sql
+++ b/prisma/migrations/20260422200000_upgrade_missions_bamf_fields/migration.sql
@@ -1,0 +1,12 @@
+-- AlterTable
+ALTER TABLE "missions" ADD COLUMN "broken_blockers" TEXT;
+ALTER TABLE "missions" ADD COLUMN "risk_factors" TEXT;
+ALTER TABLE "missions" ADD COLUMN "priority_1" TEXT;
+ALTER TABLE "missions" ADD COLUMN "priority_2" TEXT;
+ALTER TABLE "missions" ADD COLUMN "priority_3" TEXT;
+ALTER TABLE "missions" ADD COLUMN "current_state" TEXT;
+ALTER TABLE "missions" ADD COLUMN "focus_windows" TEXT;
+ALTER TABLE "missions" ADD COLUMN "fixed_commitments" TEXT;
+ALTER TABLE "missions" ADD COLUMN "weekend_schedule" TEXT;
+ALTER TABLE "missions" ADD COLUMN "deep_work_hours" DOUBLE PRECISION;
+ALTER TABLE "missions" ADD COLUMN "success_metrics" JSONB NOT NULL DEFAULT '[]';

--- a/prisma/migrations/20260422300000_add_brain_dump_field/migration.sql
+++ b/prisma/migrations/20260422300000_add_brain_dump_field/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "missions" ADD COLUMN "raw_brain_dump" JSONB;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1817,11 +1817,34 @@ model missions {
   monthlyBudget     Float?   @map("monthly_budget")
   blockers          String?  @db.Text
 
+  // Blockers & Risk (upgraded)
+  brokenBlockers    String?  @map("broken_blockers") @db.Text
+  riskFactors       String?  @map("risk_factors") @db.Text
+
+  // Top 3 Priorities
+  priority1         String?  @map("priority_1") @db.Text
+  priority2         String?  @map("priority_2") @db.Text
+  priority3         String?  @map("priority_3") @db.Text
+
+  // Current State
+  currentState      String?  @map("current_state") @db.Text
+
+  // Real Capacity
+  focusWindows      String?  @map("focus_windows")
+  fixedCommitments  String?  @map("fixed_commitments")
+  weekendSchedule   String?  @map("weekend_schedule")
+  deepWorkHours     Float?   @map("deep_work_hours")
+
+  // Success Metrics
+  successMetrics    Json     @default("[]") @map("success_metrics")
+
   healthGoals       String?  @map("health_goals") @db.Text
   personalGoals     String?  @map("personal_goals") @db.Text
   mealStrategy      String?  @map("meal_strategy") @db.Text
 
   roadmap           Json?
+
+  rawBrainDump      Json?    @map("raw_brain_dump")
 
   status            String   @default("active")
 

--- a/src/app/api/ops/brain-dump/route.ts
+++ b/src/app/api/ops/brain-dump/route.ts
@@ -1,0 +1,89 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
+import Anthropic from '@anthropic-ai/sdk';
+
+function buildPrompt(bullets: string[]): string {
+  const numbered = bullets.map((b, i) => `${i + 1}. ${b}`).join('\n');
+  return `You are an organization engine inside Temple Stuart. A neurodivergent founder just dumped everything in their head as unstructured bullet points. Your job is to categorize these scattered thoughts into structured planning categories.
+
+THE RAW BRAIN DUMP:
+${numbered}
+
+CATEGORIZE INTO THESE BUCKETS. For each bucket, write 1-3 concise sentences synthesizing what the user said. If nothing fits a bucket, set it to null. Do NOT invent information — only organize what was given.
+
+RESPOND WITH ONLY a JSON object wrapped in <structured> tags:
+
+<structured>
+{
+  "missionStatement": "string — one punchy sentence capturing the overall mission",
+  "projectName": "string — suggested project name, short",
+  "goals": "string — what they want to achieve, synthesized",
+  "doneDefinition": "string — what DONE looks like based on their bullets",
+  "priority1": "string — highest leverage outcome, or null",
+  "priority2": "string — second highest, or null",
+  "priority3": "string — third highest, or null",
+  "currentState": "string — what already exists/works, or null",
+  "deliverables": ["string — concrete milestone items extracted"],
+  "brokenBlockers": "string — broken things, dependencies, obstacles, or null",
+  "riskFactors": "string — burnout risks, distractions, derailers, or null",
+  "healthGoals": "string — health, fitness, wellness mentions, or null",
+  "personalGoals": "string — personal life, relationships, content, or null",
+  "mealStrategy": "string — food, diet, nutrition mentions, or null",
+  "unknowns": ["string — things needing answers or decisions"],
+  "timelineHints": "string — any dates, deadlines, durations mentioned, or null",
+  "budgetHints": "string — any dollar amounts or budget mentions, or null"
+}
+</structured>`;
+}
+
+export async function POST(request: Request) {
+  try {
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const user = await prisma.users.findFirst({
+      where: { email: { equals: userEmail, mode: 'insensitive' } },
+    });
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+
+    const apiKey = process.env.ANTHROPIC_API_KEY;
+    if (!apiKey) return NextResponse.json({ error: 'API key not configured' }, { status: 500 });
+
+    const body = await request.json();
+    const { bullets } = body;
+
+    if (!bullets || !Array.isArray(bullets) || bullets.length === 0) {
+      return NextResponse.json({ error: 'bullets array required' }, { status: 400 });
+    }
+
+    const client = new Anthropic({ apiKey });
+
+    const msg = await client.messages.create({
+      model: 'claude-sonnet-4-20250514',
+      max_tokens: 2000,
+      temperature: 0.4,
+      system: buildPrompt(bullets),
+      messages: [{ role: 'user', content: 'Organize my brain dump into structured categories.' }],
+    });
+
+    const text = msg.content[0].type === 'text' ? msg.content[0].text : '';
+    const match = text.match(/<structured>([\s\S]*?)<\/structured>/);
+    if (!match) {
+      return NextResponse.json({ error: 'Failed to parse structured output' }, { status: 500 });
+    }
+
+    let structured;
+    try {
+      structured = JSON.parse(match[1]);
+    } catch {
+      return NextResponse.json({ error: 'Invalid JSON from AI' }, { status: 500 });
+    }
+
+    return NextResponse.json({ structured });
+  } catch (error) {
+    console.error('[Brain Dump]', error);
+    const msg = error instanceof Error ? error.message : 'Brain dump processing failed';
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/src/app/api/ops/mission/generate-roadmap/route.ts
+++ b/src/app/api/ops/mission/generate-roadmap/route.ts
@@ -4,40 +4,86 @@ import { getVerifiedEmail } from '@/lib/cookie-auth';
 import Anthropic from '@anthropic-ai/sdk';
 
 function buildRoadmapPrompt(mission: Record<string, unknown>): string {
-  return `You are a strategic project planning engine inside Temple Stuart. You are building a detailed execution roadmap for a gifted AuDHD adult who is a solo founder. Your job is to take their vision and reverse-engineer it into a week-by-week plan with daily task templates.
+  return `You are an elite project planning engine inside Temple Stuart. You think like a combination of operator, PM, strategist, coach, and realist. You are building a detailed execution roadmap for a gifted AuDHD solo founder.
 
-PROJECT:
-- Name: ${mission.name}
-- Goal: ${mission.goalDescription}
-- Done Definition: ${mission.doneDefinition}
-- Start Date: ${mission.startDate}
-- End Date: ${mission.endDate}
-- Total Days: ${mission.totalDays}
+Your job: take their vision, current state, blockers, constraints, and priorities — and reverse-engineer a week-by-week execution plan that is practical, high-priority, and reality-based. This is NOT a motivational planner. This is a founder execution system.
 
-MILESTONES THE USER DEFINED:
+═══════════════════════════════════════════════
+PROJECT
+═══════════════════════════════════════════════
+Name: ${mission.name}
+Goal: ${mission.goalDescription}
+Done Definition: ${mission.doneDefinition}
+Start Date: ${mission.startDate}
+End Date: ${mission.endDate}
+Total Days: ${mission.totalDays}
+
+═══════════════════════════════════════════════
+TOP 3 PRIORITIES (these override everything)
+═══════════════════════════════════════════════
+Every week's tasks MUST trace to one of these. If a task doesn't advance a priority, cut it.
+1. ${mission.priority1 || 'not specified'}
+2. ${mission.priority2 || 'not specified'}
+3. ${mission.priority3 || 'not specified'}
+
+═══════════════════════════════════════════════
+CURRENT STATE (start from here, not zero)
+═══════════════════════════════════════════════
+What already works:
+${mission.currentState || 'not specified'}
+
+═══════════════════════════════════════════════
+WHAT IS BROKEN / BLOCKING LAUNCH
+═══════════════════════════════════════════════
+${mission.brokenBlockers || mission.blockers || 'none specified'}
+
+═══════════════════════════════════════════════
+RISK FACTORS / DERAILERS
+═══════════════════════════════════════════════
+${mission.riskFactors || 'none specified'}
+
+═══════════════════════════════════════════════
+MILESTONES
+═══════════════════════════════════════════════
 ${JSON.stringify(mission.milestones)}
 
-CONSTRAINTS:
-- Available hours per day: ${mission.hoursPerDay || 'not specified'}
-- Off days: ${mission.offDays || 'none specified'}
-- Monthly budget: $${mission.monthlyBudget || 'not specified'}
-- Blockers: ${mission.blockers || 'none specified'}
+═══════════════════════════════════════════════
+REAL DAILY CAPACITY
+═══════════════════════════════════════════════
+Focus windows: ${mission.focusWindows || 'not specified'}
+Fixed daily commitments: ${mission.fixedCommitments || 'not specified'}
+Weekend schedule: ${mission.weekendSchedule || 'not specified'}
+Deep work hours/day: ${mission.deepWorkHours || mission.hoursPerDay || 'not specified'}
+Off days: ${mission.offDays || 'none specified'}
 
-WHOLE LIFE CONTEXT:
-- Health goals: ${mission.healthGoals || 'none specified'}
-- Personal goals: ${mission.personalGoals || 'none specified'}
-- Meal strategy: ${mission.mealStrategy || 'none specified'}
+═══════════════════════════════════════════════
+SUCCESS METRICS (roadmap must address ALL)
+═══════════════════════════════════════════════
+${JSON.stringify(mission.successMetrics)}
 
-YOUR RULES:
-1. Break the total timeline into weeks. Each week gets a THEME (what's the focus) and a MILESTONE TARGET (what should be done by end of week).
-2. For each week, generate 3-5 DAILY TASK TEMPLATES — these are the recurring daily tasks for that week. They should directly advance the milestone.
-3. Sequence milestones logically — dependencies first, launches last. Don't put "onboard users" before "build the product."
-4. Apply the 50% rule — only schedule 50% of stated available hours for focused work. The rest is buffer, context-switching, unexpected issues.
-5. Front-load the hardest/riskiest work. Week 1-2 should tackle the scariest unknowns.
-6. Include health cadence per week — when to work out, rest days, meal prep days. These are NON-NEGOTIABLE and should be woven into the plan, not bolted on.
-7. If the user's milestones seem unrealistic for the timeline, say so in the week notes. Don't silently compress. Flag it.
-8. Include 1 recovery/buffer week every 6 weeks (Shape Up cooldown principle). Mark it as "Buffer & Recovery."
-9. Personal goals should have dedicated time blocks — content creation, personal errands, etc. Don't let business eat everything.
+═══════════════════════════════════════════════
+WHOLE LIFE CONTEXT
+═══════════════════════════════════════════════
+Health goals: ${mission.healthGoals || 'none specified'}
+Personal goals: ${mission.personalGoals || 'none specified'}
+Meal strategy: ${mission.mealStrategy || 'none specified'}
+Monthly budget: $${mission.monthlyBudget || 'not specified'}
+
+═══════════════════════════════════════════════
+YOUR RULES
+═══════════════════════════════════════════════
+1. PRIORITIES FIRST: Every week's tasks MUST trace to one of the Top 3 Priorities. If a task doesn't advance a priority, cut it. Tag each task with which priority it serves (P1, P2, or P3).
+2. FIX BEFORE BUILD: Weeks 1-2 must tackle the BROKEN/BLOCKING items first. You cannot build new features on broken foundations. Stabilize before expanding.
+3. SEQUENCE BY DEPENDENCY: Don't put "onboard users" before "build the onboarding flow." Map dependencies and sequence accordingly.
+4. REAL TIME BLOCKS: Schedule tasks within the user's stated focus windows. If they said "6-9am deep work, 1-5pm build sessions" — use those windows. Don't generate generic "morning/afternoon" blocks.
+5. 50% CAPACITY: Only schedule 50% of stated deep work hours. The other 50% is buffer for context-switching, unexpected issues, and ADHD energy fluctuation.
+6. BUFFER WEEKS: Insert 1 recovery/buffer week every 6 weeks (Shape Up cooldown). Mark it as "Buffer & Recovery." These are non-negotiable.
+7. FRONT-LOAD RISK: The stated risk factors/derailers should be mitigated EARLY. If "scope creep" is a risk, the first weeks should have tightly defined scope. If "burnout" is a risk, build in lighter days.
+8. SUCCESS METRIC CHECK: At the end, verify every Success Metric is addressed by at least one week's milestone. Flag any metric the roadmap does NOT address.
+9. HEALTH IS NON-NEGOTIABLE: Health cadence goes into every week. Workout days, rest days, meal prep — woven in, not bolted on. These are not optional.
+10. CURRENT STATE AWARENESS: Do NOT plan work for things that already exist. The Current State section tells you what's already built. Plan FROM there.
+11. MILESTONES AS GATES: If the user provided milestones with target dates, those are hard constraints. Build backward from them.
+12. BE HONEST: If the plan is too ambitious for the timeline, say so. If milestones conflict, say so. If the user needs to cut scope, recommend what to cut. Don't be a yes-machine.
 
 RESPOND WITH ONLY a JSON object wrapped in <roadmap> tags:
 
@@ -50,15 +96,19 @@ RESPOND WITH ONLY a JSON object wrapped in <roadmap> tags:
       "endDate": "YYYY-MM-DD",
       "theme": "string — what this week is about",
       "milestoneTarget": "string — what should be DONE by end of this week, or null",
+      "priorityFocus": "P1|P2|P3 — which top priority this week primarily advances",
       "dailyTasks": [
-        {"text": "string", "priority": "high|medium|low"}
+        {"text": "string", "priority": "high|medium|low", "priorityTag": "P1|P2|P3"}
       ],
       "healthCadence": "string — e.g. 'Gym M/W/F, CorePower T/Th, Rest Sun'",
-      "notes": "string — any flags, warnings, or context for this week, or null"
+      "notes": "string — any flags, warnings, risk mitigations, or context, or null"
     }
   ],
   "summary": "string — 2-3 sentence overview of the plan strategy",
-  "warnings": ["string — any concerns about timeline, scope, or feasibility"]
+  "warnings": ["string — any concerns about timeline, scope, or feasibility"],
+  "metricsCheck": [
+    {"metric": "string — the success metric", "addressed": true, "addressedInWeek": 3}
+  ]
 }
 </roadmap>`;
 }

--- a/src/app/api/ops/mission/route.ts
+++ b/src/app/api/ops/mission/route.ts
@@ -60,6 +60,17 @@ export async function POST(request: Request) {
       healthGoals: rest.healthGoals ?? null,
       personalGoals: rest.personalGoals ?? null,
       mealStrategy: rest.mealStrategy ?? null,
+      priority1: rest.priority1 ?? null,
+      priority2: rest.priority2 ?? null,
+      priority3: rest.priority3 ?? null,
+      currentState: rest.currentState ?? null,
+      brokenBlockers: rest.brokenBlockers ?? null,
+      riskFactors: rest.riskFactors ?? null,
+      focusWindows: rest.focusWindows ?? null,
+      fixedCommitments: rest.fixedCommitments ?? null,
+      weekendSchedule: rest.weekendSchedule ?? null,
+      deepWorkHours: rest.deepWorkHours ?? null,
+      successMetrics: rest.successMetrics ?? [],
     };
 
     const existing = await prisma.missions.findFirst({

--- a/src/components/ops/BrainDump.tsx
+++ b/src/components/ops/BrainDump.tsx
@@ -1,0 +1,360 @@
+'use client';
+
+import { useState, useEffect, useRef, useCallback } from 'react';
+
+const PLACEHOLDERS = [
+  'I need to launch bookkeeping by end of month...',
+  'Need to solve the dog / lease situation...',
+  'Want to post daily reels for 75 days...',
+];
+
+const LOADING_MESSAGES = [
+  'Finding your goals...',
+  'Identifying priorities...',
+  'Spotting blockers...',
+  'Mapping your plan...',
+];
+
+const CATEGORY_LABELS: Record<string, string> = {
+  goals: 'GOALS',
+  priority1: 'PRIORITY 1',
+  priority2: 'PRIORITY 2',
+  priority3: 'PRIORITY 3',
+  currentState: 'WHAT EXISTS',
+  brokenBlockers: 'BLOCKERS',
+  riskFactors: 'RISKS',
+  healthGoals: 'HEALTH & WELLNESS',
+  personalGoals: 'PERSONAL',
+  mealStrategy: 'MEALS',
+  timelineHints: 'TIMELINE HINTS',
+  budgetHints: 'BUDGET HINTS',
+};
+
+interface BrainDumpProps {
+  onComplete: (structuredData: Record<string, unknown>) => void;
+}
+
+export default function BrainDump({ onComplete }: BrainDumpProps) {
+  const [bullets, setBullets] = useState(['', '', '']);
+  const [isProcessing, setIsProcessing] = useState(false);
+  const [loadingMsgIdx, setLoadingMsgIdx] = useState(0);
+  const [structuredResult, setStructuredResult] = useState<Record<string, unknown> | null>(null);
+  const [editableResult, setEditableResult] = useState<Record<string, unknown> | null>(null);
+  const inputRefs = useRef<(HTMLInputElement | null)[]>([]);
+
+  useEffect(() => {
+    if (!isProcessing) return;
+    const interval = setInterval(() => {
+      setLoadingMsgIdx((i) => (i + 1) % LOADING_MESSAGES.length);
+    }, 1500);
+    return () => clearInterval(interval);
+  }, [isProcessing]);
+
+  const updateBullet = (idx: number, value: string) => {
+    setBullets((prev) => prev.map((b, i) => (i === idx ? value : b)));
+  };
+
+  const addBullet = () => {
+    setBullets((prev) => [...prev, '']);
+    setTimeout(() => {
+      const lastRef = inputRefs.current[inputRefs.current.length];
+      lastRef?.focus();
+    }, 50);
+  };
+
+  const removeBullet = (idx: number) => {
+    if (bullets.length <= 1) return;
+    setBullets((prev) => prev.filter((_, i) => i !== idx));
+  };
+
+  const nonEmpty = bullets.filter((b) => b.trim().length > 0);
+  const canSubmit = nonEmpty.length >= 2;
+
+  const handleSubmit = useCallback(async () => {
+    if (!canSubmit) return;
+    setIsProcessing(true);
+    try {
+      const res = await fetch('/api/ops/brain-dump', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ bullets: nonEmpty }),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setStructuredResult(data.structured);
+        setEditableResult({ ...data.structured });
+      }
+    } catch (err) {
+      console.error('Brain dump failed:', err);
+    } finally {
+      setIsProcessing(false);
+    }
+  }, [canSubmit, nonEmpty]);
+
+  const updateEditable = (key: string, value: unknown) => {
+    setEditableResult((prev) => (prev ? { ...prev, [key]: value } : prev));
+  };
+
+  const updateDeliverable = (idx: number, value: string) => {
+    setEditableResult((prev) => {
+      if (!prev) return prev;
+      const arr = [...((prev.deliverables as string[]) || [])];
+      arr[idx] = value;
+      return { ...prev, deliverables: arr };
+    });
+  };
+
+  const updateUnknown = (idx: number, value: string) => {
+    setEditableResult((prev) => {
+      if (!prev) return prev;
+      const arr = [...((prev.unknowns as string[]) || [])];
+      arr[idx] = value;
+      return { ...prev, unknowns: arr };
+    });
+  };
+
+  // ── VIEW 1: Bullet Input ──────────────────────────────────────────────────
+
+  if (!structuredResult) {
+    return (
+      <div className="max-w-2xl mx-auto px-4 py-8">
+        <h1 className="text-2xl font-bold font-mono text-text-primary">What&apos;s in your head?</h1>
+        <p className="text-sm text-text-muted font-mono mt-2">
+          Dump everything. Goals, problems, ideas, worries &mdash; all of it.
+        </p>
+        <p className="text-terminal-sm text-text-faint font-mono mt-1">
+          No wrong answers. No order needed.
+        </p>
+
+        <div className="space-y-2 mt-6">
+          {bullets.map((b, i) => (
+            <div key={i} className="flex items-center gap-2">
+              <span className="text-lg text-brand-purple font-bold w-4 text-center">&bull;</span>
+              <input
+                ref={(el) => { inputRefs.current[i] = el; }}
+                type="text"
+                value={b}
+                onChange={(e) => updateBullet(i, e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    e.preventDefault();
+                    addBullet();
+                  }
+                }}
+                placeholder={PLACEHOLDERS[i] || 'Another thought...'}
+                className="flex-1 font-mono text-base bg-transparent border-b border-border focus:border-brand-purple outline-none py-2 transition-colors placeholder:text-text-faint"
+              />
+              {bullets.length > 1 && (
+                <button
+                  onClick={() => removeBullet(i)}
+                  className="text-text-faint hover:text-brand-red text-sm transition-colors px-1"
+                >
+                  &times;
+                </button>
+              )}
+            </div>
+          ))}
+        </div>
+
+        <button
+          onClick={addBullet}
+          className="mt-2 text-sm text-text-muted hover:text-brand-purple font-mono transition-colors"
+        >
+          + Add more
+        </button>
+
+        <div className="mt-8 text-center">
+          {isProcessing ? (
+            <div className="space-y-2">
+              <p className="text-sm text-text-muted font-mono animate-pulse">
+                Organizing your thoughts...
+              </p>
+              <p className="text-terminal-sm text-text-faint font-mono">{LOADING_MESSAGES[loadingMsgIdx]}</p>
+            </div>
+          ) : (
+            <button
+              onClick={handleSubmit}
+              disabled={!canSubmit}
+              className="px-6 py-3 bg-brand-purple text-white rounded-lg font-mono font-semibold text-sm hover:bg-brand-purple-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              &#129504; Organize My Thoughts
+            </button>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  // ── VIEW 2: Structured Review ─────────────────────────────────────────────
+
+  const ed = editableResult || structuredResult;
+  const deliverables = Array.isArray(ed.deliverables) ? (ed.deliverables as string[]) : [];
+  const unknowns = Array.isArray(ed.unknowns) ? (ed.unknowns as string[]) : [];
+
+  const stringCategories: Array<{ key: string; label: string }> = [
+    { key: 'goals', label: 'GOALS' },
+    { key: 'currentState', label: 'WHAT EXISTS' },
+    { key: 'brokenBlockers', label: 'BLOCKERS' },
+    { key: 'riskFactors', label: 'RISKS' },
+    { key: 'healthGoals', label: 'HEALTH & WELLNESS' },
+    { key: 'personalGoals', label: 'PERSONAL' },
+    { key: 'mealStrategy', label: 'MEALS' },
+  ];
+
+  return (
+    <div className="max-w-2xl mx-auto px-4 py-8">
+      {/* Dimmed bullets */}
+      <div className="opacity-40 pointer-events-none">
+        <h1 className="text-2xl font-bold font-mono text-text-primary">What&apos;s in your head?</h1>
+        <div className="space-y-1 mt-4">
+          {bullets.filter((b) => b.trim()).map((b, i) => (
+            <div key={i} className="flex items-center gap-2">
+              <span className="text-lg text-brand-purple font-bold w-4 text-center">&bull;</span>
+              <span className="font-mono text-sm text-text-primary">{b}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Mission statement */}
+      {ed.missionStatement != null && (
+        <div className="bg-brand-purple-wash border border-brand-purple/10 rounded-lg p-4 mt-8">
+          <p className="text-lg font-medium text-text-primary font-mono italic">
+            &ldquo;{String(ed.missionStatement)}&rdquo;
+          </p>
+          {ed.projectName != null && (
+            <p className="text-terminal-sm text-text-muted font-mono mt-1">
+              Suggested name: {String(ed.projectName)}
+            </p>
+          )}
+        </div>
+      )}
+
+      <h2 className="text-xl font-bold font-mono text-text-primary mt-8">Here&apos;s what I found:</h2>
+
+      {/* Priorities */}
+      <div className="bg-white rounded border border-border shadow-sm overflow-hidden mt-4">
+        <div className="px-3 py-2 border-b border-border">
+          <span className="text-terminal-sm uppercase tracking-widest text-text-muted font-mono">Top Priorities</span>
+        </div>
+        <div className="px-3 py-3 space-y-2">
+          {(['priority1', 'priority2', 'priority3'] as const).map((key, idx) => (
+            <div key={key} className="flex items-start gap-2">
+              <span className="text-sm font-bold text-brand-purple w-5 flex-shrink-0 mt-2">{idx + 1}.</span>
+              <textarea
+                rows={1}
+                value={String(ed[key] ?? '')}
+                onChange={(e) => updateEditable(key, e.target.value || null)}
+                placeholder={idx === 0 ? 'Highest leverage outcome' : 'Add if identified'}
+                className="flex-1 font-mono text-sm bg-transparent border border-border rounded-md px-3 py-2 focus:border-brand-purple outline-none transition-colors placeholder:text-text-faint resize-none"
+              />
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* String categories */}
+      <div className="space-y-3 mt-3">
+        {stringCategories.map(({ key, label }) => {
+          const val = ed[key];
+          return (
+            <div key={key} className="bg-white rounded border border-border shadow-sm overflow-hidden">
+              <div className="px-3 py-2 border-b border-border">
+                <span className="text-terminal-sm uppercase tracking-widest text-text-muted font-mono">{label}</span>
+              </div>
+              <div className="px-3 py-3">
+                <textarea
+                  rows={2}
+                  value={String(val ?? '')}
+                  onChange={(e) => updateEditable(key, e.target.value || null)}
+                  placeholder={val == null ? 'Nothing identified — add here if needed' : ''}
+                  className="w-full font-mono text-sm bg-transparent border border-border rounded-md px-3 py-2 focus:border-brand-purple outline-none transition-colors placeholder:text-text-faint resize-none"
+                />
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Deliverables */}
+      {deliverables.length > 0 && (
+        <div className="bg-white rounded border border-border shadow-sm overflow-hidden mt-3">
+          <div className="px-3 py-2 border-b border-border">
+            <span className="text-terminal-sm uppercase tracking-widest text-text-muted font-mono">Deliverables</span>
+          </div>
+          <div className="px-3 py-3 space-y-1">
+            {deliverables.map((d, i) => (
+              <input
+                key={i}
+                type="text"
+                value={d}
+                onChange={(e) => updateDeliverable(i, e.target.value)}
+                className="w-full font-mono text-sm bg-transparent border-b border-border-light focus:border-brand-purple outline-none py-1.5 px-1 transition-colors"
+              />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Unknowns */}
+      {unknowns.length > 0 && (
+        <div className="bg-white rounded border border-border shadow-sm overflow-hidden mt-3">
+          <div className="px-3 py-2 border-b border-border">
+            <span className="text-terminal-sm uppercase tracking-widest text-text-muted font-mono">Unknowns</span>
+          </div>
+          <div className="px-3 py-3 space-y-1">
+            {unknowns.map((u, i) => (
+              <div key={i} className="flex items-center gap-2">
+                <span className="text-amber-500 text-terminal-sm">?</span>
+                <input
+                  type="text"
+                  value={u}
+                  onChange={(e) => updateUnknown(i, e.target.value)}
+                  className="flex-1 font-mono text-sm bg-transparent border-b border-border-light focus:border-brand-purple outline-none py-1.5 px-1 transition-colors text-amber-700"
+                />
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Info hints */}
+      {(ed.timelineHints != null || ed.budgetHints != null) && (
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-3 mt-3">
+          {ed.timelineHints != null && (
+            <div className="bg-white rounded border border-border shadow-sm p-3">
+              <p className="text-terminal-sm uppercase tracking-widest text-text-muted font-mono mb-1">{CATEGORY_LABELS.timelineHints}</p>
+              <p className="text-terminal-base font-mono text-text-secondary">{String(ed.timelineHints)}</p>
+            </div>
+          )}
+          {ed.budgetHints != null && (
+            <div className="bg-white rounded border border-border shadow-sm p-3">
+              <p className="text-terminal-sm uppercase tracking-widest text-text-muted font-mono mb-1">{CATEGORY_LABELS.budgetHints}</p>
+              <p className="text-terminal-base font-mono text-text-secondary">{String(ed.budgetHints)}</p>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Actions */}
+      <div className="mt-6 flex gap-3 justify-center">
+        <button
+          onClick={() => onComplete(ed)}
+          className="px-5 py-2.5 bg-brand-purple text-white rounded-lg font-mono font-semibold text-sm hover:bg-brand-purple-hover transition-colors"
+        >
+          &#10003; Looks good &mdash; let&apos;s plan
+        </button>
+        <button
+          onClick={() => {
+            setStructuredResult(null);
+            setEditableResult(null);
+            window.scrollTo({ top: 0, behavior: 'smooth' });
+          }}
+          className="text-sm text-text-muted hover:text-brand-purple font-mono transition-colors"
+        >
+          + Add more thoughts
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ops/DailyDashboard.tsx
+++ b/src/components/ops/DailyDashboard.tsx
@@ -22,6 +22,7 @@ import MealsCard from './MealsCard';
 import EndOfDayCard from './EndOfDayCard';
 import RecordView from './RecordView';
 import MissionPlanning from './MissionPlanning';
+import BrainDump from './BrainDump';
 
 const PRIO_DOT: Record<string, string> = { high: 'bg-red-500', medium: 'bg-amber-500', low: 'bg-emerald-500' };
 
@@ -39,6 +40,10 @@ export default function DailyDashboard() {
   const [mission, setMission] = useState<Mission | null>(null);
   const [missionLoading, setMissionLoading] = useState(true);
   const [editingMission, setEditingMission] = useState(false);
+
+  // Brain dump → mission flow
+  const [brainDumpComplete, setBrainDumpComplete] = useState(false);
+  const [prefillData, setPrefillData] = useState<Record<string, unknown> | null>(null);
 
   // ── Fetch mission on mount ────────────────────────────────────────────────
 
@@ -311,12 +316,70 @@ export default function DailyDashboard() {
     );
   }
 
-  // ── STATE 1: No mission — show MissionPlanning ────────────────────────────
+  // ── STATE 1: No mission — brain dump first, then mission planning ────────
 
   if (!mission && !editingMission) {
+    if (!brainDumpComplete) {
+      return (
+        <div className="max-w-6xl mx-auto px-4 py-3">
+          <BrainDump
+            onComplete={(data) => {
+              setPrefillData(data);
+              setBrainDumpComplete(true);
+            }}
+          />
+        </div>
+      );
+    }
+
+    const prefilled: Mission = {
+      id: '',
+      name: String(prefillData?.projectName ?? ''),
+      goalDescription: String(prefillData?.goals ?? ''),
+      doneDefinition: String(prefillData?.doneDefinition ?? ''),
+      startDate: '',
+      endDate: '',
+      totalDays: 0,
+      milestones: Array.isArray(prefillData?.deliverables)
+        ? (prefillData!.deliverables as string[]).filter(Boolean).map((d) => ({
+            id: generateId(),
+            text: d,
+            targetDate: null,
+            completed: false,
+          }))
+        : [],
+      hoursPerDay: null,
+      offDays: null,
+      monthlyBudget: null,
+      blockers: null,
+      healthGoals: prefillData?.healthGoals != null ? String(prefillData.healthGoals) : null,
+      personalGoals: prefillData?.personalGoals != null ? String(prefillData.personalGoals) : null,
+      mealStrategy: prefillData?.mealStrategy != null ? String(prefillData.mealStrategy) : null,
+      roadmap: null,
+      status: 'active',
+      priority1: prefillData?.priority1 != null ? String(prefillData.priority1) : null,
+      priority2: prefillData?.priority2 != null ? String(prefillData.priority2) : null,
+      priority3: prefillData?.priority3 != null ? String(prefillData.priority3) : null,
+      currentState: prefillData?.currentState != null ? String(prefillData.currentState) : null,
+      brokenBlockers: prefillData?.brokenBlockers != null ? String(prefillData.brokenBlockers) : null,
+      riskFactors: prefillData?.riskFactors != null ? String(prefillData.riskFactors) : null,
+      focusWindows: null,
+      fixedCommitments: null,
+      weekendSchedule: null,
+      deepWorkHours: null,
+      successMetrics: [],
+    };
+
     return (
       <div className="max-w-6xl mx-auto px-4 py-3">
-        <MissionPlanning existingMission={null} onMissionReady={handleMissionReady} />
+        <MissionPlanning
+          existingMission={prefilled}
+          onMissionReady={handleMissionReady}
+          onCancel={() => {
+            setBrainDumpComplete(false);
+            setPrefillData(null);
+          }}
+        />
       </div>
     );
   }

--- a/src/components/ops/types.ts
+++ b/src/components/ops/types.ts
@@ -76,21 +76,34 @@ export interface Milestone {
   completed: boolean;
 }
 
+export interface SuccessMetric {
+  id: string;
+  text: string;
+}
+
 export interface WeekPlan {
   weekNumber: number;
   startDate: string;
   endDate: string;
   theme: string;
   milestoneTarget: string | null;
-  dailyTasks: Array<{ text: string; priority: 'high' | 'medium' | 'low' }>;
+  priorityFocus?: string | null;
+  dailyTasks: Array<{ text: string; priority: 'high' | 'medium' | 'low'; priorityTag?: string }>;
   healthCadence: string | null;
   notes: string | null;
+}
+
+export interface MetricsCheck {
+  metric: string;
+  addressed: boolean;
+  addressedInWeek: number | null;
 }
 
 export interface Roadmap {
   weeks: WeekPlan[];
   summary?: string;
   warnings?: string[];
+  metricsCheck?: MetricsCheck[];
 }
 
 export interface Mission {
@@ -111,6 +124,17 @@ export interface Mission {
   mealStrategy: string | null;
   roadmap: Roadmap | null;
   status: string;
+  priority1: string | null;
+  priority2: string | null;
+  priority3: string | null;
+  currentState: string | null;
+  brokenBlockers: string | null;
+  riskFactors: string | null;
+  focusWindows: string | null;
+  fixedCommitments: string | null;
+  weekendSchedule: string | null;
+  deepWorkHours: number | null;
+  successMetrics: SuccessMetric[];
 }
 
 export const SPRINT_START = '2026-04-22';


### PR DESCRIPTION
…anning inputs

Schema: rawBrainDump JSON field on missions + BAMF upgrade fields (priorities,
  currentState, brokenBlockers, riskFactors, capacity fields, successMetrics).
  Two migrations created (not applied).

API: POST /api/ops/brain-dump — takes unstructured bullet points, calls Claude
  Sonnet to categorize into goals, priorities, current state, deliverables,
  blockers, risks, health/personal/meal goals, unknowns, timeline/budget hints.

BrainDump component — two views:
  1. Bullet input: clean minimal UI with bottom-line inputs, Enter to add rows, placeholder variety for first 3 rows, "Organize My Thoughts" button (disabled until 2+ bullets filled), cycling loading messages
  2. Structured review: AI output in editable category cards (priorities, goals, current state, blockers, risks, health, personal, meals, deliverables list, unknowns in amber, timeline/budget hints). "Looks good — let's plan" advances to MissionPlanning pre-filled. "Add more thoughts" goes back to bullet input.

DailyDashboard: no-mission state now shows BrainDump first. On completion,
  constructs a pre-filled Mission object from structured data (maps projectName
  → name, deliverables → milestones with IDs, etc.) and renders MissionPlanning
  with it. Cancel goes back to brain dump.

Also includes: upgraded mission API (saves all new fields), upgraded roadmap
  generation system prompt (priority-driven, fix-before-build, front-load risk,
  50% capacity, buffer weeks, metrics check, honest scope assessment).

https://claude.ai/code/session_01GQeiwocJDnF2N3pU1q7Y8t