### PR TITLE
feat(ops): add form inputs to bookkeeping questionnaire

### DIFF
--- a/src/app/ops/bookkeeping/page.tsx
+++ b/src/app/ops/bookkeeping/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import AppLayout from '@/components/ui/AppLayout';
 import OpsSubNav from '@/components/ops/OpsSubNav';
+import QuestionInput from '@/components/ops/QuestionInput';
 import { BOOKKEEPING_OPS_MODULE } from '@/lib/ops/bookkeepingQuestions';
 import type { OpsWorkstream, OpsQuestion, LaunchStage } from '@/lib/ops/bookkeepingQuestions';
 
@@ -37,9 +38,40 @@ function stageCounts() {
   return counts;
 }
 
+function isAnswered(value: string | undefined): boolean {
+  if (!value || value.trim() === '') return false;
+  if (value === '[]') return false;
+  return true;
+}
+
 export default function BookkeepingQuestionnairePage() {
   const [expandedWorkstream, setExpandedWorkstream] = useState<string | null>(null);
+  const [answers, setAnswers] = useState<Record<string, string>>({});
   const counts = stageCounts();
+
+  const setAnswer = (questionId: string, value: string) => {
+    setAnswers((prev) => {
+      const next = { ...prev };
+      if (value === '' || value === '[]') {
+        delete next[questionId];
+      } else {
+        next[questionId] = value;
+      }
+      return next;
+    });
+  };
+
+  const totalAnswered = Object.keys(answers).length;
+  const totalQuestions = BOOKKEEPING_OPS_MODULE.totalQuestions;
+  const progressPct = totalQuestions > 0 ? Math.round((totalAnswered / totalQuestions) * 100) : 0;
+
+  const wsAnsweredCount = (ws: OpsWorkstream) =>
+    ws.questions.filter((q) => isAnswered(answers[q.id])).length;
+
+  const hasDepsAnswered = (q: OpsQuestion) => {
+    if (!q.dependsOn || q.dependsOn.length === 0) return true;
+    return q.dependsOn.every((depId) => isAnswered(answers[depId]));
+  };
 
   return (
     <AppLayout>
@@ -50,18 +82,21 @@ export default function BookkeepingQuestionnairePage() {
           <h1 className="text-xl font-bold text-text-primary font-mono">{BOOKKEEPING_OPS_MODULE.title}</h1>
           <p className="text-terminal-sm text-text-muted font-mono mt-1">{BOOKKEEPING_OPS_MODULE.description}</p>
 
-          {/* Progress */}
           <div className="mt-4">
             <div className="flex items-center justify-between mb-1">
-              <span className="text-terminal-sm text-text-muted font-mono">0 / {BOOKKEEPING_OPS_MODULE.totalQuestions} questions answered</span>
-              <span className="text-terminal-sm text-text-faint font-mono">0%</span>
+              <span className="text-terminal-sm text-text-muted font-mono">
+                {totalAnswered} / {totalQuestions} questions answered
+              </span>
+              <span className="text-terminal-sm text-text-faint font-mono">{progressPct}%</span>
             </div>
             <div className="h-2 bg-bg-row rounded-full">
-              <div className="h-2 rounded-full bg-brand-purple transition-all" style={{ width: '0%' }} />
+              <div
+                className="h-2 rounded-full bg-brand-purple transition-all"
+                style={{ width: `${progressPct}%` }}
+              />
             </div>
           </div>
 
-          {/* Stage breakdown */}
           <div className="flex flex-wrap gap-3 mt-3">
             {(Object.entries(counts) as Array<[LaunchStage, number]>).map(([stage, count]) => {
               const style = STAGE_COLORS[stage];
@@ -77,6 +112,7 @@ export default function BookkeepingQuestionnairePage() {
         {/* Workstream Accordion */}
         {BOOKKEEPING_OPS_MODULE.workstreams.map((ws: OpsWorkstream) => {
           const isExpanded = expandedWorkstream === ws.id;
+          const answered = wsAnsweredCount(ws);
           return (
             <div key={ws.id} className="bg-white rounded border border-border shadow-sm overflow-hidden">
               <button
@@ -91,7 +127,9 @@ export default function BookkeepingQuestionnairePage() {
                   <p className="text-terminal-sm text-text-faint font-mono mt-0.5">{ws.description}</p>
                 </div>
                 <div className="flex items-center gap-3 flex-shrink-0 ml-4">
-                  <span className="text-terminal-sm text-text-muted font-mono">0/{ws.questions.length}</span>
+                  <span className={`text-terminal-sm font-mono ${answered === ws.questions.length && answered > 0 ? 'text-emerald-600' : 'text-text-muted'}`}>
+                    {answered}/{ws.questions.length}
+                  </span>
                   <span className="text-text-faint text-terminal-sm">{isExpanded ? '▼' : '▶'}</span>
                 </div>
               </button>
@@ -100,8 +138,14 @@ export default function BookkeepingQuestionnairePage() {
                 <div className="border-t border-border">
                   {ws.questions.map((q: OpsQuestion) => {
                     const stageStyle = STAGE_COLORS[q.launchStage];
+                    const depsOk = hasDepsAnswered(q);
                     return (
-                      <div key={q.id} className="px-4 py-3 border-b border-border-light last:border-b-0">
+                      <div
+                        key={q.id}
+                        className={`px-4 py-3 border-b border-border-light last:border-b-0 ${
+                          !depsOk ? 'opacity-50' : ''
+                        }`}
+                      >
                         <div className="flex items-start gap-2">
                           <span className="text-terminal-sm text-text-faint font-mono flex-shrink-0 mt-0.5 w-16">{q.id}</span>
                           <div className="flex-1 min-w-0">
@@ -119,11 +163,18 @@ export default function BookkeepingQuestionnairePage() {
                               <span className={`text-terminal-sm font-mono px-1.5 py-0.5 rounded-full ${stageStyle.bg} ${stageStyle.text}`}>
                                 {stageStyle.label}
                               </span>
-                              {q.dependsOn && q.dependsOn.length > 0 && (
-                                <span className="text-terminal-sm font-mono text-text-faint">
-                                  depends: {q.dependsOn.join(', ')}
+                              {!depsOk && q.dependsOn && (
+                                <span className="text-terminal-sm font-mono text-amber-600">
+                                  Answer {q.dependsOn.join(', ')} first
                                 </span>
                               )}
+                            </div>
+                            <div className="mt-3">
+                              <QuestionInput
+                                question={q}
+                                value={answers[q.id] || ''}
+                                onChange={(v) => setAnswer(q.id, v)}
+                              />
                             </div>
                           </div>
                         </div>

--- a/src/components/ops/QuestionInput.tsx
+++ b/src/components/ops/QuestionInput.tsx
@@ -1,0 +1,164 @@
+'use client';
+
+import type { OpsQuestion } from '@/lib/ops/bookkeepingQuestions';
+
+interface QuestionInputProps {
+  question: OpsQuestion;
+  value: string;
+  onChange: (value: string) => void;
+}
+
+export default function QuestionInput({ question, value, onChange }: QuestionInputProps) {
+  switch (question.type) {
+    case 'text':
+      return <TextInput value={value} onChange={onChange} />;
+    case 'boolean':
+      return <BooleanInput value={value} onChange={onChange} />;
+    case 'select':
+      return <SelectInput options={question.options || []} value={value} onChange={onChange} />;
+    case 'multiselect':
+      return <MultiselectInput options={question.options || []} value={value} onChange={onChange} />;
+    case 'checklist':
+      return <ChecklistInput options={question.options || []} value={value} onChange={onChange} />;
+    case 'date':
+      return <DateInput value={value} onChange={onChange} />;
+    default:
+      return <TextInput value={value} onChange={onChange} />;
+  }
+}
+
+function TextInput({ value, onChange }: { value: string; onChange: (v: string) => void }) {
+  return (
+    <textarea
+      rows={3}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      placeholder="Enter your answer..."
+      className="w-full resize-y font-mono text-sm bg-transparent border border-border rounded-md px-3 py-2 outline-none focus:border-brand-purple transition-colors placeholder:text-text-faint"
+    />
+  );
+}
+
+function BooleanInput({ value, onChange }: { value: string; onChange: (v: string) => void }) {
+  return (
+    <div className="flex items-center gap-2">
+      <button
+        onClick={() => onChange(value === 'true' ? '' : 'true')}
+        className={`px-4 py-1.5 rounded text-terminal-base font-mono transition-colors ${
+          value === 'true'
+            ? 'bg-brand-purple text-white'
+            : 'border border-border text-text-secondary hover:border-brand-purple'
+        }`}
+      >
+        Yes
+      </button>
+      <button
+        onClick={() => onChange(value === 'false' ? '' : 'false')}
+        className={`px-4 py-1.5 rounded text-terminal-base font-mono transition-colors ${
+          value === 'false'
+            ? 'bg-brand-purple text-white'
+            : 'border border-border text-text-secondary hover:border-brand-purple'
+        }`}
+      >
+        No
+      </button>
+    </div>
+  );
+}
+
+function SelectInput({ options, value, onChange }: { options: string[]; value: string; onChange: (v: string) => void }) {
+  return (
+    <div className="flex flex-wrap gap-2">
+      {options.map((opt) => (
+        <button
+          key={opt}
+          onClick={() => onChange(value === opt ? '' : opt)}
+          className={`px-3 py-1.5 rounded text-terminal-sm font-mono transition-colors text-left ${
+            value === opt
+              ? 'bg-brand-purple text-white'
+              : 'border border-border text-text-secondary hover:border-brand-purple'
+          }`}
+        >
+          {opt}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function MultiselectInput({ options, value, onChange }: { options: string[]; value: string; onChange: (v: string) => void }) {
+  const selected: string[] = value ? JSON.parse(value) : [];
+
+  const toggle = (opt: string) => {
+    const next = selected.includes(opt)
+      ? selected.filter((s) => s !== opt)
+      : [...selected, opt];
+    onChange(next.length > 0 ? JSON.stringify(next) : '');
+  };
+
+  const isLargeList = options.length > 10;
+
+  return (
+    <div className={isLargeList ? 'grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-1.5' : 'flex flex-wrap gap-2'}>
+      {options.map((opt) => {
+        const isSelected = selected.includes(opt);
+        return (
+          <button
+            key={opt}
+            onClick={() => toggle(opt)}
+            className={`px-2.5 py-1 rounded text-terminal-sm font-mono transition-colors text-left ${
+              isSelected
+                ? 'bg-brand-purple text-white'
+                : 'border border-border text-text-secondary hover:border-brand-purple'
+            }`}
+          >
+            {opt}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function ChecklistInput({ options, value, onChange }: { options: string[]; value: string; onChange: (v: string) => void }) {
+  const checked: string[] = value ? JSON.parse(value) : [];
+
+  const toggle = (opt: string) => {
+    const next = checked.includes(opt)
+      ? checked.filter((s) => s !== opt)
+      : [...checked, opt];
+    onChange(next.length > 0 ? JSON.stringify(next) : '');
+  };
+
+  return (
+    <div className="space-y-1.5">
+      {options.map((opt) => {
+        const isChecked = checked.includes(opt);
+        return (
+          <label key={opt} className="flex items-start gap-2 cursor-pointer group">
+            <input
+              type="checkbox"
+              checked={isChecked}
+              onChange={() => toggle(opt)}
+              className="mt-0.5 w-4 h-4 rounded border-border accent-brand-purple flex-shrink-0"
+            />
+            <span className={`text-terminal-sm font-mono ${isChecked ? 'text-text-primary' : 'text-text-secondary'}`}>
+              {opt}
+            </span>
+          </label>
+        );
+      })}
+    </div>
+  );
+}
+
+function DateInput({ value, onChange }: { value: string; onChange: (v: string) => void }) {
+  return (
+    <input
+      type="date"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      className="font-mono text-sm bg-transparent border border-border rounded-md px-3 py-2 outline-none focus:border-brand-purple transition-colors"
+    />
+  );
+}


### PR DESCRIPTION
New component: src/components/ops/QuestionInput.tsx
- Handles all 6 question types: text, boolean, select, multiselect, checklist, date
- Boolean renders as Yes/No button pair (not checkbox)
- Select renders as visible radio-style pill buttons (not dropdown)
- Multiselect renders as toggleable pills in 4-column grid for large lists
- Checklist renders as checkbox list with labels
- Text renders as resizable textarea
- Date renders as native date input
- Selected states use brand-purple, matching existing app patterns

Questionnaire page updates:
- Local useState for all answers (no persistence yet)
- Live progress indicators update as questions are answered
- Module-level "X / 90" counter + progress bar
- Workstream-level "X / N" counter, turns green when complete
- dependsOn questions shown as dimmed (opacity-50) with amber hint
- All styling matches existing app form patterns
- No API calls, no database queries — PR 5 adds persistence

https://claude.ai/code/session_01GQeiwocJDnF2N3pU1q7Y8t