### PR TITLE
feat(ops): cross-workstream synthesis — critical path, exposure & lau…

### DIFF
--- a/prisma/migrations/20260424200000_add_ops_synthesis_report/migration.sql
+++ b/prisma/migrations/20260424200000_add_ops_synthesis_report/migration.sql
@@ -1,0 +1,28 @@
+-- CreateTable
+CREATE TABLE "ops_synthesis_report" (
+    "id" TEXT NOT NULL,
+    "mission_id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "module_id" TEXT NOT NULL,
+    "synthesis_output" TEXT NOT NULL,
+    "model_used" TEXT NOT NULL,
+    "prompt_version" TEXT NOT NULL,
+    "input_hash" TEXT NOT NULL,
+    "workstreams_covered" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ops_synthesis_report_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ops_synthesis_report_mission_id_module_id_key" ON "ops_synthesis_report"("mission_id", "module_id");
+
+-- CreateIndex
+CREATE INDEX "ops_synthesis_report_user_id_idx" ON "ops_synthesis_report"("user_id");
+
+-- AddForeignKey
+ALTER TABLE "ops_synthesis_report" ADD CONSTRAINT "ops_synthesis_report_mission_id_fkey" FOREIGN KEY ("mission_id") REFERENCES "missions"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ops_synthesis_report" ADD CONSTRAINT "ops_synthesis_report_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -475,6 +475,7 @@ model users {
   missions                missions[]
   questionnaireAnswers    ops_questionnaire_answers[]
   workstreamAnalyses      ops_workstream_analysis[]
+  synthesisReports        ops_synthesis_report[]
 }
 
 model budgets {
@@ -1926,6 +1927,7 @@ model missions {
   missionTasks         mission_tasks[]
   questionnaireAnswers ops_questionnaire_answers[]
   workstreamAnalyses   ops_workstream_analysis[]
+  synthesisReports     ops_synthesis_report[]
 
   @@map("missions")
 }
@@ -2083,4 +2085,29 @@ model ops_workstream_analysis {
   @@index([userId])
   @@index([missionId, moduleId])
   @@map("ops_workstream_analysis")
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// OPS SYNTHESIS REPORT — Cross-workstream launch readiness assessment
+// ═══════════════════════════════════════════════════════════════════
+
+model ops_synthesis_report {
+  id                 String   @id @default(cuid())
+  missionId          String   @map("mission_id")
+  userId             String   @map("user_id")
+  moduleId           String   @map("module_id")
+  synthesisOutput    String   @map("synthesis_output") @db.Text
+  modelUsed          String   @map("model_used")
+  promptVersion      String   @map("prompt_version")
+  inputHash          String   @map("input_hash")
+  workstreamsCovered String   @map("workstreams_covered") @db.Text
+  createdAt          DateTime @default(now()) @map("created_at")
+  updatedAt          DateTime @updatedAt @map("updated_at")
+
+  mission missions @relation(fields: [missionId], references: [id], onDelete: Cascade)
+  user    users    @relation(fields: [userId], references: [id])
+
+  @@unique([missionId, moduleId])
+  @@index([userId])
+  @@map("ops_synthesis_report")
 }

--- a/src/app/api/ops/synthesis-report/route.ts
+++ b/src/app/api/ops/synthesis-report/route.ts
@@ -1,0 +1,206 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
+import Anthropic from '@anthropic-ai/sdk';
+import { BOOKKEEPING_OPS_MODULE } from '@/lib/ops/bookkeepingQuestions';
+import { createHash } from 'crypto';
+
+const MODEL = 'claude-sonnet-4-20250514';
+const PROMPT_VERSION = 'v1.0';
+
+async function getAuthUser() {
+  const email = await getVerifiedEmail();
+  if (!email) return null;
+  return prisma.users.findFirst({ where: { email: { equals: email, mode: 'insensitive' } } });
+}
+
+function computeSynthesisHash(analyses: Array<{ workstreamId: string; updatedAt: Date }>): string {
+  const data = analyses.map((a) => `${a.workstreamId}:${a.updatedAt.toISOString()}`).sort().join('|');
+  return createHash('sha256').update(data).digest('hex').slice(0, 16);
+}
+
+const SYSTEM_PROMPT = `You are a Chief Compliance Officer at an institutional-grade financial firm preparing a launch readiness assessment for a bookkeeping and tax preparation SaaS platform. Your audience is the founder, their legal counsel, and potential institutional investors.
+
+You will receive decision register outputs from multiple compliance workstreams. Each contains per-question status assessments, regulatory exposure quantification, and required actions. Your job is to synthesize these into a unified launch readiness assessment.
+
+RESPONSE FORMAT — respond with ONLY valid JSON, no markdown, no preamble:
+
+{
+  "synthesisId": "ISO timestamp",
+  "moduleId": "string",
+  "moduleName": "string",
+  "workstreamsCovered": ["workstream IDs"],
+  "workstreamsNotAnalyzed": ["workstream IDs with no analysis"],
+  "launchReadiness": {
+    "canLaunch": false,
+    "blockers": [
+      {
+        "questionId": "string",
+        "workstreamId": "string",
+        "reason": "specific reason this blocks launch",
+        "statute": "governing statute",
+        "penaltyIfIgnored": "specific penalty range",
+        "resolution": "what must be done",
+        "estimatedEffort": "hours | days | weeks | months"
+      }
+    ],
+    "conditionalItems": [
+      {
+        "questionId": "string",
+        "condition": "what condition makes this a blocker vs not",
+        "currentAnswer": "the user's answer"
+      }
+    ]
+  },
+  "totalRegulatoryExposure": {
+    "totalMinPenalty": "dollar amount",
+    "totalMaxPenalty": "dollar amount",
+    "breakdownByStatute": [
+      { "statute": "string", "exposure": "range", "affectedQuestions": ["ids"], "status": "resolved | unresolved" }
+    ],
+    "breakdownByWorkstream": [
+      { "workstreamId": "string", "workstreamTitle": "string", "exposure": "range", "unresolvedCount": 0 }
+    ]
+  },
+  "criticalPath": {
+    "launchDate": "estimated or Cannot estimate",
+    "longestPole": {
+      "item": "string", "reason": "string", "estimatedDuration": "string", "questionId": "string"
+    },
+    "sequencedActions": [
+      { "order": 1, "questionId": "string", "action": "string", "deadline": "string", "effort": "string", "blocksQuestions": ["ids"], "workstreamId": "string" }
+    ]
+  },
+  "contradictions": [
+    { "questionId1": "string", "answer1": "string", "questionId2": "string", "answer2": "string", "contradiction": "string", "resolution": "string" }
+  ],
+  "crossWorkstreamDependencies": [
+    { "fromWorkstream": "string", "toWorkstream": "string", "dependency": "string", "impact": "string" }
+  ],
+  "executiveSummary": "3-5 sentence summary"
+}`;
+
+export async function POST(request: NextRequest) {
+  try {
+    const user = await getAuthUser();
+    if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const apiKey = process.env.ANTHROPIC_API_KEY;
+    if (!apiKey) return NextResponse.json({ error: 'API key not configured' }, { status: 500 });
+
+    const { missionId, moduleId } = await request.json();
+    if (!missionId || !moduleId) return NextResponse.json({ error: 'missionId and moduleId required' }, { status: 400 });
+
+    const mission = await prisma.missions.findFirst({ where: { id: missionId, userId: user.id } });
+    if (!mission) return NextResponse.json({ error: 'Mission not found' }, { status: 404 });
+
+    const analyses = await prisma.ops_workstream_analysis.findMany({
+      where: { missionId, moduleId, userId: user.id },
+      orderBy: { workstreamId: 'asc' },
+    });
+
+    if (analyses.length < 2) {
+      return NextResponse.json({ error: 'At least 2 workstream analyses required before synthesis. Analyze more workstreams first.' }, { status: 400 });
+    }
+
+    const allWsIds = BOOKKEEPING_OPS_MODULE.workstreams.map((ws) => ws.id);
+    const analyzedIds = analyses.map((a) => a.workstreamId);
+    const notAnalyzed = allWsIds.filter((id) => !analyzedIds.includes(id));
+
+    const inputHash = computeSynthesisHash(analyses.map((a) => ({ workstreamId: a.workstreamId, updatedAt: a.updatedAt })));
+
+    const wsBlocks = analyses.map((a) => {
+      const ws = BOOKKEEPING_OPS_MODULE.workstreams.find((w) => w.id === a.workstreamId);
+      return `=== WORKSTREAM ${ws?.letter || '?'}: ${ws?.title || a.workstreamId} ===\n${a.analysisOutput}`;
+    }).join('\n\n');
+
+    const userPrompt = `Module: ${BOOKKEEPING_OPS_MODULE.title}
+Mission: ${mission.name}
+Total workstreams analyzed: ${analyses.length} of ${allWsIds.length}
+
+Below are the decision register outputs from each analyzed workstream.
+
+${wsBlocks}
+
+WORKSTREAMS NOT YET ANALYZED:
+${notAnalyzed.length > 0 ? notAnalyzed.map((id) => {
+  const ws = BOOKKEEPING_OPS_MODULE.workstreams.find((w) => w.id === id);
+  return `- ${ws?.letter || '?'}: ${ws?.title || id}`;
+}).join('\n') : '(all workstreams analyzed)'}`;
+
+    const client = new Anthropic({ apiKey });
+    const response = await client.messages.create({
+      model: MODEL,
+      max_tokens: 8192,
+      system: SYSTEM_PROMPT,
+      messages: [{ role: 'user', content: userPrompt }],
+    });
+
+    const rawText = response.content
+      .filter((b): b is Anthropic.TextBlock => b.type === 'text')
+      .map((b) => b.text)
+      .join('');
+
+    let parsed;
+    try {
+      const cleaned = rawText.trim().replace(/^```json\s*/, '').replace(/\s*```$/, '');
+      parsed = JSON.parse(cleaned);
+    } catch {
+      return NextResponse.json({ error: 'Failed to parse AI response', raw: rawText.substring(0, 500) }, { status: 500 });
+    }
+
+    await prisma.ops_synthesis_report.upsert({
+      where: { missionId_moduleId: { missionId, moduleId } },
+      create: {
+        missionId, moduleId, userId: user.id,
+        synthesisOutput: JSON.stringify(parsed),
+        modelUsed: MODEL, promptVersion: PROMPT_VERSION,
+        inputHash, workstreamsCovered: JSON.stringify(analyzedIds),
+      },
+      update: {
+        synthesisOutput: JSON.stringify(parsed),
+        modelUsed: MODEL, inputHash,
+        workstreamsCovered: JSON.stringify(analyzedIds),
+      },
+    });
+
+    return NextResponse.json({ synthesis: parsed, inputHash, workstreamsCovered: analyzedIds });
+  } catch (error) {
+    console.error('[Synthesis POST]', error);
+    return NextResponse.json({ error: 'Synthesis failed' }, { status: 500 });
+  }
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const user = await getAuthUser();
+    if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const { searchParams } = new URL(request.url);
+    const missionId = searchParams.get('missionId');
+    const moduleId = searchParams.get('moduleId');
+    if (!missionId || !moduleId) return NextResponse.json({ error: 'missionId and moduleId required' }, { status: 400 });
+
+    const row = await prisma.ops_synthesis_report.findFirst({
+      where: { missionId, moduleId, userId: user.id },
+    });
+
+    if (!row) return NextResponse.json({ synthesis: null, isStale: false });
+
+    const analyses = await prisma.ops_workstream_analysis.findMany({
+      where: { missionId, moduleId, userId: user.id },
+      select: { workstreamId: true, updatedAt: true },
+    });
+    const currentHash = computeSynthesisHash(analyses.map((a) => ({ workstreamId: a.workstreamId, updatedAt: a.updatedAt })));
+
+    return NextResponse.json({
+      synthesis: JSON.parse(row.synthesisOutput),
+      isStale: currentHash !== row.inputHash,
+      workstreamsCovered: JSON.parse(row.workstreamsCovered),
+      synthesizedAt: row.updatedAt,
+    });
+  } catch (error) {
+    console.error('[Synthesis GET]', error);
+    return NextResponse.json({ error: 'Failed to load synthesis' }, { status: 500 });
+  }
+}

--- a/src/app/ops/bookkeeping/page.tsx
+++ b/src/app/ops/bookkeeping/page.tsx
@@ -45,6 +45,8 @@ export default function BookkeepingQuestionnairePage() {
   const debounceTimers = useRef<Record<string, NodeJS.Timeout>>({});
   const [analyses, setAnalyses] = useState<Record<string, { analysis: Record<string, unknown>; isStale: boolean }>>({});
   const [analyzingWs, setAnalyzingWs] = useState<string | null>(null);
+  const [synthesis, setSynthesis] = useState<{ synthesis: Record<string, unknown>; isStale: boolean; workstreamsCovered: string[] } | null>(null);
+  const [runningSynthesis, setRunningSynthesis] = useState(false);
   const counts = stageCounts();
 
   // Fetch active mission
@@ -99,6 +101,43 @@ export default function BookkeepingQuestionnairePage() {
         } catch { /* skip failed loads */ }
       }
     })();
+  }, [missionId]);
+
+  // Load existing synthesis
+  useEffect(() => {
+    if (!missionId) return;
+    (async () => {
+      try {
+        const res = await fetch(`/api/ops/synthesis-report?missionId=${missionId}&moduleId=${MODULE_ID}`);
+        if (res.ok) {
+          const data = await res.json();
+          if (data.synthesis) setSynthesis({ synthesis: data.synthesis, isStale: data.isStale, workstreamsCovered: data.workstreamsCovered || [] });
+        }
+      } catch { /* skip */ }
+    })();
+  }, [missionId]);
+
+  const runSynthesis = useCallback(async () => {
+    if (!missionId) return;
+    setRunningSynthesis(true);
+    try {
+      const res = await fetch('/api/ops/synthesis-report', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ missionId, moduleId: MODULE_ID }),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setSynthesis({ synthesis: data.synthesis, isStale: false, workstreamsCovered: data.workstreamsCovered || [] });
+      } else {
+        const err = await res.json().catch(() => ({ error: 'Synthesis failed' }));
+        alert(err.error || 'Synthesis failed');
+      }
+    } catch (err) {
+      console.error('Synthesis failed:', err);
+    } finally {
+      setRunningSynthesis(false);
+    }
   }, [missionId]);
 
   const runAnalysis = useCallback(async (workstreamId: string) => {
@@ -257,6 +296,14 @@ export default function BookkeepingQuestionnairePage() {
             })}
           </div>
         </div>
+
+        {/* Synthesis */}
+        <SynthesisSection
+          analysisCount={Object.keys(analyses).length}
+          synthesis={synthesis}
+          runningSynthesis={runningSynthesis}
+          onRun={runSynthesis}
+        />
 
         {/* Workstream Accordion */}
         {BOOKKEEPING_OPS_MODULE.workstreams.map((ws: OpsWorkstream) => {
@@ -455,6 +502,186 @@ function AnalysisResults({ wsId, data }: { wsId: string; data: { analysis: Recor
           </div>
         )}
       </div>
+    </div>
+  );
+}
+
+// ── Synthesis Section ───────────────────────────────────────────────────────
+
+interface Blocker { questionId: string; workstreamId: string; reason: string; statute: string; penaltyIfIgnored: string; resolution: string; estimatedEffort: string }
+interface SeqAction { order: number; questionId: string; action: string; deadline: string; effort: string; workstreamId: string }
+
+function SynthesisSection({ analysisCount, synthesis, runningSynthesis, onRun }: {
+  analysisCount: number;
+  synthesis: { synthesis: Record<string, unknown>; isStale: boolean; workstreamsCovered: string[] } | null;
+  runningSynthesis: boolean;
+  onRun: () => void;
+}) {
+  const canRun = analysisCount >= 2;
+
+  return (
+    <div className="space-y-4">
+      {/* Run button */}
+      <div className="bg-white rounded border border-border shadow-sm p-4">
+        <div className="flex items-center justify-between">
+          <div>
+            <span className="text-terminal-sm text-text-muted font-mono">
+              {analysisCount} of 18 workstreams analyzed
+            </span>
+          </div>
+          {runningSynthesis ? (
+            <div className="flex items-center gap-2">
+              <div className="w-4 h-4 border-2 border-brand-purple border-t-transparent rounded-full animate-spin" />
+              <span className="text-terminal-sm text-text-muted font-mono">Running synthesis...</span>
+            </div>
+          ) : (
+            <button onClick={onRun} disabled={!canRun}
+              className="px-4 py-1.5 bg-brand-purple text-white rounded text-terminal-sm font-mono hover:bg-brand-purple-hover transition-colors disabled:opacity-40">
+              {synthesis ? 'Re-run Synthesis' : 'Run Full Synthesis'}
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Results */}
+      {synthesis && <SynthesisResults data={synthesis} />}
+    </div>
+  );
+}
+
+function SynthesisResults({ data }: { data: { synthesis: Record<string, unknown>; isStale: boolean; workstreamsCovered: string[] } }) {
+  const { synthesis: s, isStale, workstreamsCovered } = data;
+  const lr = s.launchReadiness as { canLaunch: boolean; blockers: Blocker[]; conditionalItems?: Array<{ questionId: string; condition: string }> } | undefined;
+  const exposure = s.totalRegulatoryExposure as { totalMinPenalty: string; totalMaxPenalty: string; breakdownByStatute?: Array<{ statute: string; exposure: string; status: string }> } | undefined;
+  const cp = s.criticalPath as { launchDate: string; longestPole?: { item: string; reason: string; estimatedDuration: string }; sequencedActions?: SeqAction[] } | undefined;
+  const contradictions = (s.contradictions as Array<{ questionId1: string; answer1: string; questionId2: string; answer2: string; contradiction: string; resolution: string }>) || [];
+  const deps = (s.crossWorkstreamDependencies as Array<{ fromWorkstream: string; toWorkstream: string; dependency: string; impact: string }>) || [];
+  const execSummary = s.executiveSummary as string | undefined;
+  const notAnalyzed = (s.workstreamsNotAnalyzed as string[]) || [];
+
+  return (
+    <div className="space-y-4">
+      {isStale && (
+        <div className="bg-amber-50 border border-amber-200 rounded p-3">
+          <span className="text-terminal-sm font-mono text-amber-700">Workstream analyses updated since this synthesis. Re-run to update.</span>
+        </div>
+      )}
+
+      {/* Launch Readiness Banner */}
+      {lr && (
+        <div className={`rounded border p-5 ${lr.canLaunch ? 'bg-emerald-50 border-emerald-200' : 'bg-red-50 border-red-200'}`}>
+          <p className={`text-lg font-bold font-mono ${lr.canLaunch ? 'text-emerald-700' : 'text-red-700'}`}>
+            {lr.canLaunch ? 'LAUNCH READY — all compliance gates passed' : `NOT READY TO LAUNCH — ${lr.blockers?.length || 0} blockers`}
+          </p>
+          {lr.blockers && lr.blockers.length > 0 && (
+            <div className="mt-3 space-y-2">
+              {lr.blockers.map((b, i) => (
+                <div key={i} className="border border-red-200 rounded p-2.5 bg-white">
+                  <div className="flex items-start gap-2">
+                    <span className="text-terminal-sm font-mono text-text-faint">{b.questionId}</span>
+                    <div className="flex-1">
+                      <p className="text-terminal-sm font-mono text-text-primary">{b.reason}</p>
+                      <p className="text-terminal-sm font-mono text-red-600 mt-0.5">{b.statute}: {b.penaltyIfIgnored}</p>
+                      <p className="text-terminal-sm font-mono text-text-secondary mt-0.5">Resolution: {b.resolution} ({b.estimatedEffort})</p>
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Executive Summary */}
+      {execSummary && (
+        <div className="bg-white rounded border border-border shadow-sm p-4">
+          <p className="text-terminal-sm uppercase tracking-widest text-text-muted font-mono mb-2">Executive Summary</p>
+          <p className="text-terminal-base font-mono text-text-primary">{execSummary}</p>
+        </div>
+      )}
+
+      {/* Exposure */}
+      {exposure && (
+        <div className="bg-white rounded border border-border shadow-sm p-4">
+          <p className="text-terminal-sm uppercase tracking-widest text-text-muted font-mono mb-2">Total Regulatory Exposure</p>
+          <p className="text-sm font-bold font-mono text-red-600">{exposure.totalMinPenalty} — {exposure.totalMaxPenalty}</p>
+          {exposure.breakdownByStatute && exposure.breakdownByStatute.length > 0 && (
+            <div className="mt-2 space-y-1">
+              {exposure.breakdownByStatute.map((s, i) => (
+                <div key={i} className="flex items-center gap-2 text-terminal-sm font-mono">
+                  <span className={`px-1.5 py-0.5 rounded ${s.status === 'resolved' ? 'bg-emerald-50 text-emerald-700' : 'bg-red-50 text-red-700'}`}>{s.status}</span>
+                  <span className="text-text-primary">{s.statute}</span>
+                  <span className="text-text-faint">{s.exposure}</span>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Critical Path */}
+      {cp && (
+        <div className="bg-white rounded border border-border shadow-sm p-4">
+          <p className="text-terminal-sm uppercase tracking-widest text-text-muted font-mono mb-2">Critical Path</p>
+          <p className="text-terminal-base font-mono text-text-primary mb-2">Earliest launch: {cp.launchDate}</p>
+          {cp.longestPole && (
+            <div className="bg-amber-50 border border-amber-100 rounded p-2.5 mb-3">
+              <p className="text-terminal-sm font-mono text-amber-700 font-medium">Longest pole: {cp.longestPole.item}</p>
+              <p className="text-terminal-sm font-mono text-text-muted">{cp.longestPole.reason} ({cp.longestPole.estimatedDuration})</p>
+            </div>
+          )}
+          {cp.sequencedActions && cp.sequencedActions.length > 0 && (
+            <div className="space-y-1.5">
+              {cp.sequencedActions.map((a) => (
+                <div key={a.order} className="flex items-start gap-2 text-terminal-sm font-mono">
+                  <span className="w-6 text-brand-purple font-bold flex-shrink-0">{a.order}.</span>
+                  <div className="flex-1">
+                    <span className="text-text-primary">{a.action}</span>
+                    <span className="text-text-faint"> — {a.deadline} ({a.effort})</span>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Contradictions */}
+      {contradictions.length > 0 && (
+        <div className="bg-white rounded border border-border shadow-sm p-4">
+          <p className="text-terminal-sm uppercase tracking-widest text-text-muted font-mono mb-2">Contradictions Found</p>
+          {contradictions.map((c, i) => (
+            <div key={i} className="border-l-2 border-l-red-300 pl-3 py-1.5 mb-2">
+              <p className="text-terminal-sm font-mono text-red-600">{c.contradiction}</p>
+              <p className="text-terminal-sm font-mono text-text-faint">{c.questionId1}: &ldquo;{c.answer1}&rdquo; vs {c.questionId2}: &ldquo;{c.answer2}&rdquo;</p>
+              <p className="text-terminal-sm font-mono text-text-secondary mt-0.5">Resolution: {c.resolution}</p>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Dependencies */}
+      {deps.length > 0 && (
+        <div className="bg-white rounded border border-border shadow-sm p-4">
+          <p className="text-terminal-sm uppercase tracking-widest text-text-muted font-mono mb-2">Cross-Workstream Dependencies</p>
+          {deps.map((d, i) => (
+            <p key={i} className="text-terminal-sm font-mono text-text-secondary mb-1">
+              <span className="text-brand-purple">{d.fromWorkstream}</span> → <span className="text-brand-purple">{d.toWorkstream}</span>: {d.dependency}
+            </p>
+          ))}
+        </div>
+      )}
+
+      {/* Not analyzed warning */}
+      {notAnalyzed.length > 0 && (
+        <div className="bg-amber-50 border border-amber-100 rounded p-3">
+          <p className="text-terminal-sm font-mono text-amber-700 font-medium">{notAnalyzed.length} workstreams not included in this assessment:</p>
+          <p className="text-terminal-sm font-mono text-amber-600 mt-1">{notAnalyzed.join(', ')}</p>
+        </div>
+      )}
+
+      {/* Covered */}
+      <p className="text-terminal-sm text-text-faint font-mono">Synthesis covers: {workstreamsCovered.join(', ')}</p>
     </div>
   );
 }


### PR DESCRIPTION
…nch readiness

New Prisma model: ops_synthesis_report
- One synthesis per module per mission
- Tracks which workstreams were covered
- inputHash for stale detection across workstream updates
- Migration SQL created (not applied)

API routes: /api/ops/synthesis-report
- POST: synthesizes all workstream analyses into unified assessment
  - Launch readiness gate (binary pass/fail with specific blockers)
  - Total regulatory exposure quantified by statute (min/max)
  - Critical path with sequenced actions and longest-pole identification
  - Cross-workstream contradictions with resolution recommendations
  - Cross-workstream dependencies with impact assessment
  - Executive summary (3-5 sentences)
  - Requires minimum 2 workstream analyses
  - Full auth + mission ownership + userId scoping
  - max_tokens: 8192 for full synthesis
- GET: loads existing synthesis with stale detection

Frontend:
- Run Full Synthesis button (requires 2+ analyzed workstreams)
- Launch Readiness banner: red NOT READY with blocker count or green LAUNCH READY
- Each blocker shows statute, penalty, resolution, effort
- Executive summary card
- Total exposure with statute breakdown (resolved/unresolved)
- Critical path: launch date estimate, longest-pole highlight, sequenced actions
- Contradictions section with resolution recommendations
- Cross-workstream dependencies
- Stale detection when workstream analyses updated
- Not-analyzed workstream warnings

https://claude.ai/code/session_01GQeiwocJDnF2N3pU1q7Y8t