### PR TITLE
feat(ops): per-workstream AI decision register analysis

### DIFF
--- a/prisma/migrations/20260424100000_add_ops_workstream_analysis/migration.sql
+++ b/prisma/migrations/20260424100000_add_ops_workstream_analysis/migration.sql
@@ -1,0 +1,31 @@
+-- CreateTable
+CREATE TABLE "ops_workstream_analysis" (
+    "id" TEXT NOT NULL,
+    "mission_id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "module_id" TEXT NOT NULL,
+    "workstream_id" TEXT NOT NULL,
+    "analysis_output" TEXT NOT NULL,
+    "model_used" TEXT NOT NULL,
+    "prompt_version" TEXT NOT NULL,
+    "input_hash" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ops_workstream_analysis_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ops_workstream_analysis_mission_id_module_id_workstream_id_key" ON "ops_workstream_analysis"("mission_id", "module_id", "workstream_id");
+
+-- CreateIndex
+CREATE INDEX "ops_workstream_analysis_user_id_idx" ON "ops_workstream_analysis"("user_id");
+
+-- CreateIndex
+CREATE INDEX "ops_workstream_analysis_mission_id_module_id_idx" ON "ops_workstream_analysis"("mission_id", "module_id");
+
+-- AddForeignKey
+ALTER TABLE "ops_workstream_analysis" ADD CONSTRAINT "ops_workstream_analysis_mission_id_fkey" FOREIGN KEY ("mission_id") REFERENCES "missions"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ops_workstream_analysis" ADD CONSTRAINT "ops_workstream_analysis_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -474,6 +474,7 @@ model users {
   dailyPlans              daily_plans[]
   missions                missions[]
   questionnaireAnswers    ops_questionnaire_answers[]
+  workstreamAnalyses      ops_workstream_analysis[]
 }
 
 model budgets {
@@ -1924,6 +1925,7 @@ model missions {
   roadmapWeeks         roadmap_weeks[]
   missionTasks         mission_tasks[]
   questionnaireAnswers ops_questionnaire_answers[]
+  workstreamAnalyses   ops_workstream_analysis[]
 
   @@map("missions")
 }
@@ -2055,4 +2057,30 @@ model ops_questionnaire_answers {
   @@index([missionId, moduleId])
   @@index([missionId, moduleId, workstreamId])
   @@map("ops_questionnaire_answers")
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// OPS WORKSTREAM ANALYSIS — AI decision register per workstream
+// ═══════════════════════════════════════════════════════════════════
+
+model ops_workstream_analysis {
+  id             String   @id @default(cuid())
+  missionId      String   @map("mission_id")
+  userId         String   @map("user_id")
+  moduleId       String   @map("module_id")
+  workstreamId   String   @map("workstream_id")
+  analysisOutput String   @map("analysis_output") @db.Text
+  modelUsed      String   @map("model_used")
+  promptVersion  String   @map("prompt_version")
+  inputHash      String   @map("input_hash")
+  createdAt      DateTime @default(now()) @map("created_at")
+  updatedAt      DateTime @updatedAt @map("updated_at")
+
+  mission missions @relation(fields: [missionId], references: [id], onDelete: Cascade)
+  user    users    @relation(fields: [userId], references: [id])
+
+  @@unique([missionId, moduleId, workstreamId])
+  @@index([userId])
+  @@index([missionId, moduleId])
+  @@map("ops_workstream_analysis")
 }

--- a/src/app/api/ops/workstream-analysis/route.ts
+++ b/src/app/api/ops/workstream-analysis/route.ts
@@ -1,0 +1,196 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
+import Anthropic from '@anthropic-ai/sdk';
+import { BOOKKEEPING_OPS_MODULE } from '@/lib/ops/bookkeepingQuestions';
+import { createHash } from 'crypto';
+
+const MODEL = 'claude-sonnet-4-20250514';
+const PROMPT_VERSION = 'v1.0';
+
+async function getAuthUser() {
+  const email = await getVerifiedEmail();
+  if (!email) return null;
+  return prisma.users.findFirst({ where: { email: { equals: email, mode: 'insensitive' } } });
+}
+
+function computeHash(answers: Record<string, string>): string {
+  const sorted = JSON.stringify(answers, Object.keys(answers).sort());
+  return createHash('sha256').update(sorted).digest('hex').slice(0, 16);
+}
+
+const SYSTEM_PROMPT = `You are a regulatory compliance analyst at an institutional-grade financial firm. You are reviewing a founder's compliance decisions for launching a bookkeeping and tax preparation SaaS platform.
+
+Your analysis must meet the standard expected by Ray Dalio's Bridgewater, Ken Griffin's Citadel, or Jim Simons's Renaissance Technologies. This means:
+- Every decision is assessed with a clear status
+- Every risk is quantified with specific statute citations and penalty ranges
+- Every required action has a concrete deadline
+- No vague recommendations. No motivational language. No "consider" or "you might want to." Direct, specific, actionable.
+
+You will receive a set of compliance questions with the founder's answers. For each question, assess the status and produce a decision register entry.
+
+RESPONSE FORMAT — respond with ONLY valid JSON, no markdown, no preamble:
+
+{
+  "workstreamId": "string",
+  "workstreamTitle": "string",
+  "assessedAt": "ISO timestamp",
+  "decisions": [
+    {
+      "questionId": "string",
+      "questionText": "string",
+      "answer": "string or null if unanswered",
+      "status": "decided | undecided | blocked | at_risk | not_applicable",
+      "statusReason": "1-2 sentence explanation",
+      "regulatoryExposure": {
+        "statute": "specific statute, e.g. IRC §6695(d)",
+        "penaltyRange": "e.g. $50/failure up to $25,000/return period or N/A",
+        "enforcementLikelihood": "high | medium | low | N/A",
+        "notes": "relevant enforcement context"
+      },
+      "requiredAction": {
+        "action": "specific action or null if decided and compliant",
+        "deadline": "e.g. Before first paying user, or null",
+        "effort": "hours | days | weeks | months",
+        "blockedBy": ["questionIds this depends on, or empty"]
+      }
+    }
+  ],
+  "workstreamSummary": {
+    "totalQuestions": 0,
+    "decided": 0,
+    "undecided": 0,
+    "blocked": 0,
+    "atRisk": 0,
+    "notApplicable": 0,
+    "totalExposure": "sum or range of penalty exposures",
+    "criticalActions": ["top 3 most urgent actions"],
+    "crossWorkstreamDependencies": [
+      { "dependsOnWorkstream": "e.g. bk-b", "reason": "why" }
+    ]
+  }
+}`;
+
+function buildUserPrompt(
+  workstream: { id: string; letter: string; title: string; description: string; questions: Array<{ id: string; text: string; type: string; regulatoryTag: string; launchStage: string; helpText?: string; sourceSection?: string; dependsOn?: string[]; options?: string[] }> },
+  answers: Record<string, string>,
+): string {
+  const lines = [`Workstream: ${workstream.letter} — ${workstream.title}`, `Description: ${workstream.description}`, '', 'Questions and Answers:', ''];
+
+  for (let i = 0; i < workstream.questions.length; i++) {
+    const q = workstream.questions[i];
+    const answer = answers[q.id];
+    lines.push(`Q${i + 1} [${q.id}] [${q.regulatoryTag}] [${q.launchStage}]`);
+    lines.push(`Question: ${q.text}`);
+    if (q.helpText) lines.push(`Regulatory Context: ${q.helpText}`);
+    if (q.sourceSection) lines.push(`Source: ${q.sourceSection}`);
+    lines.push(`Answer: ${answer || 'UNANSWERED'}`);
+    lines.push(`Dependencies: ${q.dependsOn?.join(', ') || 'None'}`);
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const user = await getAuthUser();
+    if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const apiKey = process.env.ANTHROPIC_API_KEY;
+    if (!apiKey) return NextResponse.json({ error: 'API key not configured' }, { status: 500 });
+
+    const { missionId, moduleId, workstreamId } = await request.json();
+    if (!missionId || !moduleId || !workstreamId) {
+      return NextResponse.json({ error: 'missionId, moduleId, workstreamId required' }, { status: 400 });
+    }
+
+    const mission = await prisma.missions.findFirst({ where: { id: missionId, userId: user.id } });
+    if (!mission) return NextResponse.json({ error: 'Mission not found' }, { status: 404 });
+
+    const workstream = BOOKKEEPING_OPS_MODULE.workstreams.find((ws) => ws.id === workstreamId);
+    if (!workstream) return NextResponse.json({ error: 'Workstream not found' }, { status: 404 });
+
+    const answerRows = await prisma.ops_questionnaire_answers.findMany({
+      where: { missionId, moduleId, userId: user.id, workstreamId },
+      select: { questionId: true, answerValue: true },
+    });
+    const answers: Record<string, string> = {};
+    for (const row of answerRows) answers[row.questionId] = row.answerValue;
+
+    const inputHash = computeHash(answers);
+    const userPrompt = buildUserPrompt(workstream, answers);
+
+    const client = new Anthropic({ apiKey });
+    const response = await client.messages.create({
+      model: MODEL,
+      max_tokens: 4096,
+      system: SYSTEM_PROMPT,
+      messages: [{ role: 'user', content: userPrompt }],
+    });
+
+    const rawText = response.content
+      .filter((b): b is Anthropic.TextBlock => b.type === 'text')
+      .map((b) => b.text)
+      .join('');
+
+    let parsed;
+    try {
+      const cleaned = rawText.trim().replace(/^```json\s*/, '').replace(/\s*```$/, '');
+      parsed = JSON.parse(cleaned);
+    } catch {
+      return NextResponse.json({ error: 'Failed to parse AI response', raw: rawText.substring(0, 500) }, { status: 500 });
+    }
+
+    await prisma.ops_workstream_analysis.upsert({
+      where: { missionId_moduleId_workstreamId: { missionId, moduleId, workstreamId } },
+      create: { missionId, moduleId, workstreamId, userId: user.id, analysisOutput: JSON.stringify(parsed), modelUsed: MODEL, promptVersion: PROMPT_VERSION, inputHash },
+      update: { analysisOutput: JSON.stringify(parsed), modelUsed: MODEL, inputHash },
+    });
+
+    return NextResponse.json({ analysis: parsed, inputHash });
+  } catch (error) {
+    console.error('[Workstream Analysis POST]', error);
+    return NextResponse.json({ error: 'Analysis failed' }, { status: 500 });
+  }
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const user = await getAuthUser();
+    if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const { searchParams } = new URL(request.url);
+    const missionId = searchParams.get('missionId');
+    const moduleId = searchParams.get('moduleId');
+    const workstreamId = searchParams.get('workstreamId');
+
+    if (!missionId || !moduleId || !workstreamId) {
+      return NextResponse.json({ error: 'missionId, moduleId, workstreamId required' }, { status: 400 });
+    }
+
+    const row = await prisma.ops_workstream_analysis.findFirst({
+      where: { missionId, moduleId, workstreamId, userId: user.id },
+    });
+
+    if (!row) return NextResponse.json({ analysis: null, isStale: false });
+
+    const answerRows = await prisma.ops_questionnaire_answers.findMany({
+      where: { missionId, moduleId, userId: user.id, workstreamId },
+      select: { questionId: true, answerValue: true },
+    });
+    const currentAnswers: Record<string, string> = {};
+    for (const r of answerRows) currentAnswers[r.questionId] = r.answerValue;
+    const currentHash = computeHash(currentAnswers);
+
+    return NextResponse.json({
+      analysis: JSON.parse(row.analysisOutput),
+      inputHash: row.inputHash,
+      isStale: currentHash !== row.inputHash,
+      analyzedAt: row.updatedAt,
+    });
+  } catch (error) {
+    console.error('[Workstream Analysis GET]', error);
+    return NextResponse.json({ error: 'Failed to load analysis' }, { status: 500 });
+  }
+}

--- a/src/app/ops/bookkeeping/page.tsx
+++ b/src/app/ops/bookkeeping/page.tsx
@@ -43,6 +43,8 @@ export default function BookkeepingQuestionnairePage() {
   const [loadingAnswers, setLoadingAnswers] = useState(false);
   const [savingQuestions, setSavingQuestions] = useState<Record<string, 'saving' | 'saved' | 'error'>>({});
   const debounceTimers = useRef<Record<string, NodeJS.Timeout>>({});
+  const [analyses, setAnalyses] = useState<Record<string, { analysis: Record<string, unknown>; isStale: boolean }>>({});
+  const [analyzingWs, setAnalyzingWs] = useState<string | null>(null);
   const counts = stageCounts();
 
   // Fetch active mission
@@ -79,6 +81,44 @@ export default function BookkeepingQuestionnairePage() {
         setLoadingAnswers(false);
       }
     })();
+  }, [missionId]);
+
+  // Load existing analyses
+  useEffect(() => {
+    if (!missionId) return;
+    (async () => {
+      for (const ws of BOOKKEEPING_OPS_MODULE.workstreams) {
+        try {
+          const res = await fetch(`/api/ops/workstream-analysis?missionId=${missionId}&moduleId=${MODULE_ID}&workstreamId=${ws.id}`);
+          if (res.ok) {
+            const data = await res.json();
+            if (data.analysis) {
+              setAnalyses((prev) => ({ ...prev, [ws.id]: { analysis: data.analysis, isStale: data.isStale } }));
+            }
+          }
+        } catch { /* skip failed loads */ }
+      }
+    })();
+  }, [missionId]);
+
+  const runAnalysis = useCallback(async (workstreamId: string) => {
+    if (!missionId) return;
+    setAnalyzingWs(workstreamId);
+    try {
+      const res = await fetch('/api/ops/workstream-analysis', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ missionId, moduleId: MODULE_ID, workstreamId }),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setAnalyses((prev) => ({ ...prev, [workstreamId]: { analysis: data.analysis, isStale: false } }));
+      }
+    } catch (err) {
+      console.error('Analysis failed:', err);
+    } finally {
+      setAnalyzingWs(null);
+    }
   }, [missionId]);
 
   const persistAnswer = useCallback(
@@ -278,6 +318,29 @@ export default function BookkeepingQuestionnairePage() {
                       </div>
                     );
                   })}
+
+                  {/* Analyze button */}
+                  <div className="px-4 py-3 border-t border-border-light">
+                    {analyzingWs === ws.id ? (
+                      <div className="flex items-center gap-2">
+                        <div className="w-4 h-4 border-2 border-brand-purple border-t-transparent rounded-full animate-spin" />
+                        <span className="text-terminal-sm text-text-muted font-mono">Analyzing workstream...</span>
+                      </div>
+                    ) : (
+                      <button
+                        onClick={() => runAnalysis(ws.id)}
+                        disabled={answered === 0}
+                        className="px-4 py-1.5 bg-brand-purple text-white rounded text-terminal-sm font-mono hover:bg-brand-purple-hover transition-colors disabled:opacity-40"
+                      >
+                        {analyses[ws.id] ? 'Re-analyze' : 'Analyze Workstream'}
+                      </button>
+                    )}
+                  </div>
+
+                  {/* Analysis results */}
+                  {analyses[ws.id] && (
+                    <AnalysisResults wsId={ws.id} data={analyses[ws.id]} />
+                  )}
                 </div>
               )}
             </div>
@@ -285,5 +348,113 @@ export default function BookkeepingQuestionnairePage() {
         })}
       </div>
     </AppLayout>
+  );
+}
+
+// ── Analysis Results Component ──────────────────────────────────────────────
+
+const STATUS_STYLE: Record<string, { bg: string; text: string; label: string }> = {
+  decided: { bg: 'bg-emerald-50', text: 'text-emerald-700', label: 'Decided' },
+  undecided: { bg: 'bg-amber-50', text: 'text-amber-700', label: 'Undecided' },
+  blocked: { bg: 'bg-gray-100', text: 'text-gray-600', label: 'Blocked' },
+  at_risk: { bg: 'bg-red-50', text: 'text-red-700', label: 'At Risk' },
+  not_applicable: { bg: 'bg-gray-50', text: 'text-gray-400', label: 'N/A' },
+};
+
+interface Decision {
+  questionId: string;
+  questionText: string;
+  answer: string | null;
+  status: string;
+  statusReason: string;
+  regulatoryExposure: { statute: string; penaltyRange: string; enforcementLikelihood: string; notes: string };
+  requiredAction: { action: string | null; deadline: string | null; effort: string; blockedBy: string[] };
+}
+
+function AnalysisResults({ wsId, data }: { wsId: string; data: { analysis: Record<string, unknown>; isStale: boolean } }) {
+  const { analysis, isStale } = data;
+  const decisions = (analysis.decisions as Decision[]) || [];
+  const summary = analysis.workstreamSummary as Record<string, unknown> | undefined;
+  const criticalActions = (summary?.criticalActions as string[]) || [];
+  const crossDeps = (summary?.crossWorkstreamDependencies as Array<{ dependsOnWorkstream: string; reason: string }>) || [];
+
+  void wsId;
+
+  return (
+    <div className="border-t border-border bg-bg-row/30">
+      {isStale && (
+        <div className="px-4 py-2 bg-amber-50 border-b border-amber-100">
+          <span className="text-terminal-sm font-mono text-amber-700">Answers changed since last analysis. Re-analyze to update.</span>
+        </div>
+      )}
+
+      <div className="px-4 py-3 space-y-3">
+        <p className="text-terminal-sm uppercase tracking-widest text-text-muted font-mono">Decision Register</p>
+
+        {/* Summary */}
+        {summary && (
+          <div className="flex flex-wrap gap-2 text-terminal-sm font-mono">
+            <span className="bg-emerald-50 text-emerald-700 px-2 py-0.5 rounded">Decided: {String(summary.decided || 0)}</span>
+            <span className="bg-amber-50 text-amber-700 px-2 py-0.5 rounded">Undecided: {String(summary.undecided || 0)}</span>
+            <span className="bg-gray-100 text-gray-600 px-2 py-0.5 rounded">Blocked: {String(summary.blocked || 0)}</span>
+            <span className="bg-red-50 text-red-700 px-2 py-0.5 rounded">At Risk: {String(summary.atRisk || 0)}</span>
+            {summary.totalExposure != null && <span className="text-red-600 font-medium">Exposure: {String(summary.totalExposure)}</span>}
+          </div>
+        )}
+
+        {/* Decisions */}
+        <div className="space-y-2">
+          {decisions.map((d) => {
+            const style = STATUS_STYLE[d.status] || STATUS_STYLE.undecided;
+            const showDetail = d.status === 'undecided' || d.status === 'at_risk' || d.status === 'blocked';
+            return (
+              <div key={d.questionId} className="border border-border-light rounded p-2.5">
+                <div className="flex items-start gap-2">
+                  <span className={`text-terminal-sm font-mono px-1.5 py-0.5 rounded flex-shrink-0 ${style.bg} ${style.text}`}>{style.label}</span>
+                  <div className="flex-1 min-w-0">
+                    <span className="text-terminal-sm text-text-faint font-mono">{d.questionId}</span>
+                    <p className="text-terminal-sm text-text-secondary font-mono">{d.statusReason}</p>
+                    {showDetail && d.regulatoryExposure.statute !== 'N/A' && (
+                      <p className="text-terminal-sm font-mono text-red-600 mt-1">
+                        {d.regulatoryExposure.statute}: {d.regulatoryExposure.penaltyRange}
+                      </p>
+                    )}
+                    {showDetail && d.requiredAction.action && (
+                      <p className="text-terminal-sm font-mono text-text-primary mt-1">
+                        Action: {d.requiredAction.action}
+                        {d.requiredAction.deadline && <span className="text-text-muted"> — by {d.requiredAction.deadline}</span>}
+                        {d.requiredAction.effort && <span className="text-text-faint"> ({d.requiredAction.effort})</span>}
+                      </p>
+                    )}
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Critical actions */}
+        {criticalActions.length > 0 && (
+          <div>
+            <p className="text-terminal-sm uppercase tracking-widest text-text-muted font-mono mb-1">Critical Actions</p>
+            {criticalActions.map((a, i) => (
+              <p key={i} className="text-terminal-sm font-mono text-red-600">! {a}</p>
+            ))}
+          </div>
+        )}
+
+        {/* Cross-workstream deps */}
+        {crossDeps.length > 0 && (
+          <div>
+            <p className="text-terminal-sm uppercase tracking-widest text-text-muted font-mono mb-1">Cross-Workstream Dependencies</p>
+            {crossDeps.map((d, i) => (
+              <p key={i} className="text-terminal-sm font-mono text-text-secondary">
+                Depends on <span className="text-brand-purple font-medium">{d.dependsOnWorkstream}</span>: {d.reason}
+              </p>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
   );
 }


### PR DESCRIPTION
New Prisma model: ops_workstream_analysis
- Stores AI analysis output per workstream per mission
- inputHash for stale detection when answers change
- promptVersion for tracking prompt iterations
- Migration SQL created (not applied)

API routes: /api/ops/workstream-analysis
- POST: runs Claude Sonnet analysis on a workstream's answers
  - Builds decision register with status per question (decided/undecided/blocked/at_risk/not_applicable)
  - Quantified risk exposure with statute citations and penalty ranges
  - Required actions with deadlines and effort estimates
  - Cross-workstream dependency identification
  - Full auth + mission ownership + userId scoping
- GET: loads existing analysis with stale detection via inputHash

Frontend:
- Analyze Workstream button per workstream (enabled when >=1 answer)
- Decision register renders inline below questions
- Color-coded status badges per question
- Penalty ranges shown for undecided/at_risk items
- Required actions with deadlines
- Workstream summary: decided/undecided/blocked/atRisk counts + total exposure
- Critical actions list + cross-workstream dependencies
- Stale analysis banner when answers change after analysis
- Loading state during AI processing

https://claude.ai/code/session_01GQeiwocJDnF2N3pU1q7Y8t