### PR TITLE
feat: add Mission Planner API routes

### DIFF
--- a/src/app/api/mission/[id]/brain-dump/route.ts
+++ b/src/app/api/mission/[id]/brain-dump/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { getMissionUser, getMissionWithOwnerCheck } from '@/lib/mission/auth';
+
+export async function POST(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const user = await getMissionUser();
+    if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const { id } = await params;
+    const mission = await getMissionWithOwnerCheck(id, user.id);
+    if (!mission) return NextResponse.json({ error: 'Mission not found' }, { status: 404 });
+
+    const { entries } = await request.json();
+    if (!Array.isArray(entries)) {
+      return NextResponse.json({ error: 'entries array required' }, { status: 400 });
+    }
+
+    await prisma.$transaction([
+      prisma.brain_dump_entries.deleteMany({ where: { missionId: id } }),
+      prisma.brain_dump_entries.createMany({
+        data: entries.map(
+          (
+            e: {
+              content: string;
+              source?: string;
+              triggerQuestion?: string;
+              bucket?: string;
+              category?: string;
+            },
+            i: number,
+          ) => ({
+            missionId: id,
+            content: e.content,
+            source: e.source === 'voice' ? 'voice' as const : 'typed' as const,
+            triggerQuestion: e.triggerQuestion || null,
+            bucket: 'open' as const,
+            category: e.category || null,
+            rawOrder: i,
+          }),
+        ),
+      }),
+    ]);
+
+    return NextResponse.json({ count: entries.length });
+  } catch (error) {
+    console.error('[Brain Dump Save]', error);
+    return NextResponse.json({ error: 'Failed to save brain dump' }, { status: 500 });
+  }
+}

--- a/src/app/api/mission/[id]/confirm-goal/route.ts
+++ b/src/app/api/mission/[id]/confirm-goal/route.ts
@@ -1,0 +1,48 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { getMissionUser, getMissionWithOwnerCheck } from '@/lib/mission/auth';
+
+interface GoalCandidate {
+  rank: number;
+  goalStatement: string;
+}
+
+export async function POST(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const user = await getMissionUser();
+    if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const { id } = await params;
+    const mission = await getMissionWithOwnerCheck(id, user.id);
+    if (!mission) return NextResponse.json({ error: 'Mission not found' }, { status: 404 });
+
+    const { goalRank, editedGoalStatement } = await request.json();
+    if (!goalRank) return NextResponse.json({ error: 'goalRank required' }, { status: 400 });
+
+    const goalStage = await prisma.mission_stages.findFirst({
+      where: { missionId: id, stageType: 'goal_discovery', status: 'approved' },
+      orderBy: { attemptNumber: 'desc' },
+    });
+    if (!goalStage || !goalStage.parsedOutput) {
+      return NextResponse.json({ error: 'No approved goal discovery stage found' }, { status: 400 });
+    }
+
+    const output = goalStage.parsedOutput as { candidateGoals?: GoalCandidate[] };
+    const selected = output.candidateGoals?.find((g) => g.rank === goalRank);
+    if (!selected) {
+      return NextResponse.json({ error: `No goal found with rank ${goalRank}` }, { status: 400 });
+    }
+
+    const confirmedGoal = editedGoalStatement || selected.goalStatement;
+
+    await prisma.missions.update({
+      where: { id },
+      data: { confirmedGoal },
+    });
+
+    return NextResponse.json({ confirmedGoal });
+  } catch (error) {
+    console.error('[Confirm Goal]', error);
+    return NextResponse.json({ error: 'Failed to confirm goal' }, { status: 500 });
+  }
+}

--- a/src/app/api/mission/[id]/reality-constraints/route.ts
+++ b/src/app/api/mission/[id]/reality-constraints/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { getMissionUser, getMissionWithOwnerCheck } from '@/lib/mission/auth';
+
+export async function POST(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const user = await getMissionUser();
+    if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const { id } = await params;
+    const mission = await getMissionWithOwnerCheck(id, user.id);
+    if (!mission) return NextResponse.json({ error: 'Mission not found' }, { status: 404 });
+
+    const { constraints } = await request.json();
+    if (!Array.isArray(constraints)) {
+      return NextResponse.json({ error: 'constraints array required' }, { status: 400 });
+    }
+
+    await prisma.$transaction([
+      prisma.reality_constraints.deleteMany({ where: { missionId: id } }),
+      prisma.reality_constraints.createMany({
+        data: constraints.map(
+          (c: { constraintType: string; category: string; description: string; value?: string }) => ({
+            missionId: id,
+            constraintType: c.constraintType as 'product' | 'operational',
+            category: c.category,
+            description: c.description,
+            value: c.value || null,
+            source: 'manual',
+          }),
+        ),
+      }),
+    ]);
+
+    return NextResponse.json({ count: constraints.length });
+  } catch (error) {
+    console.error('[Reality Constraints]', error);
+    return NextResponse.json({ error: 'Failed to save constraints' }, { status: 500 });
+  }
+}

--- a/src/app/api/mission/[id]/route.ts
+++ b/src/app/api/mission/[id]/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { getMissionUser } from '@/lib/mission/auth';
+
+export async function GET(_request: Request, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const user = await getMissionUser();
+    if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const { id } = await params;
+
+    const mission = await prisma.missions.findFirst({
+      where: { id, userId: user.id },
+      include: {
+        brainDumpEntries: { orderBy: { rawOrder: 'asc' } },
+        stages: { orderBy: [{ stageOrder: 'asc' }, { attemptNumber: 'desc' }] },
+        realityConstraints: true,
+        roadmapWeeks: { orderBy: { weekNumber: 'asc' } },
+        missionTasks: { orderBy: { scheduledDate: 'asc' } },
+      },
+    });
+
+    if (!mission) return NextResponse.json({ error: 'Mission not found' }, { status: 404 });
+
+    return NextResponse.json({ mission });
+  } catch (error) {
+    console.error('[Mission Get]', error);
+    return NextResponse.json({ error: 'Failed to load mission' }, { status: 500 });
+  }
+}

--- a/src/app/api/mission/[id]/run-stage/route.ts
+++ b/src/app/api/mission/[id]/run-stage/route.ts
@@ -1,0 +1,198 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { getMissionUser, getMissionWithOwnerCheck } from '@/lib/mission/auth';
+import Anthropic from '@anthropic-ai/sdk';
+import {
+  STRUCTURE_MODEL,
+  STRUCTURE_SYSTEM_PROMPT,
+  buildStructurePrompt,
+  parseStructureResponse,
+  GOAL_DISCOVERY_MODEL,
+  GOAL_DISCOVERY_SYSTEM_PROMPT,
+  buildGoalDiscoveryPrompt,
+  parseGoalDiscoveryResponse,
+  type BrainDumpItem,
+  type StructureOutput,
+} from '@/lib/mission/prompts';
+import { TRIGGER_QUESTION_GROUPS } from '@/lib/mission/trigger-questions';
+
+const STAGE_ORDER: Record<string, number> = {
+  structure: 1,
+  goal_discovery: 2,
+  research_scoping: 3,
+  reality_audit: 4,
+  roadmap: 5,
+};
+
+function inferTriggerGroupId(triggerQuestion: string | null): string | null {
+  if (!triggerQuestion) return null;
+  for (const group of TRIGGER_QUESTION_GROUPS) {
+    if (group.questions.some((q) => q.text === triggerQuestion)) return group.id;
+  }
+  return null;
+}
+
+export async function POST(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const user = await getMissionUser();
+    if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const { id } = await params;
+    const mission = await getMissionWithOwnerCheck(id, user.id);
+    if (!mission) return NextResponse.json({ error: 'Mission not found' }, { status: 404 });
+
+    const apiKey = process.env.ANTHROPIC_API_KEY;
+    if (!apiKey) return NextResponse.json({ error: 'API key not configured' }, { status: 500 });
+
+    const { stageType } = await request.json();
+    if (!stageType || !STAGE_ORDER[stageType]) {
+      return NextResponse.json({ error: 'Invalid stageType' }, { status: 400 });
+    }
+
+    // Validate prerequisites
+    const approvedStages = await prisma.mission_stages.findMany({
+      where: { missionId: id, status: 'approved' },
+      select: { stageType: true, parsedOutput: true },
+    });
+    const approvedTypes = new Set(approvedStages.map((s) => s.stageType));
+
+    if (stageType === 'structure') {
+      const entryCount = await prisma.brain_dump_entries.count({ where: { missionId: id } });
+      if (entryCount === 0) {
+        return NextResponse.json({ error: 'Brain dump entries required before running structure stage' }, { status: 400 });
+      }
+    } else if (stageType === 'goal_discovery') {
+      if (!approvedTypes.has('structure')) {
+        return NextResponse.json({ error: 'Structure stage must be approved first' }, { status: 400 });
+      }
+    } else if (stageType === 'reality_audit') {
+      if (!approvedTypes.has('goal_discovery')) {
+        return NextResponse.json({ error: 'Goal discovery must be approved first' }, { status: 400 });
+      }
+      if (!mission.confirmedGoal) {
+        return NextResponse.json({ error: 'Goal must be confirmed before reality audit' }, { status: 400 });
+      }
+    } else if (stageType === 'roadmap') {
+      if (!approvedTypes.has('reality_audit')) {
+        return NextResponse.json({ error: 'Reality audit must be approved first' }, { status: 400 });
+      }
+    }
+
+    // Check if stage is implemented
+    if (stageType === 'reality_audit' || stageType === 'roadmap' || stageType === 'research_scoping') {
+      return NextResponse.json({ error: `${stageType} stage is not yet implemented` }, { status: 400 });
+    }
+
+    // Build input + prompts
+    let systemPrompt: string;
+    let userPrompt: string;
+    let model: string;
+    let inputSnapshot: unknown;
+    let parseFn: (raw: string) => unknown;
+
+    if (stageType === 'structure') {
+      const entries = await prisma.brain_dump_entries.findMany({
+        where: { missionId: id },
+        orderBy: { rawOrder: 'asc' },
+      });
+      const brainDumpItems: BrainDumpItem[] = entries.map((e) => ({
+        id: e.id,
+        content: e.content,
+        source: e.source as 'typed' | 'voice',
+        triggerQuestion: e.triggerQuestion,
+        triggerGroupId: inferTriggerGroupId(e.triggerQuestion),
+      }));
+      const input = {
+        brainDumpEntries: brainDumpItems,
+        missionTitle: mission.name,
+        missionDuration: mission.durationDays ?? mission.totalDays,
+      };
+      systemPrompt = STRUCTURE_SYSTEM_PROMPT;
+      userPrompt = buildStructurePrompt(input);
+      model = STRUCTURE_MODEL;
+      inputSnapshot = input;
+      parseFn = parseStructureResponse;
+    } else {
+      // goal_discovery
+      const structureStage = approvedStages.find((s) => s.stageType === 'structure');
+      const input = {
+        structuredOutput: structureStage!.parsedOutput as unknown as StructureOutput,
+        missionTitle: mission.name,
+        missionDuration: mission.durationDays ?? mission.totalDays,
+      };
+      systemPrompt = GOAL_DISCOVERY_SYSTEM_PROMPT;
+      userPrompt = buildGoalDiscoveryPrompt(input);
+      model = GOAL_DISCOVERY_MODEL;
+      inputSnapshot = input;
+      parseFn = parseGoalDiscoveryResponse;
+    }
+
+    // Determine attempt number
+    const prevAttempts = await prisma.mission_stages.count({
+      where: { missionId: id, stageType: stageType as 'structure' | 'goal_discovery' },
+    });
+
+    // Create stage row
+    const stage = await prisma.mission_stages.create({
+      data: {
+        missionId: id,
+        stageType: stageType as 'structure' | 'goal_discovery',
+        stageOrder: STAGE_ORDER[stageType],
+        status: 'processing',
+        inputSnapshot: inputSnapshot as object,
+        systemPrompt,
+        userPrompt,
+        model,
+        attemptNumber: prevAttempts + 1,
+      },
+    });
+
+    // Call Claude
+    const client = new Anthropic({ apiKey });
+    const response = await client.messages.create({
+      model,
+      max_tokens: 4096,
+      system: systemPrompt,
+      messages: [{ role: 'user', content: userPrompt }],
+    });
+
+    const rawText = response.content
+      .filter((b): b is Anthropic.TextBlock => b.type === 'text')
+      .map((b) => b.text)
+      .join('');
+
+    // Parse
+    let parsedOutput: unknown = null;
+    let parseError: string | null = null;
+    try {
+      parsedOutput = parseFn(rawText);
+    } catch (err) {
+      parseError = err instanceof Error ? err.message : 'Parse failed';
+    }
+
+    // Update stage
+    await prisma.mission_stages.update({
+      where: { id: stage.id },
+      data: {
+        status: 'completed',
+        rawResponse: rawText,
+        parsedOutput: parsedOutput as object | undefined,
+      },
+    });
+
+    if (parseError) {
+      return NextResponse.json({
+        stageId: stage.id,
+        status: 'completed',
+        parseError,
+        rawResponse: rawText.substring(0, 500),
+      }, { status: 200 });
+    }
+
+    return NextResponse.json({ stageId: stage.id, status: 'completed', parsedOutput });
+  } catch (error) {
+    console.error('[Run Stage]', error);
+    const msg = error instanceof Error ? error.message : 'Stage execution failed';
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/src/app/api/mission/[id]/stage/[stageId]/approve/route.ts
+++ b/src/app/api/mission/[id]/stage/[stageId]/approve/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { getMissionUser, getMissionWithOwnerCheck } from '@/lib/mission/auth';
+
+export async function POST(_request: Request, { params }: { params: Promise<{ id: string; stageId: string }> }) {
+  try {
+    const user = await getMissionUser();
+    if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const { id, stageId } = await params;
+    const mission = await getMissionWithOwnerCheck(id, user.id);
+    if (!mission) return NextResponse.json({ error: 'Mission not found' }, { status: 404 });
+
+    const stage = await prisma.mission_stages.findFirst({
+      where: { id: stageId, missionId: id },
+    });
+    if (!stage) return NextResponse.json({ error: 'Stage not found' }, { status: 404 });
+    if (stage.status !== 'completed') {
+      return NextResponse.json({ error: 'Can only approve completed stages' }, { status: 400 });
+    }
+
+    await prisma.mission_stages.update({
+      where: { id: stageId },
+      data: { status: 'approved', approvedAt: new Date() },
+    });
+
+    return NextResponse.json({ status: 'approved' });
+  } catch (error) {
+    console.error('[Stage Approve]', error);
+    return NextResponse.json({ error: 'Failed to approve stage' }, { status: 500 });
+  }
+}

--- a/src/app/api/mission/[id]/stage/[stageId]/reject/route.ts
+++ b/src/app/api/mission/[id]/stage/[stageId]/reject/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { getMissionUser, getMissionWithOwnerCheck } from '@/lib/mission/auth';
+
+export async function POST(request: Request, { params }: { params: Promise<{ id: string; stageId: string }> }) {
+  try {
+    const user = await getMissionUser();
+    if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const { id, stageId } = await params;
+    const mission = await getMissionWithOwnerCheck(id, user.id);
+    if (!mission) return NextResponse.json({ error: 'Mission not found' }, { status: 404 });
+
+    const stage = await prisma.mission_stages.findFirst({
+      where: { id: stageId, missionId: id },
+    });
+    if (!stage) return NextResponse.json({ error: 'Stage not found' }, { status: 404 });
+    if (stage.status !== 'completed') {
+      return NextResponse.json({ error: 'Can only reject completed stages' }, { status: 400 });
+    }
+
+    const { reason } = await request.json().catch(() => ({ reason: null }));
+
+    await prisma.mission_stages.update({
+      where: { id: stageId },
+      data: { status: 'rejected', rejectedAt: new Date(), rejectionReason: reason || null },
+    });
+
+    return NextResponse.json({ status: 'rejected' });
+  } catch (error) {
+    console.error('[Stage Reject]', error);
+    return NextResponse.json({ error: 'Failed to reject stage' }, { status: 500 });
+  }
+}

--- a/src/app/api/mission/create/route.ts
+++ b/src/app/api/mission/create/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { getMissionUser } from '@/lib/mission/auth';
+
+export async function POST(request: Request) {
+  try {
+    const user = await getMissionUser();
+    if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const { title, durationDays } = await request.json();
+    if (!title) return NextResponse.json({ error: 'title required' }, { status: 400 });
+
+    const mission = await prisma.missions.create({
+      data: {
+        userId: user.id,
+        name: title,
+        goalDescription: '',
+        doneDefinition: '',
+        startDate: new Date(),
+        endDate: new Date(Date.now() + (durationDays || 75) * 86400000),
+        totalDays: durationDays || 75,
+        missionStatus: 'draft',
+        durationDays: durationDays || null,
+        status: 'active',
+      },
+      select: { id: true, name: true, missionStatus: true, durationDays: true },
+    });
+
+    return NextResponse.json({ mission });
+  } catch (error) {
+    console.error('[Mission Create]', error);
+    return NextResponse.json({ error: 'Failed to create mission' }, { status: 500 });
+  }
+}

--- a/src/lib/mission/auth.ts
+++ b/src/lib/mission/auth.ts
@@ -1,0 +1,18 @@
+import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
+
+export async function getMissionUser() {
+  const email = await getVerifiedEmail();
+  if (!email) return null;
+  const user = await prisma.users.findFirst({
+    where: { email: { equals: email, mode: 'insensitive' } },
+  });
+  return user;
+}
+
+export async function getMissionWithOwnerCheck(missionId: string, userId: string) {
+  const mission = await prisma.missions.findFirst({
+    where: { id: missionId, userId },
+  });
+  return mission;
+}


### PR DESCRIPTION
- POST /api/mission/create — create draft mission with title + duration
- GET /api/mission/[id] — load mission with all pipeline data (entries, stages, constraints, weeks, tasks)
- POST /api/mission/[id]/brain-dump — save/replace brain dump entries (transaction: deleteMany + createMany)
- POST /api/mission/[id]/run-stage — execute pipeline stage with full observability (systemPrompt, userPrompt, model, rawResponse, parsedOutput all stored in mission_stages). Stage ordering validation: each stage requires previous stage approved. Structure uses Haiku, Goal Discovery uses Sonnet. Reality audit + roadmap return 400 (not yet implemented).
- POST /api/mission/[id]/stage/[stageId]/approve — approve completed stage
- POST /api/mission/[id]/stage/[stageId]/reject — reject with optional reason
- POST /api/mission/[id]/confirm-goal — select candidate goal by rank, optionally edit statement, stores on mission.confirmedGoal
- POST /api/mission/[id]/reality-constraints — save/replace constraints (transaction: deleteMany + createMany)
- Shared auth helper (src/lib/mission/auth.ts) with getMissionUser + getMissionWithOwnerCheck to eliminate duplication across routes

https://claude.ai/code/session_01GQeiwocJDnF2N3pU1q7Y8t