### PR TITLE
PR-H: U.S. Code (USLM) weekly ingestion worker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@tanstack/react-virtual": "^3.13.18",
         "@tastytrade/api": "^6.0.1",
         "@types/pdfkit": "^0.17.5",
+        "adm-zip": "^0.5.17",
         "bcryptjs": "^2.4.3",
         "fast-xml-parser": "^5.7.2",
         "inngest": "^4.2.6",
@@ -39,6 +40,7 @@
         "xai-sdk": "^1.0.0-alpha.0"
       },
       "devDependencies": {
+        "@types/adm-zip": "^0.5.8",
         "@types/bcryptjs": "^2.4.6",
         "@types/jsonwebtoken": "^9.0.10",
         "@types/leaflet": "^1.9.21",
@@ -4080,6 +4082,16 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/adm-zip": {
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/@types/adm-zip/-/adm-zip-0.5.8.tgz",
+      "integrity": "sha512-RVVH7QvZYbN+ihqZ4kX/dMiowf6o+Jk1fNwiSdx0NahBJLU787zkULhGhJM8mf/obmLGmgdMM0bXsQTmyfbR7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/aws-lambda": {
       "version": "8.10.161",
       "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.161.tgz",
@@ -5519,6 +5531,15 @@
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/adm-zip": {
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
+      "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
       }
     },
     "node_modules/agent-base": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@tanstack/react-virtual": "^3.13.18",
     "@tastytrade/api": "^6.0.1",
     "@types/pdfkit": "^0.17.5",
+    "adm-zip": "^0.5.17",
     "bcryptjs": "^2.4.3",
     "fast-xml-parser": "^5.7.2",
     "inngest": "^4.2.6",
@@ -43,6 +44,7 @@
     "xai-sdk": "^1.0.0-alpha.0"
   },
   "devDependencies": {
+    "@types/adm-zip": "^0.5.8",
     "@types/bcryptjs": "^2.4.6",
     "@types/jsonwebtoken": "^9.0.10",
     "@types/leaflet": "^1.9.21",

--- a/src/inngest/functions/index.ts
+++ b/src/inngest/functions/index.ts
@@ -12,10 +12,12 @@
 
 import { healthCheck } from './health-check';
 import { ecfrIngest } from './ecfr-ingest';
+import { uscodeIngest } from './uscode-ingest';
 
 export const functions = [
   healthCheck,
   ecfrIngest,
+  uscodeIngest,
 ];
 
-export { healthCheck, ecfrIngest };
+export { healthCheck, ecfrIngest, uscodeIngest };

--- a/src/inngest/functions/uscode-ingest.ts
+++ b/src/inngest/functions/uscode-ingest.ts
@@ -1,0 +1,219 @@
+/**
+ * src/inngest/functions/uscode-ingest.ts
+ *
+ * Weekly U.S. Code ingestion worker. Cron fires at Sunday 07:00 UTC
+ * (30 minutes after eCFR's daily cron, weekly cadence per the
+ * regulatory_sources entry's refresh_cadence: "weekly").
+ *
+ * Flow:
+ *   step 1: discover-release-point — fetch download.shtml and
+ *           extract the highest (congress, plno) pair. If this step
+ *           fails, the entire run fails (no silent fallback).
+ *   step 2: per-title loop — for each of 55 USCODE_TITLES (54 plus
+ *           Title 5 Appendix), run a step that:
+ *             - HEAD request to get Last-Modified at this release point
+ *             - compare to our latest stored published_date
+ *             - skip if Last-Modified <= our latest
+ *             - otherwise: fetch full ZIP, unpack XML, parse, persist
+ *   step 3: write-run-summary — audit log entry with per-title summary
+ *
+ * Each step.run is automatically memoized by Inngest. If the run
+ * fails mid-flight and retries, completed titles are not re-fetched.
+ *
+ * Reference: docs/architecture/discovery-engine-institutional-grade.md § 4.1
+ */
+
+import crypto from 'crypto';
+import { PrismaClient } from '@prisma/client';
+import { inngest } from '../client';
+import {
+  USCODE_TITLES,
+  fetchTitleHeaders,
+  fetchUscTitleXml,
+  parseUscTitleToDocuments,
+  persistUscTitleDocuments,
+  discoverLatestReleasePoint,
+} from '@/lib/corpus/ingest';
+import type {
+  TitleIngestSummary,
+  RunSummary,
+  ReleasePoint,
+} from '@/lib/corpus/ingest';
+import { writeAuditLog } from '@/lib/audit/writeAuditLog';
+
+const prisma = new PrismaClient();
+
+/**
+ * Helper: latest published_date for any USC document under the given
+ * title number. Returns null if none.
+ */
+async function latestPublishedDateForTitle(
+  titleNumber: number
+): Promise<Date | null> {
+  const rows = await prisma.$queryRaw<Array<{ max: Date | null }>>`
+    SELECT MAX(d.published_date) AS max
+    FROM regulatory_documents d
+    JOIN regulatory_sources s ON d.source_id = s.id
+    WHERE s.domain = 'uscode.house.gov'
+      AND d.metadata->>'title_number' = ${String(titleNumber)}
+      AND d.superseded_by IS NULL
+  `;
+  return rows[0]?.max ?? null;
+}
+
+export const uscodeIngest = inngest.createFunction(
+  {
+    id: 'uscode-ingest-weekly',
+    name: 'U.S. Code weekly ingestion',
+    triggers: [{ cron: '0 7 * * 0' }],
+    concurrency: { limit: 1 },
+  },
+  async ({ step }) => {
+    const startedAt = new Date().toISOString();
+
+    // STEP 1: discover the latest OLRC release point.
+    // If this fails, the whole run fails — no silent fallback.
+    const releasePoint: ReleasePoint = await step.run(
+      'discover-release-point',
+      async () => {
+        return await discoverLatestReleasePoint();
+      }
+    );
+
+    const perTitle: TitleIngestSummary[] = [];
+
+    // STEP 2: per-title loop — each title in its own step.run for
+    // Inngest's automatic memoization on retry.
+    for (const title of USCODE_TITLES) {
+      const summary = await step.run(
+        `title-${title.number}`,
+        async (): Promise<TitleIngestSummary> => {
+          const titleStart = Date.now();
+          try {
+            const headers = await fetchTitleHeaders(
+              releasePoint.congress,
+              releasePoint.plno,
+              title.number
+            );
+
+            if (!headers.last_modified) {
+              return {
+                title_number: title.number,
+                title_name: title.name,
+                outcome: 'failed',
+                documents_inserted: 0,
+                chunks_inserted: 0,
+                documents_superseded: 0,
+                error_message: 'no Last-Modified header from OLRC',
+                duration_ms: Date.now() - titleStart,
+              };
+            }
+
+            const lastModifiedDate = new Date(headers.last_modified);
+            const latestKnown = await latestPublishedDateForTitle(title.number);
+
+            if (latestKnown && latestKnown >= lastModifiedDate) {
+              return {
+                title_number: title.number,
+                title_name: title.name,
+                outcome: 'unchanged',
+                documents_inserted: 0,
+                chunks_inserted: 0,
+                documents_superseded: 0,
+                ecfr_up_to_date_as_of: lastModifiedDate.toISOString(),
+                duration_ms: Date.now() - titleStart,
+              };
+            }
+
+            const xml = await fetchUscTitleXml(
+              releasePoint.congress,
+              releasePoint.plno,
+              title.number
+            );
+            const rawSha = crypto
+              .createHash('sha256')
+              .update(xml)
+              .digest('hex');
+
+            const documents = parseUscTitleToDocuments(
+              xml,
+              title.number,
+              lastModifiedDate.toISOString()
+            );
+
+            const counts = await persistUscTitleDocuments(
+              documents,
+              title.number,
+              title.name,
+              xml,
+              lastModifiedDate.toISOString()
+            );
+
+            return {
+              title_number: title.number,
+              title_name: title.name,
+              outcome: 'ingested',
+              ...counts,
+              ecfr_up_to_date_as_of: lastModifiedDate.toISOString(),
+              raw_xml_sha256: rawSha,
+              duration_ms: Date.now() - titleStart,
+            };
+          } catch (err) {
+            return {
+              title_number: title.number,
+              title_name: title.name,
+              outcome: 'failed',
+              documents_inserted: 0,
+              chunks_inserted: 0,
+              documents_superseded: 0,
+              error_message: err instanceof Error ? err.message : String(err),
+              duration_ms: Date.now() - titleStart,
+            };
+          }
+        }
+      );
+
+      perTitle.push(summary);
+    }
+
+    // STEP 3: write run summary to audit log.
+    const completedAt = new Date().toISOString();
+    const summary: RunSummary = {
+      started_at: startedAt,
+      completed_at: completedAt,
+      titles_total: USCODE_TITLES.length,
+      titles_unchanged: perTitle.filter((p) => p.outcome === 'unchanged').length,
+      titles_ingested: perTitle.filter((p) => p.outcome === 'ingested').length,
+      titles_failed: perTitle.filter((p) => p.outcome === 'failed').length,
+      documents_inserted_total: perTitle.reduce(
+        (sum, p) => sum + p.documents_inserted,
+        0
+      ),
+      chunks_inserted_total: perTitle.reduce(
+        (sum, p) => sum + p.chunks_inserted,
+        0
+      ),
+      per_title: perTitle,
+    };
+
+    await step.run('write-run-summary', async () => {
+      await writeAuditLog({
+        actor: { type: 'system_automation' },
+        action: {
+          type: 'regulatory_ingest_run_completed',
+          description: `USC ingest run @${releasePoint.identifier}: ${summary.titles_ingested} ingested, ${summary.titles_unchanged} unchanged, ${summary.titles_failed} failed`,
+        },
+        target: { table: 'regulatory_documents' },
+        payload: {
+          metadata: {
+            run_summary: summary,
+            source: 'uscode.house.gov',
+            release_point: releasePoint.identifier,
+          },
+        },
+      });
+    });
+
+    return summary;
+  }
+);

--- a/src/lib/corpus/ingest/index.ts
+++ b/src/lib/corpus/ingest/index.ts
@@ -9,6 +9,18 @@ export { fetchTitleList, fetchTitleXml } from './ecfr-fetch';
 export { parseTitleToDocuments } from './ecfr-parse';
 export { persistTitleDocuments } from './ecfr-persist';
 
+export {
+  fetchTitleHeaders,
+  fetchTitleXml as fetchUscTitleXml,
+  discoverLatestReleasePoint,
+  extractLatestReleasePoint,
+} from './uscode-fetch';
+export { parseUscTitleToDocuments } from './uscode-parse';
+export { persistUscTitleDocuments } from './uscode-persist';
+export { USCODE_TITLES, xmlUrlForTitle, downloadIndexUrl } from './uscode-titles';
+export type { UscodeTitle } from './uscode-titles';
+export type { UscodeTitleHeaders, ReleasePoint } from './uscode-fetch';
+
 export type {
   EcfrTitleListEntry,
   ParsedDocument,

--- a/src/lib/corpus/ingest/uscode-fetch.ts
+++ b/src/lib/corpus/ingest/uscode-fetch.ts
@@ -1,0 +1,231 @@
+/**
+ * src/lib/corpus/ingest/uscode-fetch.ts
+ *
+ * HTTP layer for the U.S. Code USLM XML at uscode.house.gov.
+ *
+ * URL structure (verified 2026-05 via download.shtml reconnaissance):
+ *
+ *   download.shtml is a static HTML index containing per-title and
+ *   all-titles ZIP links. Each link references one release point
+ *   identified by (congress, plno) — Public Law number.
+ *
+ *   Per-title ZIP:
+ *     /download/releasepoints/us/pl/{congress}/{plno}/xml_usc{NN}@{congress}-{plno}.zip
+ *
+ *   Inside each ZIP: one usc{NN}.xml USLM file.
+ *
+ * Discovery flow:
+ *   1. fetchDownloadIndexHtml() — GET download.shtml
+ *   2. extractLatestReleasePoint(html) — parse <a href> links, find
+ *      highest (congress, plno) pair
+ *   3. fetchTitleXml(congress, plno, titleNumber) — GET ZIP, unpack
+ *
+ * No fallback if discovery fails — we throw, the worker step fails,
+ * audit_log records the failure, next cron run retries. Citadel
+ * fail-loud principle.
+ *
+ * Throttle: 2 concurrent requests via p-limit.
+ *
+ * Reference: docs/architecture/discovery-engine-institutional-grade.md § 1.3
+ */
+
+import AdmZip from 'adm-zip';
+import pLimit from 'p-limit';
+import { downloadIndexUrl, xmlUrlForTitle } from './uscode-titles';
+
+const USER_AGENT =
+  'TempleStuart-Compliance/1.0 (+https://templestuart.com; institutional-grade-corpus)';
+
+const limit = pLimit(2);
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function fetchWithRetry(
+  url: string,
+  init?: RequestInit
+): Promise<Response> {
+  const headers = {
+    ...(init?.headers ?? {}),
+    'User-Agent': USER_AGENT,
+  };
+
+  for (let attempt = 0; attempt < 2; attempt++) {
+    const response = await fetch(url, { ...init, headers });
+
+    if (response.ok) return response;
+
+    if (response.status >= 400 && response.status < 500) {
+      throw new Error(
+        `USC fetch failed (permanent): ${response.status} ${response.statusText} for ${url}`
+      );
+    }
+
+    if (attempt === 0) {
+      await sleep(1000);
+      continue;
+    }
+
+    throw new Error(
+      `USC fetch failed (after retry): ${response.status} ${response.statusText} for ${url}`
+    );
+  }
+
+  throw new Error('USC fetch failed: exhausted retries');
+}
+
+export interface ReleasePoint {
+  congress: number;
+  plno: number;
+  /** "{congress}-{plno}" string form, e.g. "119-84" */
+  identifier: string;
+}
+
+/**
+ * Fetch the OLRC download index HTML. Returns the raw HTML string.
+ * Used for release-point discovery.
+ */
+async function fetchDownloadIndexHtml(): Promise<string> {
+  return limit(async () => {
+    const url = downloadIndexUrl();
+    const response = await fetchWithRetry(url);
+    return await response.text();
+  });
+}
+
+/**
+ * Parse the OLRC download.shtml HTML to extract the latest release
+ * point. Walks all <a href> links matching the release-point URL
+ * pattern, parses out (congress, plno), returns the highest pair.
+ *
+ * The release-point ordering: higher congress wins; within the same
+ * congress, higher plno wins.
+ *
+ * Throws if no release-point links can be parsed — institutional
+ * fail-loud, no silent fallback.
+ */
+export function extractLatestReleasePoint(html: string): ReleasePoint {
+  // Match links like: xml_uscAll@119-84.zip or xml_usc26@119-84.zip
+  const linkPattern =
+    /releasepoints\/us\/pl\/(\d+)\/(\d+)\/xml_usc(?:[0-9]{1,2}[a-zA-Z]?|All)@(\d+)-(\d+)\.zip/g;
+
+  const seen = new Map<string, ReleasePoint>();
+  let match: RegExpExecArray | null;
+  while ((match = linkPattern.exec(html)) !== null) {
+    const congress = Number(match[1]);
+    const plno = Number(match[2]);
+    if (!Number.isFinite(congress) || !Number.isFinite(plno)) continue;
+    const id = `${congress}-${plno}`;
+    if (!seen.has(id)) {
+      seen.set(id, { congress, plno, identifier: id });
+    }
+  }
+
+  if (seen.size === 0) {
+    throw new Error(
+      'OLRC download.shtml parse failed: no release-point links found. ' +
+        'The site structure may have changed; this requires manual investigation.'
+    );
+  }
+
+  // Sort by (congress DESC, plno DESC) — highest pair first.
+  const sorted = Array.from(seen.values()).sort((a, b) => {
+    if (a.congress !== b.congress) return b.congress - a.congress;
+    return b.plno - a.plno;
+  });
+
+  return sorted[0];
+}
+
+/**
+ * Combined: fetch download.shtml and extract the latest release point.
+ *
+ * @returns the latest (congress, plno) pair as published by OLRC
+ * @throws if the page fetch fails or no release-point links are found
+ */
+export async function discoverLatestReleasePoint(): Promise<ReleasePoint> {
+  const html = await fetchDownloadIndexHtml();
+  return extractLatestReleasePoint(html);
+}
+
+export interface UscodeTitleHeaders {
+  title_number: number;
+  congress: number;
+  plno: number;
+  last_modified: string | null;
+  content_length: number | null;
+  etag: string | null;
+}
+
+/**
+ * HEAD request for one title's ZIP at a specific release point.
+ * Returns Last-Modified, Content-Length, ETag for change-detection.
+ */
+export async function fetchTitleHeaders(
+  congress: number,
+  plno: number,
+  titleNumber: number
+): Promise<UscodeTitleHeaders> {
+  return limit(async () => {
+    const url = xmlUrlForTitle(congress, plno, titleNumber);
+    const response = await fetchWithRetry(url, { method: 'HEAD' });
+    return {
+      title_number: titleNumber,
+      congress,
+      plno,
+      last_modified: response.headers.get('last-modified'),
+      content_length: response.headers.get('content-length')
+        ? Number(response.headers.get('content-length'))
+        : null,
+      etag: response.headers.get('etag'),
+    };
+  });
+}
+
+/**
+ * GET one title's ZIP at a specific release point, unpack, return
+ * the inner USLM XML buffer.
+ *
+ * Throws if the ZIP is empty, contains multiple files, or cannot be
+ * unpacked — fail-loud rather than silently returning bad data.
+ */
+export async function fetchTitleXml(
+  congress: number,
+  plno: number,
+  titleNumber: number
+): Promise<Buffer> {
+  return limit(async () => {
+    const url = xmlUrlForTitle(congress, plno, titleNumber);
+    const response = await fetchWithRetry(url);
+    const arrayBuffer = await response.arrayBuffer();
+    const zipBuffer = Buffer.from(arrayBuffer);
+
+    const zip = new AdmZip(zipBuffer);
+    const entries = zip.getEntries();
+
+    if (entries.length === 0) {
+      throw new Error(`USC ZIP empty: ${url}`);
+    }
+
+    // Find the .xml entry. Most release-point ZIPs contain exactly
+    // one usc{NN}.xml file. If multiple .xml files appear, we take
+    // the largest one (defensive — but log a warning in metadata).
+    const xmlEntries = entries.filter((e) => e.entryName.endsWith('.xml'));
+
+    if (xmlEntries.length === 0) {
+      throw new Error(
+        `USC ZIP contains no .xml file: ${url} (entries: ${entries
+          .map((e) => e.entryName)
+          .join(', ')})`
+      );
+    }
+
+    if (xmlEntries.length > 1) {
+      // Sort by header.size descending; take largest
+      xmlEntries.sort((a, b) => (b.header.size ?? 0) - (a.header.size ?? 0));
+    }
+
+    return xmlEntries[0].getData();
+  });
+}

--- a/src/lib/corpus/ingest/uscode-parse.ts
+++ b/src/lib/corpus/ingest/uscode-parse.ts
@@ -1,0 +1,190 @@
+/**
+ * src/lib/corpus/ingest/uscode-parse.ts
+ *
+ * Walks USLM XML payloads (U.S. Code) and produces ParsedDocument
+ * objects. One ParsedDocument per <section>; one ParsedChunk per
+ * section (whole-section, small-to-big pattern matching PR-G).
+ *
+ * USLM structure (relevant elements, USLM 1.0 — verified 2026-05 via
+ * reconnaissance against actual OLRC release-point XML):
+ *   <uscDoc xmlns="http://xml.house.gov/schemas/uslm/1.0">
+ *     <meta>...</meta>
+ *     <main>
+ *       <title>
+ *         <subtitle>
+ *           <chapter>
+ *             <subchapter>
+ *               <part>
+ *                 <section identifier="/us/usc/t26/s162">
+ *                   <num value="162">§ 162.</num>
+ *                   <heading>Trade or business expenses</heading>
+ *                   <content>
+ *                     <p>...</p>
+ *                   </content>
+ *
+ * Citation key: 26-USC-162 (parallels PR-G's 26-CFR-1.162-1).
+ *
+ * Reference: docs/architecture/discovery-engine-institutional-grade.md § 1.2
+ */
+
+import { XMLParser } from 'fast-xml-parser';
+import type { ParsedDocument, ParsedChunk } from './types';
+
+const parser = new XMLParser({
+  ignoreAttributes: false,
+  attributeNamePrefix: '@_',
+  textNodeName: '#text',
+  parseAttributeValue: false,
+  trimValues: true,
+});
+
+/**
+ * Recursively collect all <section> elements from a parsed XML tree.
+ * Returns array of section nodes with attributes and content.
+ */
+function collectSectionNodes(node: unknown, acc: unknown[] = []): unknown[] {
+  if (!node || typeof node !== 'object') return acc;
+  const obj = node as Record<string, unknown>;
+
+  for (const [key, value] of Object.entries(obj)) {
+    if (key === 'section') {
+      if (Array.isArray(value)) {
+        acc.push(...value);
+      } else {
+        acc.push(value);
+      }
+    } else if (typeof value === 'object' && value !== null) {
+      collectSectionNodes(value, acc);
+    }
+  }
+
+  return acc;
+}
+
+/**
+ * Strip XML/HTML tags and concatenate all text content under a node.
+ */
+function extractText(node: unknown): string {
+  if (typeof node === 'string') return node;
+  if (typeof node === 'number') return String(node);
+  if (!node || typeof node !== 'object') return '';
+
+  const obj = node as Record<string, unknown>;
+
+  if ('#text' in obj && typeof obj['#text'] === 'string') {
+    return obj['#text'];
+  }
+
+  const parts: string[] = [];
+  for (const [key, value] of Object.entries(obj)) {
+    if (key.startsWith('@_')) continue;
+    if (key === '#text') continue;
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        parts.push(extractText(item));
+      }
+    } else {
+      parts.push(extractText(value));
+    }
+  }
+  return parts.join(' ').replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * Approximate token count for chunk size estimation.
+ */
+function estimateTokens(text: string): number {
+  return Math.ceil(text.length / 4);
+}
+
+/**
+ * Extract the section number from a USLM identifier attribute.
+ *
+ * Identifier format: "/us/usc/t26/s162" or "/us/usc/t26/s162a"
+ * (some sections have letter suffixes like "162A" or numbered
+ * subsections like "162.5").
+ *
+ * Returns just the section identifier portion (everything after
+ * the final 's'). Returns null if the identifier doesn't match the
+ * expected format.
+ */
+function extractSectionId(identifier: string): string | null {
+  const match = identifier.match(/\/s([^/]+)$/);
+  return match ? match[1] : null;
+}
+
+/**
+ * Parse one USC title's USLM XML payload into ParsedDocument[].
+ * One ParsedDocument per <section> element.
+ *
+ * @param xmlBuffer raw USLM XML bytes from fetchTitleXml
+ * @param titleNumber USC title number (1-54)
+ * @param effectiveDate the Last-Modified date this XML represents
+ * @returns array of ParsedDocument; empty if title has no parseable sections
+ */
+export function parseUscTitleToDocuments(
+  xmlBuffer: Buffer,
+  titleNumber: number,
+  effectiveDate: string
+): ParsedDocument[] {
+  const xmlString = xmlBuffer.toString('utf-8');
+  const parsed = parser.parse(xmlString);
+
+  const sectionNodes = collectSectionNodes(parsed);
+
+  const documents: ParsedDocument[] = [];
+
+  for (const section of sectionNodes) {
+    if (!section || typeof section !== 'object') continue;
+    const node = section as Record<string, unknown>;
+
+    const identifier = (node['@_identifier'] as string | undefined) ?? '';
+    if (!identifier) continue;
+
+    const sectionId = extractSectionId(identifier);
+    if (!sectionId) continue;
+
+    // Skip <section> elements that are repealed/reserved/transferred —
+    // they have a status attribute. We still ingest them as placeholders
+    // for citation graph completeness, but mark in metadata.
+    const status = (node['@_status'] as string | undefined) ?? null;
+
+    const num = extractText(node['num']);
+    const heading = extractText(node['heading']);
+    const bodyText = extractText(node);
+
+    if (!bodyText) continue;
+
+    const citationKey = `${titleNumber}-USC-${sectionId}`;
+    const structuralPath = `USC/${titleNumber}/${sectionId}`;
+    const pinpoint = num || `§ ${sectionId}`;
+
+    const chunk: ParsedChunk = {
+      ordinal: 0,
+      structural_path: structuralPath,
+      pinpoint,
+      text: bodyText,
+      token_count: estimateTokens(bodyText),
+    };
+
+    const title = heading
+      ? `${pinpoint} ${heading}`
+      : `USC Title ${titleNumber} ${pinpoint}`;
+
+    documents.push({
+      citation_key: citationKey,
+      title,
+      effective_date: effectiveDate,
+      structural_path: structuralPath,
+      chunks: [chunk],
+      metadata: {
+        section_id: sectionId,
+        title_number: titleNumber,
+        uslm_identifier: identifier,
+        status: status ?? 'active',
+      },
+    });
+  }
+
+  return documents;
+}

--- a/src/lib/corpus/ingest/uscode-persist.ts
+++ b/src/lib/corpus/ingest/uscode-persist.ts
@@ -1,0 +1,213 @@
+/**
+ * src/lib/corpus/ingest/uscode-persist.ts
+ *
+ * Orchestrated insertion layer for U.S. Code documents. Given a set
+ * of ParsedDocument objects from one title, writes them to
+ * regulatory_documents and regulatory_document_chunks, supersedes
+ * prior versions, and pairs each write with a writeAuditLog entry.
+ *
+ * This module is the only place inside the USC pipeline that touches
+ * Prisma. Fetch and parse modules are pure.
+ *
+ * Mirrors ecfr-persist.ts; differences:
+ *   - source domain: uscode.house.gov
+ *   - doc_type: statute (eCFR uses regulation)
+ *   - citation_key: NN-USC-NNN format
+ *   - canonical_url: uscode.house.gov per-section URL
+ *   - stable_uri: urn:cite:usc:NN-USC-NNN:date
+ *
+ * Reference: docs/architecture/discovery-engine-institutional-grade.md § 1.4
+ */
+
+import crypto from 'crypto';
+import { PrismaClient } from '@prisma/client';
+import { insertDocument, insertChunk } from '../db';
+import { writeAuditLog } from '@/lib/audit/writeAuditLog';
+import type { ParsedDocument, TitleIngestSummary } from './types';
+
+const prisma = new PrismaClient();
+
+function sha256(input: Buffer | string): Buffer {
+  const data = typeof input === 'string' ? Buffer.from(input, 'utf-8') : input;
+  return crypto.createHash('sha256').update(data).digest();
+}
+
+async function getUscodeSourceId(): Promise<string> {
+  const source = await prisma.regulatory_sources.findUnique({
+    where: { domain: 'uscode.house.gov' },
+    select: { id: true, is_active: true },
+  });
+
+  if (!source) {
+    throw new Error(
+      'USC source row not found in regulatory_sources. ' +
+        'Run `npm run seed:regulatory` to populate the registry.'
+    );
+  }
+  if (!source.is_active) {
+    throw new Error('USC source row exists but is_active=false. Aborting ingest.');
+  }
+
+  return source.id;
+}
+
+async function findCurrentVersion(
+  citationKey: string
+): Promise<{ id: string; version: number; content_hash: Buffer } | null> {
+  const rows = await prisma.$queryRaw<
+    Array<{ id: string; version: number; content_hash: Buffer }>
+  >`
+    SELECT id, version, content_hash
+    FROM regulatory_documents
+    WHERE citation_key = ${citationKey}
+      AND superseded_by IS NULL
+    ORDER BY version DESC
+    LIMIT 1
+  `;
+  return rows[0] ?? null;
+}
+
+async function markSuperseded(oldId: string, newId: string): Promise<void> {
+  await prisma.$executeRaw`
+    UPDATE regulatory_documents
+    SET superseded_by = ${newId}::uuid,
+        superseded_at = now()
+    WHERE id = ${oldId}::uuid
+  `;
+}
+
+/**
+ * Persist one title's parsed USC documents.
+ *
+ * @param documents parsed documents from parseUscTitleToDocuments()
+ * @param titleNumber USC title number
+ * @param titleName USC title name (for audit log description)
+ * @param rawXml the raw XML bytes for raw_xml column + raw_hash
+ * @param effectiveDate the Last-Modified date this XML represents
+ * @returns counts and outcome for the audit/return summary
+ */
+export async function persistUscTitleDocuments(
+  documents: ParsedDocument[],
+  titleNumber: number,
+  titleName: string,
+  rawXml: Buffer,
+  effectiveDate: string
+): Promise<Pick<TitleIngestSummary, 'documents_inserted' | 'chunks_inserted' | 'documents_superseded'>> {
+  const sourceId = await getUscodeSourceId();
+  const rawHash = sha256(rawXml);
+  const retrievedAt = new Date();
+  const publishedDate = new Date(effectiveDate);
+
+  let documentsInserted = 0;
+  let chunksInserted = 0;
+  let documentsSuperseded = 0;
+
+  for (const doc of documents) {
+    const concatenatedText = doc.chunks.map((c) => c.text).join('\n\n');
+    const contentHash = sha256(concatenatedText);
+
+    const current = await findCurrentVersion(doc.citation_key);
+
+    if (current && Buffer.compare(current.content_hash, contentHash) === 0) {
+      continue;
+    }
+
+    const newVersion = current ? current.version + 1 : 1;
+    const stableUri = `urn:cite:usc:${doc.citation_key}:${effectiveDate}`;
+    const sectionId = String(doc.metadata.section_id ?? '');
+    const canonicalUrl = sectionId
+      ? `https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title${titleNumber}-section${sectionId}`
+      : `https://uscode.house.gov/`;
+    const rawStorageUri = `postgres://regulatory_documents#raw_xml`;
+
+    const inserted = await insertDocument({
+      source_id: sourceId,
+      doc_type: 'statute',
+      jurisdiction: 'US-FED',
+      citation_key: doc.citation_key,
+      title: doc.title,
+      version: newVersion,
+      effective_date: doc.effective_date ? new Date(doc.effective_date) : null,
+      published_date: publishedDate,
+      retrieved_at: retrievedAt,
+      canonical_url: canonicalUrl,
+      stable_uri: stableUri,
+      content_hash: contentHash,
+      raw_hash: rawHash,
+      raw_storage_uri: rawStorageUri,
+      raw_xml: rawXml,
+      metadata: {
+        ...doc.metadata,
+        ingest_pr: 'PR-H',
+        last_modified: effectiveDate,
+      },
+    });
+
+    for (const chunk of doc.chunks) {
+      await insertChunk({
+        document_id: inserted.id,
+        ordinal: chunk.ordinal,
+        structural_path: chunk.structural_path,
+        pinpoint: chunk.pinpoint,
+        text: chunk.text,
+        text_hash: sha256(chunk.text),
+        token_count: chunk.token_count,
+        embedding_model: 'pending',
+      });
+      chunksInserted++;
+    }
+
+    documentsInserted++;
+
+    if (current) {
+      await markSuperseded(current.id, inserted.id);
+      documentsSuperseded++;
+
+      await writeAuditLog({
+        actor: { type: 'system_automation' },
+        action: {
+          type: 'regulatory_document_superseded',
+          description: `Prior version superseded: ${doc.citation_key} v${current.version} → v${newVersion}`,
+        },
+        target: { table: 'regulatory_documents', id: current.id },
+        payload: {
+          before: { version: current.version, superseded_by: null },
+          after: { version: current.version, superseded_by: inserted.id },
+          metadata: {
+            new_document_id: inserted.id,
+            citation_key: doc.citation_key,
+          },
+        },
+      });
+    }
+
+    await writeAuditLog({
+      actor: { type: 'system_automation' },
+      action: {
+        type: 'regulatory_document_ingested',
+        description: `USC document ingested: ${doc.citation_key} v${newVersion}`,
+      },
+      target: { table: 'regulatory_documents', id: inserted.id },
+      payload: {
+        after: {
+          citation_key: doc.citation_key,
+          version: newVersion,
+          chunks: doc.chunks.length,
+          superseded_prior: !!current,
+        },
+        metadata: {
+          source: 'uscode.house.gov',
+          title_number: titleNumber,
+          title_name: titleName,
+          last_modified: effectiveDate,
+        },
+      },
+    });
+  }
+
+  return {
+    documents_inserted: documentsInserted,
+    chunks_inserted: chunksInserted,
+    documents_superseded: documentsSuperseded,
+  };
+}

--- a/src/lib/corpus/ingest/uscode-titles.ts
+++ b/src/lib/corpus/ingest/uscode-titles.ts
@@ -1,0 +1,149 @@
+/**
+ * src/lib/corpus/ingest/uscode-titles.ts
+ *
+ * Hardcoded list of all 54 U.S. Code titles. Source-of-truth:
+ * https://uscode.house.gov/download/download.shtml
+ *
+ * The U.S. Code title list has been stable since 2014 (when titles
+ * 53 and 54 were added). Adding a new title is a major federal
+ * legislative event. If a 55th title is ever enacted, this list
+ * MUST be updated in a dedicated PR with audit-log evidence of the
+ * Public Law adding the title.
+ *
+ * Positive-law status matters for citation precedence:
+ *   - Positive-law titles ARE the law (Bluebook prefers these)
+ *   - Non-positive-law titles are PRIMA FACIE evidence of the law,
+ *     with the underlying Statutes at Large being controlling.
+ *
+ * Reference: docs/architecture/discovery-engine-institutional-grade.md § 1.1
+ * (USC source row, regulatory_sources, primary_law tier)
+ */
+
+export interface UscodeTitle {
+  /** Title number (1-54) */
+  number: number;
+
+  /** Title name as it appears at the top of the USLM document */
+  name: string;
+
+  /**
+   * Whether this title has been enacted as positive law.
+   * Positive-law titles are the controlling text of federal law.
+   * Non-positive titles are prima facie evidence; the Statutes at
+   * Large remain controlling.
+   */
+  positive_law: boolean;
+}
+
+/**
+ * Stable list of all 54 U.S. Code titles. Last verified 2026-04-28
+ * against uscode.house.gov/download/download.shtml.
+ *
+ * Source for positive-law status: 1 U.S.C. § 204 enacting clauses
+ * and the OLRC's positive-law table.
+ */
+export const USCODE_TITLES: UscodeTitle[] = [
+  { number: 1, name: 'General Provisions', positive_law: true },
+  { number: 2, name: 'The Congress', positive_law: false },
+  { number: 3, name: 'The President', positive_law: true },
+  { number: 4, name: 'Flag and Seal, Seat of Government, and the States', positive_law: true },
+  { number: 5, name: 'Government Organization and Employees', positive_law: true },
+  { number: 6, name: 'Domestic Security', positive_law: false },
+  { number: 7, name: 'Agriculture', positive_law: false },
+  { number: 8, name: 'Aliens and Nationality', positive_law: false },
+  { number: 9, name: 'Arbitration', positive_law: true },
+  { number: 10, name: 'Armed Forces', positive_law: true },
+  { number: 11, name: 'Bankruptcy', positive_law: true },
+  { number: 12, name: 'Banks and Banking', positive_law: false },
+  { number: 13, name: 'Census', positive_law: true },
+  { number: 14, name: 'Coast Guard', positive_law: true },
+  { number: 15, name: 'Commerce and Trade', positive_law: false },
+  { number: 16, name: 'Conservation', positive_law: false },
+  { number: 17, name: 'Copyrights', positive_law: true },
+  { number: 18, name: 'Crimes and Criminal Procedure', positive_law: true },
+  { number: 19, name: 'Customs Duties', positive_law: false },
+  { number: 20, name: 'Education', positive_law: false },
+  { number: 21, name: 'Food and Drugs', positive_law: false },
+  { number: 22, name: 'Foreign Relations and Intercourse', positive_law: false },
+  { number: 23, name: 'Highways', positive_law: true },
+  { number: 24, name: 'Hospitals and Asylums', positive_law: false },
+  { number: 25, name: 'Indians', positive_law: false },
+  { number: 26, name: 'Internal Revenue Code', positive_law: false },
+  { number: 27, name: 'Intoxicating Liquors', positive_law: false },
+  { number: 28, name: 'Judiciary and Judicial Procedure', positive_law: true },
+  { number: 29, name: 'Labor', positive_law: false },
+  { number: 30, name: 'Mineral Lands and Mining', positive_law: false },
+  { number: 31, name: 'Money and Finance', positive_law: true },
+  { number: 32, name: 'National Guard', positive_law: true },
+  { number: 33, name: 'Navigation and Navigable Waters', positive_law: false },
+  { number: 34, name: 'Crime Control and Law Enforcement', positive_law: false },
+  { number: 35, name: 'Patents', positive_law: true },
+  { number: 36, name: 'Patriotic and National Observances, Ceremonies, and Organizations', positive_law: true },
+  { number: 37, name: 'Pay and Allowances of the Uniformed Services', positive_law: true },
+  { number: 38, name: 'Veterans Benefits', positive_law: true },
+  { number: 39, name: 'Postal Service', positive_law: true },
+  { number: 40, name: 'Public Buildings, Property, and Works', positive_law: true },
+  { number: 41, name: 'Public Contracts', positive_law: true },
+  { number: 42, name: 'The Public Health and Welfare', positive_law: false },
+  { number: 43, name: 'Public Lands', positive_law: false },
+  { number: 44, name: 'Public Printing and Documents', positive_law: true },
+  { number: 45, name: 'Railroads', positive_law: false },
+  { number: 46, name: 'Shipping', positive_law: true },
+  { number: 47, name: 'Telecommunications', positive_law: false },
+  { number: 48, name: 'Territories and Insular Possessions', positive_law: false },
+  { number: 49, name: 'Transportation', positive_law: true },
+  { number: 50, name: 'War and National Defense', positive_law: false },
+  { number: 51, name: 'National and Commercial Space Programs', positive_law: true },
+  { number: 52, name: 'Voting and Elections', positive_law: true },
+  { number: 53, name: 'Small Business', positive_law: true },
+  { number: 54, name: 'National Park Service and Related Programs', positive_law: true },
+  // Title 5 Appendix — published separately by OLRC at usc05a.xml.
+  // Cited as "5 U.S.C. App." per Bluebook. Treated as its own corpus
+  // entry to preserve source granularity (Renaissance principle:
+  // distinct legal documents are not collapsed). Number 55 is an
+  // internal sentinel; the canonical filename suffix is "5A".
+  { number: 55, name: 'Title 5 Appendix', positive_law: false },
+];
+
+/**
+ * Build the canonical ZIP download URL for one USC title at one
+ * release point.
+ *
+ * URL pattern (verified 2026-05 via reconnaissance against the OLRC
+ * download.shtml index):
+ *   https://uscode.house.gov/download/releasepoints/us/pl/{congress}/{plno}/xml_usc{NN}@{congress}-{plno}.zip
+ *
+ * Filename convention (from recon):
+ *   - Titles 1-54: zero-padded number (usc01, usc02, ..., usc54)
+ *   - Title 5 Appendix: usc05a (special case — internal sentinel
+ *     number is 55, but the URL uses '5a')
+ *
+ * @param congress Congress number (e.g. 119)
+ * @param plno Public Law number within that Congress (e.g. 84)
+ * @param titleNumber USC title number (1-55, where 55 is Title 5 Appendix)
+ * @returns the full ZIP URL
+ */
+export function xmlUrlForTitle(
+  congress: number,
+  plno: number,
+  titleNumber: number
+): string {
+  const fileSuffix = titleNumber === 55 ? '5a' : String(titleNumber).padStart(2, '0');
+  return (
+    `https://uscode.house.gov/download/releasepoints/us/pl/` +
+    `${congress}/${plno}/xml_usc${fileSuffix}@${congress}-${plno}.zip`
+  );
+}
+
+/**
+ * Build the URL for the OLRC download index page. This is the page
+ * we scrape to discover the latest release point (congress, plno).
+ *
+ * The index is a static HTML page (despite the JSF chrome wrapper)
+ * and contains <a href> links pointing to release-point ZIPs. The
+ * highest (congress, plno) pair in the link set is the latest
+ * release point.
+ */
+export function downloadIndexUrl(): string {
+  return 'https://uscode.house.gov/download/download.shtml';
+}


### PR DESCRIPTION
Second corpus-ingestion worker, mirroring PR-G's eCFR pattern. Weekly cron at Sunday 07:00 UTC fetches the 54 U.S. Code titles from uscode.house.gov, detects changed titles via HEAD Last-Modified comparison, fetches changed titles' USLM XML, parses <section> elements into chunks, and persists as regulatory_documents + regulatory_document_chunks (chunks ship without embeddings; embedding population is PR-J).

Files:
- src/lib/corpus/ingest/uscode-titles.ts: hardcoded list of 54 USC titles (plus Title 5 Appendix as 55) with positive-law status. Renaissance reproducibility decision over scraping or non-existent API.
- src/lib/corpus/ingest/uscode-fetch.ts: HTTP layer, p-limit(2), retry-once-on-5xx, HEAD + GET methods, release-point discovery via download.shtml scrape, ZIP unpack via adm-zip.
- src/lib/corpus/ingest/uscode-parse.ts: USLM XML walker. Walks <section identifier=...> elements, produces one ParsedDocument per section (small-to-big chunking, parallel to eCFR DIV5).
- src/lib/corpus/ingest/uscode-persist.ts: orchestrated insert, source_id lookup by domain='uscode.house.gov', doc_type='statute', citation_key NN-USC-NNN format.
- src/inngest/functions/uscode-ingest.ts: weekly cron, three steps — discover-release-point, per-title loop, write-run-summary — each in its own step.run() for idempotent resumption.
- src/lib/corpus/ingest/index.ts: barrel extended with USC exports.
- src/inngest/functions/index.ts: uscodeIngest registered.
- package.json: adm-zip dependency added (ZIP unpack for OLRC release-point archives).

Citation key convention: 26-USC-162 for Title 26 § 162. Parallels PR-G's 26-CFR-1.162-1 (same {title}-{type}-{section} schema). Enables trivial citation graph queries across statutes and regulations within the same title.

No migrations. No schema or enum changes — all foundation work landed in PR-F + PR-G + PR-Hui.

Reference: docs/architecture/discovery-engine-institutional-grade.md sections 1.1, 1.2, 1.3, 1.4, 4.1, 8.1 (PR-03).