### PR TITLE
feat(ops): compliance task engine data model — 5 tables

### DIFF
--- a/prisma/migrations/20260425000000_add_compliance_task_engine/migration.sql
+++ b/prisma/migrations/20260425000000_add_compliance_task_engine/migration.sql
@@ -1,0 +1,129 @@
+-- CreateTable: compliance_tasks
+CREATE TABLE "compliance_tasks" (
+    "id" TEXT NOT NULL,
+    "mission_id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "module_id" TEXT NOT NULL,
+    "workstream_id" TEXT NOT NULL,
+    "question_id" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "action_steps" TEXT NOT NULL,
+    "research_links" TEXT,
+    "estimated_cost_min" DOUBLE PRECISION,
+    "estimated_cost_max" DOUBLE PRECISION,
+    "estimated_effort" TEXT,
+    "effort_quantity" INTEGER,
+    "deadline" TIMESTAMP(3),
+    "deadline_label" TEXT,
+    "calendar_event_id" TEXT,
+    "calendar_start" TIMESTAMP(3),
+    "calendar_end" TIMESTAMP(3),
+    "status" TEXT NOT NULL DEFAULT 'suggested',
+    "priority" TEXT NOT NULL DEFAULT 'medium',
+    "blocked_by_tasks" TEXT,
+    "statute" TEXT,
+    "penalty_range" TEXT,
+    "source_analysis_id" TEXT,
+    "verified_at" TIMESTAMP(3),
+    "verified_by" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "compliance_tasks_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable: task_evidence
+CREATE TABLE "task_evidence" (
+    "id" TEXT NOT NULL,
+    "task_id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "evidence_type" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "task_evidence_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable: task_evidence_documents
+CREATE TABLE "task_evidence_documents" (
+    "id" TEXT NOT NULL,
+    "evidence_id" TEXT NOT NULL,
+    "file_name" TEXT NOT NULL,
+    "file_type" TEXT NOT NULL,
+    "file_size" INTEGER NOT NULL,
+    "storage_path" TEXT NOT NULL,
+    "storage_url" TEXT NOT NULL,
+    "expiration_date" TIMESTAMP(3),
+    "expiration_alert_sent" BOOLEAN NOT NULL DEFAULT false,
+    "uploaded_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "task_evidence_documents_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable: task_evidence_code
+CREATE TABLE "task_evidence_code" (
+    "id" TEXT NOT NULL,
+    "evidence_id" TEXT NOT NULL,
+    "file_path" TEXT NOT NULL,
+    "start_line" INTEGER NOT NULL,
+    "end_line" INTEGER NOT NULL,
+    "function_name" TEXT,
+    "description" TEXT NOT NULL,
+    "code_snapshot" TEXT NOT NULL,
+    "code_hash" TEXT NOT NULL,
+    "commit_hash" TEXT NOT NULL,
+    "is_stale" BOOLEAN NOT NULL DEFAULT false,
+    "stale_detected_at" TIMESTAMP(3),
+    "last_verified_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "task_evidence_code_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable: task_evidence_urls
+CREATE TABLE "task_evidence_urls" (
+    "id" TEXT NOT NULL,
+    "evidence_id" TEXT NOT NULL,
+    "url" TEXT NOT NULL,
+    "archived_content" TEXT,
+    "last_checked_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "is_accessible" BOOLEAN NOT NULL DEFAULT true,
+
+    CONSTRAINT "task_evidence_urls_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "compliance_tasks_mission_id_module_id_question_id_key" ON "compliance_tasks"("mission_id", "module_id", "question_id");
+CREATE INDEX "compliance_tasks_user_id_idx" ON "compliance_tasks"("user_id");
+CREATE INDEX "compliance_tasks_mission_id_module_id_idx" ON "compliance_tasks"("mission_id", "module_id");
+CREATE INDEX "compliance_tasks_mission_id_module_id_workstream_id_idx" ON "compliance_tasks"("mission_id", "module_id", "workstream_id");
+CREATE INDEX "compliance_tasks_status_idx" ON "compliance_tasks"("status");
+CREATE INDEX "compliance_tasks_deadline_idx" ON "compliance_tasks"("deadline");
+CREATE INDEX "compliance_tasks_calendar_start_calendar_end_idx" ON "compliance_tasks"("calendar_start", "calendar_end");
+
+CREATE INDEX "task_evidence_task_id_idx" ON "task_evidence"("task_id");
+CREATE INDEX "task_evidence_user_id_idx" ON "task_evidence"("user_id");
+
+CREATE UNIQUE INDEX "task_evidence_documents_evidence_id_key" ON "task_evidence_documents"("evidence_id");
+CREATE INDEX "task_evidence_documents_expiration_date_idx" ON "task_evidence_documents"("expiration_date");
+
+CREATE UNIQUE INDEX "task_evidence_code_evidence_id_key" ON "task_evidence_code"("evidence_id");
+CREATE INDEX "task_evidence_code_is_stale_idx" ON "task_evidence_code"("is_stale");
+CREATE INDEX "task_evidence_code_file_path_idx" ON "task_evidence_code"("file_path");
+
+CREATE UNIQUE INDEX "task_evidence_urls_evidence_id_key" ON "task_evidence_urls"("evidence_id");
+
+-- AddForeignKey
+ALTER TABLE "compliance_tasks" ADD CONSTRAINT "compliance_tasks_mission_id_fkey" FOREIGN KEY ("mission_id") REFERENCES "missions"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "compliance_tasks" ADD CONSTRAINT "compliance_tasks_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "task_evidence" ADD CONSTRAINT "task_evidence_task_id_fkey" FOREIGN KEY ("task_id") REFERENCES "compliance_tasks"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "task_evidence" ADD CONSTRAINT "task_evidence_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "task_evidence_documents" ADD CONSTRAINT "task_evidence_documents_evidence_id_fkey" FOREIGN KEY ("evidence_id") REFERENCES "task_evidence"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "task_evidence_code" ADD CONSTRAINT "task_evidence_code_evidence_id_fkey" FOREIGN KEY ("evidence_id") REFERENCES "task_evidence"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "task_evidence_urls" ADD CONSTRAINT "task_evidence_urls_evidence_id_fkey" FOREIGN KEY ("evidence_id") REFERENCES "task_evidence"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -476,6 +476,8 @@ model users {
   questionnaireAnswers    ops_questionnaire_answers[]
   workstreamAnalyses      ops_workstream_analysis[]
   synthesisReports        ops_synthesis_report[]
+  complianceTasks         compliance_tasks[]
+  taskEvidence            task_evidence[]
 }
 
 model budgets {
@@ -1928,6 +1930,7 @@ model missions {
   questionnaireAnswers ops_questionnaire_answers[]
   workstreamAnalyses   ops_workstream_analysis[]
   synthesisReports     ops_synthesis_report[]
+  complianceTasks      compliance_tasks[]
 
   @@map("missions")
 }
@@ -2110,4 +2113,127 @@ model ops_synthesis_report {
   @@unique([missionId, moduleId])
   @@index([userId])
   @@map("ops_synthesis_report")
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// COMPLIANCE TASK ENGINE — Tasks, evidence, documents, code refs, URLs
+// ═══════════════════════════════════════════════════════════════════
+
+model compliance_tasks {
+  id               String    @id @default(cuid())
+  missionId        String    @map("mission_id")
+  userId           String    @map("user_id")
+  moduleId         String    @map("module_id")
+  workstreamId     String    @map("workstream_id")
+  questionId       String    @map("question_id")
+  title            String
+  description      String    @db.Text
+  actionSteps      String    @map("action_steps") @db.Text
+  researchLinks    String?   @map("research_links") @db.Text
+  estimatedCostMin Float?    @map("estimated_cost_min")
+  estimatedCostMax Float?    @map("estimated_cost_max")
+  estimatedEffort  String?   @map("estimated_effort")
+  effortQuantity   Int?      @map("effort_quantity")
+  deadline         DateTime?
+  deadlineLabel    String?   @map("deadline_label")
+  calendarEventId  String?   @map("calendar_event_id")
+  calendarStart    DateTime? @map("calendar_start")
+  calendarEnd      DateTime? @map("calendar_end")
+  status           String    @default("suggested")
+  priority         String    @default("medium")
+  blockedByTasks   String?   @map("blocked_by_tasks") @db.Text
+  statute          String?
+  penaltyRange     String?   @map("penalty_range")
+  sourceAnalysisId String?   @map("source_analysis_id")
+  verifiedAt       DateTime? @map("verified_at")
+  verifiedBy       String?   @map("verified_by")
+  createdAt        DateTime  @default(now()) @map("created_at")
+  updatedAt        DateTime  @updatedAt @map("updated_at")
+
+  mission  missions        @relation(fields: [missionId], references: [id], onDelete: Cascade)
+  user     users           @relation(fields: [userId], references: [id], onDelete: Restrict)
+  evidence task_evidence[]
+
+  @@unique([missionId, moduleId, questionId])
+  @@index([userId])
+  @@index([missionId, moduleId])
+  @@index([missionId, moduleId, workstreamId])
+  @@index([status])
+  @@index([deadline])
+  @@index([calendarStart, calendarEnd])
+  @@map("compliance_tasks")
+}
+
+model task_evidence {
+  id           String   @id @default(cuid())
+  taskId       String   @map("task_id")
+  userId       String   @map("user_id")
+  evidenceType String   @map("evidence_type")
+  title        String
+  description  String?  @db.Text
+  createdAt    DateTime @default(now()) @map("created_at")
+  updatedAt    DateTime @updatedAt @map("updated_at")
+
+  task          compliance_tasks         @relation(fields: [taskId], references: [id], onDelete: Cascade)
+  user          users                    @relation(fields: [userId], references: [id], onDelete: Restrict)
+  document      task_evidence_documents?
+  codeReference task_evidence_code?
+  urlReference  task_evidence_urls?
+
+  @@index([taskId])
+  @@index([userId])
+  @@map("task_evidence")
+}
+
+model task_evidence_documents {
+  id                  String    @id @default(cuid())
+  evidenceId          String    @unique @map("evidence_id")
+  fileName            String    @map("file_name")
+  fileType            String    @map("file_type")
+  fileSize            Int       @map("file_size")
+  storagePath         String    @map("storage_path")
+  storageUrl          String    @map("storage_url")
+  expirationDate      DateTime? @map("expiration_date")
+  expirationAlertSent Boolean   @default(false) @map("expiration_alert_sent")
+  uploadedAt          DateTime  @default(now()) @map("uploaded_at")
+
+  evidence task_evidence @relation(fields: [evidenceId], references: [id], onDelete: Cascade)
+
+  @@index([expirationDate])
+  @@map("task_evidence_documents")
+}
+
+model task_evidence_code {
+  id              String    @id @default(cuid())
+  evidenceId      String    @unique @map("evidence_id")
+  filePath        String    @map("file_path")
+  startLine       Int       @map("start_line")
+  endLine         Int       @map("end_line")
+  functionName    String?   @map("function_name")
+  description     String    @db.Text
+  codeSnapshot    String    @map("code_snapshot") @db.Text
+  codeHash        String    @map("code_hash")
+  commitHash      String    @map("commit_hash")
+  isStale         Boolean   @default(false) @map("is_stale")
+  staleDetectedAt DateTime? @map("stale_detected_at")
+  lastVerifiedAt  DateTime  @default(now()) @map("last_verified_at")
+
+  evidence task_evidence @relation(fields: [evidenceId], references: [id], onDelete: Cascade)
+
+  @@index([isStale])
+  @@index([filePath])
+  @@map("task_evidence_code")
+}
+
+model task_evidence_urls {
+  id              String   @id @default(cuid())
+  evidenceId      String   @unique @map("evidence_id")
+  url             String
+  archivedContent String?  @map("archived_content") @db.Text
+  lastCheckedAt   DateTime @default(now()) @map("last_checked_at")
+  isAccessible    Boolean  @default(true) @map("is_accessible")
+
+  evidence task_evidence @relation(fields: [evidenceId], references: [id], onDelete: Cascade)
+
+  @@map("task_evidence_urls")
 }


### PR DESCRIPTION
New Prisma models for Phase 2 compliance task system:

compliance_tasks:
- Spawned from decision register entries (suggested → verified lifecycle)
- Calendar fields for time-block scheduling (calendarStart/End/EventId)
- Cost/effort estimates, statute references, penalty ranges
- Unique per question per mission per module
- Status: suggested | not_started | in_progress | blocked | complete | verified | expired
- Priority: critical | high | medium | low
- 7 indexes including calendar range, status, deadline

task_evidence:
- Multiple evidence items per task
- Types: document, code_reference, url, note
- FK to compliance_tasks (cascade) and users (restrict)

task_evidence_documents:
- 1:1 with task_evidence
- Azure Blob Storage references (path + URL)
- Expiration tracking for insurance/bonds/licenses
- expirationAlertSent flag for cron job

task_evidence_code:
- 1:1 with task_evidence
- Live code references: filePath, startLine, endLine, functionName
- SHA-256 codeHash for staleness detection
- codeSnapshot for diff comparison
- commitHash for git traceability
- isStale flag + staleDetectedAt for deploy-hook checks
- Indexes on isStale and filePath

task_evidence_urls:
- 1:1 with task_evidence
- URL with archived content snapshot
- Accessibility monitoring (isAccessible flag)

Reverse relations added to missions and users models. Migration SQL created (not applied — Alex runs prisma migrate deploy). No API routes, no UI — schema only.

https://claude.ai/code/session_01GQeiwocJDnF2N3pU1q7Y8t