### PR TITLE
feat(ops): add OpsQuestionnaireAnswer data model

### DIFF
--- a/prisma/migrations/20260424000000_add_ops_questionnaire_answer/migration.sql
+++ b/prisma/migrations/20260424000000_add_ops_questionnaire_answer/migration.sql
@@ -1,0 +1,33 @@
+-- CreateTable
+CREATE TABLE "ops_questionnaire_answers" (
+    "id" TEXT NOT NULL,
+    "mission_id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "module_id" TEXT NOT NULL,
+    "workstream_id" TEXT NOT NULL,
+    "question_id" TEXT NOT NULL,
+    "answer_value" TEXT NOT NULL,
+    "question_type" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ops_questionnaire_answers_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ops_questionnaire_answers_mission_id_module_id_question_id_key" ON "ops_questionnaire_answers"("mission_id", "module_id", "question_id");
+
+-- CreateIndex
+CREATE INDEX "ops_questionnaire_answers_user_id_idx" ON "ops_questionnaire_answers"("user_id");
+
+-- CreateIndex
+CREATE INDEX "ops_questionnaire_answers_mission_id_module_id_idx" ON "ops_questionnaire_answers"("mission_id", "module_id");
+
+-- CreateIndex
+CREATE INDEX "ops_questionnaire_answers_mission_id_module_id_workstream_id_idx" ON "ops_questionnaire_answers"("mission_id", "module_id", "workstream_id");
+
+-- AddForeignKey
+ALTER TABLE "ops_questionnaire_answers" ADD CONSTRAINT "ops_questionnaire_answers_mission_id_fkey" FOREIGN KEY ("mission_id") REFERENCES "missions"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ops_questionnaire_answers" ADD CONSTRAINT "ops_questionnaire_answers_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -436,18 +436,18 @@ model investment_transactions {
 }
 
 model users {
-  id                      String                   @id
-  email                   String                   @unique
+  id                      String                      @id
+  email                   String                      @unique
   password                String
   name                    String
-  createdAt               DateTime                 @default(now())
+  createdAt               DateTime                    @default(now())
   updatedAt               DateTime
   accountCode             String?
   subAccount              String?
-  tier                    String                   @default("free") @db.VarChar(20)
+  tier                    String                      @default("free") @db.VarChar(20)
   stripeCustomerId        String?
   stripeSubscriptionId    String?
-  bookkeeping_initialized Boolean                  @default(false)
+  bookkeeping_initialized Boolean                     @default(false)
   scanner_start_date      DateTime?
   accounts                accounts[]
   plaid_items             plaid_items[]
@@ -473,6 +473,7 @@ model users {
   scan_snapshots          scan_snapshots[]
   dailyPlans              daily_plans[]
   missions                missions[]
+  questionnaireAnswers    ops_questionnaire_answers[]
 }
 
 model budgets {
@@ -1915,13 +1916,14 @@ model missions {
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")
 
-  user               users                 @relation(fields: [userId], references: [id])
-  dailyPlans         daily_plans[]
-  stages             mission_stages[]
-  brainDumpEntries   brain_dump_entries[]
-  realityConstraints reality_constraints[]
-  roadmapWeeks       roadmap_weeks[]
-  missionTasks       mission_tasks[]
+  user                 users                       @relation(fields: [userId], references: [id])
+  dailyPlans           daily_plans[]
+  stages               mission_stages[]
+  brainDumpEntries     brain_dump_entries[]
+  realityConstraints   reality_constraints[]
+  roadmapWeeks         roadmap_weeks[]
+  missionTasks         mission_tasks[]
+  questionnaireAnswers ops_questionnaire_answers[]
 
   @@map("missions")
 }
@@ -2027,4 +2029,30 @@ model mission_tasks {
   @@index([missionId])
   @@index([weekId])
   @@index([missionId, scheduledDate])
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// OPS QUESTIONNAIRE — Stores answers for Operations Planner questions
+// ═══════════════════════════════════════════════════════════════════
+
+model ops_questionnaire_answers {
+  id           String   @id @default(cuid())
+  missionId    String   @map("mission_id")
+  userId       String   @map("user_id")
+  moduleId     String   @map("module_id")
+  workstreamId String   @map("workstream_id")
+  questionId   String   @map("question_id")
+  answerValue  String   @map("answer_value") @db.Text
+  questionType String   @map("question_type")
+  createdAt    DateTime @default(now()) @map("created_at")
+  updatedAt    DateTime @updatedAt @map("updated_at")
+
+  mission missions @relation(fields: [missionId], references: [id], onDelete: Cascade)
+  user    users    @relation(fields: [userId], references: [id])
+
+  @@unique([missionId, moduleId, questionId])
+  @@index([userId])
+  @@index([missionId, moduleId])
+  @@index([missionId, moduleId, workstreamId])
+  @@map("ops_questionnaire_answers")
 }


### PR DESCRIPTION
New Prisma model for storing ops planner questionnaire answers:
- One row per answer per mission per module per question
- userId for user-scoped query safety
- answerValue as String (JSON-stringified for all types)
- Unique constraint on (missionId, moduleId, questionId) for upsert pattern
- Indexes for user, mission+module, and workstream-level progress queries
- FK to missions (cascade delete) and users (restrict)
- Migration SQL created but not applied (Alex runs prisma migrate deploy)
- Reverse relations added to missions and users models
- No API routes, no UI — schema only

https://claude.ai/code/session_01GQeiwocJDnF2N3pU1q7Y8t