### PR TITLE
PR-E.1: Fix profile save + surface real errors in UI

### DIFF
--- a/src/app/api/discovery/profile/route.ts
+++ b/src/app/api/discovery/profile/route.ts
@@ -19,6 +19,17 @@ export async function GET(_request: NextRequest) {
   }
 }
 
+const REVENUE_STAGES = [
+  'pre_revenue',
+  'pre_charging',
+  'charging_under_50k',
+  'charging_50k_500k',
+  'charging_500k_5m',
+  'charging_over_5m',
+] as const;
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 export async function POST(request: NextRequest) {
   try {
     const userEmail = await getVerifiedEmail();
@@ -46,6 +57,45 @@ export async function POST(request: NextRequest) {
       primary_entity_id,
     } = body;
 
+    // Validation — return 400 with structured field errors so the UI can show them inline.
+    if (typeof business_description !== 'string' || business_description.trim().length < 10) {
+      return NextResponse.json(
+        {
+          error: 'Business description must be at least 10 characters.',
+          field: 'business_description',
+          message: 'Business description must be at least 10 characters.',
+        },
+        { status: 400 },
+      );
+    }
+
+    if (!revenue_stage || !REVENUE_STAGES.includes(revenue_stage as (typeof REVENUE_STAGES)[number])) {
+      return NextResponse.json(
+        {
+          error: `Revenue stage is required and must be one of: ${REVENUE_STAGES.join(', ')}.`,
+          field: 'revenue_stage',
+          message: 'Please select a revenue stage.',
+        },
+        { status: 400 },
+      );
+    }
+
+    const normalizedPrimaryEntityId =
+      typeof primary_entity_id === 'string' && primary_entity_id.trim() !== ''
+        ? primary_entity_id.trim()
+        : null;
+
+    if (normalizedPrimaryEntityId !== null && !UUID_RE.test(normalizedPrimaryEntityId)) {
+      return NextResponse.json(
+        {
+          error: 'Primary entity ID must be a valid UUID, or left blank.',
+          field: 'primary_entity_id',
+          message: 'Primary entity ID must be a valid UUID (e.g. 550e8400-e29b-41d4-a716-446655440000), or left blank.',
+        },
+        { status: 400 },
+      );
+    }
+
     const existing = await prisma.user_profiles.findUnique({ where: { user_id: user.id } });
     const isCreate = !existing;
 
@@ -64,7 +114,7 @@ export async function POST(request: NextRequest) {
       planned_actions_24mo: planned_actions_24mo ?? [],
       known_completed_filings: known_completed_filings ?? [],
       notes: notes ?? null,
-      primary_entity_id: primary_entity_id ?? null,
+      primary_entity_id: normalizedPrimaryEntityId,
     };
 
     const profile = await prisma.user_profiles.upsert({
@@ -91,6 +141,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ profile }, { status: isCreate ? 201 : 200 });
   } catch (error) {
     console.error('[Discovery Profile POST]', error);
-    return NextResponse.json({ error: 'Failed to save profile' }, { status: 500 });
+    const message = error instanceof Error ? error.message : 'Failed to save profile';
+    return NextResponse.json({ error: message, message }, { status: 500 });
   }
 }

--- a/src/app/ops/profile/page.tsx
+++ b/src/app/ops/profile/page.tsx
@@ -66,6 +66,7 @@ export default function ProfilePage() {
   const [saving, setSaving] = useState(false);
   const [successMessage, setSuccessMessage] = useState('');
   const [error, setError] = useState('');
+  const [fieldError, setFieldError] = useState<string>('');
 
   useEffect(() => {
     (async () => {
@@ -107,6 +108,7 @@ export default function ProfilePage() {
     setSaving(true);
     setSuccessMessage('');
     setError('');
+    setFieldError('');
 
     try {
       const payload = {
@@ -152,11 +154,18 @@ export default function ProfilePage() {
         setSuccessMessage('Profile saved');
       } else {
         const data = await res.json().catch(() => ({}));
-        setError(data.error || 'Failed to save profile');
+        const msg =
+          data.message ||
+          data.error ||
+          `Save failed (HTTP ${res.status}). No error details returned.`;
+        setError(msg);
+        if (typeof data.field === 'string') {
+          setFieldError(data.field);
+        }
       }
     } catch (err) {
       console.error('Failed to save profile:', err);
-      setError('Failed to save profile');
+      setError(err instanceof Error ? err.message : 'Failed to save profile');
     } finally {
       setSaving(false);
     }
@@ -196,6 +205,12 @@ export default function ProfilePage() {
           </p>
         </div>
 
+        {error && (
+          <div className="bg-red-50 border border-red-300 rounded p-3 font-mono text-terminal-sm text-red-800 whitespace-pre-wrap">
+            <span className="font-semibold">Save failed:</span> {error}
+          </div>
+        )}
+
         <form onSubmit={handleSubmit} className="space-y-4">
           {/* Business Overview */}
           <div className="bg-white rounded border border-border shadow-sm p-5 space-y-4">
@@ -209,6 +224,10 @@ export default function ProfilePage() {
                 className={inputClass}
                 placeholder="Describe your business, what it does, and how it operates..."
               />
+              <p className={hintClass}>Required, minimum 10 characters.</p>
+              {fieldError === 'business_description' && (
+                <p className="font-mono text-terminal-sm text-red-600 mt-1">{error}</p>
+              )}
             </div>
             <div>
               <label className={labelClass}>Primary Entity ID</label>
@@ -217,8 +236,14 @@ export default function ProfilePage() {
                 value={form.primary_entity_id}
                 onChange={(e) => updateField('primary_entity_id', e.target.value)}
                 className={inputClass}
-                placeholder="UUID of your primary legal entity"
+                placeholder="UUID of your primary legal entity (optional)"
               />
+              <p className={hintClass}>
+                Optional. Must be a valid UUID (e.g. 550e8400-e29b-41d4-a716-446655440000) or left blank.
+              </p>
+              {fieldError === 'primary_entity_id' && (
+                <p className="font-mono text-terminal-sm text-red-600 mt-1">{error}</p>
+              )}
             </div>
           </div>
 
@@ -338,6 +363,9 @@ export default function ProfilePage() {
                   </option>
                 ))}
               </select>
+              {fieldError === 'revenue_stage' && (
+                <p className="font-mono text-terminal-sm text-red-600 mt-1">{error}</p>
+              )}
             </div>
             <div>
               <label className={labelClass}>Employee Count</label>
@@ -411,7 +439,6 @@ export default function ProfilePage() {
                 </Link>
               </span>
             )}
-            {error && <span className="font-mono text-terminal-sm text-red-600">{error}</span>}
           </div>
         </form>
       </div>


### PR DESCRIPTION
Bug fixed: API forwarded primary_entity_id to Prisma without UUID validation. If user typed a non-UUID into the free-text "Primary Entity ID" field, Prisma rejected it (@db.Uuid) and the generic catch-all returned 500 "Failed to save profile" with no detail.

Fix:
- API: validate business_description (min 10 chars), revenue_stage (must be valid enum), and primary_entity_id (must be valid UUID or null) before prisma.upsert. Return structured 400 with { error, field, message } so UI can show field-level errors.
- API: 500 catch now returns the underlying error.message instead of swallowing it.
- UI: red banner above form shows the actual server error. Field- level errors render under the offending field. Helper text clarifies UUID requirement on Primary Entity ID.