### PR TITLE
PR-I: Federal Register hourly ingestion worker

### DIFF
--- a/src/inngest/functions/fedreg-ingest.ts
+++ b/src/inngest/functions/fedreg-ingest.ts
@@ -1,0 +1,186 @@
+/**
+ * src/inngest/functions/fedreg-ingest.ts
+ *
+ * Hourly Federal Register ingestion worker. Cron fires every hour
+ * at minute 0.
+ *
+ * Flow:
+ *   step 1: discover-since-date — find latest stored FR
+ *           publication_date; if none, default to 90 days ago
+ *           (Bridgewater institutional 90-day review window).
+ *   step 2: paginate /documents.json since that date, processing
+ *           each page in its own step.run for memoization. Within
+ *           a page, each document is its own step.run keyed by
+ *           document_number — retries don't re-fetch.
+ *   step 3: write-run-summary — audit log entry.
+ *
+ * Volume estimate:
+ *   - First run on empty DB: 90 days × ~300 docs/day ≈ 27,000 docs.
+ *     At pLimit(2) and ~3 sec/doc end-to-end → ~11 hours one-time
+ *     backfill. Inngest's automatic resumption handles the long run.
+ *   - Subsequent hourly runs: 0-30 docs typically.
+ *
+ * Reference: docs/architecture/discovery-engine-institutional-grade.md § 4.1
+ */
+
+import { PrismaClient } from '@prisma/client';
+import { inngest } from '../client';
+import {
+  fetchDocumentList,
+  fetchDocumentDetail,
+  fetchDocumentRawText,
+  parseFedregDocument,
+  persistFedregDocument,
+} from '@/lib/corpus/ingest';
+import { writeAuditLog } from '@/lib/audit/writeAuditLog';
+
+const prisma = new PrismaClient();
+
+const FIRST_RUN_BACKFILL_DAYS = 90;
+const MAX_PAGES_PER_RUN = 50; // safety cap; 100 docs/page × 50 = 5000 docs/run
+
+interface DocumentOutcome {
+  document_number: string;
+  outcome: 'inserted' | 'unchanged' | 'failed' | 'skipped';
+  reason?: string;
+}
+
+async function latestStoredPublicationDate(): Promise<Date | null> {
+  const rows = await prisma.$queryRaw<Array<{ max: Date | null }>>`
+    SELECT MAX(d.published_date) AS max
+    FROM regulatory_documents d
+    JOIN regulatory_sources s ON d.source_id = s.id
+    WHERE s.domain = 'federalregister.gov'
+      AND d.superseded_by IS NULL
+  `;
+  return rows[0]?.max ?? null;
+}
+
+export const fedregIngest = inngest.createFunction(
+  {
+    id: 'fedreg-ingest-hourly',
+    name: 'Federal Register hourly ingestion',
+    triggers: [{ cron: '0 * * * *' }],
+    concurrency: { limit: 1 },
+  },
+  async ({ step }) => {
+    const startedAt = new Date().toISOString();
+
+    // STEP 1: determine since-date
+    const sinceDate = await step.run('discover-since-date', async () => {
+      const latest = await latestStoredPublicationDate();
+      if (latest) {
+        // Subtract one day to handle late-arriving documents that
+        // backfill into a date we've already processed.
+        const adjusted = new Date(latest);
+        adjusted.setUTCDate(adjusted.getUTCDate() - 1);
+        return adjusted.toISOString().slice(0, 10);
+      }
+      const backfill = new Date();
+      backfill.setUTCDate(backfill.getUTCDate() - FIRST_RUN_BACKFILL_DAYS);
+      return backfill.toISOString().slice(0, 10);
+    });
+
+    const outcomes: DocumentOutcome[] = [];
+    let totalInserted = 0;
+    let totalUnchanged = 0;
+    let totalFailed = 0;
+    let pagesProcessed = 0;
+
+    // STEP 2: paginate and ingest
+    for (let page = 1; page <= MAX_PAGES_PER_RUN; page++) {
+      const pageResult = await step.run(`page-${page}`, async () => {
+        return await fetchDocumentList(sinceDate, page, 100);
+      });
+
+      pagesProcessed++;
+
+      for (const entry of pageResult.results) {
+        const docOutcome = await step.run(
+          `doc-${entry.document_number}`,
+          async (): Promise<DocumentOutcome> => {
+            try {
+              const detail = await fetchDocumentDetail(entry.document_number);
+
+              if (!detail.raw_text_url) {
+                return {
+                  document_number: entry.document_number,
+                  outcome: 'skipped',
+                  reason: 'no raw_text_url',
+                };
+              }
+
+              const rawText = await fetchDocumentRawText(detail.raw_text_url);
+              const parsed = parseFedregDocument(detail, rawText);
+
+              if (!parsed) {
+                return {
+                  document_number: entry.document_number,
+                  outcome: 'skipped',
+                  reason: 'parse returned null',
+                };
+              }
+
+              const result = await persistFedregDocument(parsed, detail, rawText);
+
+              return {
+                document_number: entry.document_number,
+                outcome: result.documents_inserted > 0 ? 'inserted' : 'unchanged',
+              };
+            } catch (err) {
+              return {
+                document_number: entry.document_number,
+                outcome: 'failed',
+                reason: err instanceof Error ? err.message : String(err),
+              };
+            }
+          }
+        );
+
+        outcomes.push(docOutcome);
+        if (docOutcome.outcome === 'inserted') totalInserted++;
+        else if (docOutcome.outcome === 'unchanged') totalUnchanged++;
+        else if (docOutcome.outcome === 'failed') totalFailed++;
+      }
+
+      // Stop when we've reached the last page.
+      if (!pageResult.next_page_url) break;
+    }
+
+    // STEP 3: write run summary
+    const completedAt = new Date().toISOString();
+    const summary = {
+      started_at: startedAt,
+      completed_at: completedAt,
+      since_date: sinceDate,
+      pages_processed: pagesProcessed,
+      documents_total: outcomes.length,
+      documents_inserted: totalInserted,
+      documents_unchanged: totalUnchanged,
+      documents_failed: totalFailed,
+      documents_skipped: outcomes.filter((o) => o.outcome === 'skipped').length,
+      // Don't include the full per-document list in audit_log payload —
+      // it can be 5000+ entries on first run. Just the failures, which
+      // are the operationally interesting ones.
+      failures: outcomes
+        .filter((o) => o.outcome === 'failed')
+        .map((o) => ({ document_number: o.document_number, reason: o.reason })),
+    };
+
+    await step.run('write-run-summary', async () => {
+      await writeAuditLog({
+        actor: { type: 'system_automation' },
+        action: {
+          type: 'regulatory_ingest_run_completed',
+          description: `FR ingest run: ${totalInserted} inserted, ${totalUnchanged} unchanged, ${totalFailed} failed (since ${sinceDate})`,
+        },
+        target: { table: 'regulatory_documents' },
+        payload: {
+          metadata: { run_summary: summary, source: 'federalregister.gov' },
+        },
+      });
+    });
+
+    return summary;
+  }
+);

--- a/src/inngest/functions/index.ts
+++ b/src/inngest/functions/index.ts
@@ -13,11 +13,13 @@
 import { healthCheck } from './health-check';
 import { ecfrIngest } from './ecfr-ingest';
 import { uscodeIngest } from './uscode-ingest';
+import { fedregIngest } from './fedreg-ingest';
 
 export const functions = [
   healthCheck,
   ecfrIngest,
   uscodeIngest,
+  fedregIngest,
 ];
 
-export { healthCheck, ecfrIngest, uscodeIngest };
+export { healthCheck, ecfrIngest, uscodeIngest, fedregIngest };

--- a/src/lib/corpus/ingest/fedreg-fetch.ts
+++ b/src/lib/corpus/ingest/fedreg-fetch.ts
@@ -1,0 +1,169 @@
+/**
+ * src/lib/corpus/ingest/fedreg-fetch.ts
+ *
+ * HTTP layer for the Federal Register API at federalregister.gov.
+ *
+ * The FR API is JSON-only with three endpoints we use:
+ *
+ *   GET /api/v1/documents.json
+ *     Paginated list. Filter by publication_date range, sort by
+ *     newest. Returns 100-1000 results per page.
+ *
+ *   GET /api/v1/documents/{document_number}.json
+ *     Single document detail. Returns 47 fields including
+ *     raw_text_url, body_html_url, full_text_xml_url, agencies,
+ *     cfr_references, effective_on, citation, etc.
+ *
+ *   GET {rawTextUrl}
+ *     Plain-text body. Returns text/plain. URL comes from the
+ *     detail response's raw_text_url field.
+ *
+ * No published rate limit. Throttle conservatively at 2 concurrent.
+ *
+ * Reference: docs/architecture/discovery-engine-institutional-grade.md § 1.3
+ */
+
+import pLimit from 'p-limit';
+
+const FR_API_BASE = 'https://www.federalregister.gov/api/v1';
+const USER_AGENT =
+  'TempleStuart-Compliance/1.0 (+https://templestuart.com; institutional-grade-corpus)';
+
+const limit = pLimit(2);
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function fetchWithRetry(
+  url: string,
+  init?: RequestInit
+): Promise<Response> {
+  const headers = {
+    ...(init?.headers ?? {}),
+    'User-Agent': USER_AGENT,
+  };
+
+  for (let attempt = 0; attempt < 2; attempt++) {
+    const response = await fetch(url, { ...init, headers });
+    if (response.ok) return response;
+    if (response.status >= 400 && response.status < 500) {
+      throw new Error(
+        `FR fetch failed (permanent): ${response.status} ${response.statusText} for ${url}`
+      );
+    }
+    if (attempt === 0) {
+      await sleep(1000);
+      continue;
+    }
+    throw new Error(
+      `FR fetch failed (after retry): ${response.status} ${response.statusText} for ${url}`
+    );
+  }
+  throw new Error('FR fetch failed: exhausted retries');
+}
+
+/**
+ * Brief summary of one FR document, as returned in the list endpoint.
+ * The list endpoint returns only ~10 fields per document; the detail
+ * endpoint has ~47 fields. We use the list endpoint to discover
+ * document_numbers and then fetch detail per-doc.
+ */
+export interface FedregListEntry {
+  document_number: string;
+  title: string;
+  type: string; // "Rule" | "Proposed Rule" | "Notice" | "Presidential Document"
+  abstract: string | null;
+  publication_date: string; // ISO date
+  html_url: string;
+  pdf_url: string | null;
+}
+
+export interface FedregListResponse {
+  count: number;
+  total_pages: number;
+  next_page_url: string | null;
+  results: FedregListEntry[];
+}
+
+/**
+ * Full detail for one FR document. Subset of the ~47 fields returned
+ * by the detail endpoint; we capture the ones used in persist.
+ */
+export interface FedregDocumentDetail {
+  document_number: string;
+  title: string;
+  type: string;
+  abstract: string | null;
+  publication_date: string;
+  effective_on: string | null;
+  citation: string | null;
+  html_url: string;
+  pdf_url: string | null;
+  raw_text_url: string | null;
+  body_html_url: string | null;
+  full_text_xml_url: string | null;
+  agencies: Array<{ id: number; name: string; raw_name?: string }>;
+  cfr_references: Array<{ title: number; part?: number | null }>;
+  docket_ids: string[];
+  topics: string[];
+  volume: number | null;
+  start_page: number | null;
+  end_page: number | null;
+  comment_url: string | null;
+  comments_close_on: string | null;
+  president?: { name: string; identifier: string };
+}
+
+/**
+ * GET /api/v1/documents.json — paginated list.
+ *
+ * @param sinceDate ISO date string (e.g. "2026-04-01"). Returns
+ *                  documents with publication_date >= sinceDate.
+ * @param page 1-indexed page number.
+ * @param perPage 1-1000. We default to 100 for memory predictability.
+ */
+export async function fetchDocumentList(
+  sinceDate: string,
+  page: number = 1,
+  perPage: number = 100
+): Promise<FedregListResponse> {
+  return limit(async () => {
+    const params = new URLSearchParams({
+      'conditions[publication_date][gte]': sinceDate,
+      order: 'oldest',
+      per_page: String(perPage),
+      page: String(page),
+    });
+    const url = `${FR_API_BASE}/documents.json?${params.toString()}`;
+    const response = await fetchWithRetry(url);
+    return (await response.json()) as FedregListResponse;
+  });
+}
+
+/**
+ * GET /api/v1/documents/{document_number}.json — full document detail.
+ */
+export async function fetchDocumentDetail(
+  documentNumber: string
+): Promise<FedregDocumentDetail> {
+  return limit(async () => {
+    const url = `${FR_API_BASE}/documents/${documentNumber}.json`;
+    const response = await fetchWithRetry(url);
+    return (await response.json()) as FedregDocumentDetail;
+  });
+}
+
+/**
+ * GET the raw text body. URL comes from detail.raw_text_url.
+ * Returns a UTF-8 string. Some older FR documents have null
+ * raw_text_url; the caller should handle that case.
+ */
+export async function fetchDocumentRawText(
+  rawTextUrl: string
+): Promise<string> {
+  return limit(async () => {
+    const response = await fetchWithRetry(rawTextUrl);
+    return await response.text();
+  });
+}

--- a/src/lib/corpus/ingest/fedreg-parse.ts
+++ b/src/lib/corpus/ingest/fedreg-parse.ts
@@ -1,0 +1,114 @@
+/**
+ * src/lib/corpus/ingest/fedreg-parse.ts
+ *
+ * Transformer from Federal Register JSON detail + plain-text body
+ * into the canonical ParsedDocument shape consumed by persist.
+ *
+ * Unlike PR-G (eCFR XML) and PR-H (USC USLM XML), Federal Register
+ * is API-native: the text body is published as plain text via the
+ * detail endpoint's raw_text_url. No XML walking, no DIV5 traversal.
+ *
+ * Each FR document becomes ONE ParsedDocument with ONE ParsedChunk
+ * holding the full raw text. Metadata captures the rich detail
+ * fields (agencies, cfr_references, docket_ids, topics, citation,
+ * effective_on) for later filtering and citation-graph traversal.
+ *
+ * Reference: docs/architecture/discovery-engine-institutional-grade.md § 1.2
+ */
+
+import type { ParsedDocument, ParsedChunk } from './types';
+import type { FedregDocumentDetail } from './fedreg-fetch';
+
+/**
+ * Map FR API's `type` field to our doc_type free-text values.
+ * Distinct values preserve filtering granularity downstream
+ * (Renaissance source-granularity principle).
+ */
+export function mapFedregTypeToDocType(frType: string): string {
+  switch (frType) {
+    case 'Rule':
+      return 'regulation';
+    case 'Proposed Rule':
+      return 'proposed_regulation';
+    case 'Notice':
+      return 'agency_notice';
+    case 'Presidential Document':
+      return 'presidential_document';
+    default:
+      // Unknown types are recorded as-is in metadata but coerced to
+      // 'agency_notice' for the doc_type column. If FR ever adds a
+      // new type, this branch logs it via the actual string in metadata.
+      return 'agency_notice';
+  }
+}
+
+function estimateTokens(text: string): number {
+  return Math.ceil(text.length / 4);
+}
+
+/**
+ * Transform an FR document (detail + raw text) into a ParsedDocument.
+ *
+ * @param detail the FR detail JSON response
+ * @param rawText the plain-text body fetched from detail.raw_text_url
+ * @returns ParsedDocument ready for persist, or null if the detail
+ *          response is missing critical fields
+ */
+export function parseFedregDocument(
+  detail: FedregDocumentDetail,
+  rawText: string
+): ParsedDocument | null {
+  if (!detail.document_number || !detail.publication_date) return null;
+  if (!rawText || rawText.trim().length === 0) return null;
+
+  const documentNumber = detail.document_number;
+  const publicationDate = detail.publication_date;
+  const publicationYear = publicationDate.slice(0, 4);
+
+  const citationKey = `FR-${documentNumber}`;
+  const structuralPath = `FR/${publicationYear}/${documentNumber}`;
+  const pinpoint = detail.citation ?? null;
+
+  // The "effective_date" we record is effective_on if present
+  // (final rules with delayed effective dates), otherwise the
+  // publication_date (notices and immediately-effective documents).
+  const effectiveDate = detail.effective_on ?? publicationDate;
+
+  const chunk: ParsedChunk = {
+    ordinal: 0,
+    structural_path: structuralPath,
+    pinpoint,
+    text: rawText.trim(),
+    token_count: estimateTokens(rawText),
+  };
+
+  return {
+    citation_key: citationKey,
+    title: detail.title,
+    effective_date: effectiveDate,
+    structural_path: structuralPath,
+    chunks: [chunk],
+    metadata: {
+      fr_type: detail.type,
+      fr_document_number: documentNumber,
+      publication_date: publicationDate,
+      effective_on: detail.effective_on,
+      citation: detail.citation,
+      html_url: detail.html_url,
+      pdf_url: detail.pdf_url,
+      agencies: detail.agencies.map((a) => ({
+        id: a.id,
+        name: a.name,
+      })),
+      cfr_references: detail.cfr_references,
+      docket_ids: detail.docket_ids,
+      topics: detail.topics,
+      volume: detail.volume,
+      start_page: detail.start_page,
+      end_page: detail.end_page,
+      comment_url: detail.comment_url,
+      comments_close_on: detail.comments_close_on,
+      president: detail.president ?? null,
+    },
+  };
+}

--- a/src/lib/corpus/ingest/fedreg-persist.ts
+++ b/src/lib/corpus/ingest/fedreg-persist.ts
@@ -1,0 +1,214 @@
+/**
+ * src/lib/corpus/ingest/fedreg-persist.ts
+ *
+ * Orchestrated insertion layer for Federal Register documents. Given
+ * a ParsedDocument plus its raw text bytes and original detail
+ * response, writes the document and chunks to the corpus, supersedes
+ * any prior version, and pairs each write with a writeAuditLog entry.
+ *
+ * Mirrors ecfr-persist.ts. Differences:
+ *   - source domain: federalregister.gov
+ *   - doc_type: per-document via mapFedregTypeToDocType
+ *   - citation_key: FR-{document_number}
+ *   - stable_uri: urn:cite:fr:{document_number}:{publication_date}
+ *   - raw bytes: UTF-8 plain text from raw_text_url (no XML)
+ *
+ * Reference: docs/architecture/discovery-engine-institutional-grade.md § 1.4
+ */
+
+import crypto from 'crypto';
+import { PrismaClient } from '@prisma/client';
+import { insertDocument, insertChunk } from '../db';
+import { writeAuditLog } from '@/lib/audit/writeAuditLog';
+import type { ParsedDocument } from './types';
+import type { FedregDocumentDetail } from './fedreg-fetch';
+import { mapFedregTypeToDocType } from './fedreg-parse';
+
+const prisma = new PrismaClient();
+
+function sha256(input: Buffer | string): Buffer {
+  const data = typeof input === 'string' ? Buffer.from(input, 'utf-8') : input;
+  return crypto.createHash('sha256').update(data).digest();
+}
+
+async function getFedregSourceId(): Promise<string> {
+  const source = await prisma.regulatory_sources.findUnique({
+    where: { domain: 'federalregister.gov' },
+    select: { id: true, is_active: true },
+  });
+
+  if (!source) {
+    throw new Error(
+      'Federal Register source row not found in regulatory_sources. ' +
+        'Run `npm run seed:regulatory` to populate the registry.'
+    );
+  }
+  if (!source.is_active) {
+    throw new Error(
+      'Federal Register source row exists but is_active=false. Aborting ingest.'
+    );
+  }
+
+  return source.id;
+}
+
+async function findCurrentVersion(
+  citationKey: string
+): Promise<{ id: string; version: number; content_hash: Buffer } | null> {
+  const rows = await prisma.$queryRaw<
+    Array<{ id: string; version: number; content_hash: Buffer }>
+  >`
+    SELECT id, version, content_hash
+    FROM regulatory_documents
+    WHERE citation_key = ${citationKey}
+      AND superseded_by IS NULL
+    ORDER BY version DESC
+    LIMIT 1
+  `;
+  return rows[0] ?? null;
+}
+
+async function markSuperseded(
+  oldId: string,
+  newId: string
+): Promise<void> {
+  await prisma.$executeRaw`
+    UPDATE regulatory_documents
+    SET superseded_by = ${newId}::uuid,
+        superseded_at = now()
+    WHERE id = ${oldId}::uuid
+  `;
+}
+
+export interface FedregPersistResult {
+  documents_inserted: number;
+  chunks_inserted: number;
+  documents_superseded: number;
+  documents_unchanged: number;
+}
+
+/**
+ * Persist one FR document into the corpus.
+ *
+ * @param parsed the ParsedDocument from parseFedregDocument
+ * @param detail the original FR detail JSON (for doc_type mapping)
+ * @param rawText the raw UTF-8 text body
+ * @returns counts for the run summary
+ */
+export async function persistFedregDocument(
+  parsed: ParsedDocument,
+  detail: FedregDocumentDetail,
+  rawText: string
+): Promise<FedregPersistResult> {
+  const sourceId = await getFedregSourceId();
+  const rawBuffer = Buffer.from(rawText, 'utf-8');
+  const rawHash = sha256(rawBuffer);
+  const retrievedAt = new Date();
+
+  const result: FedregPersistResult = {
+    documents_inserted: 0,
+    chunks_inserted: 0,
+    documents_superseded: 0,
+    documents_unchanged: 0,
+  };
+
+  const concatenatedText = parsed.chunks.map((c) => c.text).join('\n\n');
+  const contentHash = sha256(concatenatedText);
+
+  const current = await findCurrentVersion(parsed.citation_key);
+
+  if (current && Buffer.compare(current.content_hash, contentHash) === 0) {
+    result.documents_unchanged = 1;
+    return result;
+  }
+
+  const newVersion = current ? current.version + 1 : 1;
+  const docType = mapFedregTypeToDocType(detail.type);
+  const stableUri = `urn:cite:fr:${detail.document_number}:${detail.publication_date}`;
+  const rawStorageUri = `postgres://regulatory_documents#raw_xml`;
+
+  const inserted = await insertDocument({
+    source_id: sourceId,
+    doc_type: docType,
+    jurisdiction: 'US-FED',
+    citation_key: parsed.citation_key,
+    title: parsed.title,
+    version: newVersion,
+    effective_date: parsed.effective_date ? new Date(parsed.effective_date) : null,
+    published_date: new Date(detail.publication_date),
+    retrieved_at: retrievedAt,
+    canonical_url: detail.html_url,
+    stable_uri: stableUri,
+    content_hash: contentHash,
+    raw_hash: rawHash,
+    raw_storage_uri: rawStorageUri,
+    raw_xml: rawBuffer,
+    metadata: {
+      ...parsed.metadata,
+      ingest_pr: 'PR-I',
+    },
+  });
+
+  for (const chunk of parsed.chunks) {
+    await insertChunk({
+      document_id: inserted.id,
+      ordinal: chunk.ordinal,
+      structural_path: chunk.structural_path,
+      pinpoint: chunk.pinpoint,
+      text: chunk.text,
+      text_hash: sha256(chunk.text),
+      token_count: chunk.token_count,
+      embedding_model: 'pending',
+    });
+    result.chunks_inserted++;
+  }
+
+  result.documents_inserted = 1;
+
+  if (current) {
+    await markSuperseded(current.id, inserted.id);
+    result.documents_superseded = 1;
+
+    await writeAuditLog({
+      actor: { type: 'system_automation' },
+      action: {
+        type: 'regulatory_document_superseded',
+        description: `Prior version superseded: ${parsed.citation_key} v${current.version} → v${newVersion}`,
+      },
+      target: { table: 'regulatory_documents', id: current.id },
+      payload: {
+        before: { version: current.version, superseded_by: null },
+        after: { version: current.version, superseded_by: inserted.id },
+        metadata: {
+          new_document_id: inserted.id,
+          citation_key: parsed.citation_key,
+        },
+      },
+    });
+  }
+
+  await writeAuditLog({
+    actor: { type: 'system_automation' },
+    action: {
+      type: 'regulatory_document_ingested',
+      description: `FR document ingested: ${parsed.citation_key} v${newVersion} (${detail.type})`,
+    },
+    target: { table: 'regulatory_documents', id: inserted.id },
+    payload: {
+      after: {
+        citation_key: parsed.citation_key,
+        version: newVersion,
+        chunks: parsed.chunks.length,
+        superseded_prior: !!current,
+        doc_type: docType,
+      },
+      metadata: {
+        source: 'federalregister.gov',
+        fr_type: detail.type,
+        publication_date: detail.publication_date,
+      },
+    },
+  });
+
+  return result;
+}

--- a/src/lib/corpus/ingest/index.ts
+++ b/src/lib/corpus/ingest/index.ts
@@ -21,6 +21,20 @@ export { USCODE_TITLES, xmlUrlForTitle, downloadIndexUrl } from './uscode-titles
 export type { UscodeTitle } from './uscode-titles';
 export type { UscodeTitleHeaders, ReleasePoint } from './uscode-fetch';
 
+export {
+  fetchDocumentList,
+  fetchDocumentDetail,
+  fetchDocumentRawText,
+} from './fedreg-fetch';
+export { parseFedregDocument, mapFedregTypeToDocType } from './fedreg-parse';
+export { persistFedregDocument } from './fedreg-persist';
+export type {
+  FedregListEntry,
+  FedregListResponse,
+  FedregDocumentDetail,
+} from './fedreg-fetch';
+export type { FedregPersistResult } from './fedreg-persist';
+
 export type {
   EcfrTitleListEntry,
   ParsedDocument,


### PR DESCRIPTION
Third corpus-ingestion worker, simpler than PR-G/PR-H because the Federal Register API exposes plain-text bodies directly (no XML walking, no ZIP unpacking). Hourly cron at minute 0 paginates the documents endpoint since the latest stored publication_date, fetches each document's detail + raw text, persists with full metadata (agencies, cfr_references, docket_ids, topics, citation, effective_on).

Files:
- src/lib/corpus/ingest/fedreg-fetch.ts: HTTP layer, pLimit(2), three functions (list, detail, raw text).
- src/lib/corpus/ingest/fedreg-parse.ts: JSON+text → ParsedDocument transformer. doc_type mapping per FR 'type' field (Rule→regulation, Proposed Rule→proposed_regulation, Notice→agency_notice, Presidential Document→presidential_document).
- src/lib/corpus/ingest/fedreg-persist.ts: orchestrated insert, source_id lookup by domain='federalregister.gov', citation_key FR-{document_number} format.
- src/inngest/functions/fedreg-ingest.ts: hourly cron, three-step structure (discover-since-date → paginate-and-ingest → run-summary). First run defaults to 90-day backfill (Bridgewater institutional 90-day review window). Subsequent runs incrementally process documents since latest stored publication_date.
- src/lib/corpus/ingest/index.ts: barrel extended.
- src/inngest/functions/index.ts: fedregIngest registered.

Citation key: FR-2026-08564 format. document_number is the immutable FR identifier per architecture doc § 1.3 version-lock specification.

doc_type column is free-text (no enum), so the four FR type values are stored as four distinct strings preserving filtering granularity (Renaissance source-granularity principle).

No migrations. No new dependencies. No schema changes.

Reference: docs/architecture/discovery-engine-institutional-grade.md sections 1.1, 1.2, 1.3, 1.4, 4.1, 8.1 (PR-04).