### PR TITLE
feat: redesign brain dump with trigger questions + project-discovery …

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1957,14 +1957,15 @@ model mission_stages {
 }
 
 model brain_dump_entries {
-  id        String          @id @default(cuid())
-  missionId String
-  category  String?
-  bucket    BrainDumpBucket @default(open)
-  content   String          @db.Text
-  source    EntrySource     @default(typed)
-  rawOrder  Int
-  createdAt DateTime        @default(now())
+  id              String          @id @default(cuid())
+  missionId       String
+  category        String?
+  bucket          BrainDumpBucket @default(open)
+  content         String          @db.Text
+  source          EntrySource     @default(typed)
+  triggerQuestion String?
+  rawOrder        Int
+  createdAt       DateTime        @default(now())
 
   mission missions @relation(fields: [missionId], references: [id], onDelete: Cascade)
 

--- a/src/lib/mission/prompts/goal-discovery.ts
+++ b/src/lib/mission/prompts/goal-discovery.ts
@@ -20,7 +20,7 @@ export const GOAL_DISCOVERY_MODEL = 'claude-sonnet-4-20250514';
 // SYSTEM PROMPT
 // ============================================
 
-export const GOAL_DISCOVERY_SYSTEM_PROMPT = `You are a strategic analyst. Your job is to analyze structured planning data and identify the top 3 candidate goals for a time-bound mission.
+export const GOAL_DISCOVERY_SYSTEM_PROMPT = `You are a strategic analyst. Your job is to analyze a set of discovered projects from a founder's brain dump and propose 3 candidate mission goals — each representing a different strategy for how to spend the mission duration.
 
 You are the analyst. The user is the strategist. You present options with honest tradeoffs. You do not recommend.
 
@@ -29,29 +29,31 @@ Rules:
 CANDIDATE GOALS
 - Present exactly 3 candidate goals. Do NOT recommend one over the others.
 - rank (1, 2, 3) is for ordering only, not recommendation strength. Present them as equal-weight options.
-- Each goal must be a specific, measurable outcome achievable within the stated mission duration. Not a vague aspiration. Not "grow the business." Something like "launch paid bookkeeping tier with Stripe integration and 3 paying users."
-- Each goal must have a distinctiveAngle — one sentence explaining what makes this goal fundamentally different from the other two. If your three goals are variations of the same idea, you have failed.
-- Each goal must include an executionProfile: what the user's days would actually look like if they chose this goal. What they would focus on, what they would deprioritize, what mode they would be operating in.
+- Each goal is a specific, measurable outcome achievable within the stated mission duration. Not a vague aspiration. Not "grow the business." Something like "launch paid bookkeeping tier with Stripe integration and 3 paying users."
+- Each goal represents a different STRATEGY — a different combination of discovered projects to prioritize. If your three goals are variations of the same idea, you have failed.
+- Each goal must have a distinctiveAngle — one sentence explaining what makes this goal fundamentally different from the other two.
+- Each goal must include an executionProfile: what the user's days would actually look like if they chose this goal. What they would focus on, what they would deprioritize, what mode they would be operating in (e.g., "deep coding sprints + weekly demo recordings" or "bug triage + sales outreach + pricing experiments").
 
 TRADEOFFS
 - Every goal has real costs and real risks. Do not soften them.
-- gains: what the user gets
-- costs: what the user gives up or deprioritizes — be specific
+- gains: what the user gets if this goal succeeds
+- costs: which discovered projects get deprioritized — name them specifically
 - risks: what could go wrong — be honest
 
 SUPPORTING EVIDENCE
-- Each goal must cite specific evidence from the structured data: cluster names, individual items, themes, or contradictions.
-- Use structured references with type ('cluster', 'item', 'theme', 'contradiction') and reference (the specific name or content).
+- Each goal must cite specific evidence from the structured data: discovered project names, individual items, themes, or contradictions.
+- Use structured references with type ('project', 'item', 'theme', 'contradiction') and reference (the specific name or content).
 - Do not fabricate evidence. If a goal is only weakly supported, say so.
 
 TIMELINE FIT
-- Honestly assess whether the goal is achievable in the stated duration given the scope implied by the structured data.
+- Honestly assess whether the goal is achievable in the stated duration given the scope of the discovered projects involved.
 - If it is a stretch, say "this is aggressive." If it is comfortable, say so. Do not assume heroic productivity.
+- Factor in any constraints the user stated in their brain dump (extracted in the Structure stage).
 
 OPEN QUESTIONS
 - Questions that MUST be answered before the user can confidently choose a goal.
 - Each question must specify which goals it affects (by rank number) and why it matters.
-- Not generic questions. Specific to the structured data and the candidate goals.
+- Not generic questions. Specific to the discovered projects and the candidate goals.
 
 ASSUMPTIONS TO VALIDATE
 - Beliefs embedded in the brain dump that may or may not be true.
@@ -78,7 +80,7 @@ export function buildGoalDiscoveryPrompt(input: GoalDiscoveryInput): string {
 Approved structured data from brain dump analysis:
 ${structuredData}
 
-Identify the top 3 candidate goals for this mission. Return JSON matching this exact schema:
+Identify the top 3 candidate goals for this mission. Each goal should represent a different strategy for combining the discovered projects. Return JSON matching this exact schema:
 
 {
   "candidateGoals": [
@@ -89,18 +91,18 @@ Identify the top 3 candidate goals for this mission. Return JSON matching this e
       "rationale": "string",
       "executionProfile": {
         "primaryFocus": ["string — what the user's days center around"],
-        "deprioritizedAreas": ["string — what gets pushed aside"],
-        "likelyOperatingMode": "string — e.g. bug triage + shipping + user validation"
+        "deprioritizedAreas": ["string — which discovered projects get pushed aside"],
+        "likelyOperatingMode": "string — e.g. deep coding sprints + weekly demo recordings"
       },
       "tradeoffs": {
         "gains": ["string"],
-        "costs": ["string — be specific about what is given up"],
+        "costs": ["string — name specific discovered projects that get deprioritized"],
         "risks": ["string — be honest about what could go wrong"]
       },
       "timelineFit": "string — honest assessment for ${input.missionDuration} days",
       "supportingEvidence": [
         {
-          "type": "cluster | item | theme | contradiction",
+          "type": "project | item | theme | contradiction",
           "reference": "string — specific name or content from structured data"
         }
       ]

--- a/src/lib/mission/prompts/index.ts
+++ b/src/lib/mission/prompts/index.ts
@@ -16,3 +16,8 @@ export {
 export { type GoalConfirmationInput, GOAL_CONFIRMATION_MODEL } from './goal-confirmation';
 export { type RealityAuditInput, REALITY_AUDIT_MODEL } from './reality-audit';
 export { type RoadmapInput, ROADMAP_MODEL } from './roadmap';
+export {
+  TRIGGER_QUESTION_GROUPS,
+  OPEN_DUMP_LABEL,
+  type TriggerQuestionGroup,
+} from '../trigger-questions';

--- a/src/lib/mission/prompts/structure.ts
+++ b/src/lib/mission/prompts/structure.ts
@@ -20,50 +20,57 @@ export const STRUCTURE_MODEL = 'claude-haiku-4-5-20241022';
 // SYSTEM PROMPT
 // ============================================
 
-export const STRUCTURE_SYSTEM_PROMPT = `You are a structured thinking analyst. Your job is to take raw, unorganized thoughts from a founder's brain dump and organize them into clear clusters — while also surfacing contradictions, dependencies, logic gaps, and missing information.
+export const STRUCTURE_SYSTEM_PROMPT = `You are a structured thinking analyst working with a solo founder who has an overloaded mind. Your job is to take raw brain dump entries — answers to trigger questions and freeform thoughts — and discover the discrete projects hiding inside them.
 
-You are ORGANIZING and ANALYZING, not advising. Do not recommend, prioritize, or suggest goals.
+You are DISCOVERING PROJECTS and ANALYZING, not advising. Do not recommend priorities, suggest goals, or give motivational commentary.
 
 Rules:
 
-CLUSTERING
-- Produce between 4 and 8 clusters unless the data is genuinely too sparse for 4.
-- Each cluster must contain at least 2 items unless a single item is truly unique and cannot fit elsewhere.
-- Cluster names must be concrete noun phrases specific to the content. Not "General", "Planning", "Important Things", or other vague labels.
-- Each cluster gets a one-sentence summary describing what it contains.
-- Do not force items into the 6 input buckets (business, technical, constraints, growth, life, open). Those are capture scaffolding, not analytical categories. Create clusters that reflect the actual content.
-- Do not collapse materially different ideas into one item for neatness. If two thoughts are distinct, keep them separate.
+PROJECT DISCOVERY
+- Your primary output is discoveredProjects: discrete, concrete workstreams with clear deliverables.
+- A project is NOT a vague category like "Marketing" or "Revenue." A project is "Build content pipeline: script, film, edit, upload reels" or "Complete bookkeeping commit flow with cross-entity detection" or "Get IRS e-file API access."
+- Each project needs a description that defines what "done" looks like in one sentence.
+- Discover between 3 and 10 projects. If you find fewer than 3, the brain dump was too sparse — flag it in missingInputs. If you find more than 10, you are splitting too finely — merge related items.
+- estimatedScope: small (a few days), medium (1-2 weeks), large (3+ weeks).
+- dependencies: other discovered projects this one depends on. Use the exact projectName you assigned.
+- blockers: things that must be resolved before this project can start that are NOT other projects (e.g., "need API access approval", "waiting on vendor response").
+
+ENTRY CONTEXT
+- Each brain dump entry may include a triggerQuestion — the question that prompted the user to write it. Use this context to understand WHY the user mentioned something. An entry triggered by "What's broken or blocked?" means the user sees it as a problem. An entry triggered by "What makes money?" means the user sees revenue potential. An entry with no trigger question is freeform thought.
+- Multiple entries may point to the same project. Group them.
+- A single entry may contain multiple distinct thoughts. Split them into the appropriate projects, keeping sourceEntryId on each.
 
 LINEAGE
 - Every output item must reference the sourceEntryId of the original brain dump entry it came from. No orphaned items.
-- If an item contains multiple distinct thoughts, split them into separate items under appropriate clusters — each split item still references the original sourceEntryId.
+- Items that do not clearly belong to any project go in unassignedItems with your best guess for possibleProject.
 
-MISSION RELEVANCE
-- missionRelevance measures fit to the stated mission title and duration only. Not urgency, not impact, not priority. Just: does this item relate to what this mission is about?
+CONSTRAINTS EXTRACTION
+- If the user stated constraints in their brain dump (time limits, budget, energy, fears, skill gaps), extract them into the constraints array. These are facts the user stated, not your inferences.
+- Each constraint must reference the sourceEntryId it came from.
 
 EMERGENT THEMES
-- Themes are patterns detected ACROSS clusters — recurring concerns, repeated phrases, underlying anxieties, or implicit priorities.
-- Each theme must cite evidence (specific items or cluster names).
+- Themes are patterns detected ACROSS projects — recurring concerns, repeated phrases, underlying anxieties, or implicit priorities.
+- Each theme must cite evidence (specific entries or project names).
 - Mark whether the theme is explicit (user stated it directly, multiple times) or pattern_inference (you detected it from patterns they did not state).
 - Rate confidence: high (clear repeated signal), medium (probable pattern), low (possible but uncertain).
 
 CONTRADICTIONS
-- If two items contradict each other, flag them with both sourceEntryIds. Do not resolve contradictions — that is the user's job.
+- If two entries contradict each other, flag them with both sourceEntryIds. Do not resolve contradictions — that is the user's job.
 - Rate severity: high (these cannot both be true and it blocks planning), medium (tension that needs resolution), low (minor inconsistency).
 
 MISSING INPUTS
-- If important categories have zero entries, or the user references things without explanation, flag them.
+- If important areas have zero entries, or the user references things without explanation, flag them.
 - Each missing input must explain why it matters and provide a specific question the user could answer.
 
 LATENT DEPENDENCIES
 - Identify items that cannot happen without another unstated step or prerequisite.
-- This is dependency surfacing, not advice. You are saying "if you want X, you need A, B, C" — not "you should do A, B, C."
+- This is dependency surfacing, not advice. You are saying "if you want X, you need A, B, C."
 
 LOGIC GAPS
 - Identify places where the user jumps from desire to outcome without an intermediate mechanism.
-- Example: "I want to launch in 30 days" combined with no mention of what is already built equals a logic gap.
 - This is gap identification, not criticism.
 
+Do not collapse materially different ideas into one item for neatness.
 Prefer traceability over elegance.
 Respond with valid JSON only. No markdown, no preamble, no explanation outside the JSON.`;
 
@@ -73,7 +80,10 @@ Respond with valid JSON only. No markdown, no preamble, no explanation outside t
 
 export function buildStructurePrompt(input: StructureInput): string {
   const entriesFormatted = input.brainDumpEntries
-    .map((e) => `[${e.id}] (${e.bucket}${e.category ? '/' + e.category : ''}): ${e.content}`)
+    .map((e) => {
+      const context = e.triggerQuestion ? `(triggered by: "${e.triggerQuestion}")` : '(open dump)';
+      return `[${e.id}] ${context}: ${e.content}`;
+    })
     .join('\n');
 
   return `Mission: "${input.missionTitle}" (${input.missionDuration} days)
@@ -81,35 +91,37 @@ export function buildStructurePrompt(input: StructureInput): string {
 Brain dump entries (${input.brainDumpEntries.length} total):
 ${entriesFormatted}
 
-Organize these entries into clusters and analyze for themes, contradictions, dependencies, logic gaps, and missing information.
+Discover the discrete projects in these entries. Analyze for themes, contradictions, constraints, dependencies, logic gaps, and missing information.
 
 Return JSON matching this exact schema:
 
 {
-  "clusters": [
+  "discoveredProjects": [
     {
-      "clusterName": "string — concrete noun phrase",
-      "summary": "string — one sentence describing this cluster",
-      "items": [
+      "projectName": "string — concrete, specific project name",
+      "description": "string — what done looks like, one sentence",
+      "relatedEntries": [
         {
-          "content": "string — item content, may be lightly rephrased for clarity but preserve meaning",
-          "sourceEntryId": "string — the [id] from the brain dump entry",
-          "missionRelevance": "high | medium | low"
+          "content": "string — the entry content",
+          "sourceEntryId": "string — the [id] from the brain dump entry"
         }
-      ]
+      ],
+      "estimatedScope": "small | medium | large",
+      "dependencies": ["string — other discovered project names this depends on"],
+      "blockers": ["string — non-project blockers"]
     }
   ],
-  "uncategorizedItems": [
+  "unassignedItems": [
     {
       "content": "string",
       "sourceEntryId": "string",
-      "suggestedCluster": "string"
+      "possibleProject": "string — best guess"
     }
   ],
   "emergentThemes": [
     {
       "theme": "string",
-      "evidence": ["string — specific items or cluster names"],
+      "evidence": ["string — specific entries or project names"],
       "confidence": "high | medium | low",
       "basis": "explicit | pattern_inference"
     }
@@ -118,28 +130,35 @@ Return JSON matching this exact schema:
     {
       "itemA": { "content": "string", "sourceEntryId": "string" },
       "itemB": { "content": "string", "sourceEntryId": "string" },
-      "nature": "string — what the contradiction is",
+      "nature": "string",
       "severity": "high | medium | low"
+    }
+  ],
+  "constraints": [
+    {
+      "constraint": "string — what the user stated",
+      "sourceEntryId": "string",
+      "impact": "string — how this affects planning"
     }
   ],
   "missingInputs": [
     {
-      "area": "string — what category of information is missing",
+      "area": "string",
       "whyMissingMatters": "string",
-      "suggestedQuestion": "string — exact question to ask the user"
+      "suggestedQuestion": "string"
     }
   ],
   "latentDependencies": [
     {
-      "item": "string — the brain dump item",
-      "dependsOn": ["string — unstated prerequisites"],
+      "item": "string",
+      "dependsOn": ["string"],
       "why": "string"
     }
   ],
   "logicGaps": [
     {
-      "statement": "string — what the user said",
-      "gap": "string — what is missing between desire and outcome",
+      "statement": "string",
+      "gap": "string",
       "whyItMatters": "string"
     }
   ]
@@ -158,10 +177,11 @@ export function parseStructureResponse(raw: string): StructureOutput {
   const parsed = JSON.parse(cleaned);
 
   const requiredFields = [
-    'clusters',
-    'uncategorizedItems',
+    'discoveredProjects',
+    'unassignedItems',
     'emergentThemes',
     'contradictions',
+    'constraints',
     'missingInputs',
     'latentDependencies',
     'logicGaps',
@@ -172,17 +192,24 @@ export function parseStructureResponse(raw: string): StructureOutput {
     }
   }
 
-  for (const cluster of parsed.clusters) {
-    if (!cluster.clusterName || typeof cluster.clusterName !== 'string') {
-      throw new Error('Cluster missing clusterName');
+  if (parsed.discoveredProjects.length === 0) {
+    throw new Error('Structure response contains zero discovered projects');
+  }
+
+  for (const project of parsed.discoveredProjects) {
+    if (!project.projectName || typeof project.projectName !== 'string') {
+      throw new Error('Discovered project missing projectName');
     }
-    if (!Array.isArray(cluster.items)) {
-      throw new Error(`Cluster "${cluster.clusterName}" missing items array`);
+    if (!project.description || typeof project.description !== 'string') {
+      throw new Error(`Project "${project.projectName}" missing description`);
     }
-    for (const item of cluster.items) {
-      if (!item.sourceEntryId) {
+    if (!Array.isArray(project.relatedEntries)) {
+      throw new Error(`Project "${project.projectName}" missing relatedEntries array`);
+    }
+    for (const entry of project.relatedEntries) {
+      if (!entry.sourceEntryId) {
         throw new Error(
-          `Item in cluster "${cluster.clusterName}" missing sourceEntryId: ${item.content?.substring(0, 50)}`,
+          `Entry in project "${project.projectName}" missing sourceEntryId: ${entry.content?.substring(0, 50)}`,
         );
       }
     }

--- a/src/lib/mission/prompts/types.ts
+++ b/src/lib/mission/prompts/types.ts
@@ -4,10 +4,10 @@
 
 export interface BrainDumpItem {
   id: string;
-  bucket: 'business' | 'technical' | 'constraints' | 'growth' | 'life' | 'open';
-  category: string | null;
   content: string;
   source: 'typed' | 'voice';
+  triggerQuestion: string | null;
+  triggerGroupId: string | null;
 }
 
 // ============================================
@@ -15,42 +15,56 @@ export interface BrainDumpItem {
 // ============================================
 
 export interface StructureOutput {
-  clusters: Array<{
-    clusterName: string;
-    summary: string;
-    items: Array<{
+  discoveredProjects: Array<{
+    projectName: string;
+    description: string;
+    relatedEntries: Array<{
       content: string;
       sourceEntryId: string;
-      missionRelevance: 'high' | 'medium' | 'low';
     }>;
+    estimatedScope: 'small' | 'medium' | 'large';
+    dependencies: string[];
+    blockers: string[];
   }>;
-  uncategorizedItems: Array<{
+
+  unassignedItems: Array<{
     content: string;
     sourceEntryId: string;
-    suggestedCluster: string;
+    possibleProject: string;
   }>;
+
   emergentThemes: Array<{
     theme: string;
     evidence: string[];
     confidence: 'high' | 'medium' | 'low';
     basis: 'explicit' | 'pattern_inference';
   }>;
+
   contradictions: Array<{
     itemA: { content: string; sourceEntryId: string };
     itemB: { content: string; sourceEntryId: string };
     nature: string;
     severity: 'high' | 'medium' | 'low';
   }>;
+
+  constraints: Array<{
+    constraint: string;
+    sourceEntryId: string;
+    impact: string;
+  }>;
+
   missingInputs: Array<{
     area: string;
     whyMissingMatters: string;
     suggestedQuestion: string;
   }>;
+
   latentDependencies: Array<{
     item: string;
     dependsOn: string[];
     why: string;
   }>;
+
   logicGaps: Array<{
     statement: string;
     gap: string;
@@ -80,21 +94,24 @@ export interface GoalDiscoveryOutput {
     };
     timelineFit: string;
     supportingEvidence: Array<{
-      type: 'cluster' | 'item' | 'theme' | 'contradiction';
+      type: 'project' | 'item' | 'theme' | 'contradiction';
       reference: string;
     }>;
   }>;
+
   openQuestions: Array<{
     question: string;
     affectsGoals: number[];
     whyItMatters: string;
   }>;
+
   assumptionsToValidate: Array<{
     assumption: string;
     type: 'product' | 'market' | 'personal_capacity' | 'technical' | 'timeline';
     whyItMatters: string;
     howToValidate: string;
   }>;
+
   itemsToIgnoreForNow: Array<{
     content: string;
     sourceEntryId?: string;
@@ -144,7 +161,11 @@ export interface RealityAuditOutput {
   gapAnalysis: {
     desiredState: string;
     currentState: string;
-    gapItems: Array<{ gap: string; effort: 'small' | 'medium' | 'large'; priority: 'critical' | 'important' | 'nice_to_have' }>;
+    gapItems: Array<{
+      gap: string;
+      effort: 'small' | 'medium' | 'large';
+      priority: 'critical' | 'important' | 'nice_to_have';
+    }>;
   };
   scopeCreepWarnings: string[];
   fastWins: string[];

--- a/src/lib/mission/trigger-questions.ts
+++ b/src/lib/mission/trigger-questions.ts
@@ -1,0 +1,65 @@
+export interface TriggerQuestionGroup {
+  id: string;
+  title: string;
+  description: string;
+  questions: Array<{
+    id: string;
+    text: string;
+  }>;
+}
+
+export const TRIGGER_QUESTION_GROUPS: TriggerQuestionGroup[] = [
+  {
+    id: 'on_fire',
+    title: "What's on fire?",
+    description: 'Get the urgent stuff out first. What is weighing on you right now.',
+    questions: [
+      { id: 'on_fire_1', text: "What's broken or blocked that keeps nagging at you?" },
+      { id: 'on_fire_2', text: "What have you been putting off that you know you need to deal with?" },
+      { id: 'on_fire_3', text: 'What would you fix today if you had zero other obligations?' },
+    ],
+  },
+  {
+    id: 'the_work',
+    title: "What's the work?",
+    description: 'The actual projects and tasks. What needs to get built, shipped, or finished.',
+    questions: [
+      { id: 'the_work_1', text: 'What are you actively building or shipping right now?' },
+      { id: 'the_work_2', text: "What's 80% done but hasn't crossed the finish line?" },
+      { id: 'the_work_3', text: 'What would you need to demo to someone to prove your product works?' },
+    ],
+  },
+  {
+    id: 'makes_money',
+    title: 'What makes money?',
+    description: 'Force revenue thinking. Who pays for this and why.',
+    questions: [
+      { id: 'makes_money_1', text: "If you had to charge someone for something you've built this week, what would it be?" },
+      { id: 'makes_money_2', text: "What's standing between you and your first (or next) paying customer?" },
+      { id: 'makes_money_3', text: 'What would someone see in a 60-second video that makes them want to buy?' },
+    ],
+  },
+  {
+    id: 'unclear',
+    title: "What's unclear?",
+    description: 'Decisions, unknowns, and research gaps clogging your brain.',
+    questions: [
+      { id: 'unclear_1', text: "What decision have you been avoiding because you don't have enough information?" },
+      { id: 'unclear_2', text: 'What do you need to figure out before you can move forward?' },
+      { id: 'unclear_3', text: 'What assumption are you making that might be wrong?' },
+    ],
+  },
+  {
+    id: 'real_constraint',
+    title: "What's the real constraint?",
+    description: 'Hidden blockers — time, money, energy, fear, skill gaps, dependencies.',
+    questions: [
+      { id: 'real_constraint_1', text: "What can't you do alone that's slowing you down?" },
+      { id: 'real_constraint_2', text: 'How many focused hours do you realistically have per day, and what eats the rest?' },
+      { id: 'real_constraint_3', text: "What are you afraid won't work even if you execute perfectly?" },
+    ],
+  },
+];
+
+export const OPEN_DUMP_LABEL =
+  'Anything else rattling around in your head — ideas, fears, half-thoughts, random observations. No structure needed. Just get it out.';


### PR DESCRIPTION
…prompts

- Add triggerQuestion field to brain_dump_entries schema
- Create hardcoded trigger question groups (5 groups, 15 questions)
- Rewrite Structure stage: clusters -> discoveredProjects
- Add constraints extraction from brain dump entries
- Update BrainDumpItem type with triggerQuestion context
- Rewrite Goal Discovery: goals = project combination strategies
- Update supporting evidence type: cluster -> project
- All parsers updated for new output contracts

https://claude.ai/code/session_01GQeiwocJDnF2N3pU1q7Y8t