### PR TITLE
PR-C: Hash-chained audit log with SOC 2 immutability

### DIFF
--- a/prisma/migrations/20260430000000_pr_c_audit_log/migration.sql
+++ b/prisma/migrations/20260430000000_pr_c_audit_log/migration.sql
@@ -1,0 +1,126 @@
+-- =================================================================
+-- PR-C: Hash-chained audit log with SOC 2 immutability
+-- =================================================================
+
+-- STEP 1: Create enums
+CREATE TYPE "AuditActorType" AS ENUM ('human_user', 'ai_agent', 'system_automation', 'external_integration');
+
+CREATE TYPE "AuditActionType" AS ENUM (
+  'citation_created', 'citation_updated', 'citation_verified',
+  'citation_status_changed', 'citation_superseded', 'citation_deleted',
+  'task_created', 'task_updated', 'task_status_changed',
+  'task_assigned', 'task_completed', 'task_evidence_attached',
+  'task_attested', 'task_deleted',
+  'mission_created', 'mission_updated', 'mission_status_changed', 'mission_deleted',
+  'project_created', 'project_updated', 'project_deleted',
+  'workstream_created', 'workstream_updated', 'workstream_deleted',
+  'ai_generation_started', 'ai_generation_completed', 'ai_generation_failed',
+  'ai_verification_passed', 'ai_verification_failed',
+  'regulatory_source_added', 'regulatory_source_updated', 'regulatory_source_deactivated',
+  'user_login', 'user_logout',
+  'permission_granted', 'permission_revoked',
+  'data_export_initiated', 'data_export_completed',
+  'system_other'
+);
+
+-- STEP 2: Create audit_log table
+CREATE TABLE "audit_log" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "sequence_number" BIGSERIAL NOT NULL,
+    "prev_hash" VARCHAR(64) NOT NULL,
+    "content_hash" VARCHAR(64) NOT NULL,
+    "actor_user_id" VARCHAR(255),
+    "actor_email" VARCHAR(255),
+    "actor_type" "AuditActorType" NOT NULL,
+    "actor_session_id" VARCHAR(255),
+    "actor_ip" VARCHAR(45),
+    "action_type" "AuditActionType" NOT NULL,
+    "action_description" TEXT NOT NULL,
+    "target_table" VARCHAR(100) NOT NULL,
+    "target_id" VARCHAR(255),
+    "payload_before" JSONB,
+    "payload_after" JSONB,
+    "payload_metadata" JSONB,
+    "request_id" VARCHAR(255),
+    "user_agent" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "audit_log_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "audit_log_sequence_number_key" ON "audit_log"("sequence_number");
+CREATE UNIQUE INDEX "audit_log_content_hash_key" ON "audit_log"("content_hash");
+CREATE INDEX "audit_log_sequence_number_idx" ON "audit_log"("sequence_number");
+CREATE INDEX "audit_log_actor_user_id_created_at_idx" ON "audit_log"("actor_user_id", "created_at");
+CREATE INDEX "audit_log_action_type_created_at_idx" ON "audit_log"("action_type", "created_at");
+CREATE INDEX "audit_log_target_table_target_id_idx" ON "audit_log"("target_table", "target_id");
+CREATE INDEX "audit_log_created_at_idx" ON "audit_log"("created_at");
+
+-- STEP 3: (sequence handled by BIGSERIAL)
+
+-- STEP 4: SOC 2 immutability triggers
+-- Pattern mirrors prisma/migrations/20260227000100_protect_journal_entries/migration.sql
+-- audit_log is APPEND-ONLY: INSERTs allowed, UPDATEs and DELETEs blocked.
+
+CREATE OR REPLACE FUNCTION prevent_audit_log_update()
+RETURNS TRIGGER AS $$
+BEGIN
+  RAISE EXCEPTION 'audit_log is append-only. UPDATE not permitted on row %', OLD.id
+    USING ERRCODE = 'check_violation';
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION prevent_audit_log_delete()
+RETURNS TRIGGER AS $$
+BEGIN
+  RAISE EXCEPTION 'audit_log is append-only. DELETE not permitted on row %', OLD.id
+    USING ERRCODE = 'check_violation';
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER audit_log_no_update
+  BEFORE UPDATE ON "audit_log"
+  FOR EACH ROW EXECUTE FUNCTION prevent_audit_log_update();
+
+CREATE TRIGGER audit_log_no_delete
+  BEFORE DELETE ON "audit_log"
+  FOR EACH ROW EXECUTE FUNCTION prevent_audit_log_delete();
+
+-- STEP 5: Hash-chain integrity CHECK constraint
+-- prev_hash must be 'GENESIS' (genesis row) or a 64-char SHA-256 hex string.
+ALTER TABLE "audit_log" ADD CONSTRAINT audit_log_genesis_or_chained
+  CHECK (
+    prev_hash = 'GENESIS' OR
+    LENGTH(prev_hash) = 64
+  );
+
+-- STEP 6: Genesis row — chain anchor
+-- content_hash is SHA-256 of the literal string 'TEMPLE_STUART_AUDIT_LOG_GENESIS_v1'
+INSERT INTO "audit_log" (
+  id,
+  prev_hash,
+  content_hash,
+  actor_user_id,
+  actor_email,
+  actor_type,
+  action_type,
+  action_description,
+  target_table,
+  target_id,
+  payload_metadata,
+  created_at
+) VALUES (
+  gen_random_uuid(),
+  'GENESIS',
+  encode(sha256('TEMPLE_STUART_AUDIT_LOG_GENESIS_v1'::bytea), 'hex'),
+  NULL,
+  NULL,
+  'system_automation',
+  'system_other',
+  'Audit log chain genesis. PR-C deployment.',
+  'audit_log',
+  NULL,
+  jsonb_build_object('version', 'v1', 'pr', 'PR-C', 'deployed_at', now()),
+  now()
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1966,3 +1966,99 @@ model citations {
   @@index([is_active])
   @@map("citations")
 }
+
+// ═══════════════════════════════════════════════════════════════════
+// AUDIT LOG — Hash-chained, append-only, SOC 2 immutability
+// ═══════════════════════════════════════════════════════════════════
+
+enum AuditActorType {
+  human_user
+  ai_agent
+  system_automation
+  external_integration
+}
+
+enum AuditActionType {
+  citation_created
+  citation_updated
+  citation_verified
+  citation_status_changed
+  citation_superseded
+  citation_deleted
+  task_created
+  task_updated
+  task_status_changed
+  task_assigned
+  task_completed
+  task_evidence_attached
+  task_attested
+  task_deleted
+  mission_created
+  mission_updated
+  mission_status_changed
+  mission_deleted
+  project_created
+  project_updated
+  project_deleted
+  workstream_created
+  workstream_updated
+  workstream_deleted
+  ai_generation_started
+  ai_generation_completed
+  ai_generation_failed
+  ai_verification_passed
+  ai_verification_failed
+  regulatory_source_added
+  regulatory_source_updated
+  regulatory_source_deactivated
+  user_login
+  user_logout
+  permission_granted
+  permission_revoked
+  data_export_initiated
+  data_export_completed
+  system_other
+}
+
+model audit_log {
+  id String @id @default(uuid()) @db.Uuid
+
+  // Hash chain
+  sequence_number BigInt @unique @default(autoincrement())
+  prev_hash       String @db.VarChar(64)
+  content_hash    String @unique @db.VarChar(64)
+
+  // Actor
+  actor_user_id    String?        @db.VarChar(255)
+  actor_email      String?        @db.VarChar(255)
+  actor_type       AuditActorType
+  actor_session_id String?        @db.VarChar(255)
+  actor_ip         String?        @db.VarChar(45)
+
+  // Action
+  action_type        AuditActionType
+  action_description String          @db.Text
+
+  // Target
+  target_table String  @db.VarChar(100)
+  target_id    String? @db.VarChar(255)
+
+  // Payload
+  payload_before   Json?
+  payload_after    Json?
+  payload_metadata Json?
+
+  // Provenance
+  request_id String? @db.VarChar(255)
+  user_agent String? @db.Text
+
+  // Time
+  created_at DateTime @default(now())
+
+  @@index([sequence_number])
+  @@index([actor_user_id, created_at])
+  @@index([action_type, created_at])
+  @@index([target_table, target_id])
+  @@index([created_at])
+  @@map("audit_log")
+}

--- a/src/app/api/audit-log/route.ts
+++ b/src/app/api/audit-log/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
+
+export async function GET(request: NextRequest) {
+  try {
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const { searchParams } = new URL(request.url);
+    const actorUserId = searchParams.get('actor_user_id');
+    const actionType = searchParams.get('action_type');
+    const targetTable = searchParams.get('target_table');
+    const targetId = searchParams.get('target_id');
+    const after = searchParams.get('after');
+    const before = searchParams.get('before');
+    const limitParam = searchParams.get('limit');
+
+    const limit = Math.min(Math.max(parseInt(limitParam || '100', 10) || 100, 1), 500);
+
+    const where: Record<string, unknown> = {};
+    if (actorUserId) where.actor_user_id = actorUserId;
+    if (actionType) where.action_type = actionType;
+    if (targetTable) where.target_table = targetTable;
+    if (targetId) where.target_id = targetId;
+    if (after || before) {
+      where.created_at = {};
+      if (after) (where.created_at as Record<string, unknown>).gte = new Date(after);
+      if (before) (where.created_at as Record<string, unknown>).lte = new Date(before);
+    }
+
+    const rows = await prisma.audit_log.findMany({
+      where,
+      orderBy: [{ sequence_number: 'desc' }],
+      take: limit,
+    });
+
+    const serialized = rows.map((r) => ({
+      ...r,
+      sequence_number: r.sequence_number.toString(),
+    }));
+
+    return NextResponse.json({ count: serialized.length, rows: serialized });
+  } catch (error) {
+    console.error('[Audit Log]', error);
+    return NextResponse.json({ error: 'Failed to load audit log' }, { status: 500 });
+  }
+}

--- a/src/app/api/audit-log/verify-chain/route.ts
+++ b/src/app/api/audit-log/verify-chain/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from 'next/server';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { verifyAuditChain } from '@/lib/audit/verifyAuditChain';
+import { writeAuditLog } from '@/lib/audit/writeAuditLog';
+
+export async function POST() {
+  try {
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const result = await verifyAuditChain();
+
+    await writeAuditLog({
+      actor: {
+        email: userEmail,
+        type: 'human_user',
+      },
+      action: {
+        type: result.is_valid ? 'ai_verification_passed' : 'ai_verification_failed',
+        description: `Audit chain verification: ${result.total_rows} rows, ${result.is_valid ? 'valid' : 'BROKEN'}`,
+      },
+      target: {
+        table: 'audit_log',
+      },
+      payload: {
+        metadata: {
+          total_rows: result.total_rows,
+          break_point_count: result.break_points.length,
+          is_valid: result.is_valid,
+        },
+      },
+    });
+
+    const serialized = {
+      ...result,
+      break_points: result.break_points.map((bp) => ({
+        ...bp,
+        sequence_number: bp.sequence_number.toString(),
+      })),
+    };
+
+    return NextResponse.json(serialized);
+  } catch (error) {
+    console.error('[Audit Chain Verify]', error);
+    return NextResponse.json({ error: 'Chain verification failed' }, { status: 500 });
+  }
+}

--- a/src/app/api/citations/[id]/verify/route.ts
+++ b/src/app/api/citations/[id]/verify/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { verifyCitation } from '@/lib/citations/verifyCitation';
+import { writeAuditLog } from '@/lib/audit/writeAuditLog';
 
 export async function POST(
   request: NextRequest,
@@ -24,10 +25,12 @@ export async function POST(
       partial: 'pending_review',
     } as const;
 
+    const updatedStatus = statusMap[result.overall_status];
+
     await prisma.citations.update({
       where: { id },
       data: {
-        status: statusMap[result.overall_status],
+        status: updatedStatus,
         last_verified_at: result.ran_at,
         last_verified_by: userEmail,
         verification_notes: result.notes.join('\n'),
@@ -40,6 +43,38 @@ export async function POST(
         source_authority_match_check: result.checks.source_authority_match,
         content_hash_check: result.checks.content_hash,
       },
+    });
+
+    await writeAuditLog({
+      actor: {
+        email: userEmail,
+        type: 'human_user',
+      },
+      action: {
+        type: 'citation_verified',
+        description: `Ran 8-step verification protocol on citation ${citation.citation_string}`,
+      },
+      target: {
+        table: 'citations',
+        id: citation.id,
+      },
+      payload: {
+        before: {
+          status: citation.status,
+          last_verified_at: citation.last_verified_at,
+        },
+        after: {
+          status: updatedStatus,
+          last_verified_at: result.ran_at,
+          checks: result.checks,
+        },
+        metadata: {
+          overall_status: result.overall_status,
+          notes: result.notes,
+        },
+      },
+      request_id: request.headers.get('x-request-id') ?? undefined,
+      user_agent: request.headers.get('user-agent') ?? undefined,
     });
 
     return NextResponse.json(result);

--- a/src/app/ops/audit-log/page.tsx
+++ b/src/app/ops/audit-log/page.tsx
@@ -1,0 +1,403 @@
+'use client';
+
+import React, { useState, useEffect, useMemo, useCallback } from 'react';
+import AppLayout from '@/components/ui/AppLayout';
+import OpsSubNav from '@/components/ops/OpsSubNav';
+
+interface AuditRow {
+  id: string;
+  sequence_number: string;
+  prev_hash: string;
+  content_hash: string;
+  actor_user_id: string | null;
+  actor_email: string | null;
+  actor_type: string;
+  actor_session_id: string | null;
+  actor_ip: string | null;
+  action_type: string;
+  action_description: string;
+  target_table: string;
+  target_id: string | null;
+  payload_before: unknown;
+  payload_after: unknown;
+  payload_metadata: unknown;
+  request_id: string | null;
+  user_agent: string | null;
+  created_at: string;
+}
+
+interface ChainStatus {
+  total_rows: number;
+  verified_at: string;
+  is_valid: boolean;
+  break_points: Array<{
+    sequence_number: string;
+    expected_hash: string;
+    actual_hash: string;
+    reason: string;
+  }>;
+  notes: string[];
+}
+
+const ACTION_CATEGORY: Record<string, string> = {
+  citation_created: 'citation',
+  citation_updated: 'citation',
+  citation_verified: 'citation',
+  citation_status_changed: 'citation',
+  citation_superseded: 'citation',
+  citation_deleted: 'citation',
+  task_created: 'task',
+  task_updated: 'task',
+  task_status_changed: 'task',
+  task_assigned: 'task',
+  task_completed: 'task',
+  task_evidence_attached: 'task',
+  task_attested: 'task',
+  task_deleted: 'task',
+  mission_created: 'mission',
+  mission_updated: 'mission',
+  mission_status_changed: 'mission',
+  mission_deleted: 'mission',
+  project_created: 'project',
+  project_updated: 'project',
+  project_deleted: 'project',
+  workstream_created: 'workstream',
+  workstream_updated: 'workstream',
+  workstream_deleted: 'workstream',
+  ai_generation_started: 'ai',
+  ai_generation_completed: 'ai',
+  ai_generation_failed: 'ai',
+  ai_verification_passed: 'ai',
+  ai_verification_failed: 'ai',
+  regulatory_source_added: 'regulatory',
+  regulatory_source_updated: 'regulatory',
+  regulatory_source_deactivated: 'regulatory',
+  user_login: 'system',
+  user_logout: 'system',
+  permission_granted: 'system',
+  permission_revoked: 'system',
+  data_export_initiated: 'system',
+  data_export_completed: 'system',
+  system_other: 'system',
+};
+
+const CATEGORY_STYLE: Record<string, string> = {
+  citation: 'bg-blue-100 text-blue-800',
+  task: 'bg-purple-100 text-purple-800',
+  mission: 'bg-indigo-100 text-indigo-800',
+  project: 'bg-teal-100 text-teal-800',
+  workstream: 'bg-cyan-100 text-cyan-800',
+  ai: 'bg-amber-100 text-amber-800',
+  regulatory: 'bg-emerald-100 text-emerald-800',
+  system: 'bg-gray-100 text-gray-600',
+};
+
+const ACTION_TYPE_OPTIONS = [
+  '',
+  'citation_created', 'citation_updated', 'citation_verified',
+  'citation_status_changed', 'citation_superseded', 'citation_deleted',
+  'task_created', 'task_updated', 'task_status_changed',
+  'task_assigned', 'task_completed', 'task_evidence_attached',
+  'task_attested', 'task_deleted',
+  'ai_generation_started', 'ai_generation_completed', 'ai_generation_failed',
+  'ai_verification_passed', 'ai_verification_failed',
+  'regulatory_source_added', 'regulatory_source_updated', 'regulatory_source_deactivated',
+  'system_other',
+];
+
+const TARGET_TABLE_OPTIONS = ['', 'citations', 'audit_log', 'regulatory_sources'];
+
+function relativeTime(dateStr: string): string {
+  const date = new Date(dateStr);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffSec = Math.floor(diffMs / 1000);
+  if (diffSec < 60) return 'just now';
+  const diffMin = Math.floor(diffSec / 60);
+  if (diffMin < 60) return `${diffMin}m ago`;
+  const diffHr = Math.floor(diffMin / 60);
+  if (diffHr < 24) return `${diffHr}h ago`;
+  const diffDay = Math.floor(diffHr / 24);
+  if (diffDay < 30) return `${diffDay}d ago`;
+  const diffMonth = Math.floor(diffDay / 30);
+  return `${diffMonth}mo ago`;
+}
+
+function formatActor(row: AuditRow): string {
+  if (row.actor_email) return row.actor_email;
+  if (row.actor_type === 'ai_agent') return 'ai_agent';
+  if (row.actor_type === 'system_automation') return 'system';
+  return row.actor_type;
+}
+
+export default function AuditLogPage() {
+  const [rows, setRows] = useState<AuditRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [chainStatus, setChainStatus] = useState<ChainStatus | null>(null);
+  const [chainLoading, setChainLoading] = useState(true);
+  const [chainExpanded, setChainExpanded] = useState(false);
+  const [actionFilter, setActionFilter] = useState('');
+  const [targetTableFilter, setTargetTableFilter] = useState('');
+  const [expandedRow, setExpandedRow] = useState<string | null>(null);
+  const [limit, setLimit] = useState(100);
+
+  const fetchRows = useCallback(async (take: number) => {
+    try {
+      const params = new URLSearchParams();
+      params.set('limit', String(take));
+      if (actionFilter) params.set('action_type', actionFilter);
+      if (targetTableFilter) params.set('target_table', targetTableFilter);
+      const res = await fetch(`/api/audit-log?${params}`);
+      if (res.ok) {
+        const data = await res.json();
+        setRows(data.rows || []);
+      }
+    } catch (err) {
+      console.error('Failed to load audit log:', err);
+    } finally {
+      setLoading(false);
+    }
+  }, [actionFilter, targetTableFilter]);
+
+  useEffect(() => {
+    setLoading(true);
+    fetchRows(limit);
+  }, [fetchRows, limit]);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const res = await fetch('/api/audit-log/verify-chain', { method: 'POST' });
+        if (res.ok) {
+          const data = await res.json();
+          setChainStatus(data);
+        }
+      } catch (err) {
+        console.error('Failed to verify chain:', err);
+      } finally {
+        setChainLoading(false);
+      }
+    })();
+  }, []);
+
+  const filtered = useMemo(() => rows, [rows]);
+
+  if (loading && rows.length === 0) {
+    return (
+      <AppLayout>
+        <OpsSubNav />
+        <div className="flex items-center justify-center min-h-[40vh]">
+          <div className="flex items-center gap-3">
+            <div className="w-5 h-5 border-2 border-brand-purple border-t-transparent rounded-full animate-spin" />
+            <span className="text-text-muted font-mono text-terminal-base">Loading audit log...</span>
+          </div>
+        </div>
+      </AppLayout>
+    );
+  }
+
+  return (
+    <AppLayout>
+      <OpsSubNav />
+      <div className="max-w-[1600px] mx-auto px-4 pt-4 pb-8 space-y-4">
+        {/* Header + Chain Status */}
+        <div className="bg-white rounded border border-border shadow-sm p-5">
+          <div className="flex items-start justify-between">
+            <div>
+              <h1 className="text-xl font-bold text-text-primary font-mono">Audit Log</h1>
+              <p className="text-terminal-sm text-text-muted font-mono mt-1">
+                Hash-chained, append-only compliance timeline with SOC 2 immutability.
+              </p>
+            </div>
+            <div>
+              {chainLoading ? (
+                <span className="text-terminal-sm font-mono text-text-faint">Verifying chain...</span>
+              ) : chainStatus ? (
+                <div>
+                  <button
+                    onClick={() => setChainExpanded(!chainExpanded)}
+                    className={`text-terminal-sm font-mono px-3 py-1 rounded ${
+                      chainStatus.is_valid
+                        ? 'bg-emerald-100 text-emerald-800'
+                        : 'bg-red-100 text-red-800'
+                    }`}
+                  >
+                    {chainStatus.is_valid
+                      ? `Chain verified — ${chainStatus.total_rows} rows`
+                      : `Chain broken — see details`}
+                  </button>
+                  {chainExpanded && !chainStatus.is_valid && (
+                    <div className="mt-3 p-3 bg-red-50 border border-red-200 rounded text-terminal-sm font-mono">
+                      {chainStatus.break_points.map((bp, i) => (
+                        <div key={i} className="mb-1">
+                          <span className="text-red-800 font-medium">Seq #{bp.sequence_number}:</span>{' '}
+                          <span className="text-red-700">{bp.reason}</span>
+                        </div>
+                      ))}
+                      {chainStatus.notes.map((n, i) => (
+                        <div key={`n-${i}`} className="text-red-600">{n}</div>
+                      ))}
+                    </div>
+                  )}
+                  {chainExpanded && chainStatus.is_valid && (
+                    <div className="mt-3 p-3 bg-emerald-50 border border-emerald-200 rounded text-terminal-sm font-mono text-emerald-700">
+                      {chainStatus.notes.map((n, i) => (
+                        <div key={i}>{n}</div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              ) : null}
+            </div>
+          </div>
+          <p className="text-terminal-sm text-text-faint font-mono mt-2">
+            Showing {filtered.length} rows
+          </p>
+        </div>
+
+        {/* Filters */}
+        <div className="bg-white rounded border border-border shadow-sm p-4 flex flex-wrap gap-3">
+          <select
+            value={actionFilter}
+            onChange={(e) => setActionFilter(e.target.value)}
+            className="font-mono text-sm bg-transparent border border-border rounded-md px-3 py-1.5 focus:border-brand-purple outline-none"
+          >
+            <option value="">All actions</option>
+            {ACTION_TYPE_OPTIONS.filter(Boolean).map((a) => (
+              <option key={a} value={a}>{a.replace(/_/g, ' ')}</option>
+            ))}
+          </select>
+          <select
+            value={targetTableFilter}
+            onChange={(e) => setTargetTableFilter(e.target.value)}
+            className="font-mono text-sm bg-transparent border border-border rounded-md px-3 py-1.5 focus:border-brand-purple outline-none"
+          >
+            <option value="">All targets</option>
+            {TARGET_TABLE_OPTIONS.filter(Boolean).map((t) => (
+              <option key={t} value={t}>{t}</option>
+            ))}
+          </select>
+        </div>
+
+        {/* Table */}
+        {filtered.length === 0 ? (
+          <div className="bg-white rounded border border-border shadow-sm p-12 text-center">
+            <p className="text-text-muted font-mono text-terminal-base">
+              No audit entries match the current filters.
+            </p>
+          </div>
+        ) : (
+          <div className="bg-white rounded border border-border shadow-sm overflow-x-auto">
+            <table className="w-full text-terminal-base font-mono">
+              <thead className="bg-gray-50 border-b border-border">
+                <tr>
+                  <th className="px-3 py-2 text-left text-terminal-sm font-semibold text-text-secondary uppercase tracking-wider">Time</th>
+                  <th className="px-3 py-2 text-left text-terminal-sm font-semibold text-text-secondary uppercase tracking-wider">Actor</th>
+                  <th className="px-3 py-2 text-left text-terminal-sm font-semibold text-text-secondary uppercase tracking-wider">Action</th>
+                  <th className="px-3 py-2 text-left text-terminal-sm font-semibold text-text-secondary uppercase tracking-wider">Target</th>
+                  <th className="px-3 py-2 text-left text-terminal-sm font-semibold text-text-secondary uppercase tracking-wider">Description</th>
+                  <th className="px-3 py-2 text-right text-terminal-sm font-semibold text-text-secondary uppercase tracking-wider">Seq #</th>
+                </tr>
+              </thead>
+              <tbody>
+                {filtered.map((row) => {
+                  const category = ACTION_CATEGORY[row.action_type] || 'system';
+                  const isExpanded = expandedRow === row.id;
+                  return (
+                    <React.Fragment key={row.id}>
+                      <tr className="border-b border-border-light hover:bg-bg-row/50 transition-colors">
+                        <td className="px-3 py-2 text-text-muted text-terminal-sm">
+                          <span title={new Date(row.created_at).toLocaleString()}>
+                            {relativeTime(row.created_at)}
+                          </span>
+                        </td>
+                        <td className="px-3 py-2 text-text-primary text-terminal-sm">
+                          {formatActor(row)}
+                        </td>
+                        <td className="px-3 py-2">
+                          <span className={`text-terminal-sm px-1.5 py-0.5 rounded ${CATEGORY_STYLE[category] || 'bg-gray-100'}`}>
+                            {row.action_type.replace(/_/g, ' ')}
+                          </span>
+                        </td>
+                        <td className="px-3 py-2 text-text-muted text-terminal-sm">
+                          {row.target_table}
+                          {row.target_id ? `.${row.target_id.slice(0, 8)}` : ''}
+                        </td>
+                        <td className="px-3 py-2 text-text-muted text-terminal-sm max-w-xs">
+                          <button
+                            onClick={() => setExpandedRow(isExpanded ? null : row.id)}
+                            className="text-left hover:text-text-primary transition-colors"
+                          >
+                            <span className="truncate block max-w-xs">
+                              {row.action_description}
+                            </span>
+                          </button>
+                        </td>
+                        <td className="px-3 py-2 text-text-faint text-terminal-sm text-right">
+                          {row.sequence_number}
+                        </td>
+                      </tr>
+                      {isExpanded && (
+                        <tr className="border-b border-border-light">
+                          <td colSpan={6} className="px-3 py-3 bg-gray-50">
+                            <div className="space-y-2 text-terminal-sm">
+                              <div className="font-medium text-text-secondary">Full Description</div>
+                              <div className="text-text-muted">{row.action_description}</div>
+
+                              {row.payload_before != null && (
+                                <div>
+                                  <div className="font-medium text-text-secondary mt-2">Before</div>
+                                  <pre className="text-text-faint bg-white border border-border rounded p-2 overflow-x-auto text-xs">
+                                    {JSON.stringify(row.payload_before, null, 2)}
+                                  </pre>
+                                </div>
+                              )}
+                              {row.payload_after != null && (
+                                <div>
+                                  <div className="font-medium text-text-secondary mt-2">After</div>
+                                  <pre className="text-text-faint bg-white border border-border rounded p-2 overflow-x-auto text-xs">
+                                    {JSON.stringify(row.payload_after, null, 2)}
+                                  </pre>
+                                </div>
+                              )}
+                              {row.payload_metadata != null && (
+                                <div>
+                                  <div className="font-medium text-text-secondary mt-2">Metadata</div>
+                                  <pre className="text-text-faint bg-white border border-border rounded p-2 overflow-x-auto text-xs">
+                                    {JSON.stringify(row.payload_metadata, null, 2)}
+                                  </pre>
+                                </div>
+                              )}
+
+                              <div className="flex gap-4 text-text-faint text-xs mt-2">
+                                <span>Hash: {row.content_hash.slice(0, 16)}...</span>
+                                <span>Prev: {row.prev_hash === 'GENESIS' ? 'GENESIS' : `${row.prev_hash.slice(0, 16)}...`}</span>
+                                {row.request_id && <span>Req: {row.request_id}</span>}
+                              </div>
+                            </div>
+                          </td>
+                        </tr>
+                      )}
+                    </React.Fragment>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+
+        {/* Load More */}
+        {filtered.length >= limit && (
+          <div className="text-center">
+            <button
+              onClick={() => setLimit((prev) => prev + 100)}
+              className="font-mono text-terminal-sm px-4 py-2 rounded border border-border text-text-muted hover:text-text-primary hover:border-brand-purple transition-colors"
+            >
+              Load more
+            </button>
+          </div>
+        )}
+      </div>
+    </AppLayout>
+  );
+}

--- a/src/components/ops/OpsSubNav.tsx
+++ b/src/components/ops/OpsSubNav.tsx
@@ -7,6 +7,7 @@ const OPS_TABS = [
   { name: 'Daily Plan', href: '/ops', exact: true },
   { name: 'Registry', href: '/ops/registry', exact: false },
   { name: 'Citations', href: '/ops/citations', exact: false },
+  { name: 'Audit Log', href: '/ops/audit-log', exact: false },
   { name: 'Bookkeeping', href: '', disabled: true },
   { name: 'Trading', href: '', disabled: true },
   { name: 'Travel', href: '', disabled: true },

--- a/src/lib/audit/verifyAuditChain.ts
+++ b/src/lib/audit/verifyAuditChain.ts
@@ -1,0 +1,104 @@
+import { createHash } from 'crypto';
+import { prisma } from '@/lib/prisma';
+
+export interface ChainVerificationResult {
+  total_rows: number;
+  verified_at: Date;
+  is_valid: boolean;
+  break_points: Array<{
+    sequence_number: bigint;
+    expected_hash: string;
+    actual_hash: string;
+    reason: string;
+  }>;
+  notes: string[];
+}
+
+export async function verifyAuditChain(): Promise<ChainVerificationResult> {
+  const rows = await prisma.audit_log.findMany({
+    orderBy: { sequence_number: 'asc' },
+  });
+
+  const result: ChainVerificationResult = {
+    total_rows: rows.length,
+    verified_at: new Date(),
+    is_valid: true,
+    break_points: [],
+    notes: [],
+  };
+
+  if (rows.length === 0) {
+    result.is_valid = false;
+    result.notes.push('audit_log is empty — genesis row missing');
+    return result;
+  }
+
+  const genesis = rows[0];
+  if (genesis.prev_hash !== 'GENESIS') {
+    result.is_valid = false;
+    result.break_points.push({
+      sequence_number: genesis.sequence_number,
+      expected_hash: 'GENESIS',
+      actual_hash: genesis.prev_hash,
+      reason: 'first row prev_hash is not GENESIS',
+    });
+  }
+
+  const expected_genesis_hash = createHash('sha256')
+    .update('TEMPLE_STUART_AUDIT_LOG_GENESIS_v1')
+    .digest('hex');
+
+  if (genesis.content_hash !== expected_genesis_hash) {
+    result.is_valid = false;
+    result.notes.push(
+      `genesis content_hash mismatch — expected ${expected_genesis_hash}, got ${genesis.content_hash}`
+    );
+  }
+
+  for (let i = 1; i < rows.length; i++) {
+    const prev = rows[i - 1];
+    const curr = rows[i];
+
+    if (curr.prev_hash !== prev.content_hash) {
+      result.is_valid = false;
+      result.break_points.push({
+        sequence_number: curr.sequence_number,
+        expected_hash: prev.content_hash,
+        actual_hash: curr.prev_hash,
+        reason: `chain broken: row ${curr.sequence_number} prev_hash does not match row ${prev.sequence_number} content_hash`,
+      });
+    }
+
+    const reconstructed_content = JSON.stringify({
+      prev_hash: curr.prev_hash,
+      actor_user_id: curr.actor_user_id,
+      actor_email: curr.actor_email,
+      actor_type: curr.actor_type,
+      action_type: curr.action_type,
+      action_description: curr.action_description,
+      target_table: curr.target_table,
+      target_id: curr.target_id,
+      payload_before: curr.payload_before,
+      payload_after: curr.payload_after,
+      payload_metadata: curr.payload_metadata,
+      request_id: curr.request_id,
+    });
+    const expected_hash = createHash('sha256').update(reconstructed_content).digest('hex');
+
+    if (curr.content_hash !== expected_hash) {
+      result.is_valid = false;
+      result.break_points.push({
+        sequence_number: curr.sequence_number,
+        expected_hash,
+        actual_hash: curr.content_hash,
+        reason: `content_hash does not match row content — possible tampering or schema drift`,
+      });
+    }
+  }
+
+  if (result.break_points.length === 0 && result.is_valid) {
+    result.notes.push('chain integrity verified — all rows hash-linked correctly');
+  }
+
+  return result;
+}

--- a/src/lib/audit/writeAuditLog.ts
+++ b/src/lib/audit/writeAuditLog.ts
@@ -1,0 +1,91 @@
+import { AuditActorType, AuditActionType, audit_log } from '@prisma/client';
+import { createHash } from 'crypto';
+import { prisma } from '@/lib/prisma';
+
+export interface WriteAuditLogInput {
+  actor: {
+    user_id?: string | null;
+    email?: string | null;
+    type: AuditActorType;
+    session_id?: string | null;
+    ip?: string | null;
+  };
+  action: {
+    type: AuditActionType;
+    description: string;
+  };
+  target: {
+    table: string;
+    id?: string | null;
+  };
+  payload?: {
+    before?: unknown;
+    after?: unknown;
+    metadata?: unknown;
+  };
+  request_id?: string;
+  user_agent?: string;
+}
+
+export async function writeAuditLog(input: WriteAuditLogInput): Promise<audit_log> {
+  if (input.request_id) {
+    const existing = await prisma.audit_log.findFirst({
+      where: { request_id: input.request_id },
+    });
+    if (existing) return existing;
+  }
+
+  return await prisma.$transaction(
+    async (tx) => {
+      const prev = await tx.audit_log.findFirst({
+        orderBy: { sequence_number: 'desc' },
+      });
+
+      if (!prev) {
+        throw new Error(
+          'audit_log has no rows — genesis row missing. ' +
+            'PR-C migration should have inserted the genesis row.'
+        );
+      }
+
+      const content = JSON.stringify({
+        prev_hash: prev.content_hash,
+        actor_user_id: input.actor.user_id ?? null,
+        actor_email: input.actor.email ?? null,
+        actor_type: input.actor.type,
+        action_type: input.action.type,
+        action_description: input.action.description,
+        target_table: input.target.table,
+        target_id: input.target.id ?? null,
+        payload_before: input.payload?.before ?? null,
+        payload_after: input.payload?.after ?? null,
+        payload_metadata: input.payload?.metadata ?? null,
+        request_id: input.request_id ?? null,
+      });
+
+      const content_hash = createHash('sha256').update(content).digest('hex');
+
+      return await tx.audit_log.create({
+        data: {
+          prev_hash: prev.content_hash,
+          content_hash,
+          actor_user_id: input.actor.user_id ?? null,
+          actor_email: input.actor.email ?? null,
+          actor_type: input.actor.type,
+          actor_session_id: input.actor.session_id ?? null,
+          actor_ip: input.actor.ip ?? null,
+          action_type: input.action.type,
+          action_description: input.action.description,
+          target_table: input.target.table,
+          target_id: input.target.id ?? null,
+          payload_before: input.payload?.before ?? undefined,
+          payload_after: input.payload?.after ?? undefined,
+          payload_metadata: input.payload?.metadata ?? undefined,
+          request_id: input.request_id ?? null,
+          user_agent: input.user_agent ?? null,
+        },
+      });
+    },
+    { isolationLevel: 'Serializable' }
+  );
+}


### PR DESCRIPTION
CREATED:
- audit_log table with hash chain (prev_hash + content_hash columns), monotonic sequence_number, full actor/action/target/payload schema
- 2 enums: AuditActorType, AuditActionType (38 action values covering citations, tasks, missions, projects, AI events, system)
- SOC 2 triggers: prevent_audit_log_update / _delete (matches journal_entries pattern — append-only)
- Hash-chain CHECK constraint (GENESIS or 64-char SHA-256)
- Genesis row inserted in migration (chain anchor)
- src/lib/audit/writeAuditLog.ts (idempotent on request_id, transactional with SERIALIZABLE isolation)
- src/lib/audit/verifyAuditChain.ts (full chain walk + content hash verification)
- API: GET /api/audit-log, POST /api/audit-log/verify-chain
- UI: /ops/audit-log (chain status indicator + filterable timeline with expandable rows showing before/after payloads)

WIRED:
- src/app/api/citations/[id]/verify/route.ts now writes an audit_log entry on every citation verification (action_type: citation_verified)

Verified: prisma generate, tsc --noEmit pass clean.

https://claude.ai/code/session_01GQeiwocJDnF2N3pU1q7Y8t