### PR TITLE
feat(ops): restructure ops routing + add bookkeeping questionnaire shell

### DIFF
--- a/src/app/ops/bookkeeping/page.tsx
+++ b/src/app/ops/bookkeeping/page.tsx
@@ -1,0 +1,139 @@
+'use client';
+
+import { useState } from 'react';
+import AppLayout from '@/components/ui/AppLayout';
+import { BOOKKEEPING_OPS_MODULE } from '@/lib/ops/bookkeepingQuestions';
+import type { OpsWorkstream, OpsQuestion, LaunchStage } from '@/lib/ops/bookkeepingQuestions';
+
+const STAGE_COLORS: Record<LaunchStage, { bg: string; text: string; label: string }> = {
+  required_now: { bg: 'bg-red-50', text: 'text-red-700', label: 'Required Now' },
+  required_before_charging: { bg: 'bg-amber-50', text: 'text-amber-700', label: 'Before Charging' },
+  required_at_scale: { bg: 'bg-blue-50', text: 'text-blue-700', label: 'At Scale' },
+  best_practice: { bg: 'bg-gray-50', text: 'text-gray-600', label: 'Best Practice' },
+};
+
+const TYPE_LABELS: Record<string, string> = {
+  text: 'Text',
+  boolean: 'Yes/No',
+  select: 'Select',
+  multiselect: 'Multi',
+  checklist: 'Checklist',
+  date: 'Date',
+};
+
+function stageCounts() {
+  const counts: Record<LaunchStage, number> = {
+    required_now: 0,
+    required_before_charging: 0,
+    required_at_scale: 0,
+    best_practice: 0,
+  };
+  for (const ws of BOOKKEEPING_OPS_MODULE.workstreams) {
+    for (const q of ws.questions) {
+      counts[q.launchStage]++;
+    }
+  }
+  return counts;
+}
+
+export default function BookkeepingQuestionnairePage() {
+  const [expandedWorkstream, setExpandedWorkstream] = useState<string | null>(null);
+  const counts = stageCounts();
+
+  return (
+    <AppLayout>
+      <div className="max-w-6xl mx-auto px-4 pt-4 pb-8 space-y-4">
+        {/* Module Header */}
+        <div className="bg-white rounded border border-border shadow-sm p-5">
+          <h1 className="text-xl font-bold text-text-primary font-mono">{BOOKKEEPING_OPS_MODULE.title}</h1>
+          <p className="text-terminal-sm text-text-muted font-mono mt-1">{BOOKKEEPING_OPS_MODULE.description}</p>
+
+          {/* Progress */}
+          <div className="mt-4">
+            <div className="flex items-center justify-between mb-1">
+              <span className="text-terminal-sm text-text-muted font-mono">0 / {BOOKKEEPING_OPS_MODULE.totalQuestions} questions answered</span>
+              <span className="text-terminal-sm text-text-faint font-mono">0%</span>
+            </div>
+            <div className="h-2 bg-bg-row rounded-full">
+              <div className="h-2 rounded-full bg-brand-purple transition-all" style={{ width: '0%' }} />
+            </div>
+          </div>
+
+          {/* Stage breakdown */}
+          <div className="flex flex-wrap gap-3 mt-3">
+            {(Object.entries(counts) as Array<[LaunchStage, number]>).map(([stage, count]) => {
+              const style = STAGE_COLORS[stage];
+              return (
+                <span key={stage} className={`${style.bg} ${style.text} text-terminal-sm font-mono px-2 py-0.5 rounded-full`}>
+                  {style.label}: {count}
+                </span>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* Workstream Accordion */}
+        {BOOKKEEPING_OPS_MODULE.workstreams.map((ws: OpsWorkstream) => {
+          const isExpanded = expandedWorkstream === ws.id;
+          return (
+            <div key={ws.id} className="bg-white rounded border border-border shadow-sm overflow-hidden">
+              <button
+                onClick={() => setExpandedWorkstream(isExpanded ? null : ws.id)}
+                className="w-full px-4 py-3 flex items-center justify-between text-left hover:bg-bg-row/50 transition-colors"
+              >
+                <div className="min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className="text-sm font-bold text-brand-purple font-mono">{ws.letter}</span>
+                    <span className="text-sm font-semibold text-text-primary font-mono">{ws.title}</span>
+                  </div>
+                  <p className="text-terminal-sm text-text-faint font-mono mt-0.5">{ws.description}</p>
+                </div>
+                <div className="flex items-center gap-3 flex-shrink-0 ml-4">
+                  <span className="text-terminal-sm text-text-muted font-mono">0/{ws.questions.length}</span>
+                  <span className="text-text-faint text-terminal-sm">{isExpanded ? '▼' : '▶'}</span>
+                </div>
+              </button>
+
+              {isExpanded && (
+                <div className="border-t border-border">
+                  {ws.questions.map((q: OpsQuestion) => {
+                    const stageStyle = STAGE_COLORS[q.launchStage];
+                    return (
+                      <div key={q.id} className="px-4 py-3 border-b border-border-light last:border-b-0">
+                        <div className="flex items-start gap-2">
+                          <span className="text-terminal-sm text-text-faint font-mono flex-shrink-0 mt-0.5 w-16">{q.id}</span>
+                          <div className="flex-1 min-w-0">
+                            <p className="text-terminal-base text-text-primary font-mono">{q.text}</p>
+                            {q.helpText && (
+                              <p className="text-terminal-sm text-text-faint font-mono mt-1">{q.helpText}</p>
+                            )}
+                            <div className="flex flex-wrap items-center gap-1.5 mt-2">
+                              <span className="text-terminal-sm font-mono px-1.5 py-0.5 rounded bg-gray-100 text-gray-600">
+                                {TYPE_LABELS[q.type] || q.type}
+                              </span>
+                              <span className="text-terminal-sm font-mono px-1.5 py-0.5 rounded bg-brand-purple-wash text-brand-purple">
+                                {q.regulatoryTag.replace(/_/g, ' ')}
+                              </span>
+                              <span className={`text-terminal-sm font-mono px-1.5 py-0.5 rounded-full ${stageStyle.bg} ${stageStyle.text}`}>
+                                {stageStyle.label}
+                              </span>
+                              {q.dependsOn && q.dependsOn.length > 0 && (
+                                <span className="text-terminal-sm font-mono text-text-faint">
+                                  depends: {q.dependsOn.join(', ')}
+                                </span>
+                              )}
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </AppLayout>
+  );
+}

--- a/src/app/ops/layout.tsx
+++ b/src/app/ops/layout.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+import Link from 'next/link';
+
+const OPS_TABS = [
+  { name: 'Overview', href: '/ops', exact: true },
+  { name: 'Bookkeeping', href: '/ops/bookkeeping', exact: false },
+  { name: 'Trading', href: '', disabled: true },
+  { name: 'Travel', href: '', disabled: true },
+  { name: 'Operations', href: '', disabled: true },
+];
+
+export default function OpsLayout({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+
+  const isActive = (tab: typeof OPS_TABS[number]) => {
+    if (tab.disabled) return false;
+    if (tab.exact) return pathname === tab.href;
+    return pathname?.startsWith(tab.href);
+  };
+
+  return (
+    <div>
+      <div className="border-b border-border bg-white">
+        <div className="max-w-6xl mx-auto px-4">
+          <nav className="flex items-center gap-1 -mb-px">
+            {OPS_TABS.map((tab) => {
+              const active = isActive(tab);
+              if (tab.disabled) {
+                return (
+                  <span
+                    key={tab.name}
+                    className="px-3 py-2 text-terminal-sm font-mono text-text-faint cursor-default"
+                  >
+                    {tab.name}
+                  </span>
+                );
+              }
+              return (
+                <Link
+                  key={tab.name}
+                  href={tab.href}
+                  className={`px-3 py-2 text-terminal-sm font-mono transition-colors border-b-2 ${
+                    active
+                      ? 'border-brand-purple text-brand-purple font-medium'
+                      : 'border-transparent text-text-muted hover:text-text-primary hover:border-border'
+                  }`}
+                >
+                  {tab.name}
+                </Link>
+              );
+            })}
+          </nav>
+        </div>
+      </div>
+      {children}
+    </div>
+  );
+}


### PR DESCRIPTION
Routing changes:
- /ops now has sub-navigation layout (Overview, Bookkeeping, Trading, Travel, Operations)
- Existing brain dump + Structure stage preserved at /ops (unchanged page.tsx)
- Trading/Travel/Operations tabs shown as disabled (coming soon)
- Active tab highlighted with brand-purple bottom border

New page: /ops/bookkeeping
- Renders all 90 questions from BOOKKEEPING_OPS_MODULE registry
- 18 workstreams in collapsible accordion with letter + title + description
- Each question shows: ID, text, type badge, regulatory tag pill, launch stage pill, helpText
- Launch stage color coding: red (required_now), amber (before_charging), blue (at_scale), gray (best_practice)
- Module-level progress summary (hardcoded 0/90 — no persistence yet)
- Stage breakdown counts computed from registry data
- Purely presentational — no API calls, no database queries, no form inputs

No existing functionality modified — original ops page.tsx is zero-diff.

https://claude.ai/code/session_01GQeiwocJDnF2N3pU1q7Y8t