### PR TITLE
PR-D: Missions, projects, workstreams, compliance_tasks (institutiona…

### DIFF
--- a/prisma/migrations/20260501000000_pr_d_tasks_schema/migration.sql
+++ b/prisma/migrations/20260501000000_pr_d_tasks_schema/migration.sql
@@ -1,0 +1,188 @@
+-- =================================================================
+-- PR-D: Missions, Projects, Workstreams, Compliance Tasks
+-- Institutional schema with RACI, FAIR risk, lifecycle clocks
+-- =================================================================
+
+-- STEP 1: Create enums
+CREATE TYPE "MissionStatus" AS ENUM ('draft', 'active', 'paused', 'blocked', 'completed', 'cancelled', 'archived');
+CREATE TYPE "ProjectStatus" AS ENUM ('not_started', 'in_progress', 'blocked', 'completed', 'cancelled', 'archived');
+CREATE TYPE "WorkstreamStatus" AS ENUM ('not_started', 'in_progress', 'blocked', 'completed', 'not_applicable');
+CREATE TYPE "TaskStatus" AS ENUM ('proposed', 'scoped', 'scheduled', 'in_progress', 'blocked', 'awaiting_evidence', 'awaiting_attestation', 'completed', 'superseded', 'cancelled');
+CREATE TYPE "TaskPriorityTier" AS ENUM ('required_now', 'before_charging_users', 'at_scale', 'best_practice');
+CREATE TYPE "DueDateBasis" AS ENUM ('regulatory_deadline', 'internal_target', 'risk_based', 'vendor_sla', 'not_applicable');
+CREATE TYPE "MonitoringFrequency" AS ENUM ('continuous', 'daily', 'weekly', 'monthly', 'quarterly', 'annual', 'event_driven', 'not_applicable');
+CREATE TYPE "AttestationFrequency" AS ENUM ('per_change', 'monthly', 'quarterly', 'semi_annual', 'annual', 'biennial', 'not_applicable');
+CREATE TYPE "ResidualRiskLevel" AS ENUM ('very_low', 'low', 'moderate', 'high', 'very_high');
+CREATE TYPE "AttestationStatus" AS ENUM ('not_required', 'pending', 'attested', 'expired', 'revoked');
+
+-- STEP 2: Create missions table
+CREATE TABLE "missions" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "user_id" TEXT NOT NULL,
+    "entity_id" TEXT,
+    "title" VARCHAR(500) NOT NULL,
+    "description" TEXT,
+    "status" "MissionStatus" NOT NULL DEFAULT 'draft',
+    "target_completion" TIMESTAMP(3),
+    "actual_completion" TIMESTAMP(3),
+    "framework_mappings" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "is_active" BOOLEAN NOT NULL DEFAULT true,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "missions_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "missions_user_id_status_idx" ON "missions"("user_id", "status");
+CREATE INDEX "missions_entity_id_idx" ON "missions"("entity_id");
+CREATE INDEX "missions_is_active_idx" ON "missions"("is_active");
+
+ALTER TABLE "missions" ADD CONSTRAINT "missions_user_id_fkey"
+    FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- STEP 3: Create projects table
+CREATE TABLE "projects" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "mission_id" UUID NOT NULL,
+    "title" VARCHAR(500) NOT NULL,
+    "description" TEXT,
+    "domain_label" VARCHAR(255) NOT NULL,
+    "status" "ProjectStatus" NOT NULL DEFAULT 'not_started',
+    "target_completion" TIMESTAMP(3),
+    "display_order" INTEGER NOT NULL DEFAULT 0,
+    "is_active" BOOLEAN NOT NULL DEFAULT true,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "projects_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "projects_mission_id_status_idx" ON "projects"("mission_id", "status");
+CREATE INDEX "projects_is_active_idx" ON "projects"("is_active");
+
+ALTER TABLE "projects" ADD CONSTRAINT "projects_mission_id_fkey"
+    FOREIGN KEY ("mission_id") REFERENCES "missions"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- STEP 4: Create workstreams table
+CREATE TABLE "workstreams" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "project_id" UUID NOT NULL,
+    "title" VARCHAR(500) NOT NULL,
+    "description" TEXT,
+    "status" "WorkstreamStatus" NOT NULL DEFAULT 'not_started',
+    "display_order" INTEGER NOT NULL DEFAULT 0,
+    "is_active" BOOLEAN NOT NULL DEFAULT true,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "workstreams_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "workstreams_project_id_status_idx" ON "workstreams"("project_id", "status");
+CREATE INDEX "workstreams_is_active_idx" ON "workstreams"("is_active");
+
+ALTER TABLE "workstreams" ADD CONSTRAINT "workstreams_project_id_fkey"
+    FOREIGN KEY ("project_id") REFERENCES "projects"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- STEP 5: Create compliance_tasks table
+CREATE TABLE "compliance_tasks" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "workstream_id" UUID NOT NULL,
+    "title" VARCHAR(500) NOT NULL,
+    "description" TEXT NOT NULL,
+    "status" "TaskStatus" NOT NULL DEFAULT 'proposed',
+    "priority_tier" "TaskPriorityTier" NOT NULL,
+    "priority_rationale" TEXT,
+    "inherent_likelihood" "ResidualRiskLevel" NOT NULL,
+    "inherent_impact" "ResidualRiskLevel" NOT NULL,
+    "residual_likelihood" "ResidualRiskLevel",
+    "residual_impact" "ResidualRiskLevel",
+    "penalty_min_amount" DECIMAL(15,2),
+    "penalty_max_amount" DECIMAL(15,2),
+    "penalty_currency" VARCHAR(3) NOT NULL DEFAULT 'USD',
+    "penalty_description" TEXT,
+    "penalty_weight" INTEGER NOT NULL DEFAULT 0,
+    "estimated_effort_hours_min" DECIMAL(6,2),
+    "estimated_effort_hours_max" DECIMAL(6,2),
+    "estimated_cost_min" DECIMAL(15,2),
+    "estimated_cost_max" DECIMAL(15,2),
+    "due_date" TIMESTAMP(3),
+    "due_date_basis" "DueDateBasis" NOT NULL DEFAULT 'not_applicable',
+    "due_date_rationale" TEXT,
+    "monitoring_frequency" "MonitoringFrequency" NOT NULL DEFAULT 'not_applicable',
+    "attestation_frequency" "AttestationFrequency" NOT NULL DEFAULT 'not_applicable',
+    "evidence_freshness_days" INTEGER,
+    "next_regulatory_review_at" TIMESTAMP(3),
+    "accountable_user_id" TEXT,
+    "responsible_user_ids" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "consulted_user_ids" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "informed_user_ids" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "attestation_status" "AttestationStatus" NOT NULL DEFAULT 'not_required',
+    "last_attested_at" TIMESTAMP(3),
+    "last_attested_by" VARCHAR(255),
+    "attestation_expires_at" TIMESTAMP(3),
+    "action_steps" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "display_order" INTEGER NOT NULL DEFAULT 0,
+    "module_relevance" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "framework_mappings" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "calendar_event_id" VARCHAR(255),
+    "scheduled_start" TIMESTAMP(3),
+    "scheduled_end" TIMESTAMP(3),
+    "is_active" BOOLEAN NOT NULL DEFAULT true,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "compliance_tasks_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "compliance_tasks_workstream_id_status_idx" ON "compliance_tasks"("workstream_id", "status");
+CREATE INDEX "compliance_tasks_priority_tier_status_idx" ON "compliance_tasks"("priority_tier", "status");
+CREATE INDEX "compliance_tasks_due_date_idx" ON "compliance_tasks"("due_date");
+CREATE INDEX "compliance_tasks_accountable_user_id_idx" ON "compliance_tasks"("accountable_user_id");
+CREATE INDEX "compliance_tasks_is_active_idx" ON "compliance_tasks"("is_active");
+
+ALTER TABLE "compliance_tasks" ADD CONSTRAINT "compliance_tasks_workstream_id_fkey"
+    FOREIGN KEY ("workstream_id") REFERENCES "workstreams"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "compliance_tasks" ADD CONSTRAINT "compliance_tasks_accountable_user_id_fkey"
+    FOREIGN KEY ("accountable_user_id") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- STEP 6: Create task_citations join table
+CREATE TABLE "task_citations" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "task_id" UUID NOT NULL,
+    "citation_id" UUID NOT NULL,
+    "relevance_note" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "task_citations_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "task_citations_task_id_citation_id_key" ON "task_citations"("task_id", "citation_id");
+CREATE INDEX "task_citations_task_id_idx" ON "task_citations"("task_id");
+CREATE INDEX "task_citations_citation_id_idx" ON "task_citations"("citation_id");
+
+ALTER TABLE "task_citations" ADD CONSTRAINT "task_citations_task_id_fkey"
+    FOREIGN KEY ("task_id") REFERENCES "compliance_tasks"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "task_citations" ADD CONSTRAINT "task_citations_citation_id_fkey"
+    FOREIGN KEY ("citation_id") REFERENCES "citations"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- STEP 7: CHECK constraints on compliance_tasks
+ALTER TABLE "compliance_tasks" ADD CONSTRAINT compliance_tasks_penalty_range_valid
+    CHECK ("penalty_min_amount" IS NULL OR "penalty_max_amount" IS NULL
+           OR "penalty_min_amount" <= "penalty_max_amount");
+
+ALTER TABLE "compliance_tasks" ADD CONSTRAINT compliance_tasks_effort_range_valid
+    CHECK ("estimated_effort_hours_min" IS NULL OR "estimated_effort_hours_max" IS NULL
+           OR "estimated_effort_hours_min" <= "estimated_effort_hours_max");
+
+ALTER TABLE "compliance_tasks" ADD CONSTRAINT compliance_tasks_cost_range_valid
+    CHECK ("estimated_cost_min" IS NULL OR "estimated_cost_max" IS NULL
+           OR "estimated_cost_min" <= "estimated_cost_max");
+
+ALTER TABLE "compliance_tasks" ADD CONSTRAINT compliance_tasks_penalty_weight_valid
+    CHECK ("penalty_weight" >= 0 AND "penalty_weight" <= 100);
+
+ALTER TABLE "compliance_tasks" ADD CONSTRAINT compliance_tasks_evidence_freshness_valid
+    CHECK ("evidence_freshness_days" IS NULL OR "evidence_freshness_days" > 0);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -472,6 +472,8 @@ model users {
   bank_reconciliations    bank_reconciliations[]
   scan_snapshots          scan_snapshots[]
   dailyPlans              daily_plans[]
+  missions                missions[]
+  accountable_tasks       compliance_tasks[]       @relation("task_accountable")
 }
 
 model budgets {
@@ -1960,6 +1962,8 @@ model citations {
   created_at DateTime @default(now())
   updated_at DateTime @updatedAt
 
+  task_citations task_citations[]
+
   @@index([regulatory_source_id])
   @@index([document_type, status])
   @@index([status])
@@ -2061,4 +2065,238 @@ model audit_log {
   @@index([target_table, target_id])
   @@index([created_at])
   @@map("audit_log")
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// MISSIONS / PROJECTS / WORKSTREAMS / COMPLIANCE TASKS
+// Institutional schema — RACI, FAIR risk, lifecycle clocks, citation FKs
+// ═══════════════════════════════════════════════════════════════════
+
+enum MissionStatus {
+  draft
+  active
+  paused
+  blocked
+  completed
+  cancelled
+  archived
+}
+
+enum ProjectStatus {
+  not_started
+  in_progress
+  blocked
+  completed
+  cancelled
+  archived
+}
+
+enum WorkstreamStatus {
+  not_started
+  in_progress
+  blocked
+  completed
+  not_applicable
+}
+
+enum TaskStatus {
+  proposed
+  scoped
+  scheduled
+  in_progress
+  blocked
+  awaiting_evidence
+  awaiting_attestation
+  completed
+  superseded
+  cancelled
+}
+
+enum TaskPriorityTier {
+  required_now
+  before_charging_users
+  at_scale
+  best_practice
+}
+
+enum DueDateBasis {
+  regulatory_deadline
+  internal_target
+  risk_based
+  vendor_sla
+  not_applicable
+}
+
+enum MonitoringFrequency {
+  continuous
+  daily
+  weekly
+  monthly
+  quarterly
+  annual
+  event_driven
+  not_applicable
+}
+
+enum AttestationFrequency {
+  per_change
+  monthly
+  quarterly
+  semi_annual
+  annual
+  biennial
+  not_applicable
+}
+
+enum ResidualRiskLevel {
+  very_low
+  low
+  moderate
+  high
+  very_high
+}
+
+enum AttestationStatus {
+  not_required
+  pending
+  attested
+  expired
+  revoked
+}
+
+model missions {
+  id                 String        @id @default(uuid()) @db.Uuid
+  user_id            String
+  user               users         @relation(fields: [user_id], references: [id], onDelete: Cascade)
+  entity_id          String?
+  title              String        @db.VarChar(500)
+  description        String?       @db.Text
+  status             MissionStatus @default(draft)
+  target_completion  DateTime?
+  actual_completion  DateTime?
+  framework_mappings String[]      @default([])
+  is_active          Boolean       @default(true)
+  created_at         DateTime      @default(now())
+  updated_at         DateTime      @updatedAt
+
+  projects projects[]
+
+  @@index([user_id, status])
+  @@index([entity_id])
+  @@index([is_active])
+  @@map("missions")
+}
+
+model projects {
+  id                String        @id @default(uuid()) @db.Uuid
+  mission_id        String        @db.Uuid
+  mission           missions      @relation(fields: [mission_id], references: [id], onDelete: Cascade)
+  title             String        @db.VarChar(500)
+  description       String?       @db.Text
+  domain_label      String        @db.VarChar(255)
+  status            ProjectStatus @default(not_started)
+  target_completion DateTime?
+  display_order     Int           @default(0)
+  is_active         Boolean       @default(true)
+  created_at        DateTime      @default(now())
+  updated_at        DateTime      @updatedAt
+
+  workstreams workstreams[]
+
+  @@index([mission_id, status])
+  @@index([is_active])
+  @@map("projects")
+}
+
+model workstreams {
+  id            String           @id @default(uuid()) @db.Uuid
+  project_id    String           @db.Uuid
+  project       projects         @relation(fields: [project_id], references: [id], onDelete: Cascade)
+  title         String           @db.VarChar(500)
+  description   String?          @db.Text
+  status        WorkstreamStatus @default(not_started)
+  display_order Int              @default(0)
+  is_active     Boolean          @default(true)
+  created_at    DateTime         @default(now())
+  updated_at    DateTime         @updatedAt
+
+  tasks compliance_tasks[]
+
+  @@index([project_id, status])
+  @@index([is_active])
+  @@map("workstreams")
+}
+
+model compliance_tasks {
+  id                         String               @id @default(uuid()) @db.Uuid
+  workstream_id              String               @db.Uuid
+  workstream                 workstreams          @relation(fields: [workstream_id], references: [id], onDelete: Cascade)
+  title                      String               @db.VarChar(500)
+  description                String               @db.Text
+  status                     TaskStatus           @default(proposed)
+  priority_tier              TaskPriorityTier
+  priority_rationale         String?              @db.Text
+  inherent_likelihood        ResidualRiskLevel
+  inherent_impact            ResidualRiskLevel
+  residual_likelihood        ResidualRiskLevel?
+  residual_impact            ResidualRiskLevel?
+  penalty_min_amount         Decimal?             @db.Decimal(15, 2)
+  penalty_max_amount         Decimal?             @db.Decimal(15, 2)
+  penalty_currency           String               @default("USD") @db.VarChar(3)
+  penalty_description        String?              @db.Text
+  penalty_weight             Int                  @default(0)
+  estimated_effort_hours_min Decimal?             @db.Decimal(6, 2)
+  estimated_effort_hours_max Decimal?             @db.Decimal(6, 2)
+  estimated_cost_min         Decimal?             @db.Decimal(15, 2)
+  estimated_cost_max         Decimal?             @db.Decimal(15, 2)
+  due_date                   DateTime?
+  due_date_basis             DueDateBasis         @default(not_applicable)
+  due_date_rationale         String?              @db.Text
+  monitoring_frequency       MonitoringFrequency  @default(not_applicable)
+  attestation_frequency      AttestationFrequency @default(not_applicable)
+  evidence_freshness_days    Int?
+  next_regulatory_review_at  DateTime?
+  accountable_user_id        String?
+  accountable                users?               @relation("task_accountable", fields: [accountable_user_id], references: [id])
+  responsible_user_ids       String[]             @default([])
+  consulted_user_ids         String[]             @default([])
+  informed_user_ids          String[]             @default([])
+  attestation_status         AttestationStatus    @default(not_required)
+  last_attested_at           DateTime?
+  last_attested_by           String?              @db.VarChar(255)
+  attestation_expires_at     DateTime?
+  action_steps               String[]             @default([])
+  display_order              Int                  @default(0)
+  module_relevance           String[]             @default([])
+  framework_mappings         String[]             @default([])
+  calendar_event_id          String?              @db.VarChar(255)
+  scheduled_start            DateTime?
+  scheduled_end              DateTime?
+  is_active                  Boolean              @default(true)
+  created_at                 DateTime             @default(now())
+  updated_at                 DateTime             @updatedAt
+
+  citations task_citations[]
+
+  @@index([workstream_id, status])
+  @@index([priority_tier, status])
+  @@index([due_date])
+  @@index([accountable_user_id])
+  @@index([is_active])
+  @@map("compliance_tasks")
+}
+
+model task_citations {
+  id             String           @id @default(uuid()) @db.Uuid
+  task_id        String           @db.Uuid
+  task           compliance_tasks @relation(fields: [task_id], references: [id], onDelete: Cascade)
+  citation_id    String           @db.Uuid
+  citation       citations        @relation(fields: [citation_id], references: [id], onDelete: Restrict)
+  relevance_note String?          @db.Text
+  created_at     DateTime         @default(now())
+
+  @@unique([task_id, citation_id])
+  @@index([task_id])
+  @@index([citation_id])
+  @@map("task_citations")
 }

--- a/src/app/api/compliance-tasks/[id]/citations/[citationId]/route.ts
+++ b/src/app/api/compliance-tasks/[id]/citations/[citationId]/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { writeAuditLog } from '@/lib/audit/writeAuditLog';
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string; citationId: string }> }
+) {
+  try {
+    const { id, citationId } = await params;
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const user = await prisma.users.findFirst({ where: { email: { equals: userEmail, mode: 'insensitive' } } });
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+
+    // Verify task ownership via chain
+    const task = await prisma.compliance_tasks.findUnique({
+      where: { id },
+      include: { workstream: { include: { project: { include: { mission: true } } } } },
+    });
+    if (!task || task.workstream.project.mission.user_id !== user.id) {
+      return NextResponse.json({ error: 'Not found' }, { status: 404 });
+    }
+
+    // Find the task_citation row by composite unique (task_id + citation_id)
+    const taskCitation = await prisma.task_citations.findUnique({
+      where: { task_id_citation_id: { task_id: id, citation_id: citationId } },
+    });
+    if (!taskCitation) {
+      return NextResponse.json({ error: 'Citation link not found' }, { status: 404 });
+    }
+
+    await prisma.task_citations.delete({
+      where: { id: taskCitation.id },
+    });
+
+    await writeAuditLog({
+      actor: { user_id: user.id, email: userEmail, type: 'human_user' },
+      action: { type: 'task_evidence_attached', description: `Detached citation from task "${task.title}"` },
+      target: { table: 'task_citations', id: taskCitation.id },
+      payload: {
+        before: taskCitation,
+        metadata: { task_id: id, citation_id: citationId, action: 'detached' },
+      },
+    });
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('[TaskCitations DELETE]', error);
+    return NextResponse.json({ error: 'Failed to detach citation' }, { status: 500 });
+  }
+}

--- a/src/app/api/compliance-tasks/[id]/citations/route.ts
+++ b/src/app/api/compliance-tasks/[id]/citations/route.ts
@@ -1,0 +1,58 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { writeAuditLog } from '@/lib/audit/writeAuditLog';
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const user = await prisma.users.findFirst({ where: { email: { equals: userEmail, mode: 'insensitive' } } });
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+
+    // Verify task ownership via chain
+    const task = await prisma.compliance_tasks.findUnique({
+      where: { id },
+      include: { workstream: { include: { project: { include: { mission: true } } } } },
+    });
+    if (!task || task.workstream.project.mission.user_id !== user.id) {
+      return NextResponse.json({ error: 'Not found' }, { status: 404 });
+    }
+
+    const body = await request.json();
+    const { citation_id, relevance_note } = body;
+
+    if (!citation_id) {
+      return NextResponse.json({ error: 'citation_id is required' }, { status: 400 });
+    }
+
+    const taskCitation = await prisma.task_citations.create({
+      data: {
+        task_id: id,
+        citation_id,
+        relevance_note: relevance_note ?? null,
+      },
+      include: { citation: true },
+    });
+
+    await writeAuditLog({
+      actor: { user_id: user.id, email: userEmail, type: 'human_user' },
+      action: { type: 'task_evidence_attached', description: `Attached citation to task "${task.title}"` },
+      target: { table: 'task_citations', id: taskCitation.id },
+      payload: {
+        after: taskCitation,
+        metadata: { task_id: id, citation_id, action: 'attached' },
+      },
+    });
+
+    return NextResponse.json(taskCitation, { status: 201 });
+  } catch (error) {
+    console.error('[TaskCitations POST]', error);
+    return NextResponse.json({ error: 'Failed to attach citation' }, { status: 500 });
+  }
+}

--- a/src/app/api/compliance-tasks/[id]/route.ts
+++ b/src/app/api/compliance-tasks/[id]/route.ts
@@ -1,0 +1,172 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { writeAuditLog } from '@/lib/audit/writeAuditLog';
+
+async function getAuthUser(userEmail: string) {
+  return prisma.users.findFirst({ where: { email: { equals: userEmail, mode: 'insensitive' } } });
+}
+
+async function getTaskWithOwnership(id: string) {
+  return prisma.compliance_tasks.findUnique({
+    where: { id },
+    include: { workstream: { include: { project: { include: { mission: true } } } } },
+  });
+}
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const user = await getAuthUser(userEmail);
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+
+    const task = await prisma.compliance_tasks.findUnique({
+      where: { id },
+      include: {
+        workstream: { include: { project: { include: { mission: true } } } },
+        citations: {
+          include: { citation: true },
+        },
+      },
+    });
+
+    if (!task || task.workstream.project.mission.user_id !== user.id) {
+      return NextResponse.json({ error: 'Not found' }, { status: 404 });
+    }
+
+    return NextResponse.json(task);
+  } catch (error) {
+    console.error('[ComplianceTask GET]', error);
+    return NextResponse.json({ error: 'Failed to load task' }, { status: 500 });
+  }
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const user = await getAuthUser(userEmail);
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+
+    const existing = await getTaskWithOwnership(id);
+    if (!existing || existing.workstream.project.mission.user_id !== user.id) {
+      return NextResponse.json({ error: 'Not found' }, { status: 404 });
+    }
+
+    const body = await request.json();
+    const allowedFields = [
+      'title', 'description', 'status', 'priority_tier',
+      'priority_rationale', 'inherent_likelihood', 'inherent_impact',
+      'residual_likelihood', 'residual_impact',
+      'penalty_min_amount', 'penalty_max_amount', 'penalty_currency',
+      'penalty_description', 'penalty_weight',
+      'estimated_effort_hours_min', 'estimated_effort_hours_max',
+      'estimated_cost_min', 'estimated_cost_max',
+      'due_date', 'due_date_basis', 'due_date_rationale',
+      'monitoring_frequency', 'attestation_frequency',
+      'evidence_freshness_days', 'next_regulatory_review_at',
+      'accountable_user_id', 'responsible_user_ids',
+      'consulted_user_ids', 'informed_user_ids',
+      'attestation_status', 'last_attested_at', 'last_attested_by',
+      'attestation_expires_at',
+      'action_steps', 'display_order', 'module_relevance',
+      'framework_mappings', 'calendar_event_id',
+      'scheduled_start', 'scheduled_end', 'is_active',
+    ];
+
+    const dateFields = [
+      'due_date', 'next_regulatory_review_at', 'scheduled_start',
+      'scheduled_end', 'last_attested_at', 'attestation_expires_at',
+    ];
+
+    const data: Record<string, unknown> = {};
+    for (const field of allowedFields) {
+      if (body[field] !== undefined) {
+        if (dateFields.includes(field)) {
+          data[field] = body[field] ? new Date(body[field]) : null;
+        } else {
+          data[field] = body[field];
+        }
+      }
+    }
+
+    const task = await prisma.compliance_tasks.update({
+      where: { id },
+      data,
+    });
+
+    await writeAuditLog({
+      actor: { user_id: user.id, email: userEmail, type: 'human_user' },
+      action: { type: 'task_updated', description: `Updated compliance task "${task.title}"` },
+      target: { table: 'compliance_tasks', id: task.id },
+      payload: { before: existing, after: task },
+    });
+
+    if (body.status !== undefined && body.status !== existing.status) {
+      await writeAuditLog({
+        actor: { user_id: user.id, email: userEmail, type: 'human_user' },
+        action: {
+          type: 'task_status_changed',
+          description: `Task status changed from ${existing.status} to ${body.status}`,
+        },
+        target: { table: 'compliance_tasks', id: task.id },
+        payload: {
+          before: { status: existing.status },
+          after: { status: task.status },
+        },
+      });
+    }
+
+    return NextResponse.json(task);
+  } catch (error) {
+    console.error('[ComplianceTask PATCH]', error);
+    return NextResponse.json({ error: 'Failed to update task' }, { status: 500 });
+  }
+}
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const user = await getAuthUser(userEmail);
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+
+    const existing = await getTaskWithOwnership(id);
+    if (!existing || existing.workstream.project.mission.user_id !== user.id) {
+      return NextResponse.json({ error: 'Not found' }, { status: 404 });
+    }
+
+    const task = await prisma.compliance_tasks.update({
+      where: { id },
+      data: { is_active: false },
+    });
+
+    await writeAuditLog({
+      actor: { user_id: user.id, email: userEmail, type: 'human_user' },
+      action: { type: 'task_deleted', description: `Soft-deleted compliance task "${task.title}"` },
+      target: { table: 'compliance_tasks', id: task.id },
+      payload: { before: existing, after: task },
+    });
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('[ComplianceTask DELETE]', error);
+    return NextResponse.json({ error: 'Failed to delete task' }, { status: 500 });
+  }
+}

--- a/src/app/api/compliance-tasks/route.ts
+++ b/src/app/api/compliance-tasks/route.ts
@@ -1,0 +1,184 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { writeAuditLog } from '@/lib/audit/writeAuditLog';
+
+export async function GET(request: NextRequest) {
+  try {
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const user = await prisma.users.findFirst({ where: { email: { equals: userEmail, mode: 'insensitive' } } });
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+
+    const { searchParams } = new URL(request.url);
+    const workstream_id = searchParams.get('workstream_id');
+    const status = searchParams.get('status');
+    const priority_tier = searchParams.get('priority_tier');
+    const accountable_user_id = searchParams.get('accountable_user_id');
+    const due_before = searchParams.get('due_before');
+    const due_after = searchParams.get('due_after');
+
+    if (!workstream_id) {
+      return NextResponse.json({ error: 'workstream_id is required' }, { status: 400 });
+    }
+
+    // Verify ownership via workstream -> project -> mission chain
+    const workstream = await prisma.workstreams.findUnique({
+      where: { id: workstream_id },
+      include: { project: { include: { mission: true } } },
+    });
+    if (!workstream || workstream.project.mission.user_id !== user.id) {
+      return NextResponse.json({ error: 'Not found' }, { status: 404 });
+    }
+
+    const where: Record<string, unknown> = { workstream_id, is_active: true };
+    if (status) where.status = status;
+    if (priority_tier) where.priority_tier = priority_tier;
+    if (accountable_user_id) where.accountable_user_id = accountable_user_id;
+
+    if (due_before || due_after) {
+      const dueDateFilter: Record<string, Date> = {};
+      if (due_before) dueDateFilter.lte = new Date(due_before);
+      if (due_after) dueDateFilter.gte = new Date(due_after);
+      where.due_date = dueDateFilter;
+    }
+
+    const tasks = await prisma.compliance_tasks.findMany({
+      where,
+      orderBy: [{ display_order: 'asc' }, { created_at: 'desc' }],
+      take: 200,
+    });
+
+    return NextResponse.json({ count: tasks.length, tasks });
+  } catch (error) {
+    console.error('[ComplianceTasks GET]', error);
+    return NextResponse.json({ error: 'Failed to load tasks' }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const user = await prisma.users.findFirst({ where: { email: { equals: userEmail, mode: 'insensitive' } } });
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+
+    const body = await request.json();
+    const {
+      workstream_id,
+      title,
+      description,
+      priority_tier,
+      inherent_likelihood,
+      inherent_impact,
+      citation_ids,
+      ...optionalFields
+    } = body;
+
+    if (!workstream_id || !title || !description || !priority_tier || !inherent_likelihood || !inherent_impact) {
+      return NextResponse.json(
+        { error: 'workstream_id, title, description, priority_tier, inherent_likelihood, and inherent_impact are required' },
+        { status: 400 },
+      );
+    }
+
+    // Verify ownership via workstream -> project -> mission chain
+    const workstream = await prisma.workstreams.findUnique({
+      where: { id: workstream_id },
+      include: { project: { include: { mission: true } } },
+    });
+    if (!workstream || workstream.project.mission.user_id !== user.id) {
+      return NextResponse.json({ error: 'Workstream not found' }, { status: 404 });
+    }
+
+    // Build data object with allowed optional fields
+    const allowedOptional = [
+      'priority_rationale',
+      'residual_likelihood',
+      'residual_impact',
+      'penalty_min_amount',
+      'penalty_max_amount',
+      'penalty_currency',
+      'penalty_description',
+      'penalty_weight',
+      'estimated_effort_hours_min',
+      'estimated_effort_hours_max',
+      'estimated_cost_min',
+      'estimated_cost_max',
+      'due_date',
+      'due_date_basis',
+      'due_date_rationale',
+      'monitoring_frequency',
+      'attestation_frequency',
+      'evidence_freshness_days',
+      'next_regulatory_review_at',
+      'accountable_user_id',
+      'responsible_user_ids',
+      'consulted_user_ids',
+      'informed_user_ids',
+      'attestation_status',
+      'action_steps',
+      'display_order',
+      'module_relevance',
+      'framework_mappings',
+      'calendar_event_id',
+      'scheduled_start',
+      'scheduled_end',
+    ];
+
+    const data: Record<string, unknown> = {
+      workstream_id,
+      title,
+      description,
+      priority_tier,
+      inherent_likelihood,
+      inherent_impact,
+    };
+
+    const dateFields = [
+      'due_date', 'next_regulatory_review_at', 'scheduled_start', 'scheduled_end',
+    ];
+
+    for (const field of allowedOptional) {
+      if (optionalFields[field] !== undefined) {
+        if (dateFields.includes(field)) {
+          data[field] = optionalFields[field] ? new Date(optionalFields[field]) : null;
+        } else {
+          data[field] = optionalFields[field];
+        }
+      }
+    }
+
+    // If citation_ids provided, create task_citations in the same operation
+    if (Array.isArray(citation_ids) && citation_ids.length > 0) {
+      data.citations = {
+        create: citation_ids.map((cid: string) => ({
+          citation_id: cid,
+        })),
+      };
+    }
+
+    const task = await prisma.compliance_tasks.create({
+      data: data as any,
+      include: {
+        citations: {
+          include: { citation: true },
+        },
+      },
+    });
+
+    await writeAuditLog({
+      actor: { user_id: user.id, email: userEmail, type: 'human_user' },
+      action: { type: 'task_created', description: `Created compliance task "${title}"` },
+      target: { table: 'compliance_tasks', id: task.id },
+      payload: { after: task },
+    });
+
+    return NextResponse.json(task, { status: 201 });
+  } catch (error) {
+    console.error('[ComplianceTasks POST]', error);
+    return NextResponse.json({ error: 'Failed to create task' }, { status: 500 });
+  }
+}

--- a/src/app/api/missions/[id]/route.ts
+++ b/src/app/api/missions/[id]/route.ts
@@ -1,0 +1,155 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { writeAuditLog } from '@/lib/audit/writeAuditLog';
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const user = await prisma.users.findFirst({ where: { email: { equals: userEmail, mode: 'insensitive' } } });
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+
+    const mission = await prisma.missions.findUnique({
+      where: { id },
+      include: {
+        projects: {
+          where: { is_active: true },
+          include: {
+            workstreams: {
+              where: { is_active: true },
+              include: {
+                tasks: {
+                  where: { is_active: true },
+                  include: {
+                    citations: {
+                      include: { citation: true },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    if (!mission || mission.user_id !== user.id) {
+      return NextResponse.json({ error: 'Not found' }, { status: 404 });
+    }
+
+    return NextResponse.json(mission);
+  } catch (error) {
+    console.error('[Mission GET]', error);
+    return NextResponse.json({ error: 'Failed to load mission' }, { status: 500 });
+  }
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const user = await prisma.users.findFirst({ where: { email: { equals: userEmail, mode: 'insensitive' } } });
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+
+    const existing = await prisma.missions.findUnique({ where: { id } });
+    if (!existing || existing.user_id !== user.id) {
+      return NextResponse.json({ error: 'Not found' }, { status: 404 });
+    }
+
+    const body = await request.json();
+    const allowedFields = [
+      'title', 'description', 'status', 'target_completion',
+      'actual_completion', 'framework_mappings', 'is_active',
+    ];
+
+    const data: Record<string, unknown> = {};
+    for (const field of allowedFields) {
+      if (body[field] !== undefined) {
+        if (field === 'target_completion' || field === 'actual_completion') {
+          data[field] = body[field] ? new Date(body[field]) : null;
+        } else {
+          data[field] = body[field];
+        }
+      }
+    }
+
+    const mission = await prisma.missions.update({
+      where: { id },
+      data,
+    });
+
+    await writeAuditLog({
+      actor: { user_id: user.id, email: userEmail, type: 'human_user' },
+      action: { type: 'mission_updated', description: `Updated mission "${mission.title}"` },
+      target: { table: 'missions', id: mission.id },
+      payload: { before: existing, after: mission },
+    });
+
+    if (body.status !== undefined && body.status !== existing.status) {
+      await writeAuditLog({
+        actor: { user_id: user.id, email: userEmail, type: 'human_user' },
+        action: {
+          type: 'mission_status_changed',
+          description: `Mission status changed from ${existing.status} to ${body.status}`,
+        },
+        target: { table: 'missions', id: mission.id },
+        payload: {
+          before: { status: existing.status },
+          after: { status: mission.status },
+        },
+      });
+    }
+
+    return NextResponse.json(mission);
+  } catch (error) {
+    console.error('[Mission PATCH]', error);
+    return NextResponse.json({ error: 'Failed to update mission' }, { status: 500 });
+  }
+}
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const user = await prisma.users.findFirst({ where: { email: { equals: userEmail, mode: 'insensitive' } } });
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+
+    const existing = await prisma.missions.findUnique({ where: { id } });
+    if (!existing || existing.user_id !== user.id) {
+      return NextResponse.json({ error: 'Not found' }, { status: 404 });
+    }
+
+    const mission = await prisma.missions.update({
+      where: { id },
+      data: { is_active: false },
+    });
+
+    await writeAuditLog({
+      actor: { user_id: user.id, email: userEmail, type: 'human_user' },
+      action: { type: 'mission_deleted', description: `Soft-deleted mission "${mission.title}"` },
+      target: { table: 'missions', id: mission.id },
+      payload: { before: existing, after: mission },
+    });
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('[Mission DELETE]', error);
+    return NextResponse.json({ error: 'Failed to delete mission' }, { status: 500 });
+  }
+}

--- a/src/app/api/missions/route.ts
+++ b/src/app/api/missions/route.ts
@@ -1,0 +1,79 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { writeAuditLog } from '@/lib/audit/writeAuditLog';
+
+export async function GET(request: NextRequest) {
+  try {
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const user = await prisma.users.findFirst({ where: { email: { equals: userEmail, mode: 'insensitive' } } });
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+
+    const { searchParams } = new URL(request.url);
+    const status = searchParams.get('status');
+    const entity_id = searchParams.get('entity_id');
+    const is_active = searchParams.get('is_active');
+
+    const where: Record<string, unknown> = { user_id: user.id };
+    if (status) where.status = status;
+    if (entity_id) where.entity_id = entity_id;
+    if (is_active !== null && is_active !== undefined && is_active !== '') {
+      where.is_active = is_active === 'true';
+    } else {
+      where.is_active = true;
+    }
+
+    const missions = await prisma.missions.findMany({
+      where,
+      orderBy: { created_at: 'desc' },
+      take: 100,
+    });
+
+    return NextResponse.json({ count: missions.length, missions });
+  } catch (error) {
+    console.error('[Missions GET]', error);
+    return NextResponse.json({ error: 'Failed to load missions' }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const user = await prisma.users.findFirst({ where: { email: { equals: userEmail, mode: 'insensitive' } } });
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+
+    const body = await request.json();
+    const { title, description, entity_id, target_completion, framework_mappings } = body;
+
+    if (!title) {
+      return NextResponse.json({ error: 'title is required' }, { status: 400 });
+    }
+
+    const mission = await prisma.missions.create({
+      data: {
+        user_id: user.id,
+        title,
+        description: description ?? null,
+        entity_id: entity_id ?? null,
+        target_completion: target_completion ? new Date(target_completion) : null,
+        framework_mappings: framework_mappings ?? [],
+      },
+    });
+
+    await writeAuditLog({
+      actor: { user_id: user.id, email: userEmail, type: 'human_user' },
+      action: { type: 'mission_created', description: `Created mission "${title}"` },
+      target: { table: 'missions', id: mission.id },
+      payload: { after: mission },
+    });
+
+    return NextResponse.json(mission, { status: 201 });
+  } catch (error) {
+    console.error('[Missions POST]', error);
+    return NextResponse.json({ error: 'Failed to create mission' }, { status: 500 });
+  }
+}

--- a/src/app/api/projects/[id]/route.ts
+++ b/src/app/api/projects/[id]/route.ts
@@ -1,0 +1,147 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { writeAuditLog } from '@/lib/audit/writeAuditLog';
+
+async function getAuthUser(userEmail: string) {
+  return prisma.users.findFirst({ where: { email: { equals: userEmail, mode: 'insensitive' } } });
+}
+
+async function getProjectWithOwnership(id: string) {
+  return prisma.projects.findUnique({
+    where: { id },
+    include: { mission: true },
+  });
+}
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const user = await getAuthUser(userEmail);
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+
+    const project = await prisma.projects.findUnique({
+      where: { id },
+      include: {
+        mission: true,
+        workstreams: {
+          where: { is_active: true },
+          include: {
+            tasks: {
+              where: { is_active: true },
+              include: {
+                citations: {
+                  include: { citation: true },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    if (!project || project.mission.user_id !== user.id) {
+      return NextResponse.json({ error: 'Not found' }, { status: 404 });
+    }
+
+    return NextResponse.json(project);
+  } catch (error) {
+    console.error('[Project GET]', error);
+    return NextResponse.json({ error: 'Failed to load project' }, { status: 500 });
+  }
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const user = await getAuthUser(userEmail);
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+
+    const existing = await getProjectWithOwnership(id);
+    if (!existing || existing.mission.user_id !== user.id) {
+      return NextResponse.json({ error: 'Not found' }, { status: 404 });
+    }
+
+    const body = await request.json();
+    const allowedFields = [
+      'title', 'description', 'domain_label', 'status',
+      'target_completion', 'display_order', 'is_active',
+    ];
+
+    const data: Record<string, unknown> = {};
+    for (const field of allowedFields) {
+      if (body[field] !== undefined) {
+        if (field === 'target_completion') {
+          data[field] = body[field] ? new Date(body[field]) : null;
+        } else {
+          data[field] = body[field];
+        }
+      }
+    }
+
+    const project = await prisma.projects.update({
+      where: { id },
+      data,
+    });
+
+    await writeAuditLog({
+      actor: { user_id: user.id, email: userEmail, type: 'human_user' },
+      action: { type: 'project_updated', description: `Updated project "${project.title}"` },
+      target: { table: 'projects', id: project.id },
+      payload: { before: existing, after: project },
+    });
+
+    return NextResponse.json(project);
+  } catch (error) {
+    console.error('[Project PATCH]', error);
+    return NextResponse.json({ error: 'Failed to update project' }, { status: 500 });
+  }
+}
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const user = await getAuthUser(userEmail);
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+
+    const existing = await getProjectWithOwnership(id);
+    if (!existing || existing.mission.user_id !== user.id) {
+      return NextResponse.json({ error: 'Not found' }, { status: 404 });
+    }
+
+    const project = await prisma.projects.update({
+      where: { id },
+      data: { is_active: false },
+    });
+
+    await writeAuditLog({
+      actor: { user_id: user.id, email: userEmail, type: 'human_user' },
+      action: { type: 'project_deleted', description: `Soft-deleted project "${project.title}"` },
+      target: { table: 'projects', id: project.id },
+      payload: { before: existing, after: project },
+    });
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('[Project DELETE]', error);
+    return NextResponse.json({ error: 'Failed to delete project' }, { status: 500 });
+  }
+}

--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -1,0 +1,87 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { writeAuditLog } from '@/lib/audit/writeAuditLog';
+
+export async function GET(request: NextRequest) {
+  try {
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const user = await prisma.users.findFirst({ where: { email: { equals: userEmail, mode: 'insensitive' } } });
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+
+    const { searchParams } = new URL(request.url);
+    const mission_id = searchParams.get('mission_id');
+    const status = searchParams.get('status');
+
+    if (!mission_id) {
+      return NextResponse.json({ error: 'mission_id is required' }, { status: 400 });
+    }
+
+    // Verify mission ownership
+    const mission = await prisma.missions.findUnique({ where: { id: mission_id } });
+    if (!mission || mission.user_id !== user.id) {
+      return NextResponse.json({ error: 'Not found' }, { status: 404 });
+    }
+
+    const where: Record<string, unknown> = { mission_id, is_active: true };
+    if (status) where.status = status;
+
+    const projects = await prisma.projects.findMany({
+      where,
+      orderBy: { created_at: 'desc' },
+    });
+
+    return NextResponse.json({ count: projects.length, projects });
+  } catch (error) {
+    console.error('[Projects GET]', error);
+    return NextResponse.json({ error: 'Failed to load projects' }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const user = await prisma.users.findFirst({ where: { email: { equals: userEmail, mode: 'insensitive' } } });
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+
+    const body = await request.json();
+    const { mission_id, title, description, domain_label, target_completion, display_order } = body;
+
+    if (!mission_id || !title || !domain_label) {
+      return NextResponse.json({ error: 'mission_id, title, and domain_label are required' }, { status: 400 });
+    }
+
+    // Verify mission ownership
+    const mission = await prisma.missions.findUnique({ where: { id: mission_id } });
+    if (!mission || mission.user_id !== user.id) {
+      return NextResponse.json({ error: 'Mission not found' }, { status: 404 });
+    }
+
+    const project = await prisma.projects.create({
+      data: {
+        mission_id,
+        title,
+        description: description ?? null,
+        domain_label,
+        target_completion: target_completion ? new Date(target_completion) : null,
+        display_order: display_order ?? 0,
+      },
+    });
+
+    await writeAuditLog({
+      actor: { user_id: user.id, email: userEmail, type: 'human_user' },
+      action: { type: 'project_created', description: `Created project "${title}"` },
+      target: { table: 'projects', id: project.id },
+      payload: { after: project },
+    });
+
+    return NextResponse.json(project, { status: 201 });
+  } catch (error) {
+    console.error('[Projects POST]', error);
+    return NextResponse.json({ error: 'Failed to create project' }, { status: 500 });
+  }
+}

--- a/src/app/api/workstreams/[id]/route.ts
+++ b/src/app/api/workstreams/[id]/route.ts
@@ -1,0 +1,135 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { writeAuditLog } from '@/lib/audit/writeAuditLog';
+
+async function getAuthUser(userEmail: string) {
+  return prisma.users.findFirst({ where: { email: { equals: userEmail, mode: 'insensitive' } } });
+}
+
+async function getWorkstreamWithOwnership(id: string) {
+  return prisma.workstreams.findUnique({
+    where: { id },
+    include: { project: { include: { mission: true } } },
+  });
+}
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const user = await getAuthUser(userEmail);
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+
+    const workstream = await prisma.workstreams.findUnique({
+      where: { id },
+      include: {
+        project: { include: { mission: true } },
+        tasks: {
+          where: { is_active: true },
+          include: {
+            citations: {
+              include: { citation: true },
+            },
+          },
+        },
+      },
+    });
+
+    if (!workstream || workstream.project.mission.user_id !== user.id) {
+      return NextResponse.json({ error: 'Not found' }, { status: 404 });
+    }
+
+    return NextResponse.json(workstream);
+  } catch (error) {
+    console.error('[Workstream GET]', error);
+    return NextResponse.json({ error: 'Failed to load workstream' }, { status: 500 });
+  }
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const user = await getAuthUser(userEmail);
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+
+    const existing = await getWorkstreamWithOwnership(id);
+    if (!existing || existing.project.mission.user_id !== user.id) {
+      return NextResponse.json({ error: 'Not found' }, { status: 404 });
+    }
+
+    const body = await request.json();
+    const allowedFields = ['title', 'description', 'status', 'display_order', 'is_active'];
+
+    const data: Record<string, unknown> = {};
+    for (const field of allowedFields) {
+      if (body[field] !== undefined) {
+        data[field] = body[field];
+      }
+    }
+
+    const workstream = await prisma.workstreams.update({
+      where: { id },
+      data,
+    });
+
+    await writeAuditLog({
+      actor: { user_id: user.id, email: userEmail, type: 'human_user' },
+      action: { type: 'workstream_updated', description: `Updated workstream "${workstream.title}"` },
+      target: { table: 'workstreams', id: workstream.id },
+      payload: { before: existing, after: workstream },
+    });
+
+    return NextResponse.json(workstream);
+  } catch (error) {
+    console.error('[Workstream PATCH]', error);
+    return NextResponse.json({ error: 'Failed to update workstream' }, { status: 500 });
+  }
+}
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const user = await getAuthUser(userEmail);
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+
+    const existing = await getWorkstreamWithOwnership(id);
+    if (!existing || existing.project.mission.user_id !== user.id) {
+      return NextResponse.json({ error: 'Not found' }, { status: 404 });
+    }
+
+    const workstream = await prisma.workstreams.update({
+      where: { id },
+      data: { is_active: false },
+    });
+
+    await writeAuditLog({
+      actor: { user_id: user.id, email: userEmail, type: 'human_user' },
+      action: { type: 'workstream_deleted', description: `Soft-deleted workstream "${workstream.title}"` },
+      target: { table: 'workstreams', id: workstream.id },
+      payload: { before: existing, after: workstream },
+    });
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('[Workstream DELETE]', error);
+    return NextResponse.json({ error: 'Failed to delete workstream' }, { status: 500 });
+  }
+}

--- a/src/app/api/workstreams/route.ts
+++ b/src/app/api/workstreams/route.ts
@@ -1,0 +1,91 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { writeAuditLog } from '@/lib/audit/writeAuditLog';
+
+export async function GET(request: NextRequest) {
+  try {
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const user = await prisma.users.findFirst({ where: { email: { equals: userEmail, mode: 'insensitive' } } });
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+
+    const { searchParams } = new URL(request.url);
+    const project_id = searchParams.get('project_id');
+    const status = searchParams.get('status');
+
+    if (!project_id) {
+      return NextResponse.json({ error: 'project_id is required' }, { status: 400 });
+    }
+
+    // Verify ownership via project -> mission chain
+    const project = await prisma.projects.findUnique({
+      where: { id: project_id },
+      include: { mission: true },
+    });
+    if (!project || project.mission.user_id !== user.id) {
+      return NextResponse.json({ error: 'Not found' }, { status: 404 });
+    }
+
+    const where: Record<string, unknown> = { project_id, is_active: true };
+    if (status) where.status = status;
+
+    const workstreams = await prisma.workstreams.findMany({
+      where,
+      orderBy: { created_at: 'desc' },
+    });
+
+    return NextResponse.json({ count: workstreams.length, workstreams });
+  } catch (error) {
+    console.error('[Workstreams GET]', error);
+    return NextResponse.json({ error: 'Failed to load workstreams' }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const user = await prisma.users.findFirst({ where: { email: { equals: userEmail, mode: 'insensitive' } } });
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+
+    const body = await request.json();
+    const { project_id, title, description, display_order } = body;
+
+    if (!project_id || !title) {
+      return NextResponse.json({ error: 'project_id and title are required' }, { status: 400 });
+    }
+
+    // Verify ownership via project -> mission chain
+    const project = await prisma.projects.findUnique({
+      where: { id: project_id },
+      include: { mission: true },
+    });
+    if (!project || project.mission.user_id !== user.id) {
+      return NextResponse.json({ error: 'Project not found' }, { status: 404 });
+    }
+
+    const workstream = await prisma.workstreams.create({
+      data: {
+        project_id,
+        title,
+        description: description ?? null,
+        display_order: display_order ?? 0,
+      },
+    });
+
+    await writeAuditLog({
+      actor: { user_id: user.id, email: userEmail, type: 'human_user' },
+      action: { type: 'workstream_created', description: `Created workstream "${title}"` },
+      target: { table: 'workstreams', id: workstream.id },
+      payload: { after: workstream },
+    });
+
+    return NextResponse.json(workstream, { status: 201 });
+  } catch (error) {
+    console.error('[Workstreams POST]', error);
+    return NextResponse.json({ error: 'Failed to create workstream' }, { status: 500 });
+  }
+}

--- a/src/app/ops/missions/[id]/page.tsx
+++ b/src/app/ops/missions/[id]/page.tsx
@@ -1,0 +1,334 @@
+'use client';
+
+import React, { useState, useEffect, useCallback } from 'react';
+import { useParams } from 'next/navigation';
+import AppLayout from '@/components/ui/AppLayout';
+import OpsSubNav from '@/components/ops/OpsSubNav';
+
+interface Citation { id: string; citation_string: string; status: string; }
+interface TaskCitation { id: string; citation_id: string; relevance_note: string | null; citation: Citation; }
+interface Task {
+  id: string; title: string; description: string; status: string; priority_tier: string;
+  inherent_likelihood: string; inherent_impact: string; due_date: string | null;
+  display_order: number; citations: TaskCitation[]; is_active: boolean;
+  penalty_description: string | null; monitoring_frequency: string; attestation_frequency: string;
+  action_steps: string[]; framework_mappings: string[];
+}
+interface Workstream {
+  id: string; title: string; description: string | null; status: string;
+  display_order: number; is_active: boolean; tasks: Task[];
+}
+interface Project {
+  id: string; title: string; description: string | null; domain_label: string;
+  status: string; display_order: number; is_active: boolean; workstreams: Workstream[];
+}
+interface Mission {
+  id: string; title: string; description: string | null; status: string;
+  target_completion: string | null; actual_completion: string | null;
+  framework_mappings: string[]; is_active: boolean; created_at: string;
+  projects: Project[];
+}
+
+const STATUS_STYLE: Record<string, string> = {
+  draft: 'bg-gray-100 text-gray-600', active: 'bg-emerald-100 text-emerald-800',
+  paused: 'bg-amber-100 text-amber-800', blocked: 'bg-red-100 text-red-800',
+  completed: 'bg-blue-100 text-blue-800', cancelled: 'bg-gray-100 text-gray-500',
+  archived: 'bg-gray-50 text-gray-400', not_started: 'bg-gray-100 text-gray-600',
+  in_progress: 'bg-emerald-100 text-emerald-800', not_applicable: 'bg-gray-50 text-gray-400',
+  proposed: 'bg-gray-100 text-gray-600', scoped: 'bg-blue-100 text-blue-800',
+  scheduled: 'bg-indigo-100 text-indigo-800', awaiting_evidence: 'bg-amber-100 text-amber-800',
+  awaiting_attestation: 'bg-orange-100 text-orange-800', superseded: 'bg-gray-100 text-gray-500',
+};
+const PRIORITY_STYLE: Record<string, string> = {
+  required_now: 'bg-red-100 text-red-800', before_charging_users: 'bg-amber-100 text-amber-800',
+  at_scale: 'bg-blue-100 text-blue-800', best_practice: 'bg-gray-100 text-gray-600',
+};
+const MISSION_STATUSES = ['draft','active','paused','blocked','completed','cancelled','archived'];
+const PRIORITY_TIERS = ['required_now','before_charging_users','at_scale','best_practice'];
+const RISK_LEVELS = ['very_low','low','moderate','high','very_high'];
+
+function Badge({ value, styles }: { value: string; styles: Record<string, string> }) {
+  return (
+    <span className={`text-terminal-sm px-1.5 py-0.5 rounded ${styles[value] || 'bg-gray-100 text-gray-600'}`}>
+      {value.replace(/_/g, ' ')}
+    </span>
+  );
+}
+
+export default function MissionDetailPage() {
+  const params = useParams();
+  const missionId = params.id as string;
+  const [mission, setMission] = useState<Mission | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [editing, setEditing] = useState(false);
+  const [editForm, setEditForm] = useState({ title: '', description: '', status: '', target_completion: '' });
+  const [expandedTasks, setExpandedTasks] = useState<Set<string>>(new Set());
+  const [expandedProjects, setExpandedProjects] = useState<Set<string>>(new Set());
+  const [expandedWorkstreams, setExpandedWorkstreams] = useState<Set<string>>(new Set());
+  const [addingProject, setAddingProject] = useState(false);
+  const [addingWorkstream, setAddingWorkstream] = useState<string | null>(null);
+  const [addingTask, setAddingTask] = useState<string | null>(null);
+  const [newProject, setNewProject] = useState({ title: '', domain_label: '', description: '' });
+  const [newWorkstream, setNewWorkstream] = useState({ title: '', description: '' });
+  const [newTask, setNewTask] = useState({ title: '', description: '', priority_tier: 'required_now', inherent_likelihood: 'moderate', inherent_impact: 'moderate' });
+
+  const fetchMission = useCallback(async () => {
+    try {
+      const res = await fetch(`/api/missions/${missionId}`);
+      if (res.ok) { const data = await res.json(); setMission(data); }
+    } catch (err) { console.error('Failed to load mission:', err); }
+    finally { setLoading(false); }
+  }, [missionId]);
+
+  useEffect(() => { fetchMission(); }, [fetchMission]);
+
+  const handleSave = async () => {
+    const body: Record<string, unknown> = {};
+    if (editForm.title && editForm.title !== mission?.title) body.title = editForm.title;
+    if (editForm.description !== (mission?.description || '')) body.description = editForm.description;
+    if (editForm.status && editForm.status !== mission?.status) body.status = editForm.status;
+    if (editForm.target_completion) body.target_completion = editForm.target_completion;
+    if (Object.keys(body).length === 0) { setEditing(false); return; }
+    await fetch(`/api/missions/${missionId}`, { method: 'PATCH', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
+    setEditing(false);
+    fetchMission();
+  };
+
+  const startEdit = () => {
+    if (!mission) return;
+    setEditForm({ title: mission.title, description: mission.description || '', status: mission.status, target_completion: mission.target_completion?.slice(0, 10) || '' });
+    setEditing(true);
+  };
+
+  const handleAddProject = async () => {
+    if (!newProject.title || !newProject.domain_label) return;
+    await fetch('/api/projects', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ mission_id: missionId, ...newProject }) });
+    setAddingProject(false);
+    setNewProject({ title: '', domain_label: '', description: '' });
+    fetchMission();
+  };
+
+  const handleAddWorkstream = async (projectId: string) => {
+    if (!newWorkstream.title) return;
+    await fetch('/api/workstreams', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ project_id: projectId, ...newWorkstream }) });
+    setAddingWorkstream(null);
+    setNewWorkstream({ title: '', description: '' });
+    fetchMission();
+  };
+
+  const handleAddTask = async (workstreamId: string) => {
+    if (!newTask.title || !newTask.description) return;
+    await fetch('/api/compliance-tasks', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ workstream_id: workstreamId, ...newTask }) });
+    setAddingTask(null);
+    setNewTask({ title: '', description: '', priority_tier: 'required_now', inherent_likelihood: 'moderate', inherent_impact: 'moderate' });
+    fetchMission();
+  };
+
+  const toggle = (set: Set<string>, id: string, setter: React.Dispatch<React.SetStateAction<Set<string>>>) => {
+    const next = new Set(set);
+    if (next.has(id)) next.delete(id); else next.add(id);
+    setter(next);
+  };
+
+  if (loading) {
+    return (<AppLayout><OpsSubNav /><div className="flex items-center justify-center min-h-[40vh]"><div className="flex items-center gap-3"><div className="w-5 h-5 border-2 border-brand-purple border-t-transparent rounded-full animate-spin" /><span className="text-text-muted font-mono text-terminal-base">Loading mission...</span></div></div></AppLayout>);
+  }
+  if (!mission) {
+    return (<AppLayout><OpsSubNav /><div className="max-w-[1600px] mx-auto px-4 pt-8 text-center"><p className="text-text-muted font-mono">Mission not found.</p></div></AppLayout>);
+  }
+
+  return (
+    <AppLayout>
+      <OpsSubNav />
+      <div className="max-w-[1600px] mx-auto px-4 pt-4 pb-8 space-y-4">
+        {/* Mission Header */}
+        <div className="bg-white rounded border border-border shadow-sm p-5">
+          {editing ? (
+            <div className="space-y-3">
+              <input value={editForm.title} onChange={(e) => setEditForm({ ...editForm, title: e.target.value })} className="font-mono text-xl font-bold w-full bg-transparent border border-border rounded px-2 py-1 focus:border-brand-purple outline-none" />
+              <textarea value={editForm.description} onChange={(e) => setEditForm({ ...editForm, description: e.target.value })} rows={3} className="font-mono text-sm w-full bg-transparent border border-border rounded px-2 py-1 focus:border-brand-purple outline-none" />
+              <div className="flex gap-3">
+                <select value={editForm.status} onChange={(e) => setEditForm({ ...editForm, status: e.target.value })} className="font-mono text-sm border border-border rounded px-2 py-1 focus:border-brand-purple outline-none">
+                  {MISSION_STATUSES.map((s) => <option key={s} value={s}>{s.replace(/_/g, ' ')}</option>)}
+                </select>
+                <input type="date" value={editForm.target_completion} onChange={(e) => setEditForm({ ...editForm, target_completion: e.target.value })} className="font-mono text-sm border border-border rounded px-2 py-1 focus:border-brand-purple outline-none" />
+              </div>
+              <div className="flex gap-2">
+                <button onClick={handleSave} className="font-mono text-terminal-sm px-3 py-1 rounded bg-brand-purple text-white hover:bg-brand-purple/90 transition-colors">Save</button>
+                <button onClick={() => setEditing(false)} className="font-mono text-terminal-sm px-3 py-1 rounded border border-border text-text-muted hover:text-text-primary transition-colors">Cancel</button>
+              </div>
+            </div>
+          ) : (
+            <div>
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-3">
+                  <h1 className="text-xl font-bold text-text-primary font-mono">{mission.title}</h1>
+                  <Badge value={mission.status} styles={STATUS_STYLE} />
+                </div>
+                <button onClick={startEdit} className="font-mono text-terminal-sm px-3 py-1 rounded border border-border text-text-muted hover:text-text-primary hover:border-brand-purple transition-colors">Edit</button>
+              </div>
+              {mission.description && <p className="text-terminal-sm text-text-muted font-mono mt-2">{mission.description}</p>}
+              <div className="flex gap-4 mt-2 text-terminal-sm text-text-faint font-mono">
+                {mission.target_completion && <span>Target: {new Date(mission.target_completion).toLocaleDateString()}</span>}
+                {mission.framework_mappings.length > 0 && <span>Frameworks: {mission.framework_mappings.join(', ')}</span>}
+                <span>{mission.projects.length} projects</span>
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* Projects Tree */}
+        {mission.projects.filter((p) => p.is_active).map((project) => (
+          <div key={project.id} className="bg-white rounded border border-border shadow-sm">
+            <button onClick={() => toggle(expandedProjects, project.id, setExpandedProjects)} className="w-full px-5 py-3 flex items-center justify-between hover:bg-gray-50 transition-colors">
+              <div className="flex items-center gap-3">
+                <span className="text-text-faint font-mono text-terminal-sm">{expandedProjects.has(project.id) ? '▼' : '▶'}</span>
+                <span className="font-mono font-medium text-text-primary">{project.title}</span>
+                <span className="text-terminal-sm font-mono bg-brand-purple/10 text-brand-purple px-1.5 py-0.5 rounded">{project.domain_label}</span>
+                <Badge value={project.status} styles={STATUS_STYLE} />
+              </div>
+              <span className="text-terminal-sm text-text-faint font-mono">{project.workstreams.length} workstreams</span>
+            </button>
+
+            {expandedProjects.has(project.id) && (
+              <div className="border-t border-border px-5 pb-4">
+                {project.workstreams.filter((w) => w.is_active).map((ws) => (
+                  <div key={ws.id} className="mt-3 border border-border-light rounded">
+                    <button onClick={() => toggle(expandedWorkstreams, ws.id, setExpandedWorkstreams)} className="w-full px-4 py-2 flex items-center justify-between hover:bg-gray-50 transition-colors">
+                      <div className="flex items-center gap-3">
+                        <span className="text-text-faint font-mono text-terminal-sm">{expandedWorkstreams.has(ws.id) ? '▼' : '▶'}</span>
+                        <span className="font-mono text-sm text-text-primary">{ws.title}</span>
+                        <Badge value={ws.status} styles={STATUS_STYLE} />
+                      </div>
+                      <span className="text-terminal-sm text-text-faint font-mono">{ws.tasks.length} tasks</span>
+                    </button>
+
+                    {expandedWorkstreams.has(ws.id) && (
+                      <div className="border-t border-border-light">
+                        {ws.tasks.filter((t) => t.is_active).map((task) => (
+                          <div key={task.id} className="border-b border-border-light last:border-b-0">
+                            <button onClick={() => toggle(expandedTasks, task.id, setExpandedTasks)} className="w-full px-4 py-2 flex items-center justify-between hover:bg-gray-50 transition-colors text-left">
+                              <div className="flex items-center gap-2 flex-1 min-w-0">
+                                <span className="font-mono text-sm text-text-primary truncate">{task.title}</span>
+                                <Badge value={task.status} styles={STATUS_STYLE} />
+                                <Badge value={task.priority_tier} styles={PRIORITY_STYLE} />
+                              </div>
+                              <div className="flex items-center gap-3 text-terminal-sm text-text-faint font-mono flex-shrink-0">
+                                {task.due_date && <span>{new Date(task.due_date).toLocaleDateString()}</span>}
+                                {task.citations.length > 0 && <span>{task.citations.length} citations</span>}
+                              </div>
+                            </button>
+
+                            {expandedTasks.has(task.id) && (
+                              <div className="px-4 py-3 bg-gray-50 border-t border-border-light">
+                                <div className="grid grid-cols-2 gap-4 text-terminal-sm font-mono">
+                                  <div>
+                                    <div className="font-medium text-text-secondary mb-1">Description</div>
+                                    <div className="text-text-muted">{task.description}</div>
+                                  </div>
+                                  <div>
+                                    <div className="font-medium text-text-secondary mb-1">Risk</div>
+                                    <div className="text-text-muted">Likelihood: {task.inherent_likelihood.replace(/_/g, ' ')} / Impact: {task.inherent_impact.replace(/_/g, ' ')}</div>
+                                  </div>
+                                  {task.penalty_description && (
+                                    <div><div className="font-medium text-text-secondary mb-1">Penalty</div><div className="text-text-muted">{task.penalty_description}</div></div>
+                                  )}
+                                  {task.monitoring_frequency !== 'not_applicable' && (
+                                    <div><div className="font-medium text-text-secondary mb-1">Monitoring</div><div className="text-text-muted">{task.monitoring_frequency.replace(/_/g, ' ')}</div></div>
+                                  )}
+                                  {task.attestation_frequency !== 'not_applicable' && (
+                                    <div><div className="font-medium text-text-secondary mb-1">Attestation</div><div className="text-text-muted">{task.attestation_frequency.replace(/_/g, ' ')}</div></div>
+                                  )}
+                                  {task.action_steps.length > 0 && (
+                                    <div className="col-span-2"><div className="font-medium text-text-secondary mb-1">Action Steps</div><ul className="list-disc list-inside text-text-muted">{task.action_steps.map((s, i) => <li key={i}>{s}</li>)}</ul></div>
+                                  )}
+                                  {task.citations.length > 0 && (
+                                    <div className="col-span-2">
+                                      <div className="font-medium text-text-secondary mb-1">Citations</div>
+                                      <div className="space-y-1">{task.citations.map((tc) => (
+                                        <div key={tc.id} className="flex items-center gap-2">
+                                          <Badge value={tc.citation.status} styles={STATUS_STYLE} />
+                                          <span className="text-text-muted">{tc.citation.citation_string}</span>
+                                          {tc.relevance_note && <span className="text-text-faint">— {tc.relevance_note}</span>}
+                                        </div>
+                                      ))}</div>
+                                    </div>
+                                  )}
+                                </div>
+                              </div>
+                            )}
+                          </div>
+                        ))}
+
+                        {/* Add Task */}
+                        <div className="px-4 py-2">
+                          {addingTask === ws.id ? (
+                            <div className="space-y-2 p-3 border border-border rounded bg-white">
+                              <input value={newTask.title} onChange={(e) => setNewTask({ ...newTask, title: e.target.value })} placeholder="Task title" className="font-mono text-sm w-full bg-transparent border border-border rounded px-2 py-1 focus:border-brand-purple outline-none placeholder:text-text-faint" />
+                              <textarea value={newTask.description} onChange={(e) => setNewTask({ ...newTask, description: e.target.value })} placeholder="Description" rows={2} className="font-mono text-sm w-full bg-transparent border border-border rounded px-2 py-1 focus:border-brand-purple outline-none placeholder:text-text-faint" />
+                              <div className="flex gap-2">
+                                <select value={newTask.priority_tier} onChange={(e) => setNewTask({ ...newTask, priority_tier: e.target.value })} className="font-mono text-sm border border-border rounded px-2 py-1 focus:border-brand-purple outline-none">
+                                  {PRIORITY_TIERS.map((p) => <option key={p} value={p}>{p.replace(/_/g, ' ')}</option>)}
+                                </select>
+                                <select value={newTask.inherent_likelihood} onChange={(e) => setNewTask({ ...newTask, inherent_likelihood: e.target.value })} className="font-mono text-sm border border-border rounded px-2 py-1 focus:border-brand-purple outline-none">
+                                  {RISK_LEVELS.map((r) => <option key={r} value={r}>{r.replace(/_/g, ' ')}</option>)}
+                                </select>
+                                <select value={newTask.inherent_impact} onChange={(e) => setNewTask({ ...newTask, inherent_impact: e.target.value })} className="font-mono text-sm border border-border rounded px-2 py-1 focus:border-brand-purple outline-none">
+                                  {RISK_LEVELS.map((r) => <option key={r} value={r}>{r.replace(/_/g, ' ')}</option>)}
+                                </select>
+                              </div>
+                              <div className="flex gap-2">
+                                <button onClick={() => handleAddTask(ws.id)} className="font-mono text-terminal-sm px-3 py-1 rounded bg-brand-purple text-white hover:bg-brand-purple/90 transition-colors">Add</button>
+                                <button onClick={() => setAddingTask(null)} className="font-mono text-terminal-sm px-3 py-1 rounded border border-border text-text-muted transition-colors">Cancel</button>
+                              </div>
+                            </div>
+                          ) : (
+                            <button onClick={() => setAddingTask(ws.id)} className="font-mono text-terminal-sm text-brand-purple hover:text-brand-purple/80 transition-colors">+ Add Task</button>
+                          )}
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                ))}
+
+                {/* Add Workstream */}
+                <div className="mt-3">
+                  {addingWorkstream === project.id ? (
+                    <div className="space-y-2 p-3 border border-border rounded">
+                      <input value={newWorkstream.title} onChange={(e) => setNewWorkstream({ ...newWorkstream, title: e.target.value })} placeholder="Workstream title" className="font-mono text-sm w-full bg-transparent border border-border rounded px-2 py-1 focus:border-brand-purple outline-none placeholder:text-text-faint" />
+                      <textarea value={newWorkstream.description} onChange={(e) => setNewWorkstream({ ...newWorkstream, description: e.target.value })} placeholder="Description" rows={2} className="font-mono text-sm w-full bg-transparent border border-border rounded px-2 py-1 focus:border-brand-purple outline-none placeholder:text-text-faint" />
+                      <div className="flex gap-2">
+                        <button onClick={() => handleAddWorkstream(project.id)} className="font-mono text-terminal-sm px-3 py-1 rounded bg-brand-purple text-white hover:bg-brand-purple/90 transition-colors">Add</button>
+                        <button onClick={() => setAddingWorkstream(null)} className="font-mono text-terminal-sm px-3 py-1 rounded border border-border text-text-muted transition-colors">Cancel</button>
+                      </div>
+                    </div>
+                  ) : (
+                    <button onClick={() => setAddingWorkstream(project.id)} className="font-mono text-terminal-sm text-brand-purple hover:text-brand-purple/80 transition-colors">+ Add Workstream</button>
+                  )}
+                </div>
+              </div>
+            )}
+          </div>
+        ))}
+
+        {/* Add Project */}
+        <div className="bg-white rounded border border-border shadow-sm p-5">
+          {addingProject ? (
+            <div className="space-y-3">
+              <div className="font-mono font-medium text-text-primary">New Project</div>
+              <input value={newProject.title} onChange={(e) => setNewProject({ ...newProject, title: e.target.value })} placeholder="Project title" className="font-mono text-sm w-full bg-transparent border border-border rounded px-2 py-1 focus:border-brand-purple outline-none placeholder:text-text-faint" />
+              <input value={newProject.domain_label} onChange={(e) => setNewProject({ ...newProject, domain_label: e.target.value })} placeholder="Domain label (e.g. Bookkeeping)" className="font-mono text-sm w-full bg-transparent border border-border rounded px-2 py-1 focus:border-brand-purple outline-none placeholder:text-text-faint" />
+              <textarea value={newProject.description} onChange={(e) => setNewProject({ ...newProject, description: e.target.value })} placeholder="Description" rows={2} className="font-mono text-sm w-full bg-transparent border border-border rounded px-2 py-1 focus:border-brand-purple outline-none placeholder:text-text-faint" />
+              <div className="flex gap-2">
+                <button onClick={handleAddProject} className="font-mono text-terminal-sm px-3 py-1 rounded bg-brand-purple text-white hover:bg-brand-purple/90 transition-colors">Add Project</button>
+                <button onClick={() => setAddingProject(false)} className="font-mono text-terminal-sm px-3 py-1 rounded border border-border text-text-muted transition-colors">Cancel</button>
+              </div>
+            </div>
+          ) : (
+            <button onClick={() => setAddingProject(true)} className="font-mono text-terminal-sm text-brand-purple hover:text-brand-purple/80 transition-colors">+ Add Project</button>
+          )}
+        </div>
+      </div>
+    </AppLayout>
+  );
+}

--- a/src/app/ops/missions/page.tsx
+++ b/src/app/ops/missions/page.tsx
@@ -1,0 +1,336 @@
+'use client';
+
+import { useState, useEffect, useMemo } from 'react';
+import Link from 'next/link';
+import AppLayout from '@/components/ui/AppLayout';
+import OpsSubNav from '@/components/ops/OpsSubNav';
+
+interface Mission {
+  id: string;
+  title: string;
+  description: string | null;
+  status: string;
+  target_completion: string | null;
+  actual_completion: string | null;
+  framework_mappings: string[];
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+  _count?: { projects: number };
+}
+
+const MISSION_STATUS_OPTIONS = ['', 'draft', 'active', 'paused', 'blocked', 'completed', 'cancelled', 'archived'];
+
+const STATUS_STYLE: Record<string, string> = {
+  draft: 'bg-gray-100 text-gray-600',
+  active: 'bg-emerald-100 text-emerald-800',
+  paused: 'bg-amber-100 text-amber-800',
+  blocked: 'bg-red-100 text-red-800',
+  completed: 'bg-blue-100 text-blue-800',
+  cancelled: 'bg-gray-100 text-gray-500',
+  archived: 'bg-gray-50 text-gray-400',
+};
+
+function relativeTime(dateStr: string | null): string {
+  if (!dateStr) return '—';
+  const date = new Date(dateStr);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffSec = Math.floor(diffMs / 1000);
+  if (diffSec < 60) return 'just now';
+  const diffMin = Math.floor(diffSec / 60);
+  if (diffMin < 60) return `${diffMin}m ago`;
+  const diffHr = Math.floor(diffMin / 60);
+  if (diffHr < 24) return `${diffHr}h ago`;
+  const diffDay = Math.floor(diffHr / 24);
+  if (diffDay < 30) return `${diffDay}d ago`;
+  const diffMonth = Math.floor(diffDay / 30);
+  return `${diffMonth}mo ago`;
+}
+
+export default function MissionsPage() {
+  const [missions, setMissions] = useState<Mission[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [statusFilter, setStatusFilter] = useState('');
+  const [isActiveFilter, setIsActiveFilter] = useState(true);
+  const [showCreateForm, setShowCreateForm] = useState(false);
+  const [creating, setCreating] = useState(false);
+  const [archivingId, setArchivingId] = useState<string | null>(null);
+
+  // Create form state
+  const [newTitle, setNewTitle] = useState('');
+  const [newDescription, setNewDescription] = useState('');
+  const [newTargetCompletion, setNewTargetCompletion] = useState('');
+  const [newFrameworkMappings, setNewFrameworkMappings] = useState('');
+
+  const fetchMissions = async () => {
+    try {
+      const res = await fetch('/api/missions');
+      if (res.ok) {
+        const data = await res.json();
+        setMissions(data.missions || []);
+      }
+    } catch (err) {
+      console.error('Failed to load missions:', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchMissions();
+  }, []);
+
+  const filtered = useMemo(() => {
+    return missions.filter((m) => {
+      if (statusFilter && m.status !== statusFilter) return false;
+      if (isActiveFilter && !m.is_active) return false;
+      return true;
+    });
+  }, [missions, statusFilter, isActiveFilter]);
+
+  const handleCreate = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!newTitle.trim()) return;
+    setCreating(true);
+    try {
+      const body: Record<string, unknown> = { title: newTitle.trim() };
+      if (newDescription.trim()) body.description = newDescription.trim();
+      if (newTargetCompletion) body.target_completion = newTargetCompletion;
+      if (newFrameworkMappings.trim()) {
+        body.framework_mappings = newFrameworkMappings.split(',').map((s) => s.trim()).filter(Boolean);
+      }
+      const res = await fetch('/api/missions', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      if (res.ok) {
+        setNewTitle('');
+        setNewDescription('');
+        setNewTargetCompletion('');
+        setNewFrameworkMappings('');
+        setShowCreateForm(false);
+        await fetchMissions();
+      }
+    } catch (err) {
+      console.error('Failed to create mission:', err);
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const handleArchive = async (id: string) => {
+    setArchivingId(id);
+    try {
+      const res = await fetch(`/api/missions/${id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ is_active: false }),
+      });
+      if (res.ok) {
+        await fetchMissions();
+      }
+    } catch (err) {
+      console.error('Failed to archive mission:', err);
+    } finally {
+      setArchivingId(null);
+    }
+  };
+
+  if (loading) {
+    return (
+      <AppLayout>
+        <OpsSubNav />
+        <div className="flex items-center justify-center min-h-[40vh]">
+          <div className="flex items-center gap-3">
+            <div className="w-5 h-5 border-2 border-brand-purple border-t-transparent rounded-full animate-spin" />
+            <span className="text-text-muted font-mono text-terminal-base">Loading missions...</span>
+          </div>
+        </div>
+      </AppLayout>
+    );
+  }
+
+  return (
+    <AppLayout>
+      <OpsSubNav />
+      <div className="max-w-[1600px] mx-auto px-4 pt-4 pb-8 space-y-4">
+        {/* Header */}
+        <div className="bg-white rounded border border-border shadow-sm p-5">
+          <div className="flex items-start justify-between">
+            <div>
+              <h1 className="text-xl font-bold text-text-primary font-mono">PR-D Missions</h1>
+              <p className="text-terminal-sm text-text-muted font-mono mt-1">
+                Organize compliance work into missions, projects, workstreams, and tasks.
+              </p>
+              <p className="text-terminal-sm text-text-faint font-mono mt-2">
+                Showing {filtered.length} of {missions.length} missions
+              </p>
+            </div>
+            <button
+              onClick={() => setShowCreateForm(!showCreateForm)}
+              className="font-mono text-terminal-sm px-3 py-1 rounded border border-brand-purple text-brand-purple hover:bg-brand-purple hover:text-white transition-colors"
+            >
+              {showCreateForm ? 'Cancel' : 'New Mission'}
+            </button>
+          </div>
+        </div>
+
+        {/* Create Form */}
+        {showCreateForm && (
+          <div className="bg-white rounded border border-border shadow-sm p-5">
+            <h2 className="text-terminal-base font-semibold text-text-primary font-mono mb-3">Create Mission</h2>
+            <form onSubmit={handleCreate} className="space-y-3">
+              <div>
+                <label className="block text-terminal-sm font-mono text-text-secondary mb-1">Title *</label>
+                <input
+                  type="text"
+                  value={newTitle}
+                  onChange={(e) => setNewTitle(e.target.value)}
+                  required
+                  placeholder="e.g., SOC 2 Type II Readiness"
+                  className="font-mono text-sm bg-transparent border border-border rounded-md px-3 py-1.5 w-full focus:border-brand-purple outline-none transition-colors placeholder:text-text-faint"
+                />
+              </div>
+              <div>
+                <label className="block text-terminal-sm font-mono text-text-secondary mb-1">Description</label>
+                <textarea
+                  value={newDescription}
+                  onChange={(e) => setNewDescription(e.target.value)}
+                  rows={3}
+                  placeholder="Describe the mission scope and objectives..."
+                  className="font-mono text-sm bg-transparent border border-border rounded-md px-3 py-1.5 w-full focus:border-brand-purple outline-none transition-colors placeholder:text-text-faint resize-y"
+                />
+              </div>
+              <div className="flex gap-3">
+                <div className="flex-1">
+                  <label className="block text-terminal-sm font-mono text-text-secondary mb-1">Target Completion</label>
+                  <input
+                    type="date"
+                    value={newTargetCompletion}
+                    onChange={(e) => setNewTargetCompletion(e.target.value)}
+                    className="font-mono text-sm bg-transparent border border-border rounded-md px-3 py-1.5 w-full focus:border-brand-purple outline-none transition-colors"
+                  />
+                </div>
+                <div className="flex-1">
+                  <label className="block text-terminal-sm font-mono text-text-secondary mb-1">Framework Mappings</label>
+                  <input
+                    type="text"
+                    value={newFrameworkMappings}
+                    onChange={(e) => setNewFrameworkMappings(e.target.value)}
+                    placeholder="SOC2, ISO27001, GDPR"
+                    className="font-mono text-sm bg-transparent border border-border rounded-md px-3 py-1.5 w-full focus:border-brand-purple outline-none transition-colors placeholder:text-text-faint"
+                  />
+                </div>
+              </div>
+              <div className="flex justify-end">
+                <button
+                  type="submit"
+                  disabled={creating || !newTitle.trim()}
+                  className="font-mono text-terminal-sm px-4 py-1.5 rounded border border-brand-purple text-brand-purple hover:bg-brand-purple hover:text-white transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  {creating ? 'Creating...' : 'Create Mission'}
+                </button>
+              </div>
+            </form>
+          </div>
+        )}
+
+        {/* Filters */}
+        <div className="bg-white rounded border border-border shadow-sm p-4 flex flex-wrap gap-3 items-center">
+          <select
+            value={statusFilter}
+            onChange={(e) => setStatusFilter(e.target.value)}
+            className="font-mono text-sm bg-transparent border border-border rounded-md px-3 py-1.5 focus:border-brand-purple outline-none"
+          >
+            <option value="">All statuses</option>
+            {MISSION_STATUS_OPTIONS.filter(Boolean).map((s) => (
+              <option key={s} value={s}>{s.replace(/_/g, ' ')}</option>
+            ))}
+          </select>
+          <label className="flex items-center gap-2 font-mono text-terminal-sm text-text-secondary cursor-pointer">
+            <input
+              type="checkbox"
+              checked={isActiveFilter}
+              onChange={(e) => setIsActiveFilter(e.target.checked)}
+              className="rounded border-border"
+            />
+            Active only
+          </label>
+        </div>
+
+        {/* Table */}
+        {filtered.length === 0 ? (
+          <div className="bg-white rounded border border-border shadow-sm p-12 text-center">
+            <p className="text-text-muted font-mono text-terminal-base">
+              No missions yet. Create your first mission to start organizing compliance work.
+            </p>
+          </div>
+        ) : (
+          <div className="bg-white rounded border border-border shadow-sm overflow-x-auto">
+            <table className="w-full text-terminal-base font-mono">
+              <thead className="bg-gray-50 border-b border-border">
+                <tr>
+                  <th className="px-3 py-2 text-left text-terminal-sm font-semibold text-text-secondary uppercase tracking-wider">Title</th>
+                  <th className="px-3 py-2 text-center text-terminal-sm font-semibold text-text-secondary uppercase tracking-wider">Status</th>
+                  <th className="px-3 py-2 text-center text-terminal-sm font-semibold text-text-secondary uppercase tracking-wider">Projects</th>
+                  <th className="px-3 py-2 text-left text-terminal-sm font-semibold text-text-secondary uppercase tracking-wider">Target Completion</th>
+                  <th className="px-3 py-2 text-left text-terminal-sm font-semibold text-text-secondary uppercase tracking-wider">Created</th>
+                  <th className="px-3 py-2 text-center text-terminal-sm font-semibold text-text-secondary uppercase tracking-wider">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {filtered.map((m) => (
+                  <tr key={m.id} className="border-b border-border-light hover:bg-bg-row/50 transition-colors">
+                    <td className="px-3 py-2 text-text-primary font-medium max-w-xs">
+                      <div className="truncate">{m.title}</div>
+                      {m.description && (
+                        <div className="text-terminal-sm text-text-faint truncate max-w-xs">{m.description}</div>
+                      )}
+                    </td>
+                    <td className="px-3 py-2 text-center">
+                      <span className={`text-terminal-sm px-1.5 py-0.5 rounded ${STATUS_STYLE[m.status] || 'bg-gray-100 text-gray-600'}`}>
+                        {m.status.replace(/_/g, ' ')}
+                      </span>
+                    </td>
+                    <td className="px-3 py-2 text-center text-text-muted text-terminal-sm">
+                      {m._count?.projects ?? '—'}
+                    </td>
+                    <td className="px-3 py-2 text-text-muted text-terminal-sm">
+                      {m.target_completion ? new Date(m.target_completion).toLocaleDateString() : '—'}
+                    </td>
+                    <td className="px-3 py-2 text-text-muted text-terminal-sm">
+                      <span title={new Date(m.created_at).toLocaleString()}>
+                        {relativeTime(m.created_at)}
+                      </span>
+                    </td>
+                    <td className="px-3 py-2 text-center">
+                      <div className="flex items-center justify-center gap-2">
+                        <Link
+                          href={`/ops/missions/${m.id}`}
+                          className="font-mono text-terminal-sm px-3 py-1 rounded border border-brand-purple text-brand-purple hover:bg-brand-purple hover:text-white transition-colors"
+                        >
+                          Open
+                        </Link>
+                        {m.is_active && (
+                          <button
+                            onClick={() => handleArchive(m.id)}
+                            disabled={archivingId === m.id}
+                            className="font-mono text-terminal-sm px-3 py-1 rounded border border-border text-text-muted hover:text-red-600 hover:border-red-300 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                          >
+                            {archivingId === m.id ? 'Archiving...' : 'Archive'}
+                          </button>
+                        )}
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </AppLayout>
+  );
+}

--- a/src/components/ops/OpsSubNav.tsx
+++ b/src/components/ops/OpsSubNav.tsx
@@ -8,6 +8,7 @@ const OPS_TABS = [
   { name: 'Registry', href: '/ops/registry', exact: false },
   { name: 'Citations', href: '/ops/citations', exact: false },
   { name: 'Audit Log', href: '/ops/audit-log', exact: false },
+  { name: 'Missions', href: '/ops/missions', exact: false },
   { name: 'Bookkeeping', href: '', disabled: true },
   { name: 'Trading', href: '', disabled: true },
   { name: 'Travel', href: '', disabled: true },


### PR DESCRIPTION
…l schema)

CREATED:
- 5 tables: missions, projects, workstreams, compliance_tasks, task_citations (M:N join)
- 10 enums: MissionStatus, ProjectStatus, WorkstreamStatus, TaskStatus, TaskPriorityTier, DueDateBasis, MonitoringFrequency, AttestationFrequency, ResidualRiskLevel, AttestationStatus
- Full institutional fields on compliance_tasks: RACI, FAIR risk axis, two-axis priority, four lifecycle clocks, penalty fields, citation FKs via task_citations join
- 5 CHECK constraints: penalty range, effort range, cost range, penalty_weight 0-100, evidence_freshness > 0
- Back-relations added to users (missions, accountable_tasks) and citations (task_citations)

API ENDPOINTS (all auth-gated, all mutations write audit_log):
- /api/missions (GET, POST), /api/missions/[id] (GET, PATCH, DELETE)
- /api/projects (GET, POST), /api/projects/[id] (GET, PATCH, DELETE)
- /api/workstreams (GET, POST), /api/workstreams/[id] (GET, PATCH, DELETE)
- /api/compliance-tasks (GET, POST), /api/compliance-tasks/[id] (GET, PATCH, DELETE)
- /api/compliance-tasks/[id]/citations (POST attach)
- /api/compliance-tasks/[id]/citations/[citationId] (DELETE detach)

UI:
- /ops/missions (list view with filters + New Mission inline form)
- /ops/missions/[id] (detail view with nested projects/workstreams/tasks tree, inline add forms, expandable task detail panels)
- Missions tab added to OpsSubNav

NO AI yet. PR-E onward wires AI to populate.

Verified: prisma generate, tsc --noEmit pass clean.

https://claude.ai/code/session_01GQeiwocJDnF2N3pU1q7Y8t