### PR TITLE
PR-Hui: institutional single-page workbench (Section 6 scaffold)

### DIFF
--- a/src/app/api/workbench/corpus-context/route.ts
+++ b/src/app/api/workbench/corpus-context/route.ts
@@ -1,0 +1,102 @@
+/**
+ * src/app/api/workbench/corpus-context/route.ts
+ *
+ * Section C of the institutional workbench: corpus context summary.
+ *
+ * Returns:
+ *   - total documents in regulatory_documents
+ *   - total chunks in regulatory_document_chunks
+ *   - count of currently-superseded documents
+ *   - most recent regulatory_ingest_run_completed audit event
+ *   - per-source: domain, count, last-fetched
+ *
+ * Reference: docs/architecture/discovery-engine-institutional-grade.md § 6.2
+ */
+
+import { NextResponse } from 'next/server';
+import { PrismaClient } from '@prisma/client';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
+
+const prisma = new PrismaClient();
+
+export async function GET() {
+  const email = await getVerifiedEmail();
+  if (!email) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  }
+
+  try {
+    const [documentRows, chunkRows, supersededRows, lastIngestRows, perSource] =
+      await Promise.all([
+        prisma.$queryRaw<Array<{ count: bigint }>>`
+          SELECT COUNT(*)::bigint AS count FROM regulatory_documents
+        `,
+        prisma.$queryRaw<Array<{ count: bigint }>>`
+          SELECT COUNT(*)::bigint AS count FROM regulatory_document_chunks
+        `,
+        prisma.$queryRaw<Array<{ count: bigint }>>`
+          SELECT COUNT(*)::bigint AS count
+          FROM regulatory_documents
+          WHERE superseded_by IS NOT NULL
+        `,
+        prisma.$queryRaw<
+          Array<{
+            created_at: Date;
+            action_description: string;
+            payload_metadata: unknown;
+          }>
+        >`
+          SELECT created_at, action_description, payload_metadata
+          FROM audit_log
+          WHERE action_type = 'regulatory_ingest_run_completed'
+          ORDER BY sequence_number DESC
+          LIMIT 1
+        `,
+        prisma.$queryRaw<
+          Array<{
+            domain: string;
+            source_name: string;
+            document_count: bigint;
+            last_retrieved_at: Date | null;
+          }>
+        >`
+          SELECT
+            s.domain,
+            s.source_name,
+            COUNT(d.id)::bigint AS document_count,
+            MAX(d.retrieved_at) AS last_retrieved_at
+          FROM regulatory_sources s
+          LEFT JOIN regulatory_documents d ON d.source_id = s.id
+          WHERE s.is_active = true
+          GROUP BY s.domain, s.source_name
+          HAVING COUNT(d.id) > 0
+          ORDER BY MAX(d.retrieved_at) DESC NULLS LAST
+        `,
+      ]);
+
+    return NextResponse.json({
+      total_documents: Number(documentRows[0]?.count ?? 0),
+      total_chunks: Number(chunkRows[0]?.count ?? 0),
+      superseded_documents: Number(supersededRows[0]?.count ?? 0),
+      last_ingest_event: lastIngestRows[0]
+        ? {
+            timestamp: lastIngestRows[0].created_at.toISOString(),
+            description: lastIngestRows[0].action_description,
+            payload: lastIngestRows[0].payload_metadata,
+          }
+        : null,
+      per_source: perSource.map((row) => ({
+        domain: row.domain,
+        source_name: row.source_name,
+        document_count: Number(row.document_count),
+        last_retrieved_at: row.last_retrieved_at?.toISOString() ?? null,
+      })),
+    });
+  } catch (err) {
+    console.error('[workbench/corpus-context] error', err);
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : 'unknown' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/workbench/recent-chunks/route.ts
+++ b/src/app/api/workbench/recent-chunks/route.ts
@@ -1,0 +1,107 @@
+/**
+ * src/app/api/workbench/recent-chunks/route.ts
+ *
+ * Section H of the workbench: corpus inspector.
+ *
+ * v1: returns the most recent chunks across all documents, with
+ * parent document context. Sorted by document published_date DESC.
+ *
+ * v2 (after PR-J Voyage embeddings): if ?q= is provided, performs
+ * HNSW similarity search via src/lib/corpus/db.ts searchSimilarChunks.
+ * Until then, ?q= falls back to ts_vector keyword search via the
+ * existing bm25_tsv GIN index.
+ *
+ * Reference: docs/architecture/discovery-engine-institutional-grade.md § 6.2 H
+ */
+
+import { NextResponse } from 'next/server';
+import { PrismaClient } from '@prisma/client';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
+
+const prisma = new PrismaClient();
+
+interface ChunkResult {
+  id: string;
+  document_id: string;
+  citation_key: string;
+  document_title: string;
+  jurisdiction: string;
+  pinpoint: string | null;
+  structural_path: string;
+  text_snippet: string;
+  ingested_at: Date;
+}
+
+export async function GET(request: Request) {
+  const email = await getVerifiedEmail();
+  if (!email) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  }
+
+  const url = new URL(request.url);
+  const q = url.searchParams.get('q')?.trim() ?? '';
+  const limit = Math.min(
+    parseInt(url.searchParams.get('limit') ?? '20', 10) || 20,
+    100
+  );
+
+  try {
+    let rows: ChunkResult[];
+
+    if (q.length > 0) {
+      // BM25 keyword search via existing GIN index on bm25_tsv
+      rows = await prisma.$queryRaw<ChunkResult[]>`
+        SELECT
+          c.id,
+          c.document_id,
+          d.citation_key,
+          d.title AS document_title,
+          d.jurisdiction,
+          c.pinpoint,
+          c.structural_path,
+          LEFT(c.text, 400) AS text_snippet,
+          c.created_at AS ingested_at
+        FROM regulatory_document_chunks c
+        JOIN regulatory_documents d ON c.document_id = d.id
+        WHERE c.bm25_tsv @@ plainto_tsquery('english', ${q})
+          AND d.superseded_by IS NULL
+        ORDER BY ts_rank(c.bm25_tsv, plainto_tsquery('english', ${q})) DESC
+        LIMIT ${limit}
+      `;
+    } else {
+      // No query: return most recent chunks by ingestion time
+      rows = await prisma.$queryRaw<ChunkResult[]>`
+        SELECT
+          c.id,
+          c.document_id,
+          d.citation_key,
+          d.title AS document_title,
+          d.jurisdiction,
+          c.pinpoint,
+          c.structural_path,
+          LEFT(c.text, 400) AS text_snippet,
+          c.created_at AS ingested_at
+        FROM regulatory_document_chunks c
+        JOIN regulatory_documents d ON c.document_id = d.id
+        WHERE d.superseded_by IS NULL
+        ORDER BY c.created_at DESC
+        LIMIT ${limit}
+      `;
+    }
+
+    return NextResponse.json({
+      query: q || null,
+      results: rows.map((r) => ({
+        ...r,
+        ingested_at: r.ingested_at.toISOString(),
+      })),
+      result_count: rows.length,
+    });
+  } catch (err) {
+    console.error('[workbench/recent-chunks] error', err);
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : 'unknown' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/ops/page.tsx
+++ b/src/app/ops/page.tsx
@@ -1,14 +1,51 @@
-'use client';
+/**
+ * src/app/ops/page.tsx
+ *
+ * The institutional single-page workbench. Replaces the legacy tabbed
+ * landing page. Sections A through J render in a continuous vertical
+ * stream per architecture doc § 6.
+ *
+ * Five sections wire fully today: A · B · C · F · I
+ * One section partially: H (BM25 keyword search; HNSW after PR-J)
+ * Four placeholders: D · E · G · J (with explicit Phase-X notices)
+ *
+ * The placeholders are intentional scaffolding. Each future PR fills in
+ * one section without restructuring the page:
+ *   PR-J Voyage embeddings → upgrades H from BM25 to HNSW
+ *   PR-16-25 ensemble       → fills in D and E
+ *   PR-23 cost ledger       → fills in J
+ *   PR-26-35 verifier       → fills in G
+ */
 
 import AppLayout from '@/components/ui/AppLayout';
 import OpsSubNav from '@/components/ops/OpsSubNav';
-import DailyDashboard from '@/components/ops/DailyDashboard';
+import { SectionA_IdentityBar } from '@/components/workbench/SectionA_IdentityBar';
+import { SectionB_FounderProfile } from '@/components/workbench/SectionB_FounderProfile';
+import { SectionC_CorpusContext } from '@/components/workbench/SectionC_CorpusContext';
+import { SectionD_DiscoveryLauncher } from '@/components/workbench/SectionD_DiscoveryLauncher';
+import { SectionE_LiveStream } from '@/components/workbench/SectionE_LiveStream';
+import { SectionF_Roadmap } from '@/components/workbench/SectionF_Roadmap';
+import { SectionG_CitationVerification } from '@/components/workbench/SectionG_CitationVerification';
+import { SectionH_CorpusInspector } from '@/components/workbench/SectionH_CorpusInspector';
+import { SectionI_AuditTail } from '@/components/workbench/SectionI_AuditTail';
+import { SectionJ_CostLedger } from '@/components/workbench/SectionJ_CostLedger';
 
-export default function OpsPage() {
+export default function OpsWorkbenchPage() {
   return (
     <AppLayout>
+      <SectionA_IdentityBar />
       <OpsSubNav />
-      <DailyDashboard />
+      <div className="max-w-[1600px] mx-auto px-4 pt-4 pb-8 space-y-4">
+        <SectionB_FounderProfile />
+        <SectionC_CorpusContext />
+        <SectionD_DiscoveryLauncher />
+        <SectionE_LiveStream />
+        <SectionF_Roadmap />
+        <SectionG_CitationVerification />
+        <SectionH_CorpusInspector />
+        <SectionI_AuditTail />
+        <SectionJ_CostLedger />
+      </div>
     </AppLayout>
   );
 }

--- a/src/components/workbench/SectionA_IdentityBar.tsx
+++ b/src/components/workbench/SectionA_IdentityBar.tsx
@@ -1,0 +1,71 @@
+/**
+ * src/components/workbench/SectionA_IdentityBar.tsx
+ *
+ * Sticky top bar of the institutional workbench. Always visible while
+ * scrolling. Shows identity, entity context, build SHA, audit tail hash.
+ *
+ * Reference: docs/architecture/discovery-engine-institutional-grade.md § 6.2 A
+ */
+
+'use client';
+
+import { useEffect, useState } from 'react';
+
+interface IdentityBarData {
+  user_email: string | null;
+  current_entity_name: string | null;
+  build_sha: string;
+  audit_tail_hash: string | null;
+}
+
+const BUILD_SHA = (process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA ?? 'dev').slice(0, 8);
+
+export function SectionA_IdentityBar() {
+  const [data, setData] = useState<IdentityBarData>({
+    user_email: null,
+    current_entity_name: null,
+    build_sha: BUILD_SHA,
+    audit_tail_hash: null,
+  });
+
+  useEffect(() => {
+    const fetchTail = async () => {
+      try {
+        const res = await fetch('/api/audit-log?limit=1');
+        if (res.ok) {
+          const body = await res.json();
+          const tail = body?.rows?.[0]?.content_hash ?? null;
+          setData((d) => ({
+            ...d,
+            audit_tail_hash: tail ? String(tail).slice(0, 8) : null,
+          }));
+        }
+      } catch {
+        // silent — bar still renders without tail
+      }
+    };
+    fetchTail();
+    const id = setInterval(fetchTail, 15000);
+    return () => clearInterval(id);
+  }, []);
+
+  return (
+    <div className="sticky top-0 z-30 bg-white border-b border-border shadow-sm">
+      <div className="max-w-[1600px] mx-auto px-4 py-2 flex items-center justify-between text-xs font-mono text-text-secondary">
+        <div className="flex items-center gap-4">
+          <span className="font-bold text-text-primary tracking-wide">WORKBENCH</span>
+          <span>build:{data.build_sha}</span>
+          {data.audit_tail_hash && (
+            <span title="Audit log tail hash (last 8 chars of latest content_hash)">
+              tail:{data.audit_tail_hash}
+            </span>
+          )}
+        </div>
+        <div className="flex items-center gap-4">
+          <span>entity: {data.current_entity_name ?? '—'}</span>
+          <span>{data.user_email ?? ''}</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/workbench/SectionB_FounderProfile.tsx
+++ b/src/components/workbench/SectionB_FounderProfile.tsx
@@ -1,0 +1,88 @@
+/**
+ * src/components/workbench/SectionB_FounderProfile.tsx
+ *
+ * Compact summary of the founder profile (entities, jurisdictions,
+ * income types, key dates). Read-only here; full editing lives at
+ * /ops/profile.
+ */
+
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+
+interface ProfileSummary {
+  primary_entity_name: string | null;
+  jurisdictions: string[];
+  income_types: string[];
+  entity_count: number;
+}
+
+export function SectionB_FounderProfile() {
+  const [profile, setProfile] = useState<ProfileSummary | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchProfile = async () => {
+      try {
+        const res = await fetch('/api/profile');
+        if (res.ok) {
+          const body = await res.json();
+          setProfile({
+            primary_entity_name: body?.primary_entity_name ?? null,
+            jurisdictions: body?.jurisdictions ?? [],
+            income_types: body?.income_types ?? [],
+            entity_count: body?.entity_count ?? 0,
+          });
+        }
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchProfile();
+  }, []);
+
+  return (
+    <section className="bg-white rounded border border-border shadow-sm p-5">
+      <div className="flex items-center justify-between mb-3">
+        <h2 className="font-mono text-sm font-bold tracking-wide text-text-primary">
+          B · FOUNDER PROFILE
+        </h2>
+        <Link
+          href="/ops/profile"
+          className="text-xs font-mono text-brand-purple hover:underline"
+        >
+          edit →
+        </Link>
+      </div>
+
+      {loading ? (
+        <div className="text-xs font-mono text-text-muted">loading…</div>
+      ) : profile ? (
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-3 text-xs font-mono">
+          <KeyValue label="primary entity" value={profile.primary_entity_name ?? '—'} />
+          <KeyValue label="entities" value={String(profile.entity_count)} />
+          <KeyValue
+            label="jurisdictions"
+            value={profile.jurisdictions.length ? profile.jurisdictions.join(', ') : '—'}
+          />
+          <KeyValue
+            label="income types"
+            value={profile.income_types.length ? profile.income_types.join(', ') : '—'}
+          />
+        </div>
+      ) : (
+        <div className="text-xs font-mono text-text-muted">profile not yet configured</div>
+      )}
+    </section>
+  );
+}
+
+function KeyValue({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <div className="text-text-faint uppercase tracking-wide mb-1">{label}</div>
+      <div className="text-text-primary truncate">{value}</div>
+    </div>
+  );
+}

--- a/src/components/workbench/SectionC_CorpusContext.tsx
+++ b/src/components/workbench/SectionC_CorpusContext.tsx
@@ -1,0 +1,138 @@
+/**
+ * src/components/workbench/SectionC_CorpusContext.tsx
+ *
+ * Live corpus state: total documents, total chunks, superseded count,
+ * last ingestion event, per-source breakdown. Polls every 30s while
+ * the workbench is open.
+ *
+ * Wires to /api/workbench/corpus-context.
+ */
+
+'use client';
+
+import { useEffect, useState } from 'react';
+
+interface CorpusContextData {
+  total_documents: number;
+  total_chunks: number;
+  superseded_documents: number;
+  last_ingest_event: {
+    timestamp: string;
+    description: string;
+  } | null;
+  per_source: Array<{
+    domain: string;
+    source_name: string;
+    document_count: number;
+    last_retrieved_at: string | null;
+  }>;
+}
+
+function relTime(iso: string | null): string {
+  if (!iso) return 'never';
+  const ms = Date.now() - new Date(iso).getTime();
+  if (ms < 60_000) return 'just now';
+  if (ms < 3_600_000) return `${Math.floor(ms / 60_000)}m ago`;
+  if (ms < 86_400_000) return `${Math.floor(ms / 3_600_000)}h ago`;
+  return `${Math.floor(ms / 86_400_000)}d ago`;
+}
+
+export function SectionC_CorpusContext() {
+  const [data, setData] = useState<CorpusContextData | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const res = await fetch('/api/workbench/corpus-context');
+        if (res.ok) {
+          setData(await res.json());
+        }
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchData();
+    const id = setInterval(fetchData, 30000);
+    return () => clearInterval(id);
+  }, []);
+
+  return (
+    <section className="bg-white rounded border border-border shadow-sm p-5">
+      <div className="flex items-center justify-between mb-3">
+        <h2 className="font-mono text-sm font-bold tracking-wide text-text-primary">
+          C · CORPUS CONTEXT
+        </h2>
+        <span className="text-xs font-mono text-text-muted">refresh 30s</span>
+      </div>
+
+      {loading && !data ? (
+        <div className="text-xs font-mono text-text-muted">loading…</div>
+      ) : data ? (
+        <div className="space-y-4 text-xs font-mono">
+          <div className="grid grid-cols-3 gap-3">
+            <Stat label="documents" value={data.total_documents.toLocaleString()} />
+            <Stat label="chunks" value={data.total_chunks.toLocaleString()} />
+            <Stat label="superseded" value={data.superseded_documents.toLocaleString()} />
+          </div>
+
+          <div>
+            <div className="text-text-faint uppercase tracking-wide mb-1">
+              last ingestion event
+            </div>
+            <div className="text-text-primary">
+              {data.last_ingest_event
+                ? `${data.last_ingest_event.description} · ${relTime(
+                    data.last_ingest_event.timestamp
+                  )}`
+                : 'no ingestion runs yet — first cron at 06:00 UTC'}
+            </div>
+          </div>
+
+          {data.per_source.length > 0 && (
+            <div>
+              <div className="text-text-faint uppercase tracking-wide mb-1">
+                per source
+              </div>
+              <table className="w-full">
+                <thead>
+                  <tr className="text-text-muted">
+                    <th className="text-left pb-1">domain</th>
+                    <th className="text-right pb-1">documents</th>
+                    <th className="text-right pb-1">last fetched</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {data.per_source.map((s) => (
+                    <tr key={s.domain} className="border-t border-border-light">
+                      <td className="py-1 text-text-primary">{s.domain}</td>
+                      <td className="py-1 text-right tabular-nums">
+                        {s.document_count.toLocaleString()}
+                      </td>
+                      <td className="py-1 text-right text-text-muted">
+                        {relTime(s.last_retrieved_at)}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      ) : (
+        <div className="text-xs font-mono text-text-muted">
+          unable to load corpus context
+        </div>
+      )}
+    </section>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <div className="text-text-faint uppercase tracking-wide mb-1">{label}</div>
+      <div className="text-2xl font-mono text-text-primary tabular-nums">{value}</div>
+    </div>
+  );
+}

--- a/src/components/workbench/SectionD_DiscoveryLauncher.tsx
+++ b/src/components/workbench/SectionD_DiscoveryLauncher.tsx
@@ -1,0 +1,64 @@
+/**
+ * src/components/workbench/SectionD_DiscoveryLauncher.tsx
+ *
+ * Discovery run launcher: model selection, cost cap, snapshot lock,
+ * launch button. Currently a placeholder — the multi-model ensemble
+ * (proposer/critic/judge) lands in PR-16 through PR-25 per architecture
+ * doc § 8.1 Phase 2.
+ */
+
+'use client';
+
+export function SectionD_DiscoveryLauncher() {
+  return (
+    <section className="bg-white rounded border border-border shadow-sm p-5">
+      <div className="flex items-center justify-between mb-3">
+        <h2 className="font-mono text-sm font-bold tracking-wide text-text-primary">
+          D · DISCOVERY RUN LAUNCHER
+        </h2>
+        <span className="text-xs font-mono text-amber-700 bg-amber-50 border border-amber-200 px-2 py-0.5 rounded">
+          UNBUILT
+        </span>
+      </div>
+
+      <div className="space-y-3 text-xs font-mono">
+        <div className="grid grid-cols-3 gap-3 opacity-50">
+          <div>
+            <div className="text-text-faint uppercase tracking-wide mb-1">
+              proposer models
+            </div>
+            <div className="text-text-muted">Claude · GPT · Gemini</div>
+          </div>
+          <div>
+            <div className="text-text-faint uppercase tracking-wide mb-1">
+              cost cap
+            </div>
+            <div className="text-text-muted">$5.00 default</div>
+          </div>
+          <div>
+            <div className="text-text-faint uppercase tracking-wide mb-1">
+              corpus snapshot
+            </div>
+            <div className="text-text-muted">locked</div>
+          </div>
+        </div>
+
+        <button
+          disabled
+          className="px-4 py-2 bg-gray-100 text-text-muted font-mono text-xs rounded border border-border cursor-not-allowed"
+        >
+          launch discovery (disabled)
+        </button>
+
+        <div className="text-text-muted leading-relaxed pt-2 border-t border-border-light">
+          The multi-model proposer/critic/judge ensemble lands in
+          architecture doc § 8.1 Phase 2 (PRs 16-25). Until then, this
+          section is a placeholder. Once Phase 2 ships, clicking
+          &quot;launch discovery&quot; will fire an Inngest event,
+          stream proposer/critic/judge outputs into Section E in real
+          time, and write a typed roadmap into Section F.
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/workbench/SectionE_LiveStream.tsx
+++ b/src/components/workbench/SectionE_LiveStream.tsx
@@ -1,0 +1,93 @@
+/**
+ * src/components/workbench/SectionE_LiveStream.tsx
+ *
+ * Live discovery stream: per-query retrieval blocks, three proposer
+ * columns with token streaming, critic block, judge block, verification
+ * block. The "everything surfaced" heart of the workbench.
+ *
+ * Currently a placeholder — depends on:
+ *   - PR-16-25 (multi-model ensemble)
+ *   - PR-24 (discovery_run_events + SSE relay)
+ *   - PR-26-35 (8-step verification)
+ *
+ * Once Phase 2 lands, this component will subscribe to
+ * /api/runs/{run_id}/stream via EventSource (mirroring
+ * src/app/api/trading/convergence/route.ts pattern) and render every
+ * token as it streams.
+ */
+
+'use client';
+
+const PHASE_2_BLOCKS = [
+  {
+    id: 'profile-signature',
+    name: 'Profile signature',
+    note: 'SHA-256 of profile JSON sent to the run',
+  },
+  {
+    id: 'retrieval',
+    name: 'Retrieval blocks (per query)',
+    note: 'BM25 query + dense vector + RRF + reranker output, top-30 per query',
+  },
+  {
+    id: 'proposers',
+    name: 'Proposer A/B/C blocks',
+    note: 'Claude · GPT · Gemini parallel columns, token-by-token streaming',
+  },
+  {
+    id: 'critic',
+    name: 'Critic block',
+    note: 'Adversarial defect list streaming',
+  },
+  {
+    id: 'judge',
+    name: 'Judge block',
+    note: 'Canonical roadmap with provenance trace',
+  },
+  {
+    id: 'verification',
+    name: 'Verification table (8 steps × N citations)',
+    note: 'Existence · Currency · Groundedness · Pinpoint · Supersession · Jurisdiction · Source · Hash',
+  },
+];
+
+export function SectionE_LiveStream() {
+  return (
+    <section className="bg-white rounded border border-border shadow-sm p-5">
+      <div className="flex items-center justify-between mb-3">
+        <h2 className="font-mono text-sm font-bold tracking-wide text-text-primary">
+          E · LIVE DISCOVERY STREAM
+        </h2>
+        <span className="text-xs font-mono text-amber-700 bg-amber-50 border border-amber-200 px-2 py-0.5 rounded">
+          UNBUILT · PHASE 2/3
+        </span>
+      </div>
+
+      <div className="space-y-2 text-xs font-mono">
+        <div className="text-text-muted leading-relaxed mb-3">
+          Architecture doc § 6.2 E. Six blocks render in document-flow order
+          while a discovery run is in progress. Each block remains visible
+          after the run completes — nothing is hidden.
+        </div>
+
+        {PHASE_2_BLOCKS.map((b) => (
+          <div
+            key={b.id}
+            className="border border-border-light rounded p-3 opacity-60"
+          >
+            <div className="text-text-primary font-bold">{b.name}</div>
+            <div className="text-text-muted mt-0.5">{b.note}</div>
+          </div>
+        ))}
+
+        <div className="text-text-muted leading-relaxed pt-3 border-t border-border-light">
+          SSE relay implementation will mirror{' '}
+          <code className="font-mono">
+            src/app/api/trading/convergence/route.ts
+          </code>{' '}
+          (existing institutional pattern in the repo).
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/workbench/SectionF_Roadmap.tsx
+++ b/src/components/workbench/SectionF_Roadmap.tsx
@@ -1,0 +1,114 @@
+/**
+ * src/components/workbench/SectionF_Roadmap.tsx
+ *
+ * Compact roadmap summary: missions/projects/workstreams/compliance_tasks
+ * count per status, list of recent missions. Full editing lives at
+ * /ops/missions.
+ */
+
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+
+interface MissionRow {
+  id: string;
+  title: string;
+  status: string;
+  updated_at: string;
+}
+
+interface RoadmapData {
+  missions: MissionRow[];
+  total_missions: number;
+}
+
+function relTime(iso: string): string {
+  const ms = Date.now() - new Date(iso).getTime();
+  if (ms < 60_000) return 'just now';
+  if (ms < 3_600_000) return `${Math.floor(ms / 60_000)}m ago`;
+  if (ms < 86_400_000) return `${Math.floor(ms / 3_600_000)}h ago`;
+  return `${Math.floor(ms / 86_400_000)}d ago`;
+}
+
+export function SectionF_Roadmap() {
+  const [data, setData] = useState<RoadmapData | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const res = await fetch('/api/missions?limit=10');
+        if (res.ok) {
+          const body = await res.json();
+          const allMissions: MissionRow[] = (body?.missions ?? []).map(
+            (m: { id: string; title: string; status: string; updated_at: string }) => ({
+              id: m.id,
+              title: m.title,
+              status: m.status,
+              updated_at: m.updated_at,
+            })
+          );
+          // /api/missions ignores ?limit and returns up to 100; trim client-side.
+          const missions = allMissions.slice(0, 10);
+          setData({
+            missions,
+            total_missions: body?.count ?? allMissions.length,
+          });
+        }
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchData();
+  }, []);
+
+  return (
+    <section className="bg-white rounded border border-border shadow-sm p-5">
+      <div className="flex items-center justify-between mb-3">
+        <h2 className="font-mono text-sm font-bold tracking-wide text-text-primary">
+          F · ROADMAP
+        </h2>
+        <Link
+          href="/ops/missions"
+          className="text-xs font-mono text-brand-purple hover:underline"
+        >
+          full view →
+        </Link>
+      </div>
+
+      {loading ? (
+        <div className="text-xs font-mono text-text-muted">loading…</div>
+      ) : data && data.missions.length > 0 ? (
+        <div className="space-y-1 text-xs font-mono">
+          <div className="text-text-faint uppercase tracking-wide mb-2">
+            {data.total_missions.toLocaleString()} mission(s)
+          </div>
+          {data.missions.map((m) => (
+            <Link
+              key={m.id}
+              href={`/ops/missions/${m.id}`}
+              className="flex items-center justify-between py-1 px-2 -mx-2 rounded hover:bg-bg-row"
+            >
+              <span className="text-text-primary truncate">{m.title}</span>
+              <span className="text-text-muted ml-3 shrink-0">
+                {m.status} · {relTime(m.updated_at)}
+              </span>
+            </Link>
+          ))}
+        </div>
+      ) : (
+        <div className="text-xs font-mono text-text-muted leading-relaxed">
+          No missions yet. Once Phase 2 (PRs 16-25) ships the multi-model
+          ensemble, discovery runs will populate this section automatically
+          from the founder profile + corpus retrieval. Until then, missions
+          can be created manually at{' '}
+          <Link href="/ops/missions" className="text-brand-purple hover:underline">
+            /ops/missions
+          </Link>
+          .
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/workbench/SectionG_CitationVerification.tsx
+++ b/src/components/workbench/SectionG_CitationVerification.tsx
@@ -1,0 +1,65 @@
+/**
+ * src/components/workbench/SectionG_CitationVerification.tsx
+ *
+ * Citation verification panel: 8-step status badges per citation,
+ * force re-verify button, evidence detail. Currently a placeholder —
+ * the 8-step adversarial verifier lands in PR-26 through PR-35 per
+ * architecture doc § 8.1 Phase 3.
+ */
+
+'use client';
+
+const STEPS = [
+  { n: 1, name: 'Existence', tool: 'HEAD/GET to canonical URL' },
+  { n: 2, name: 'Currency', tool: 'effective_date <= today, not superseded' },
+  { n: 3, name: 'Groundedness', tool: 'NLI ≥0.85 + verifier LLM + embedding floor' },
+  { n: 4, name: 'Pinpoint', tool: 'structural_path + text_hash match' },
+  { n: 5, name: 'Supersession', tool: 'graph traversal for newer authority' },
+  { n: 6, name: 'Jurisdiction', tool: 'jurisdiction graph match' },
+  { n: 7, name: 'Source authority', tool: 'regulatory_sources allow-list' },
+  { n: 8, name: 'Content hash', tool: 'SHA-256 chunk text vs recorded hash' },
+];
+
+export function SectionG_CitationVerification() {
+  return (
+    <section className="bg-white rounded border border-border shadow-sm p-5">
+      <div className="flex items-center justify-between mb-3">
+        <h2 className="font-mono text-sm font-bold tracking-wide text-text-primary">
+          G · CITATION VERIFICATION
+        </h2>
+        <span className="text-xs font-mono text-amber-700 bg-amber-50 border border-amber-200 px-2 py-0.5 rounded">
+          UNBUILT · PHASE 3
+        </span>
+      </div>
+
+      <div className="space-y-2 text-xs font-mono">
+        <div className="text-text-muted leading-relaxed mb-3">
+          The 8-step adversarial verification protocol from architecture
+          doc § 3. Each citation passes only if all eight steps pass.
+          Failure of any step degrades status to{' '}
+          <code className="font-mono">defective</code> and blocks
+          dependent tasks until human review.
+        </div>
+
+        <table className="w-full">
+          <thead>
+            <tr className="text-text-faint uppercase tracking-wide">
+              <th className="text-left pb-1 w-8">#</th>
+              <th className="text-left pb-1">step</th>
+              <th className="text-left pb-1">tool</th>
+            </tr>
+          </thead>
+          <tbody>
+            {STEPS.map((s) => (
+              <tr key={s.n} className="border-t border-border-light opacity-60">
+                <td className="py-1 text-text-primary tabular-nums">{s.n}</td>
+                <td className="py-1 text-text-primary">{s.name}</td>
+                <td className="py-1 text-text-muted">{s.tool}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}

--- a/src/components/workbench/SectionH_CorpusInspector.tsx
+++ b/src/components/workbench/SectionH_CorpusInspector.tsx
@@ -1,0 +1,111 @@
+/**
+ * src/components/workbench/SectionH_CorpusInspector.tsx
+ *
+ * Corpus inspector: search box (BM25 keyword now, HNSW similarity once
+ * PR-J brings embeddings online), recently retrieved chunks list with
+ * parent document context.
+ *
+ * Wires to /api/workbench/recent-chunks.
+ */
+
+'use client';
+
+import { useEffect, useState } from 'react';
+
+interface ChunkRow {
+  id: string;
+  document_id: string;
+  citation_key: string;
+  document_title: string;
+  jurisdiction: string;
+  pinpoint: string | null;
+  structural_path: string;
+  text_snippet: string;
+  ingested_at: string;
+}
+
+export function SectionH_CorpusInspector() {
+  const [query, setQuery] = useState('');
+  const [debouncedQuery, setDebouncedQuery] = useState('');
+  const [results, setResults] = useState<ChunkRow[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    const id = setTimeout(() => setDebouncedQuery(query), 300);
+    return () => clearTimeout(id);
+  }, [query]);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      setLoading(true);
+      try {
+        const url = debouncedQuery
+          ? `/api/workbench/recent-chunks?q=${encodeURIComponent(debouncedQuery)}&limit=20`
+          : '/api/workbench/recent-chunks?limit=20';
+        const res = await fetch(url);
+        if (res.ok) {
+          const body = await res.json();
+          setResults(body?.results ?? []);
+        } else {
+          setResults([]);
+        }
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchData();
+  }, [debouncedQuery]);
+
+  return (
+    <section className="bg-white rounded border border-border shadow-sm p-5">
+      <div className="flex items-center justify-between mb-3">
+        <h2 className="font-mono text-sm font-bold tracking-wide text-text-primary">
+          H · CORPUS INSPECTOR
+        </h2>
+        <span className="text-xs font-mono text-text-muted">
+          BM25 keyword (HNSW after PR-J)
+        </span>
+      </div>
+
+      <input
+        type="text"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        placeholder="search corpus (e.g., 'trade or business expenses')"
+        className="w-full px-3 py-2 text-xs font-mono border border-border rounded mb-3 focus:outline-none focus:border-brand-purple"
+      />
+
+      {loading ? (
+        <div className="text-xs font-mono text-text-muted">loading…</div>
+      ) : results.length > 0 ? (
+        <div className="space-y-2 text-xs font-mono max-h-96 overflow-y-auto">
+          {results.map((r) => (
+            <div
+              key={r.id}
+              className="border border-border-light rounded p-2 hover:bg-bg-row"
+            >
+              <div className="flex items-baseline justify-between mb-1">
+                <span className="text-text-primary font-bold">
+                  {r.citation_key}
+                  {r.pinpoint && <span className="text-text-muted"> {r.pinpoint}</span>}
+                </span>
+                <span className="text-text-faint">{r.jurisdiction}</span>
+              </div>
+              <div className="text-text-muted truncate">{r.document_title}</div>
+              <div className="text-text-secondary mt-1 leading-relaxed">
+                {r.text_snippet}
+                {r.text_snippet.length >= 400 && '…'}
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className="text-xs font-mono text-text-muted leading-relaxed">
+          {debouncedQuery
+            ? 'No results for that query.'
+            : 'No chunks ingested yet. The eCFR worker runs at 06:00 UTC daily; first run will populate this section. Or invoke the function manually from the Inngest dashboard to backfill now.'}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/workbench/SectionI_AuditTail.tsx
+++ b/src/components/workbench/SectionI_AuditTail.tsx
@@ -1,0 +1,154 @@
+/**
+ * src/components/workbench/SectionI_AuditTail.tsx
+ *
+ * Audit log tail: last 50 entries, newest first. Verify-chain button
+ * computes the hash chain locally and reports any mismatch.
+ *
+ * Wires to /api/audit-log and /api/audit-log/verify-chain (existing).
+ */
+
+'use client';
+
+import { useEffect, useState } from 'react';
+
+interface AuditRow {
+  id: string;
+  created_at: string;
+  actor_type: string;
+  action_type: string;
+  action_description: string;
+  target_table: string | null;
+  target_id: string | null;
+  prev_hash: string;
+  content_hash: string;
+}
+
+interface VerifyResult {
+  ok: boolean;
+  rows_checked: number;
+  message?: string;
+}
+
+function shortHash(h: string | null): string {
+  if (!h) return '—';
+  return h.length > 12 ? `${h.slice(0, 6)}…${h.slice(-4)}` : h;
+}
+
+function relTime(iso: string): string {
+  const ms = Date.now() - new Date(iso).getTime();
+  if (ms < 60_000) return `${Math.floor(ms / 1000)}s ago`;
+  if (ms < 3_600_000) return `${Math.floor(ms / 60_000)}m ago`;
+  if (ms < 86_400_000) return `${Math.floor(ms / 3_600_000)}h ago`;
+  return `${Math.floor(ms / 86_400_000)}d ago`;
+}
+
+export function SectionI_AuditTail() {
+  const [rows, setRows] = useState<AuditRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [verifying, setVerifying] = useState(false);
+  const [verifyResult, setVerifyResult] = useState<VerifyResult | null>(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const res = await fetch('/api/audit-log?limit=50');
+        if (res.ok) {
+          const body = await res.json();
+          setRows(body?.entries ?? body?.rows ?? []);
+        }
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchData();
+    const id = setInterval(fetchData, 10000);
+    return () => clearInterval(id);
+  }, []);
+
+  const verifyChain = async () => {
+    setVerifying(true);
+    setVerifyResult(null);
+    try {
+      const res = await fetch('/api/audit-log/verify-chain');
+      if (res.ok) {
+        setVerifyResult(await res.json());
+      } else {
+        setVerifyResult({ ok: false, rows_checked: 0, message: 'request failed' });
+      }
+    } finally {
+      setVerifying(false);
+    }
+  };
+
+  return (
+    <section className="bg-white rounded border border-border shadow-sm p-5">
+      <div className="flex items-center justify-between mb-3">
+        <h2 className="font-mono text-sm font-bold tracking-wide text-text-primary">
+          I · AUDIT LOG TAIL
+        </h2>
+        <div className="flex items-center gap-3 text-xs font-mono">
+          <span className="text-text-muted">refresh 10s</span>
+          <button
+            onClick={verifyChain}
+            disabled={verifying}
+            className="px-2 py-1 border border-border rounded hover:bg-bg-row disabled:opacity-50"
+          >
+            {verifying ? 'verifying…' : 'verify chain'}
+          </button>
+        </div>
+      </div>
+
+      {verifyResult && (
+        <div
+          className={`text-xs font-mono mb-3 px-3 py-2 rounded border ${
+            verifyResult.ok
+              ? 'bg-green-50 border-green-200 text-green-800'
+              : 'bg-red-50 border-red-200 text-red-800'
+          }`}
+        >
+          {verifyResult.ok
+            ? `chain valid · ${verifyResult.rows_checked} rows checked`
+            : `chain INVALID · ${verifyResult.message ?? 'see /ops/audit-log'}`}
+        </div>
+      )}
+
+      {loading ? (
+        <div className="text-xs font-mono text-text-muted">loading…</div>
+      ) : rows.length > 0 ? (
+        <div className="text-xs font-mono max-h-96 overflow-y-auto">
+          <table className="w-full">
+            <thead className="sticky top-0 bg-white">
+              <tr className="text-text-faint uppercase tracking-wide">
+                <th className="text-left pb-1 w-20">when</th>
+                <th className="text-left pb-1">action</th>
+                <th className="text-left pb-1 w-24">target</th>
+                <th className="text-left pb-1 w-28">prev_hash</th>
+                <th className="text-left pb-1 w-28">this_hash</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((r) => (
+                <tr key={r.id} className="border-t border-border-light">
+                  <td className="py-1 text-text-muted">{relTime(r.created_at)}</td>
+                  <td className="py-1 text-text-primary">
+                    <div className="font-bold">{r.action_type}</div>
+                    <div className="text-text-muted truncate max-w-md">
+                      {r.action_description}
+                    </div>
+                  </td>
+                  <td className="py-1 text-text-muted truncate">
+                    {r.target_table ?? '—'}
+                  </td>
+                  <td className="py-1 text-text-faint">{shortHash(r.prev_hash)}</td>
+                  <td className="py-1 text-text-faint">{shortHash(r.content_hash)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ) : (
+        <div className="text-xs font-mono text-text-muted">no audit entries</div>
+      )}
+    </section>
+  );
+}

--- a/src/components/workbench/SectionJ_CostLedger.tsx
+++ b/src/components/workbench/SectionJ_CostLedger.tsx
@@ -1,0 +1,49 @@
+/**
+ * src/components/workbench/SectionJ_CostLedger.tsx
+ *
+ * Cost ledger: cumulative cost today/week/month, per-run breakdown,
+ * per-model breakdown. Currently a placeholder — cost_ledger table
+ * lands in PR-23 per architecture doc § 8.1 Phase 2.
+ */
+
+'use client';
+
+export function SectionJ_CostLedger() {
+  return (
+    <section className="bg-white rounded border border-border shadow-sm p-5">
+      <div className="flex items-center justify-between mb-3">
+        <h2 className="font-mono text-sm font-bold tracking-wide text-text-primary">
+          J · COST LEDGER
+        </h2>
+        <span className="text-xs font-mono text-amber-700 bg-amber-50 border border-amber-200 px-2 py-0.5 rounded">
+          UNBUILT · PHASE 2 · PR-23
+        </span>
+      </div>
+
+      <div className="space-y-3 text-xs font-mono">
+        <div className="grid grid-cols-3 gap-3 opacity-50">
+          <div>
+            <div className="text-text-faint uppercase tracking-wide mb-1">today</div>
+            <div className="text-2xl text-text-muted tabular-nums">$ —</div>
+          </div>
+          <div>
+            <div className="text-text-faint uppercase tracking-wide mb-1">this week</div>
+            <div className="text-2xl text-text-muted tabular-nums">$ —</div>
+          </div>
+          <div>
+            <div className="text-text-faint uppercase tracking-wide mb-1">this month</div>
+            <div className="text-2xl text-text-muted tabular-nums">$ —</div>
+          </div>
+        </div>
+
+        <div className="text-text-muted leading-relaxed pt-2 border-t border-border-light">
+          Per architecture doc § 4.4, every model call writes to a
+          versioned <code>cost_ledger</code> table. Cost cap enforcement
+          fires <code>CostCapExceeded</code> if a run exceeds its
+          budget. Per-run economics target is $1.35-$1.80 (Phase 2
+          ensemble) per architecture doc § 4.4. Lands in PR-23.
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
Replaces the legacy tabbed Ops landing page with the single-page workbench from architecture doc Section 6. Sections render top-to- bottom in one continuous stream per the institutional design tradition (Bloomberg Terminal / Bridgewater / Citadel internal monitoring tools): no tabs, dense, scrollable, audit-deeplinkable.

Five sections wire fully today using existing data:
- A: identity bar (sticky, build SHA, audit tail hash)
- B: founder profile summary (link to /ops/profile for editing)
- C: corpus context (live counts, last ingestion event, per-source)
- F: roadmap (missions list, link to /ops/missions for editing)
- I: audit log tail (last 50 entries, verify-chain button)

One section partial (H: corpus inspector, BM25 keyword search now; upgrades to HNSW once PR-J Voyage embeddings ship).

Four sections placeholder with explicit Phase-X notices:
- D: discovery run launcher (PRs 16-25 — multi-model ensemble)
- E: live discovery stream (PRs 16-25 + 26-35 + 24 SSE relay)
- G: citation verification (PRs 26-35 — 8-step verifier)
- J: cost ledger (PR-23 — cost_ledger table + cap enforcement)

Two new API routes:
- /api/workbench/corpus-context: counts + last ingest + per-source
- /api/workbench/recent-chunks: BM25 search or recent-chunks fallback

The placeholders are intentional scaffolding. Each future PR fills in one section without restructuring the page. The workbench grows as the backend grows.

Reference: docs/architecture/discovery-engine-institutional-grade.md Section 6 in full, plus § 8.1 Phase 4 PRs 36-47 (this PR is the foundation that those 12 PRs progressively replace section-by-section).