### PR TITLE
feat: add mission pipeline prompt templates + amend mission_stages sc…

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1937,9 +1937,12 @@ model mission_stages {
   stageOrder      Int
   status          StageStatus @default(pending)
   inputSnapshot   Json?
-  promptText      String?     @db.Text
+  systemPrompt    String?     @db.Text
+  userPrompt      String?     @db.Text
+  model           String?
   rawResponse     String?     @db.Text
   parsedOutput    Json?
+  editedOutput    Json?
   attemptNumber   Int         @default(1)
   approvedAt      DateTime?
   rejectedAt      DateTime?

--- a/src/lib/mission/prompts/goal-confirmation.ts
+++ b/src/lib/mission/prompts/goal-confirmation.ts
@@ -1,0 +1,34 @@
+import { StructureOutput, GoalDiscoveryOutput, GoalConfirmationOutput } from './types';
+
+// ============================================
+// INPUT
+// ============================================
+
+export interface GoalConfirmationInput {
+  selectedGoalRank: number;
+  editedGoalStatement?: string;
+  structuredOutput: StructureOutput;
+  goalDiscoveryOutput: GoalDiscoveryOutput;
+  answeredQuestions?: Array<{
+    question: string;
+    answer: string;
+  }>;
+}
+
+// ============================================
+// MODEL
+// ============================================
+
+export const GOAL_CONFIRMATION_MODEL = 'claude-sonnet-4-20250514';
+
+// Reserved for future implementation — MVP uses manual goal selection without AI call
+
+export const GOAL_CONFIRMATION_SYSTEM_PROMPT = '// TODO: implement in phase 2';
+
+export function buildGoalConfirmationPrompt(_input: GoalConfirmationInput): string {
+  throw new Error('Goal confirmation prompt not yet implemented — MVP uses manual selection');
+}
+
+export function parseGoalConfirmationResponse(_raw: string): GoalConfirmationOutput {
+  throw new Error('Goal confirmation parser not yet implemented');
+}

--- a/src/lib/mission/prompts/goal-discovery.ts
+++ b/src/lib/mission/prompts/goal-discovery.ts
@@ -1,0 +1,170 @@
+import { StructureOutput, GoalDiscoveryOutput } from './types';
+
+// ============================================
+// INPUT
+// ============================================
+
+export interface GoalDiscoveryInput {
+  structuredOutput: StructureOutput;
+  missionTitle: string;
+  missionDuration: number;
+}
+
+// ============================================
+// MODEL
+// ============================================
+
+export const GOAL_DISCOVERY_MODEL = 'claude-sonnet-4-20250514';
+
+// ============================================
+// SYSTEM PROMPT
+// ============================================
+
+export const GOAL_DISCOVERY_SYSTEM_PROMPT = `You are a strategic analyst. Your job is to analyze structured planning data and identify the top 3 candidate goals for a time-bound mission.
+
+You are the analyst. The user is the strategist. You present options with honest tradeoffs. You do not recommend.
+
+Rules:
+
+CANDIDATE GOALS
+- Present exactly 3 candidate goals. Do NOT recommend one over the others.
+- rank (1, 2, 3) is for ordering only, not recommendation strength. Present them as equal-weight options.
+- Each goal must be a specific, measurable outcome achievable within the stated mission duration. Not a vague aspiration. Not "grow the business." Something like "launch paid bookkeeping tier with Stripe integration and 3 paying users."
+- Each goal must have a distinctiveAngle — one sentence explaining what makes this goal fundamentally different from the other two. If your three goals are variations of the same idea, you have failed.
+- Each goal must include an executionProfile: what the user's days would actually look like if they chose this goal. What they would focus on, what they would deprioritize, what mode they would be operating in.
+
+TRADEOFFS
+- Every goal has real costs and real risks. Do not soften them.
+- gains: what the user gets
+- costs: what the user gives up or deprioritizes — be specific
+- risks: what could go wrong — be honest
+
+SUPPORTING EVIDENCE
+- Each goal must cite specific evidence from the structured data: cluster names, individual items, themes, or contradictions.
+- Use structured references with type ('cluster', 'item', 'theme', 'contradiction') and reference (the specific name or content).
+- Do not fabricate evidence. If a goal is only weakly supported, say so.
+
+TIMELINE FIT
+- Honestly assess whether the goal is achievable in the stated duration given the scope implied by the structured data.
+- If it is a stretch, say "this is aggressive." If it is comfortable, say so. Do not assume heroic productivity.
+
+OPEN QUESTIONS
+- Questions that MUST be answered before the user can confidently choose a goal.
+- Each question must specify which goals it affects (by rank number) and why it matters.
+- Not generic questions. Specific to the structured data and the candidate goals.
+
+ASSUMPTIONS TO VALIDATE
+- Beliefs embedded in the brain dump that may or may not be true.
+- Each must be typed: product (will this feature work?), market (do users want this?), personal_capacity (can the user sustain this pace?), technical (is this technically feasible?), timeline (can this be done in time?).
+- Include how to validate: a concrete step, not "do more research."
+
+ITEMS TO IGNORE
+- Real items from the structured data that should be explicitly deprioritized for THIS mission.
+- Include sourceEntryId when traceable.
+- Give a clear reason — this is permission to let go, not dismissal.
+
+Do not add motivational language, affirmations, or coaching tone. Be direct and analytical.
+Respond with valid JSON only. No markdown, no preamble, no explanation outside the JSON.`;
+
+// ============================================
+// USER PROMPT BUILDER
+// ============================================
+
+export function buildGoalDiscoveryPrompt(input: GoalDiscoveryInput): string {
+  const structuredData = JSON.stringify(input.structuredOutput, null, 2);
+
+  return `Mission: "${input.missionTitle}" (${input.missionDuration} days)
+
+Approved structured data from brain dump analysis:
+${structuredData}
+
+Identify the top 3 candidate goals for this mission. Return JSON matching this exact schema:
+
+{
+  "candidateGoals": [
+    {
+      "rank": 1,
+      "goalStatement": "string — specific, measurable outcome",
+      "distinctiveAngle": "string — what makes this fundamentally different from the other goals",
+      "rationale": "string",
+      "executionProfile": {
+        "primaryFocus": ["string — what the user's days center around"],
+        "deprioritizedAreas": ["string — what gets pushed aside"],
+        "likelyOperatingMode": "string — e.g. bug triage + shipping + user validation"
+      },
+      "tradeoffs": {
+        "gains": ["string"],
+        "costs": ["string — be specific about what is given up"],
+        "risks": ["string — be honest about what could go wrong"]
+      },
+      "timelineFit": "string — honest assessment for ${input.missionDuration} days",
+      "supportingEvidence": [
+        {
+          "type": "cluster | item | theme | contradiction",
+          "reference": "string — specific name or content from structured data"
+        }
+      ]
+    }
+  ],
+  "openQuestions": [
+    {
+      "question": "string",
+      "affectsGoals": [1, 2],
+      "whyItMatters": "string"
+    }
+  ],
+  "assumptionsToValidate": [
+    {
+      "assumption": "string",
+      "type": "product | market | personal_capacity | technical | timeline",
+      "whyItMatters": "string",
+      "howToValidate": "string — concrete step"
+    }
+  ],
+  "itemsToIgnoreForNow": [
+    {
+      "content": "string",
+      "sourceEntryId": "string or omit if not traceable",
+      "reason": "string"
+    }
+  ]
+}`;
+}
+
+// ============================================
+// RESPONSE PARSER
+// ============================================
+
+export function parseGoalDiscoveryResponse(raw: string): GoalDiscoveryOutput {
+  const cleaned = raw
+    .trim()
+    .replace(/^```json\s*/, '')
+    .replace(/\s*```$/, '');
+  const parsed = JSON.parse(cleaned);
+
+  if (!Array.isArray(parsed.candidateGoals) || parsed.candidateGoals.length !== 3) {
+    throw new Error(
+      `Goal discovery must return exactly 3 candidate goals, got ${parsed.candidateGoals?.length ?? 0}`,
+    );
+  }
+
+  for (const goal of parsed.candidateGoals) {
+    if (!goal.goalStatement)
+      throw new Error(`Candidate goal rank ${goal.rank} missing goalStatement`);
+    if (!goal.distinctiveAngle)
+      throw new Error(`Candidate goal rank ${goal.rank} missing distinctiveAngle`);
+    if (!goal.executionProfile)
+      throw new Error(`Candidate goal rank ${goal.rank} missing executionProfile`);
+    if (!goal.tradeoffs) throw new Error(`Candidate goal rank ${goal.rank} missing tradeoffs`);
+    if (!Array.isArray(goal.supportingEvidence))
+      throw new Error(`Candidate goal rank ${goal.rank} missing supportingEvidence array`);
+  }
+
+  if (!Array.isArray(parsed.openQuestions)) throw new Error('Missing openQuestions array');
+  if (!Array.isArray(parsed.assumptionsToValidate))
+    throw new Error('Missing assumptionsToValidate array');
+  if (!Array.isArray(parsed.itemsToIgnoreForNow))
+    throw new Error('Missing itemsToIgnoreForNow array');
+
+  return parsed as GoalDiscoveryOutput;
+}

--- a/src/lib/mission/prompts/index.ts
+++ b/src/lib/mission/prompts/index.ts
@@ -1,0 +1,18 @@
+export * from './types';
+export {
+  type StructureInput,
+  STRUCTURE_MODEL,
+  STRUCTURE_SYSTEM_PROMPT,
+  buildStructurePrompt,
+  parseStructureResponse,
+} from './structure';
+export {
+  type GoalDiscoveryInput,
+  GOAL_DISCOVERY_MODEL,
+  GOAL_DISCOVERY_SYSTEM_PROMPT,
+  buildGoalDiscoveryPrompt,
+  parseGoalDiscoveryResponse,
+} from './goal-discovery';
+export { type GoalConfirmationInput, GOAL_CONFIRMATION_MODEL } from './goal-confirmation';
+export { type RealityAuditInput, REALITY_AUDIT_MODEL } from './reality-audit';
+export { type RoadmapInput, ROADMAP_MODEL } from './roadmap';

--- a/src/lib/mission/prompts/reality-audit.ts
+++ b/src/lib/mission/prompts/reality-audit.ts
@@ -1,0 +1,41 @@
+import { StructureOutput, GoalDiscoveryOutput, RealityAuditOutput } from './types';
+
+// ============================================
+// INPUT
+// ============================================
+
+export interface RealityAuditInput {
+  confirmedGoal: string;
+  structuredOutput: StructureOutput;
+  goalDiscoveryOutput: GoalDiscoveryOutput;
+  constraints: {
+    product: Array<{
+      category: string;
+      description: string;
+      value: string | null;
+      source: string;
+    }>;
+    operational: Array<{
+      category: string;
+      description: string;
+      value: string | null;
+      source: string;
+    }>;
+  };
+}
+
+// ============================================
+// MODEL
+// ============================================
+
+export const REALITY_AUDIT_MODEL = 'claude-sonnet-4-20250514';
+
+export const REALITY_AUDIT_SYSTEM_PROMPT = '// TODO: implement in phase 2';
+
+export function buildRealityAuditPrompt(_input: RealityAuditInput): string {
+  throw new Error('Reality audit prompt not yet implemented');
+}
+
+export function parseRealityAuditResponse(_raw: string): RealityAuditOutput {
+  throw new Error('Reality audit parser not yet implemented');
+}

--- a/src/lib/mission/prompts/roadmap.ts
+++ b/src/lib/mission/prompts/roadmap.ts
@@ -1,0 +1,28 @@
+import { RealityAuditOutput, RoadmapOutput } from './types';
+
+// ============================================
+// INPUT
+// ============================================
+
+export interface RoadmapInput {
+  confirmedGoal: string;
+  realityAuditOutput: RealityAuditOutput;
+  missionDuration: number;
+  startDate: string;
+}
+
+// ============================================
+// MODEL
+// ============================================
+
+export const ROADMAP_MODEL = 'claude-sonnet-4-20250514';
+
+export const ROADMAP_SYSTEM_PROMPT = '// TODO: implement in phase 2';
+
+export function buildRoadmapPrompt(_input: RoadmapInput): string {
+  throw new Error('Roadmap prompt not yet implemented');
+}
+
+export function parseRoadmapResponse(_raw: string): RoadmapOutput {
+  throw new Error('Roadmap parser not yet implemented');
+}

--- a/src/lib/mission/prompts/structure.ts
+++ b/src/lib/mission/prompts/structure.ts
@@ -1,0 +1,192 @@
+import { BrainDumpItem, StructureOutput } from './types';
+
+// ============================================
+// INPUT
+// ============================================
+
+export interface StructureInput {
+  brainDumpEntries: BrainDumpItem[];
+  missionTitle: string;
+  missionDuration: number;
+}
+
+// ============================================
+// MODEL
+// ============================================
+
+export const STRUCTURE_MODEL = 'claude-haiku-4-5-20241022';
+
+// ============================================
+// SYSTEM PROMPT
+// ============================================
+
+export const STRUCTURE_SYSTEM_PROMPT = `You are a structured thinking analyst. Your job is to take raw, unorganized thoughts from a founder's brain dump and organize them into clear clusters — while also surfacing contradictions, dependencies, logic gaps, and missing information.
+
+You are ORGANIZING and ANALYZING, not advising. Do not recommend, prioritize, or suggest goals.
+
+Rules:
+
+CLUSTERING
+- Produce between 4 and 8 clusters unless the data is genuinely too sparse for 4.
+- Each cluster must contain at least 2 items unless a single item is truly unique and cannot fit elsewhere.
+- Cluster names must be concrete noun phrases specific to the content. Not "General", "Planning", "Important Things", or other vague labels.
+- Each cluster gets a one-sentence summary describing what it contains.
+- Do not force items into the 6 input buckets (business, technical, constraints, growth, life, open). Those are capture scaffolding, not analytical categories. Create clusters that reflect the actual content.
+- Do not collapse materially different ideas into one item for neatness. If two thoughts are distinct, keep them separate.
+
+LINEAGE
+- Every output item must reference the sourceEntryId of the original brain dump entry it came from. No orphaned items.
+- If an item contains multiple distinct thoughts, split them into separate items under appropriate clusters — each split item still references the original sourceEntryId.
+
+MISSION RELEVANCE
+- missionRelevance measures fit to the stated mission title and duration only. Not urgency, not impact, not priority. Just: does this item relate to what this mission is about?
+
+EMERGENT THEMES
+- Themes are patterns detected ACROSS clusters — recurring concerns, repeated phrases, underlying anxieties, or implicit priorities.
+- Each theme must cite evidence (specific items or cluster names).
+- Mark whether the theme is explicit (user stated it directly, multiple times) or pattern_inference (you detected it from patterns they did not state).
+- Rate confidence: high (clear repeated signal), medium (probable pattern), low (possible but uncertain).
+
+CONTRADICTIONS
+- If two items contradict each other, flag them with both sourceEntryIds. Do not resolve contradictions — that is the user's job.
+- Rate severity: high (these cannot both be true and it blocks planning), medium (tension that needs resolution), low (minor inconsistency).
+
+MISSING INPUTS
+- If important categories have zero entries, or the user references things without explanation, flag them.
+- Each missing input must explain why it matters and provide a specific question the user could answer.
+
+LATENT DEPENDENCIES
+- Identify items that cannot happen without another unstated step or prerequisite.
+- This is dependency surfacing, not advice. You are saying "if you want X, you need A, B, C" — not "you should do A, B, C."
+
+LOGIC GAPS
+- Identify places where the user jumps from desire to outcome without an intermediate mechanism.
+- Example: "I want to launch in 30 days" combined with no mention of what is already built equals a logic gap.
+- This is gap identification, not criticism.
+
+Prefer traceability over elegance.
+Respond with valid JSON only. No markdown, no preamble, no explanation outside the JSON.`;
+
+// ============================================
+// USER PROMPT BUILDER
+// ============================================
+
+export function buildStructurePrompt(input: StructureInput): string {
+  const entriesFormatted = input.brainDumpEntries
+    .map((e) => `[${e.id}] (${e.bucket}${e.category ? '/' + e.category : ''}): ${e.content}`)
+    .join('\n');
+
+  return `Mission: "${input.missionTitle}" (${input.missionDuration} days)
+
+Brain dump entries (${input.brainDumpEntries.length} total):
+${entriesFormatted}
+
+Organize these entries into clusters and analyze for themes, contradictions, dependencies, logic gaps, and missing information.
+
+Return JSON matching this exact schema:
+
+{
+  "clusters": [
+    {
+      "clusterName": "string — concrete noun phrase",
+      "summary": "string — one sentence describing this cluster",
+      "items": [
+        {
+          "content": "string — item content, may be lightly rephrased for clarity but preserve meaning",
+          "sourceEntryId": "string — the [id] from the brain dump entry",
+          "missionRelevance": "high | medium | low"
+        }
+      ]
+    }
+  ],
+  "uncategorizedItems": [
+    {
+      "content": "string",
+      "sourceEntryId": "string",
+      "suggestedCluster": "string"
+    }
+  ],
+  "emergentThemes": [
+    {
+      "theme": "string",
+      "evidence": ["string — specific items or cluster names"],
+      "confidence": "high | medium | low",
+      "basis": "explicit | pattern_inference"
+    }
+  ],
+  "contradictions": [
+    {
+      "itemA": { "content": "string", "sourceEntryId": "string" },
+      "itemB": { "content": "string", "sourceEntryId": "string" },
+      "nature": "string — what the contradiction is",
+      "severity": "high | medium | low"
+    }
+  ],
+  "missingInputs": [
+    {
+      "area": "string — what category of information is missing",
+      "whyMissingMatters": "string",
+      "suggestedQuestion": "string — exact question to ask the user"
+    }
+  ],
+  "latentDependencies": [
+    {
+      "item": "string — the brain dump item",
+      "dependsOn": ["string — unstated prerequisites"],
+      "why": "string"
+    }
+  ],
+  "logicGaps": [
+    {
+      "statement": "string — what the user said",
+      "gap": "string — what is missing between desire and outcome",
+      "whyItMatters": "string"
+    }
+  ]
+}`;
+}
+
+// ============================================
+// RESPONSE PARSER
+// ============================================
+
+export function parseStructureResponse(raw: string): StructureOutput {
+  const cleaned = raw
+    .trim()
+    .replace(/^```json\s*/, '')
+    .replace(/\s*```$/, '');
+  const parsed = JSON.parse(cleaned);
+
+  const requiredFields = [
+    'clusters',
+    'uncategorizedItems',
+    'emergentThemes',
+    'contradictions',
+    'missingInputs',
+    'latentDependencies',
+    'logicGaps',
+  ];
+  for (const field of requiredFields) {
+    if (!Array.isArray(parsed[field])) {
+      throw new Error(`Structure response missing required array field: ${field}`);
+    }
+  }
+
+  for (const cluster of parsed.clusters) {
+    if (!cluster.clusterName || typeof cluster.clusterName !== 'string') {
+      throw new Error('Cluster missing clusterName');
+    }
+    if (!Array.isArray(cluster.items)) {
+      throw new Error(`Cluster "${cluster.clusterName}" missing items array`);
+    }
+    for (const item of cluster.items) {
+      if (!item.sourceEntryId) {
+        throw new Error(
+          `Item in cluster "${cluster.clusterName}" missing sourceEntryId: ${item.content?.substring(0, 50)}`,
+        );
+      }
+    }
+  }
+
+  return parsed as StructureOutput;
+}

--- a/src/lib/mission/prompts/types.ts
+++ b/src/lib/mission/prompts/types.ts
@@ -1,0 +1,191 @@
+// ============================================
+// BRAIN DUMP INPUT (shared across stages)
+// ============================================
+
+export interface BrainDumpItem {
+  id: string;
+  bucket: 'business' | 'technical' | 'constraints' | 'growth' | 'life' | 'open';
+  category: string | null;
+  content: string;
+  source: 'typed' | 'voice';
+}
+
+// ============================================
+// STAGE 1: STRUCTURE — Output Contract
+// ============================================
+
+export interface StructureOutput {
+  clusters: Array<{
+    clusterName: string;
+    summary: string;
+    items: Array<{
+      content: string;
+      sourceEntryId: string;
+      missionRelevance: 'high' | 'medium' | 'low';
+    }>;
+  }>;
+  uncategorizedItems: Array<{
+    content: string;
+    sourceEntryId: string;
+    suggestedCluster: string;
+  }>;
+  emergentThemes: Array<{
+    theme: string;
+    evidence: string[];
+    confidence: 'high' | 'medium' | 'low';
+    basis: 'explicit' | 'pattern_inference';
+  }>;
+  contradictions: Array<{
+    itemA: { content: string; sourceEntryId: string };
+    itemB: { content: string; sourceEntryId: string };
+    nature: string;
+    severity: 'high' | 'medium' | 'low';
+  }>;
+  missingInputs: Array<{
+    area: string;
+    whyMissingMatters: string;
+    suggestedQuestion: string;
+  }>;
+  latentDependencies: Array<{
+    item: string;
+    dependsOn: string[];
+    why: string;
+  }>;
+  logicGaps: Array<{
+    statement: string;
+    gap: string;
+    whyItMatters: string;
+  }>;
+}
+
+// ============================================
+// STAGE 2: GOAL DISCOVERY — Output Contract
+// ============================================
+
+export interface GoalDiscoveryOutput {
+  candidateGoals: Array<{
+    rank: number;
+    goalStatement: string;
+    distinctiveAngle: string;
+    rationale: string;
+    executionProfile: {
+      primaryFocus: string[];
+      deprioritizedAreas: string[];
+      likelyOperatingMode: string;
+    };
+    tradeoffs: {
+      gains: string[];
+      costs: string[];
+      risks: string[];
+    };
+    timelineFit: string;
+    supportingEvidence: Array<{
+      type: 'cluster' | 'item' | 'theme' | 'contradiction';
+      reference: string;
+    }>;
+  }>;
+  openQuestions: Array<{
+    question: string;
+    affectsGoals: number[];
+    whyItMatters: string;
+  }>;
+  assumptionsToValidate: Array<{
+    assumption: string;
+    type: 'product' | 'market' | 'personal_capacity' | 'technical' | 'timeline';
+    whyItMatters: string;
+    howToValidate: string;
+  }>;
+  itemsToIgnoreForNow: Array<{
+    content: string;
+    sourceEntryId?: string;
+    reason: string;
+  }>;
+}
+
+// ============================================
+// STAGE 3: GOAL CONFIRMATION — Output Contract (reserved, not built in MVP)
+// ============================================
+
+export interface GoalConfirmationOutput {
+  refinedGoalStatement: string;
+  selectedRank: number;
+  rejectedGoals: Array<{
+    rank: number;
+    goalStatement: string;
+    rejectionReason: string;
+  }>;
+  validationPlan: Array<{
+    item: string;
+    type: 'assumption' | 'open_question' | 'dependency';
+    priority: 'must_resolve' | 'should_resolve' | 'nice_to_know';
+    howToValidate: string;
+  }>;
+  researchPriorities: string[];
+  remainingRisks: string[];
+}
+
+// ============================================
+// STAGE 4: REALITY AUDIT — Output Contract
+// ============================================
+
+export interface RealityAuditOutput {
+  productReality: {
+    alreadyBuilt: Array<{ item: string; status: 'working' | 'partial' | 'broken' }>;
+    reusableAssets: string[];
+    missingComponents: string[];
+    brokenOrRisky: Array<{ item: string; risk: string; severity: 'high' | 'medium' | 'low' }>;
+  };
+  operationalReality: {
+    timeAvailable: { hoursPerWeek: number; constraints: string[] };
+    budget: { available: string; burnRate: string; runway: string };
+    personalConstraints: string[];
+    energyBlockers: string[];
+  };
+  gapAnalysis: {
+    desiredState: string;
+    currentState: string;
+    gapItems: Array<{ gap: string; effort: 'small' | 'medium' | 'large'; priority: 'critical' | 'important' | 'nice_to_have' }>;
+  };
+  scopeCreepWarnings: string[];
+  fastWins: string[];
+  criticalPath: string[];
+  recommendedFocus: string;
+}
+
+// ============================================
+// STAGE 5: ROADMAP — Output Contract
+// ============================================
+
+export interface RoadmapOutput {
+  weeklyPlan: Array<{
+    weekNumber: number;
+    theme: string;
+    milestones: Array<{
+      title: string;
+      description: string;
+      successCriteria: string;
+    }>;
+    focusAreas: string[];
+  }>;
+  firstWeekDailyTasks: Array<{
+    day: number;
+    tasks: Array<{
+      title: string;
+      description: string;
+      priority: number;
+      estimatedMinutes: number;
+    }>;
+  }>;
+  kpiTargets: Array<{
+    metric: string;
+    target: string;
+    measurementMethod: string;
+  }>;
+  riskWatchlist: Array<{
+    risk: string;
+    trigger: string;
+    mitigation: string;
+  }>;
+  whatToIgnore: string[];
+  definitionOfWinning: string;
+}


### PR DESCRIPTION
…hema for full observability

Schema amendment (mission_stages):
- Replaced: promptText (single Text) → systemPrompt + userPrompt (separate Text fields)
- Added: model (String?) — which Claude model ran the stage
- Added: editedOutput (Json?) — user's edited version of parsedOutput

Prompt template files (src/lib/mission/prompts/):
- types.ts: typed output contracts for all 5 stages (StructureOutput, GoalDiscoveryOutput, GoalConfirmationOutput, RealityAuditOutput, RoadmapOutput)
  + BrainDumpItem input type shared across stages
- structure.ts: Stage 1 full implementation — Haiku model, system prompt (clustering, lineage, mission relevance, emergent themes, contradictions, missing inputs, latent dependencies, logic gaps), user prompt builder, response parser with field + lineage validation
- goal-discovery.ts: Stage 2 full implementation — Sonnet model, system prompt (3 candidate goals with distinctive angles, execution profiles, tradeoffs, timeline fit, supporting evidence, open questions, assumptions, items to ignore), user prompt builder, response parser with goal count + field validation
- goal-confirmation.ts: Stage 3 stub — typed input/output, reserved for phase 2
- reality-audit.ts: Stage 4 stub — typed input/output, reserved for phase 2
- roadmap.ts: Stage 5 stub — typed input/output, reserved for phase 2
- index.ts: barrel exports for all stages

https://claude.ai/code/session_01GQeiwocJDnF2N3pU1q7Y8t