### PR TITLE
feat: add Mission Planner single-page pipeline UI

### DIFF
--- a/src/app/mission/[id]/page.tsx
+++ b/src/app/mission/[id]/page.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { useParams } from 'next/navigation';
+import AppLayout from '@/components/ui/AppLayout';
+import MissionPipeline from '@/components/mission/MissionPipeline';
+
+export default function MissionPipelinePage() {
+  const params = useParams();
+  const id = params.id as string;
+  const [mission, setMission] = useState<Record<string, unknown> | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const fetchMission = useCallback(async () => {
+    try {
+      const res = await fetch(`/api/mission/${id}`);
+      if (res.ok) {
+        const data = await res.json();
+        setMission(data.mission);
+      }
+    } catch (err) {
+      console.error('Failed to load mission:', err);
+    } finally {
+      setLoading(false);
+    }
+  }, [id]);
+
+  useEffect(() => {
+    fetchMission();
+  }, [fetchMission]);
+
+  if (loading) {
+    return (
+      <AppLayout>
+        <div className="flex items-center justify-center min-h-[40vh]">
+          <div className="flex items-center gap-3">
+            <div className="w-5 h-5 border-2 border-brand-purple border-t-transparent rounded-full animate-spin" />
+            <span className="text-text-muted font-mono text-terminal-base">Loading mission...</span>
+          </div>
+        </div>
+      </AppLayout>
+    );
+  }
+
+  if (!mission) {
+    return (
+      <AppLayout>
+        <div className="max-w-2xl mx-auto px-4 py-8 text-center">
+          <p className="text-text-muted font-mono">Mission not found.</p>
+        </div>
+      </AppLayout>
+    );
+  }
+
+  return (
+    <AppLayout>
+      <MissionPipeline mission={mission} onUpdate={fetchMission} />
+    </AppLayout>
+  );
+}

--- a/src/app/mission/page.tsx
+++ b/src/app/mission/page.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import AppLayout from '@/components/ui/AppLayout';
+
+const DURATION_PRESETS = [30, 75, 90];
+
+export default function MissionListPage() {
+  const router = useRouter();
+  const [title, setTitle] = useState('');
+  const [duration, setDuration] = useState(75);
+  const [customDuration, setCustomDuration] = useState('');
+  const [creating, setCreating] = useState(false);
+
+  const effectiveDuration = customDuration ? parseInt(customDuration, 10) || 75 : duration;
+
+  const handleCreate = async () => {
+    if (!title.trim()) return;
+    setCreating(true);
+    try {
+      const res = await fetch('/api/mission/create', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title: title.trim(), durationDays: effectiveDuration }),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        router.push(`/mission/${data.mission.id}`);
+      }
+    } catch (err) {
+      console.error('Failed to create mission:', err);
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  return (
+    <AppLayout>
+      <div className="max-w-2xl mx-auto px-4 py-8">
+        <h1 className="text-xl font-bold text-text-primary font-mono">Mission Planner</h1>
+        <p className="text-sm text-text-muted font-mono mt-1">
+          Define a time-bound mission. The pipeline will help you plan it.
+        </p>
+
+        <div className="bg-white rounded border border-border shadow-sm overflow-hidden mt-6">
+          <div className="px-3 py-2 border-b border-border">
+            <span className="text-terminal-lg font-semibold text-text-primary">New Mission</span>
+          </div>
+          <div className="px-4 py-4 space-y-4">
+            <div>
+              <label className="block text-terminal-sm text-text-muted font-mono uppercase tracking-wider mb-1">
+                Mission Title
+              </label>
+              <input
+                type="text"
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                placeholder="Temple Stuart Bookkeeping Launch"
+                className="font-mono text-sm bg-transparent border border-border rounded-md px-3 py-2 w-full focus:border-brand-purple outline-none transition-colors placeholder:text-text-faint"
+              />
+            </div>
+            <div>
+              <label className="block text-terminal-sm text-text-muted font-mono uppercase tracking-wider mb-1">
+                Duration
+              </label>
+              <div className="flex items-center gap-2">
+                {DURATION_PRESETS.map((d) => (
+                  <button
+                    key={d}
+                    onClick={() => { setDuration(d); setCustomDuration(''); }}
+                    className={`px-3 py-1.5 rounded text-terminal-base font-mono transition-colors ${
+                      duration === d && !customDuration
+                        ? 'bg-brand-purple text-white'
+                        : 'border border-border text-text-secondary hover:border-brand-purple'
+                    }`}
+                  >
+                    {d} days
+                  </button>
+                ))}
+                <input
+                  type="number"
+                  value={customDuration}
+                  onChange={(e) => setCustomDuration(e.target.value)}
+                  placeholder="Custom"
+                  className="font-mono text-sm bg-transparent border border-border rounded-md px-3 py-1.5 w-24 focus:border-brand-purple outline-none transition-colors placeholder:text-text-faint"
+                />
+              </div>
+            </div>
+            <button
+              onClick={handleCreate}
+              disabled={!title.trim() || creating}
+              className="w-full py-2.5 bg-brand-purple text-white rounded hover:bg-brand-purple-hover transition-colors font-mono text-sm font-medium disabled:opacity-40"
+            >
+              {creating ? 'Creating...' : 'Create Mission'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </AppLayout>
+  );
+}

--- a/src/components/mission/BrainDumpSection.tsx
+++ b/src/components/mission/BrainDumpSection.tsx
@@ -1,0 +1,149 @@
+'use client';
+
+import { useState } from 'react';
+import { TRIGGER_QUESTION_GROUPS, OPEN_DUMP_LABEL } from '@/lib/mission/trigger-questions';
+
+interface BrainDumpSectionProps {
+  mission: Record<string, unknown>;
+  onUpdate: () => void;
+}
+
+interface LocalEntry {
+  content: string;
+  triggerQuestion: string | null;
+  triggerGroupId: string | null;
+}
+
+export default function BrainDumpSection({ mission, onUpdate }: BrainDumpSectionProps) {
+  const missionId = mission.id as string;
+  const existingEntries = (mission.brainDumpEntries as Array<{ content: string; triggerQuestion?: string }>) || [];
+
+  const [questionEntries, setQuestionEntries] = useState<Record<string, string>>(() => {
+    const map: Record<string, string> = {};
+    for (const e of existingEntries) {
+      if (e.triggerQuestion) {
+        map[e.triggerQuestion] = (map[e.triggerQuestion] || '') + (map[e.triggerQuestion] ? '\n' : '') + e.content;
+      }
+    }
+    return map;
+  });
+  const [openDump, setOpenDump] = useState(() =>
+    existingEntries.filter((e) => !e.triggerQuestion).map((e) => e.content).join('\n'),
+  );
+  const [expandedGroup, setExpandedGroup] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  const allEntries: LocalEntry[] = [];
+
+  for (const group of TRIGGER_QUESTION_GROUPS) {
+    for (const q of group.questions) {
+      const text = questionEntries[q.text]?.trim();
+      if (text) {
+        for (const line of text.split('\n').filter(Boolean)) {
+          allEntries.push({ content: line, triggerQuestion: q.text, triggerGroupId: group.id });
+        }
+      }
+    }
+  }
+  for (const line of openDump.split('\n').filter((l) => l.trim())) {
+    allEntries.push({ content: line.trim(), triggerQuestion: null, triggerGroupId: null });
+  }
+
+  const handleSaveAndProcess = async () => {
+    if (allEntries.length === 0) return;
+    setSaving(true);
+    try {
+      const saveRes = await fetch(`/api/mission/${missionId}/brain-dump`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          entries: allEntries.map((e) => ({
+            content: e.content,
+            source: 'typed',
+            triggerQuestion: e.triggerQuestion,
+          })),
+        }),
+      });
+      if (!saveRes.ok) return;
+
+      await fetch(`/api/mission/${missionId}/run-stage`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ stageType: 'structure' }),
+      });
+
+      onUpdate();
+    } catch (err) {
+      console.error('Save & process failed:', err);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="bg-white rounded border border-border shadow-sm overflow-hidden">
+      <div className="px-3 py-2 border-b border-border flex items-center justify-between">
+        <span className="text-terminal-lg font-semibold text-text-primary">Brain Dump</span>
+        <span className="text-terminal-sm text-text-muted font-mono">{allEntries.length} entries</span>
+      </div>
+
+      <div className="md:flex">
+        {/* Left: Trigger questions */}
+        <div className="flex-1 border-r border-border-light p-4 space-y-2">
+          <p className="text-terminal-sm text-text-muted font-mono mb-2">Answer what resonates. Skip the rest.</p>
+          {TRIGGER_QUESTION_GROUPS.map((group) => (
+            <div key={group.id} className="border border-border-light rounded">
+              <button
+                onClick={() => setExpandedGroup(expandedGroup === group.id ? null : group.id)}
+                className="w-full px-3 py-2 flex items-center justify-between text-left hover:bg-bg-row/50 transition-colors"
+              >
+                <span className="text-sm font-medium text-text-primary font-mono">{group.title}</span>
+                <span className="text-text-faint text-terminal-sm">{expandedGroup === group.id ? '▲' : '▼'}</span>
+              </button>
+              {expandedGroup === group.id && (
+                <div className="px-3 pb-3 space-y-3 border-t border-border-light">
+                  <p className="text-terminal-sm text-text-faint font-mono pt-2">{group.description}</p>
+                  {group.questions.map((q) => (
+                    <div key={q.id}>
+                      <p className="text-terminal-sm text-text-secondary font-mono mb-1">{q.text}</p>
+                      <textarea
+                        rows={2}
+                        value={questionEntries[q.text] || ''}
+                        onChange={(e) => setQuestionEntries((prev) => ({ ...prev, [q.text]: e.target.value }))}
+                        placeholder="Type your answer..."
+                        className="w-full resize-none font-mono text-terminal-base text-text-primary bg-transparent border border-border rounded px-2 py-1.5 outline-none focus:border-brand-purple transition-colors placeholder:text-text-faint"
+                      />
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+
+        {/* Right: Open dump */}
+        <div className="flex-1 p-4 md:max-w-[40%]">
+          <p className="text-terminal-sm text-text-muted font-mono mb-2">Open dump</p>
+          <textarea
+            rows={12}
+            value={openDump}
+            onChange={(e) => setOpenDump(e.target.value)}
+            placeholder={OPEN_DUMP_LABEL}
+            className="w-full resize-none font-mono text-terminal-base text-text-primary bg-transparent border border-border rounded px-3 py-2 outline-none focus:border-brand-purple transition-colors placeholder:text-text-faint"
+          />
+        </div>
+      </div>
+
+      {/* Save & Process */}
+      <div className="px-4 py-3 border-t border-border">
+        <button
+          onClick={handleSaveAndProcess}
+          disabled={allEntries.length === 0 || saving}
+          className="w-full py-2.5 bg-brand-purple text-white rounded hover:bg-brand-purple-hover transition-colors font-mono text-sm font-medium disabled:opacity-40"
+        >
+          {saving ? 'Processing...' : `Save & Process (${allEntries.length} entries) →`}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/mission/GoalConfirmationSection.tsx
+++ b/src/components/mission/GoalConfirmationSection.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+import { useState } from 'react';
+
+interface GoalCandidate {
+  rank: number;
+  goalStatement: string;
+  distinctiveAngle: string;
+  tradeoffs: { gains: string[]; costs: string[]; risks: string[] };
+  timelineFit: string;
+}
+
+interface GoalConfirmationSectionProps {
+  mission: Record<string, unknown>;
+  onUpdate: () => void;
+}
+
+export default function GoalConfirmationSection({ mission, onUpdate }: GoalConfirmationSectionProps) {
+  const missionId = mission.id as string;
+  const stages = (mission.stages as Array<{ stageType: string; status: string; parsedOutput?: Record<string, unknown> }>) || [];
+  const goalStage = stages.find((s) => s.stageType === 'goal_discovery' && s.status === 'approved');
+  const goals = ((goalStage?.parsedOutput?.candidateGoals || []) as GoalCandidate[]);
+  const openQuestions = ((goalStage?.parsedOutput?.openQuestions || []) as Array<{ question: string; whyItMatters: string }>);
+
+  const [selectedRank, setSelectedRank] = useState<number | null>(null);
+  const [editedGoal, setEditedGoal] = useState('');
+  const [confirming, setConfirming] = useState(false);
+
+  const handleConfirm = async () => {
+    if (!selectedRank) return;
+    setConfirming(true);
+    try {
+      await fetch(`/api/mission/${missionId}/confirm-goal`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ goalRank: selectedRank, editedGoalStatement: editedGoal || undefined }),
+      });
+      onUpdate();
+    } catch (err) {
+      console.error('Goal confirmation failed:', err);
+    } finally {
+      setConfirming(false);
+    }
+  };
+
+  return (
+    <div className="bg-white rounded border border-border shadow-sm overflow-hidden">
+      <div className="px-3 py-2 border-b border-border">
+        <span className="text-terminal-lg font-semibold text-text-primary">Confirm Your Goal</span>
+      </div>
+
+      <div className="p-4 space-y-3">
+        <p className="text-terminal-sm text-text-muted font-mono">Select a goal to commit to for this mission.</p>
+
+        {goals.map((g) => (
+          <button
+            key={g.rank}
+            onClick={() => {
+              setSelectedRank(g.rank);
+              setEditedGoal(g.goalStatement);
+            }}
+            className={`w-full text-left border rounded p-3 transition-colors ${
+              selectedRank === g.rank
+                ? 'border-brand-purple bg-brand-purple-wash'
+                : 'border-border-light hover:border-border'
+            }`}
+          >
+            <div className="flex items-center gap-2 mb-1">
+              <span className="text-sm font-bold text-brand-purple font-mono">Goal {g.rank}</span>
+              {selectedRank === g.rank && <span className="text-terminal-sm text-brand-purple font-mono">Selected</span>}
+            </div>
+            <p className="text-sm font-medium text-text-primary font-mono">{g.goalStatement}</p>
+            <p className="text-terminal-sm text-text-faint font-mono mt-1">{g.distinctiveAngle}</p>
+          </button>
+        ))}
+
+        {selectedRank && (
+          <div>
+            <label className="block text-terminal-sm text-text-muted font-mono uppercase tracking-wider mb-1">
+              Edit goal statement (optional)
+            </label>
+            <textarea
+              rows={2}
+              value={editedGoal}
+              onChange={(e) => setEditedGoal(e.target.value)}
+              className="w-full resize-none font-mono text-sm bg-transparent border border-border rounded-md px-3 py-2 outline-none focus:border-brand-purple transition-colors"
+            />
+          </div>
+        )}
+
+        {openQuestions.length > 0 && (
+          <div className="border-t border-border-light pt-3">
+            <p className="text-terminal-sm uppercase tracking-widest text-text-muted font-mono mb-1">Open Questions to Consider</p>
+            {openQuestions.map((q, i) => (
+              <p key={i} className="text-terminal-base font-mono text-text-secondary">? {q.question}</p>
+            ))}
+          </div>
+        )}
+
+        <button
+          onClick={handleConfirm}
+          disabled={!selectedRank || confirming}
+          className="w-full py-2.5 bg-brand-purple text-white rounded hover:bg-brand-purple-hover transition-colors font-mono text-sm font-medium disabled:opacity-40"
+        >
+          {confirming ? 'Confirming...' : 'Confirm Goal →'}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/mission/MissionPipeline.tsx
+++ b/src/components/mission/MissionPipeline.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+import BrainDumpSection from './BrainDumpSection';
+import StageSection from './StageSection';
+import GoalConfirmationSection from './GoalConfirmationSection';
+import RealityConstraintsSection from './RealityConstraintsSection';
+
+interface Stage {
+  stageType: string;
+  status: string;
+  attemptNumber: number;
+}
+
+function hasApprovedStage(mission: Record<string, unknown>, stageType: string): boolean {
+  const stages = (mission.stages as Stage[]) || [];
+  return stages.some((s) => s.stageType === stageType && s.status === 'approved');
+}
+
+interface MissionPipelineProps {
+  mission: Record<string, unknown>;
+  onUpdate: () => void;
+}
+
+export default function MissionPipeline({ mission, onUpdate }: MissionPipelineProps) {
+  const entries = (mission.brainDumpEntries as Array<unknown>) || [];
+  const constraints = (mission.realityConstraints as Array<unknown>) || [];
+  const confirmedGoal = mission.confirmedGoal as string | null;
+
+  return (
+    <div className="max-w-4xl mx-auto px-4 py-6 space-y-1">
+      {/* Header */}
+      <div className="mb-6">
+        <h1 className="text-xl font-bold text-text-primary font-mono">{String(mission.name)}</h1>
+        <p className="text-terminal-sm text-text-muted font-mono mt-1">
+          {mission.durationDays ? `${String(mission.durationDays)} day mission` : 'Mission'} &middot; Status: {String(mission.missionStatus)}
+        </p>
+      </div>
+
+      {/* 1. Brain Dump */}
+      <BrainDumpSection mission={mission} onUpdate={onUpdate} />
+
+      <PipelineConnector />
+
+      {/* 2. Structure */}
+      {entries.length > 0 && (
+        <>
+          <StageSection mission={mission} stageType="structure" title="Structure — Project Discovery" onUpdate={onUpdate} />
+          <PipelineConnector />
+        </>
+      )}
+
+      {/* 3. Goal Discovery */}
+      {hasApprovedStage(mission, 'structure') && (
+        <>
+          <StageSection mission={mission} stageType="goal_discovery" title="Goal Discovery" onUpdate={onUpdate} />
+          <PipelineConnector />
+        </>
+      )}
+
+      {/* 4. Goal Confirmation */}
+      {hasApprovedStage(mission, 'goal_discovery') && !confirmedGoal && (
+        <>
+          <GoalConfirmationSection mission={mission} onUpdate={onUpdate} />
+          <PipelineConnector />
+        </>
+      )}
+
+      {/* Show confirmed goal */}
+      {confirmedGoal && (
+        <div className="bg-white rounded border border-border shadow-sm p-4">
+          <p className="text-terminal-sm uppercase tracking-widest text-text-muted font-mono mb-1">Confirmed Goal</p>
+          <p className="text-sm font-medium text-text-primary font-mono">{confirmedGoal}</p>
+        </div>
+      )}
+
+      {/* 5. Reality Constraints */}
+      {confirmedGoal && (
+        <>
+          <PipelineConnector />
+          <RealityConstraintsSection mission={mission} onUpdate={onUpdate} />
+        </>
+      )}
+
+      {/* 6. Reality Audit */}
+      {confirmedGoal && constraints.length > 0 && (
+        <>
+          <PipelineConnector />
+          <StageSection mission={mission} stageType="reality_audit" title="Reality Audit" onUpdate={onUpdate} />
+        </>
+      )}
+
+      {/* 7. Roadmap */}
+      {hasApprovedStage(mission, 'reality_audit') && (
+        <>
+          <PipelineConnector />
+          <StageSection mission={mission} stageType="roadmap" title="Roadmap" onUpdate={onUpdate} />
+        </>
+      )}
+    </div>
+  );
+}
+
+function PipelineConnector() {
+  return (
+    <div className="flex justify-center py-1">
+      <div className="w-px h-6 bg-border" />
+    </div>
+  );
+}

--- a/src/components/mission/RealityConstraintsSection.tsx
+++ b/src/components/mission/RealityConstraintsSection.tsx
@@ -1,0 +1,146 @@
+'use client';
+
+import { useState } from 'react';
+
+interface RealityConstraintsSectionProps {
+  mission: Record<string, unknown>;
+  onUpdate: () => void;
+}
+
+export default function RealityConstraintsSection({ mission, onUpdate }: RealityConstraintsSectionProps) {
+  const missionId = mission.id as string;
+  const existing = (mission.realityConstraints as Array<{ constraintType: string; category: string; description: string; value?: string }>) || [];
+
+  const [builtExists, setBuiltExists] = useState(
+    existing.filter((c) => c.constraintType === 'product' && c.category === 'already_built').map((c) => c.description).join('\n'),
+  );
+  const [broken, setBroken] = useState(
+    existing.filter((c) => c.constraintType === 'product' && c.category === 'broken').map((c) => c.description).join('\n'),
+  );
+  const [missing, setMissing] = useState(
+    existing.filter((c) => c.constraintType === 'product' && c.category === 'missing').map((c) => c.description).join('\n'),
+  );
+  const [hoursPerDay, setHoursPerDay] = useState(
+    existing.find((c) => c.category === 'hours_per_day')?.value || '',
+  );
+  const [budget, setBudget] = useState(
+    existing.find((c) => c.category === 'budget')?.value || '',
+  );
+  const [personalConstraints, setPersonalConstraints] = useState(
+    existing.filter((c) => c.constraintType === 'operational' && c.category === 'personal').map((c) => c.description).join('\n'),
+  );
+  const [energyBlockers, setEnergyBlockers] = useState(
+    existing.filter((c) => c.constraintType === 'operational' && c.category === 'energy').map((c) => c.description).join('\n'),
+  );
+  const [saving, setSaving] = useState(false);
+
+  const buildConstraints = () => {
+    const constraints: Array<{ constraintType: string; category: string; description: string; value?: string }> = [];
+
+    for (const line of builtExists.split('\n').filter((l) => l.trim())) {
+      constraints.push({ constraintType: 'product', category: 'already_built', description: line.trim() });
+    }
+    for (const line of broken.split('\n').filter((l) => l.trim())) {
+      constraints.push({ constraintType: 'product', category: 'broken', description: line.trim() });
+    }
+    for (const line of missing.split('\n').filter((l) => l.trim())) {
+      constraints.push({ constraintType: 'product', category: 'missing', description: line.trim() });
+    }
+    if (hoursPerDay.trim()) {
+      constraints.push({ constraintType: 'operational', category: 'hours_per_day', description: `${hoursPerDay} hours per day`, value: hoursPerDay });
+    }
+    if (budget.trim()) {
+      constraints.push({ constraintType: 'operational', category: 'budget', description: `Monthly budget: $${budget}`, value: budget });
+    }
+    for (const line of personalConstraints.split('\n').filter((l) => l.trim())) {
+      constraints.push({ constraintType: 'operational', category: 'personal', description: line.trim() });
+    }
+    for (const line of energyBlockers.split('\n').filter((l) => l.trim())) {
+      constraints.push({ constraintType: 'operational', category: 'energy', description: line.trim() });
+    }
+
+    return constraints;
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      await fetch(`/api/mission/${missionId}/reality-constraints`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ constraints: buildConstraints() }),
+      });
+      onUpdate();
+    } catch (err) {
+      console.error('Save constraints failed:', err);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const LABEL = 'block text-terminal-sm text-text-muted font-mono uppercase tracking-wider mb-1';
+  const TEXTAREA = 'w-full resize-none font-mono text-terminal-base text-text-primary bg-transparent border border-border rounded px-3 py-2 outline-none focus:border-brand-purple transition-colors placeholder:text-text-faint';
+  const INPUT = 'font-mono text-sm bg-transparent border border-border rounded-md px-3 py-2 w-full focus:border-brand-purple outline-none transition-colors placeholder:text-text-faint';
+
+  return (
+    <div className="bg-white rounded border border-border shadow-sm overflow-hidden">
+      <div className="px-3 py-2 border-b border-border">
+        <span className="text-terminal-lg font-semibold text-text-primary">Reality Constraints</span>
+      </div>
+
+      <div className="p-4 space-y-4">
+        {/* Product Reality */}
+        <div>
+          <p className="text-terminal-sm uppercase tracking-widest text-text-muted font-mono mb-2">Product Reality</p>
+          <div className="space-y-3">
+            <div>
+              <label className={LABEL}>What already exists and works</label>
+              <textarea rows={3} value={builtExists} onChange={(e) => setBuiltExists(e.target.value)} placeholder="One item per line..." className={TEXTAREA} />
+            </div>
+            <div>
+              <label className={LABEL}>What&apos;s broken</label>
+              <textarea rows={3} value={broken} onChange={(e) => setBroken(e.target.value)} placeholder="One item per line..." className={TEXTAREA} />
+            </div>
+            <div>
+              <label className={LABEL}>What&apos;s missing</label>
+              <textarea rows={3} value={missing} onChange={(e) => setMissing(e.target.value)} placeholder="One item per line..." className={TEXTAREA} />
+            </div>
+          </div>
+        </div>
+
+        {/* Operational Reality */}
+        <div>
+          <p className="text-terminal-sm uppercase tracking-widest text-text-muted font-mono mb-2">Operational Reality</p>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+            <div>
+              <label className={LABEL}>Hours per day available</label>
+              <input type="number" value={hoursPerDay} onChange={(e) => setHoursPerDay(e.target.value)} placeholder="5" className={INPUT} />
+            </div>
+            <div>
+              <label className={LABEL}>Monthly budget ($)</label>
+              <input type="number" value={budget} onChange={(e) => setBudget(e.target.value)} placeholder="800" className={INPUT} />
+            </div>
+          </div>
+          <div className="space-y-3 mt-3">
+            <div>
+              <label className={LABEL}>Personal constraints</label>
+              <textarea rows={2} value={personalConstraints} onChange={(e) => setPersonalConstraints(e.target.value)} placeholder="Dog walks, lease situation, appointments..." className={TEXTAREA} />
+            </div>
+            <div>
+              <label className={LABEL}>Energy blockers</label>
+              <textarea rows={2} value={energyBlockers} onChange={(e) => setEnergyBlockers(e.target.value)} placeholder="Sleep issues, medication timing, energy crashes..." className={TEXTAREA} />
+            </div>
+          </div>
+        </div>
+
+        <button
+          onClick={handleSave}
+          disabled={saving}
+          className="w-full py-2.5 bg-brand-purple text-white rounded hover:bg-brand-purple-hover transition-colors font-mono text-sm font-medium disabled:opacity-40"
+        >
+          {saving ? 'Saving...' : 'Save Constraints'}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/mission/StageSection.tsx
+++ b/src/components/mission/StageSection.tsx
@@ -1,0 +1,377 @@
+'use client';
+
+import { useState } from 'react';
+
+interface StageData {
+  id: string;
+  stageType: string;
+  status: string;
+  attemptNumber: number;
+  inputSnapshot?: unknown;
+  systemPrompt?: string;
+  userPrompt?: string;
+  rawResponse?: string;
+  parsedOutput?: Record<string, unknown>;
+  approvedAt?: string;
+  rejectedAt?: string;
+  rejectionReason?: string;
+}
+
+const STATUS_BADGE: Record<string, string> = {
+  pending: 'bg-gray-100 text-gray-600',
+  processing: 'bg-blue-100 text-blue-700',
+  completed: 'bg-amber-100 text-amber-700',
+  approved: 'bg-emerald-100 text-emerald-700',
+  rejected: 'bg-red-100 text-red-600',
+};
+
+const PRIO_DOT: Record<string, string> = { high: 'bg-red-500', medium: 'bg-amber-500', low: 'bg-emerald-500' };
+const SCOPE_BADGE: Record<string, string> = { small: 'bg-emerald-50 text-emerald-700', medium: 'bg-amber-50 text-amber-700', large: 'bg-red-50 text-red-700' };
+const SEV_COLOR: Record<string, string> = { high: 'text-red-600', medium: 'text-amber-600', low: 'text-text-muted' };
+
+interface StageSectionProps {
+  mission: Record<string, unknown>;
+  stageType: string;
+  title: string;
+  onUpdate: () => void;
+}
+
+export default function StageSection({ mission, stageType, title, onUpdate }: StageSectionProps) {
+  const missionId = mission.id as string;
+  const stages = ((mission.stages as StageData[]) || []).filter((s) => s.stageType === stageType);
+  const latestStage = stages[0] || null;
+  const [running, setRunning] = useState(false);
+  const [rejecting, setRejecting] = useState(false);
+  const [rejectReason, setRejectReason] = useState('');
+
+  const canRun = !latestStage || latestStage.status === 'rejected';
+  const canApprove = latestStage?.status === 'completed';
+
+  const runStage = async () => {
+    setRunning(true);
+    try {
+      await fetch(`/api/mission/${missionId}/run-stage`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ stageType }),
+      });
+      onUpdate();
+    } catch (err) {
+      console.error('Run stage failed:', err);
+    } finally {
+      setRunning(false);
+    }
+  };
+
+  const approve = async () => {
+    if (!latestStage) return;
+    await fetch(`/api/mission/${missionId}/stage/${latestStage.id}/approve`, { method: 'POST' });
+    onUpdate();
+  };
+
+  const reject = async () => {
+    if (!latestStage) return;
+    await fetch(`/api/mission/${missionId}/stage/${latestStage.id}/reject`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ reason: rejectReason || null }),
+    });
+    setRejecting(false);
+    setRejectReason('');
+    onUpdate();
+  };
+
+  return (
+    <div className="bg-white rounded border border-border shadow-sm overflow-hidden">
+      {/* Header */}
+      <div className="px-3 py-2 border-b border-border flex items-center justify-between">
+        <span className="text-terminal-lg font-semibold text-text-primary">{title}</span>
+        {latestStage && (
+          <span className={`text-terminal-sm font-mono px-2 py-0.5 rounded-full ${STATUS_BADGE[latestStage.status] || ''}`}>
+            {latestStage.status}
+            {latestStage.attemptNumber > 1 && ` (attempt ${latestStage.attemptNumber})`}
+          </span>
+        )}
+      </div>
+
+      <div className="p-4 space-y-3">
+        {/* Run button */}
+        {canRun && (
+          <button
+            onClick={runStage}
+            disabled={running}
+            className="w-full py-2 bg-brand-purple text-white rounded hover:bg-brand-purple-hover transition-colors font-mono text-sm font-medium disabled:opacity-40"
+          >
+            {running ? 'Running...' : `Run ${title}`}
+          </button>
+        )}
+
+        {running && (
+          <div className="flex items-center justify-center gap-2 py-4">
+            <div className="w-4 h-4 border-2 border-brand-purple border-t-transparent rounded-full animate-spin" />
+            <span className="text-sm text-text-muted font-mono">Processing with AI...</span>
+          </div>
+        )}
+
+        {/* Observability sections */}
+        {latestStage && (
+          <>
+            <Collapsible title="Input Snapshot">
+              <pre className="text-terminal-sm font-mono text-text-secondary whitespace-pre-wrap overflow-x-auto">
+                {JSON.stringify(latestStage.inputSnapshot, null, 2)}
+              </pre>
+            </Collapsible>
+
+            <Collapsible title="System Prompt">
+              <pre className="text-terminal-sm font-mono text-text-secondary whitespace-pre-wrap">
+                {latestStage.systemPrompt || '(none)'}
+              </pre>
+            </Collapsible>
+
+            <Collapsible title="User Prompt">
+              <pre className="text-terminal-sm font-mono text-text-secondary whitespace-pre-wrap">
+                {latestStage.userPrompt || '(none)'}
+              </pre>
+            </Collapsible>
+
+            {/* Parsed output */}
+            {latestStage.parsedOutput && (
+              <div className="border border-border-light rounded p-3">
+                <p className="text-terminal-sm uppercase tracking-widest text-text-muted font-mono mb-2">Output</p>
+                <StageOutput stageType={stageType} output={latestStage.parsedOutput} />
+              </div>
+            )}
+
+            <Collapsible title="Raw API Response">
+              <pre className="text-terminal-sm font-mono text-text-secondary whitespace-pre-wrap overflow-x-auto max-h-60 overflow-y-auto">
+                {latestStage.rawResponse || '(none)'}
+              </pre>
+            </Collapsible>
+
+            {/* Approve / Reject */}
+            {canApprove && (
+              <div className="flex items-center gap-2 pt-2 border-t border-border-light">
+                <button
+                  onClick={approve}
+                  className="px-4 py-1.5 bg-emerald-600 text-white rounded text-terminal-base font-mono hover:bg-emerald-700 transition-colors"
+                >
+                  Approve
+                </button>
+                {rejecting ? (
+                  <div className="flex items-center gap-2 flex-1">
+                    <input
+                      type="text"
+                      value={rejectReason}
+                      onChange={(e) => setRejectReason(e.target.value)}
+                      placeholder="Reason (optional)"
+                      className="flex-1 font-mono text-terminal-base border border-border rounded px-2 py-1 outline-none focus:border-brand-purple"
+                    />
+                    <button onClick={reject} className="px-3 py-1.5 bg-red-600 text-white rounded text-terminal-base font-mono">Reject</button>
+                    <button onClick={() => setRejecting(false)} className="text-terminal-base text-text-muted font-mono">Cancel</button>
+                  </div>
+                ) : (
+                  <button
+                    onClick={() => setRejecting(true)}
+                    className="px-4 py-1.5 border border-red-300 text-red-600 rounded text-terminal-base font-mono hover:bg-red-50 transition-colors"
+                  >
+                    Reject
+                  </button>
+                )}
+              </div>
+            )}
+
+            {latestStage.status === 'rejected' && latestStage.rejectionReason && (
+              <p className="text-terminal-sm text-red-600 font-mono">Rejected: {latestStage.rejectionReason}</p>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ── Collapsible ─────────────────────────────────────────────────────────────
+
+function Collapsible({ title, children }: { title: string; children: React.ReactNode }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="border border-border-light rounded">
+      <button
+        onClick={() => setOpen(!open)}
+        className="w-full px-3 py-1.5 flex items-center justify-between text-left hover:bg-bg-row/50 transition-colors"
+      >
+        <span className="text-terminal-sm text-text-muted font-mono">{title}</span>
+        <span className="text-text-faint text-terminal-sm">{open ? '▲' : '▼'}</span>
+      </button>
+      {open && <div className="px-3 pb-3 border-t border-border-light max-h-96 overflow-y-auto">{children}</div>}
+    </div>
+  );
+}
+
+// ── Stage-specific output renderers ─────────────────────────────────────────
+
+function StageOutput({ stageType, output }: { stageType: string; output: Record<string, unknown> }) {
+  if (stageType === 'structure') return <StructureOutputView output={output} />;
+  if (stageType === 'goal_discovery') return <GoalDiscoveryOutputView output={output} />;
+  return <pre className="text-terminal-sm font-mono text-text-secondary whitespace-pre-wrap">{JSON.stringify(output, null, 2)}</pre>;
+}
+
+function StructureOutputView({ output }: { output: Record<string, unknown> }) {
+  const projects = (output.discoveredProjects as Array<{ projectName: string; description: string; estimatedScope: string; relatedEntries: Array<{ content: string }>; dependencies: string[]; blockers: string[] }>) || [];
+  const themes = (output.emergentThemes as Array<{ theme: string; confidence: string; basis: string; evidence: string[] }>) || [];
+  const contradictions = (output.contradictions as Array<{ itemA: { content: string }; itemB: { content: string }; nature: string; severity: string }>) || [];
+  const constraints = (output.constraints as Array<{ constraint: string; impact: string }>) || [];
+  const missingInputs = (output.missingInputs as Array<{ area: string; suggestedQuestion: string }>) || [];
+  const gaps = (output.logicGaps as Array<{ statement: string; gap: string }>) || [];
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <p className="text-terminal-sm uppercase tracking-widest text-text-muted font-mono mb-2">Discovered Projects ({projects.length})</p>
+        <div className="space-y-2">
+          {projects.map((p, i) => (
+            <div key={i} className="border border-border-light rounded p-3">
+              <div className="flex items-center gap-2 mb-1">
+                <span className="text-sm font-semibold text-text-primary font-mono">{p.projectName}</span>
+                <span className={`text-terminal-sm font-mono px-1.5 py-0.5 rounded ${SCOPE_BADGE[p.estimatedScope] || ''}`}>{p.estimatedScope}</span>
+              </div>
+              <p className="text-terminal-base text-text-secondary font-mono">{p.description}</p>
+              {p.relatedEntries.length > 0 && (
+                <div className="mt-1">
+                  {p.relatedEntries.map((e, j) => (
+                    <p key={j} className="text-terminal-sm text-text-faint font-mono">• {e.content}</p>
+                  ))}
+                </div>
+              )}
+              {p.dependencies.length > 0 && <p className="text-terminal-sm text-text-muted font-mono mt-1">Depends on: {p.dependencies.join(', ')}</p>}
+              {p.blockers.length > 0 && <p className="text-terminal-sm text-red-500 font-mono mt-1">Blockers: {p.blockers.join(', ')}</p>}
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {themes.length > 0 && (
+        <div>
+          <p className="text-terminal-sm uppercase tracking-widest text-text-muted font-mono mb-1">Emergent Themes</p>
+          {themes.map((t, i) => (
+            <p key={i} className="text-terminal-base font-mono text-text-secondary">
+              <span className="font-medium">{t.theme}</span> <span className="text-text-faint">({t.confidence}, {t.basis})</span>
+            </p>
+          ))}
+        </div>
+      )}
+
+      {contradictions.length > 0 && (
+        <div>
+          <p className="text-terminal-sm uppercase tracking-widest text-text-muted font-mono mb-1">Contradictions</p>
+          {contradictions.map((c, i) => (
+            <div key={i} className={`text-terminal-base font-mono ${SEV_COLOR[c.severity]}`}>
+              &ldquo;{c.itemA.content}&rdquo; vs &ldquo;{c.itemB.content}&rdquo; — {c.nature}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {constraints.length > 0 && (
+        <div>
+          <p className="text-terminal-sm uppercase tracking-widest text-text-muted font-mono mb-1">Constraints</p>
+          {constraints.map((c, i) => (
+            <p key={i} className="text-terminal-base font-mono text-text-secondary">{c.constraint} — <span className="text-text-faint">{c.impact}</span></p>
+          ))}
+        </div>
+      )}
+
+      {missingInputs.length > 0 && (
+        <div>
+          <p className="text-terminal-sm uppercase tracking-widest text-text-muted font-mono mb-1">Missing Inputs</p>
+          {missingInputs.map((m, i) => (
+            <p key={i} className="text-terminal-base font-mono text-amber-700">{m.area}: {m.suggestedQuestion}</p>
+          ))}
+        </div>
+      )}
+
+      {gaps.length > 0 && (
+        <div>
+          <p className="text-terminal-sm uppercase tracking-widest text-text-muted font-mono mb-1">Logic Gaps</p>
+          {gaps.map((g, i) => (
+            <p key={i} className="text-terminal-base font-mono text-text-secondary">&ldquo;{g.statement}&rdquo; → Gap: {g.gap}</p>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function GoalDiscoveryOutputView({ output }: { output: Record<string, unknown> }) {
+  const goals = (output.candidateGoals as Array<{
+    rank: number; goalStatement: string; distinctiveAngle: string; rationale: string;
+    executionProfile: { primaryFocus: string[]; deprioritizedAreas: string[]; likelyOperatingMode: string };
+    tradeoffs: { gains: string[]; costs: string[]; risks: string[] };
+    timelineFit: string; supportingEvidence: Array<{ type: string; reference: string }>;
+  }>) || [];
+  const questions = (output.openQuestions as Array<{ question: string; whyItMatters: string }>) || [];
+  const assumptions = (output.assumptionsToValidate as Array<{ assumption: string; type: string; howToValidate: string }>) || [];
+  const ignore = (output.itemsToIgnoreForNow as Array<{ content: string; reason: string }>) || [];
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-3">
+        {goals.map((g) => (
+          <div key={g.rank} className="border border-border-light rounded p-3">
+            <div className="flex items-center gap-2 mb-1">
+              <span className="text-sm font-bold text-brand-purple font-mono">Goal {g.rank}</span>
+            </div>
+            <p className="text-sm font-semibold text-text-primary font-mono">{g.goalStatement}</p>
+            <p className="text-terminal-sm text-text-muted font-mono mt-1 italic">{g.distinctiveAngle}</p>
+            <p className="text-terminal-sm text-text-secondary font-mono mt-1">{g.rationale}</p>
+            <div className="mt-2 grid grid-cols-1 md:grid-cols-3 gap-2">
+              <div>
+                <p className="text-terminal-sm text-emerald-600 font-mono font-medium">Gains</p>
+                {g.tradeoffs.gains.map((t, i) => <p key={i} className="text-terminal-sm font-mono text-text-secondary">+ {t}</p>)}
+              </div>
+              <div>
+                <p className="text-terminal-sm text-red-500 font-mono font-medium">Costs</p>
+                {g.tradeoffs.costs.map((t, i) => <p key={i} className="text-terminal-sm font-mono text-text-secondary">- {t}</p>)}
+              </div>
+              <div>
+                <p className="text-terminal-sm text-amber-600 font-mono font-medium">Risks</p>
+                {g.tradeoffs.risks.map((t, i) => <p key={i} className="text-terminal-sm font-mono text-text-secondary">! {t}</p>)}
+              </div>
+            </div>
+            <p className="text-terminal-sm text-text-faint font-mono mt-2">Mode: {g.executionProfile.likelyOperatingMode}</p>
+            <p className="text-terminal-sm text-text-faint font-mono">Timeline: {g.timelineFit}</p>
+          </div>
+        ))}
+      </div>
+
+      {questions.length > 0 && (
+        <div>
+          <p className="text-terminal-sm uppercase tracking-widest text-text-muted font-mono mb-1">Open Questions</p>
+          {questions.map((q, i) => (
+            <p key={i} className="text-terminal-base font-mono text-text-secondary">? {q.question}</p>
+          ))}
+        </div>
+      )}
+
+      {assumptions.length > 0 && (
+        <div>
+          <p className="text-terminal-sm uppercase tracking-widest text-text-muted font-mono mb-1">Assumptions to Validate</p>
+          {assumptions.map((a, i) => (
+            <p key={i} className="text-terminal-base font-mono text-text-secondary">
+              <span className="text-text-faint">[{a.type}]</span> {a.assumption} → {a.howToValidate}
+            </p>
+          ))}
+        </div>
+      )}
+
+      {ignore.length > 0 && (
+        <div>
+          <p className="text-terminal-sm uppercase tracking-widest text-text-muted font-mono mb-1">Items to Ignore</p>
+          {ignore.map((item, i) => (
+            <p key={i} className="text-terminal-base font-mono text-text-faint">{item.content} — {item.reason}</p>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/ui/AppLayout.tsx
+++ b/src/components/ui/AppLayout.tsx
@@ -4,7 +4,7 @@ import { useRouter, usePathname } from 'next/navigation';
 import { useSession, signOut } from 'next-auth/react';
 import { useEffect, useState, Suspense } from 'react';
 import Link from 'next/link';
-import { BookOpen, User, Briefcase, Plane, TrendingUp, Rocket, LayoutGrid, Menu, X } from 'lucide-react';
+import { BookOpen, User, Briefcase, Plane, TrendingUp, Target, Rocket, LayoutGrid, Menu, X } from 'lucide-react';
 import TripCreationBar from '@/components/trips/TripCreationBar';
 
 export interface LedgerMetrics {
@@ -69,6 +69,8 @@ const TRAVEL_PREFIXES = ['/budgets/trips', '/trips'];
 
 const TRADING_PREFIXES = ['/trading'];
 
+const MISSION_PREFIXES = ['/mission'];
+
 const OPS_PREFIXES = ['/ops'];
 
 // Primary nav tabs — order matters (left to right)
@@ -78,6 +80,7 @@ const NAV_TABS = [
   { name: 'Business', href: '/business', Icon: Briefcase, prefixes: BUSINESS_PREFIXES },
   { name: 'Travel', href: '/budgets/trips', Icon: Plane, prefixes: TRAVEL_PREFIXES },
   { name: 'Trading', href: '/trading', Icon: TrendingUp, prefixes: TRADING_PREFIXES },
+  { name: 'Mission', href: '/mission', Icon: Target, prefixes: MISSION_PREFIXES },
   { name: 'Ops', href: '/ops', Icon: Rocket, prefixes: OPS_PREFIXES },
 ];
 


### PR DESCRIPTION
Nav: Added Mission tab (Target icon) between Trading and Ops

Pages:
- /mission — create mission form with title + duration presets (30/75/90 days)
- /mission/[id] — single continuous pipeline page, fetches full mission data

Components:
- MissionPipeline: vertical pipeline orchestrator, conditionally renders each stage based on prerequisites (brain dump → structure → goal discovery → goal confirmation → reality constraints → reality audit → roadmap). Thin gray connector lines between stages.
- BrainDumpSection: two-column layout — trigger question groups (5 groups, 15 questions, collapsible) on left, open dump textarea on right. "Save & Process" button saves entries + runs structure stage in one action.
- StageSection: reusable for any pipeline stage. Full observability: collapsible input snapshot, system prompt, user prompt, raw API response. Parsed output rendered by stage type (StructureOutputView with project cards, scope badges, themes, contradictions, constraints, logic gaps; GoalDiscoveryOutputView with 3 goal cards, tradeoffs grid, open questions, assumptions, items to ignore). Approve/reject with inline reason input. Status badges (gray/blue/amber/green/red).
- GoalConfirmationSection: selectable goal cards, optional statement editing, open questions review, confirm button.
- RealityConstraintsSection: product reality (exists/broken/missing) + operational reality (hours, budget, personal, energy) forms.

Every AI input, prompt, and output is visible and auditable on the page.

https://claude.ai/code/session_01GQeiwocJDnF2N3pU1q7Y8t