### PR TITLE
PR-F: corpus foundation — schema + access layer

### DIFF
--- a/prisma/migrations/20260503000000_pr_f_corpus_foundation/down.sql
+++ b/prisma/migrations/20260503000000_pr_f_corpus_foundation/down.sql
@@ -1,0 +1,36 @@
+-- =============================================================================
+-- PR-F: Corpus Foundation — DOWN MIGRATION
+-- =============================================================================
+-- Reverses the schema changes from migration.sql.
+--
+-- Reverses in inverse order: indexes first, then chunks table (which has
+-- foreign key to documents), then documents table.
+--
+-- The vector extension is intentionally NOT dropped. Other future migrations
+-- may use vector columns elsewhere. Removing the extension would orphan them.
+--
+-- This down script is for emergency rollback only. Standard practice is to
+-- ship a forward-fix migration rather than apply this. Documented for SOC 2
+-- change-management completeness.
+-- =============================================================================
+
+BEGIN;
+
+-- STEP 1: Drop indexes on chunks first (depend on the chunks table).
+DROP INDEX IF EXISTS regulatory_document_chunks_document_id_structural_path_idx;
+DROP INDEX IF EXISTS regulatory_document_chunks_bm25_tsv_idx;
+DROP INDEX IF EXISTS regulatory_document_chunks_embedding_hnsw_idx;
+
+-- STEP 2: Drop the chunks table. CASCADE removes the FK constraint cleanly.
+DROP TABLE IF EXISTS regulatory_document_chunks CASCADE;
+
+-- STEP 3: Drop indexes on documents.
+DROP INDEX IF EXISTS regulatory_documents_source_id_retrieved_at_idx;
+DROP INDEX IF EXISTS regulatory_documents_citation_key_effective_date_idx;
+
+-- STEP 4: Drop the documents table.
+DROP TABLE IF EXISTS regulatory_documents CASCADE;
+
+-- Note: pgvector extension is left in place by design.
+
+COMMIT;

--- a/prisma/migrations/20260503000000_pr_f_corpus_foundation/migration.sql
+++ b/prisma/migrations/20260503000000_pr_f_corpus_foundation/migration.sql
@@ -1,0 +1,114 @@
+-- =============================================================================
+-- PR-F: Corpus Foundation
+-- =============================================================================
+-- Creates the document corpus storage layer for the Discovery Engine.
+-- Reference: docs/architecture/discovery-engine-institutional-grade.md § 1.5
+--
+-- Two tables:
+--   regulatory_documents       — versioned, hash-anchored authoritative texts
+--   regulatory_document_chunks — embedded sub-document units for retrieval
+--
+-- Indexes:
+--   B-tree on (citation_key, effective_date DESC) WHERE superseded_by IS NULL
+--   B-tree on (source_id, retrieved_at)
+--   HNSW on embedding (vector_cosine_ops) for nearest-neighbor search
+--   GIN on bm25_tsv for keyword search
+--   B-tree on (document_id, structural_path)
+--
+-- Prerequisite: pgvector extension allow-listed in Azure server parameters
+-- and installed in this database. See architecture doc § 1.2.
+--
+-- This migration is idempotent (IF NOT EXISTS everywhere) and atomic
+-- (wrapped in BEGIN/COMMIT). Down script: down.sql in this directory.
+-- =============================================================================
+
+BEGIN;
+
+-- STEP 1: Ensure pgvector is installed in the database.
+-- Safe no-op if already installed. Fails fast if extension is not allow-listed
+-- at the server level (Azure azure.extensions parameter).
+CREATE EXTENSION IF NOT EXISTS vector;
+
+-- STEP 2: regulatory_documents — top-level authoritative document registry.
+-- Each row represents one version of one canonical document (e.g. IRC § 162
+-- effective 2026-01-01). New versions are inserted; prior versions are kept
+-- and linked via superseded_by. Content_hash and raw_hash provide cryptographic
+-- integrity. Stable_uri is the institutional contract for citation.
+CREATE TABLE IF NOT EXISTS regulatory_documents (
+    id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    source_id       uuid NOT NULL REFERENCES regulatory_sources(id),
+    doc_type        text NOT NULL,
+    jurisdiction    text NOT NULL,
+    citation_key    text NOT NULL,
+    title           text NOT NULL,
+    version         int  NOT NULL,
+    effective_date  date,
+    published_date  date NOT NULL,
+    retrieved_at    timestamptz NOT NULL,
+    canonical_url   text NOT NULL,
+    stable_uri      text NOT NULL,
+    content_hash    bytea NOT NULL,
+    raw_hash        bytea NOT NULL,
+    raw_storage_uri text NOT NULL,
+    superseded_by   uuid REFERENCES regulatory_documents(id),
+    superseded_at   timestamptz,
+    metadata        jsonb NOT NULL DEFAULT '{}'::jsonb,
+    CONSTRAINT regulatory_documents_citation_key_version_key
+        UNIQUE (citation_key, version)
+);
+
+-- STEP 3: Indexes on regulatory_documents.
+-- Partial index on (citation_key, effective_date DESC) WHERE superseded_by IS NULL
+-- supports the common "give me the current version of citation X" query path.
+-- Index on (source_id, retrieved_at) supports per-source ingestion audits.
+CREATE INDEX IF NOT EXISTS regulatory_documents_citation_key_effective_date_idx
+    ON regulatory_documents (citation_key, effective_date DESC)
+    WHERE superseded_by IS NULL;
+
+CREATE INDEX IF NOT EXISTS regulatory_documents_source_id_retrieved_at_idx
+    ON regulatory_documents (source_id, retrieved_at);
+
+-- STEP 4: regulatory_document_chunks — embedded sub-document units.
+-- Each chunk is a structural unit (statute section, CFR paragraph) of a
+-- parent document. parent_chunk_id supports the "small-to-big" retrieval
+-- pattern from architecture doc § 1.2. The embedding column stores the
+-- voyage-3.5-large output (1024-dim cosine). bm25_tsv is a generated
+-- tsvector for hybrid retrieval.
+CREATE TABLE IF NOT EXISTS regulatory_document_chunks (
+    id               uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    document_id      uuid NOT NULL REFERENCES regulatory_documents(id) ON DELETE CASCADE,
+    parent_chunk_id  uuid REFERENCES regulatory_document_chunks(id),
+    ordinal          int  NOT NULL,
+    structural_path  text NOT NULL,
+    pinpoint         text,
+    text             text NOT NULL,
+    text_hash        bytea NOT NULL,
+    token_count      int  NOT NULL,
+    embedding        vector(1024),
+    embedding_model  text NOT NULL,
+    bm25_tsv         tsvector GENERATED ALWAYS AS (to_tsvector('english', text)) STORED,
+    created_at       timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT regulatory_document_chunks_document_id_ordinal_key
+        UNIQUE (document_id, ordinal)
+);
+
+-- STEP 5: Indexes on regulatory_document_chunks.
+-- HNSW index for approximate nearest-neighbor search on embeddings using
+-- cosine distance. Parameters m=16 and ef_construction=200 are the
+-- production-recommended values per architecture doc § 1.2 (>95% recall up
+-- to ~10M vectors).
+-- GIN index on the generated bm25_tsv column for keyword search.
+-- B-tree on (document_id, structural_path) for hierarchical lookup.
+CREATE INDEX IF NOT EXISTS regulatory_document_chunks_embedding_hnsw_idx
+    ON regulatory_document_chunks
+    USING hnsw (embedding vector_cosine_ops)
+    WITH (m = 16, ef_construction = 200);
+
+CREATE INDEX IF NOT EXISTS regulatory_document_chunks_bm25_tsv_idx
+    ON regulatory_document_chunks
+    USING gin (bm25_tsv);
+
+CREATE INDEX IF NOT EXISTS regulatory_document_chunks_document_id_structural_path_idx
+    ON regulatory_document_chunks (document_id, structural_path);
+
+COMMIT;

--- a/src/lib/corpus/db.ts
+++ b/src/lib/corpus/db.ts
@@ -1,0 +1,214 @@
+/**
+ * src/lib/corpus/db.ts
+ *
+ * Sole TypeScript access layer for the regulatory document corpus.
+ *
+ * The corpus tables (regulatory_documents, regulatory_document_chunks) are
+ * intentionally NOT modeled in prisma/schema.prisma. Prisma 5.22 cannot
+ * express the vector(1024) column type or HNSW index method, so the corpus
+ * lives outside Prisma's typed client and is accessed through this module.
+ *
+ * Reference: docs/architecture/discovery-engine-institutional-grade.md
+ * Sections 1.2 (technology stack), 1.5 (schema sketch).
+ *
+ * Design rules:
+ *   - Pure data accessors. No business logic.
+ *   - All inserts use $executeRaw with parameterized placeholders.
+ *   - Vector embeddings are passed as Postgres array literals.
+ *   - Similarity search uses the <=> cosine-distance operator.
+ *   - All callers must provide their own SHA-256 content_hash, raw_hash,
+ *     and text_hash. This module never computes them.
+ */
+
+import { PrismaClient } from '@prisma/client';
+import { Prisma } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+/* -------------------------------------------------------------------------- */
+/* Types                                                                       */
+/* -------------------------------------------------------------------------- */
+
+export interface InsertDocumentInput {
+  source_id: string;
+  doc_type: string;
+  jurisdiction: string;
+  citation_key: string;
+  title: string;
+  version: number;
+  effective_date: Date | null;
+  published_date: Date;
+  retrieved_at: Date;
+  canonical_url: string;
+  stable_uri: string;
+  content_hash: Buffer;
+  raw_hash: Buffer;
+  raw_storage_uri: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface InsertChunkInput {
+  document_id: string;
+  parent_chunk_id?: string | null;
+  ordinal: number;
+  structural_path: string;
+  pinpoint?: string | null;
+  text: string;
+  text_hash: Buffer;
+  token_count: number;
+  embedding: number[];
+  embedding_model: string;
+}
+
+export interface SimilarChunkResult {
+  id: string;
+  document_id: string;
+  structural_path: string;
+  pinpoint: string | null;
+  text: string;
+  cosine_distance: number;
+}
+
+export interface SearchFilters {
+  jurisdiction?: string;
+  doc_type?: string;
+  superseded_only_currrent?: boolean;
+}
+
+/* -------------------------------------------------------------------------- */
+/* insertDocument                                                              */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Inserts a row into regulatory_documents and returns the new id.
+ * Caller must pre-compute content_hash and raw_hash as SHA-256 Buffers.
+ */
+export async function insertDocument(
+  input: InsertDocumentInput
+): Promise<{ id: string }> {
+  const result = await prisma.$queryRaw<Array<{ id: string }>>`
+    INSERT INTO regulatory_documents (
+      source_id, doc_type, jurisdiction, citation_key, title, version,
+      effective_date, published_date, retrieved_at, canonical_url,
+      stable_uri, content_hash, raw_hash, raw_storage_uri, metadata
+    ) VALUES (
+      ${input.source_id}::uuid,
+      ${input.doc_type},
+      ${input.jurisdiction},
+      ${input.citation_key},
+      ${input.title},
+      ${input.version},
+      ${input.effective_date},
+      ${input.published_date},
+      ${input.retrieved_at},
+      ${input.canonical_url},
+      ${input.stable_uri},
+      ${input.content_hash},
+      ${input.raw_hash},
+      ${input.raw_storage_uri},
+      ${JSON.stringify(input.metadata ?? {})}::jsonb
+    )
+    RETURNING id
+  `;
+  return result[0];
+}
+
+/* -------------------------------------------------------------------------- */
+/* insertChunk                                                                 */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Inserts a row into regulatory_document_chunks. The embedding is converted
+ * to the Postgres vector literal format (e.g., '[0.1,0.2,...]'::vector).
+ *
+ * Embedding length is NOT validated here — caller must pass a 1024-dim array
+ * matching the column definition. Mismatch will throw at the Postgres level.
+ */
+export async function insertChunk(
+  input: InsertChunkInput
+): Promise<{ id: string }> {
+  const embeddingLiteral = `[${input.embedding.join(',')}]`;
+
+  const result = await prisma.$queryRaw<Array<{ id: string }>>`
+    INSERT INTO regulatory_document_chunks (
+      document_id, parent_chunk_id, ordinal, structural_path, pinpoint,
+      text, text_hash, token_count, embedding, embedding_model
+    ) VALUES (
+      ${input.document_id}::uuid,
+      ${input.parent_chunk_id ?? null}::uuid,
+      ${input.ordinal},
+      ${input.structural_path},
+      ${input.pinpoint ?? null},
+      ${input.text},
+      ${input.text_hash},
+      ${input.token_count},
+      ${embeddingLiteral}::vector,
+      ${input.embedding_model}
+    )
+    RETURNING id
+  `;
+  return result[0];
+}
+
+/* -------------------------------------------------------------------------- */
+/* searchSimilarChunks                                                         */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Performs HNSW approximate nearest-neighbor search by cosine distance.
+ * Returns the top-k chunks with their distance scores.
+ *
+ * Filters are applied via JOIN to regulatory_documents. The
+ * superseded_only_current filter excludes chunks whose parent document
+ * has been superseded.
+ */
+export async function searchSimilarChunks(
+  queryEmbedding: number[],
+  k: number,
+  filters: SearchFilters = {}
+): Promise<SimilarChunkResult[]> {
+  const embeddingLiteral = `[${queryEmbedding.join(',')}]`;
+
+  const jurisdictionClause = filters.jurisdiction
+    ? Prisma.sql`AND d.jurisdiction = ${filters.jurisdiction}`
+    : Prisma.empty;
+  const docTypeClause = filters.doc_type
+    ? Prisma.sql`AND d.doc_type = ${filters.doc_type}`
+    : Prisma.empty;
+  const supersededClause = filters.superseded_only_currrent
+    ? Prisma.sql`AND d.superseded_by IS NULL`
+    : Prisma.empty;
+
+  return prisma.$queryRaw<SimilarChunkResult[]>`
+    SELECT
+      c.id,
+      c.document_id,
+      c.structural_path,
+      c.pinpoint,
+      c.text,
+      (c.embedding <=> ${embeddingLiteral}::vector)::float8 AS cosine_distance
+    FROM regulatory_document_chunks c
+    JOIN regulatory_documents d ON c.document_id = d.id
+    WHERE 1=1
+      ${jurisdictionClause}
+      ${docTypeClause}
+      ${supersededClause}
+    ORDER BY c.embedding <=> ${embeddingLiteral}::vector
+    LIMIT ${k}
+  `;
+}
+
+/* -------------------------------------------------------------------------- */
+/* deleteDocument (for tests and rollback only)                                */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Deletes a document and all its chunks (CASCADE).
+ * Intended for test cleanup and emergency rollback. NOT for production use —
+ * production should set superseded_by instead of deleting.
+ */
+export async function deleteDocument(documentId: string): Promise<void> {
+  await prisma.$executeRaw`
+    DELETE FROM regulatory_documents WHERE id = ${documentId}::uuid
+  `;
+}

--- a/src/lib/corpus/index.ts
+++ b/src/lib/corpus/index.ts
@@ -1,0 +1,20 @@
+/**
+ * src/lib/corpus/index.ts
+ *
+ * Barrel export for the corpus access layer. Other code imports from
+ * '@/lib/corpus' rather than reaching into individual files.
+ */
+
+export {
+  insertDocument,
+  insertChunk,
+  searchSimilarChunks,
+  deleteDocument,
+} from './db';
+
+export type {
+  InsertDocumentInput,
+  InsertChunkInput,
+  SimilarChunkResult,
+  SearchFilters,
+} from './db';


### PR DESCRIPTION
prisma/migrations/20260503000000_pr_f_corpus_foundation/:
  - migration.sql: regulatory_documents and regulatory_document_chunks tables with HNSW index on embedding(1024), GIN index on bm25_tsv, and supporting B-tree indexes per architecture doc § 1.5. Idempotent and atomic. CREATE EXTENSION IF NOT EXISTS vector self-bootstraps on fresh databases (Azure pgvector allow-list must be enabled separately at server-parameter level).
  - down.sql: reverses the migration. Vector extension intentionally not dropped on rollback.

src/lib/corpus/db.ts:
  Sole TypeScript access layer for the corpus tables. Tables are
  intentionally not modeled in schema.prisma because Prisma 5.22
  cannot express vector(1024) or HNSW. All access flows through
  insertDocument, insertChunk, searchSimilarChunks, deleteDocument
  via prisma.$queryRaw / $executeRaw with parameterized queries.

src/lib/corpus/index.ts: barrel export.

Reference: docs/architecture/discovery-engine-institutional-grade.md sections 1.2 and 1.5.

Migration sits unapplied on Azure until PR-G (eCFR ingestion) is ready, deployed together as a coordinated release per architecture doc § 8.1 PR-01.