### PR TITLE
Fix Inngest webhook auth: add /api/inngest to PUBLIC_PATHS + explicit…

### DIFF
--- a/src/app/api/inngest/route.ts
+++ b/src/app/api/inngest/route.ts
@@ -18,6 +18,16 @@ import { serve } from 'inngest/next';
 import { inngest } from '@/inngest/client';
 import { functions } from '@/inngest/functions';
 
+/**
+ * Inngest webhook endpoint. Auth is signature-based via
+ * INNGEST_SIGNING_KEY, NOT cookie-based. /api/inngest is in
+ * middleware PUBLIC_PATHS to bypass the auth gate; serve() validates
+ * Inngest's signature on every inbound webhook before invoking any
+ * registered function. The signing key is wired explicitly on the
+ * Inngest client in src/inngest/client.ts (ServeHandlerOptions does
+ * not accept signingKey in the current SDK version; the client
+ * constructor does).
+ */
 export const { GET, POST, PUT } = serve({
   client: inngest,
   functions,

--- a/src/inngest/client.ts
+++ b/src/inngest/client.ts
@@ -27,4 +27,6 @@ import { Inngest } from 'inngest';
 export const inngest = new Inngest({
   id: 'temple-stuart-accounting',
   name: 'Temple Stuart Accounting',
+  eventKey: process.env.INNGEST_EVENT_KEY,
+  signingKey: process.env.INNGEST_SIGNING_KEY,
 });

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -57,6 +57,7 @@ const PUBLIC_PATHS = [
   '/favicon.ico',
   '/pricing',
   '/api/stripe/webhook',
+  '/api/inngest',
   '/opengraph-image',
   '/terms',
   '/privacy',


### PR DESCRIPTION
… auth keys

Two real bugs preventing every cron-scheduled function from firing since Inngest infrastructure shipped:

1. /api/inngest was caught by the auth middleware (src/middleware.ts). Inngest webhook calls have no auth cookie; they were redirected to / (HTTP 307), which Inngest treats as sync failure. Result: Inngest dashboard showed only "Unattached syncs," zero functions ever invoked, zero corpus chunks ever ingested. Fix: add '/api/inngest' to PUBLIC_PATHS, mirroring the '/api/stripe/webhook' precedent. Auth boundary moves to the serve() handler, which validates Inngest's signature header.

2. Auth keys were picked up implicitly from process.env by the Inngest SDK. The convention works but makes the auth contract invisible to grep and to code review. Fix: explicit eventKey and signingKey on the Inngest client constructor in src/inngest/client.ts.

   Note: signingKey lives on ClientOptions (the Inngest constructor), not on ServeHandlerOptions. Verified via SDK 4.2.6 types.

Files:
- src/middleware.ts: PUBLIC_PATHS gains '/api/inngest' between '/api/stripe/webhook' and '/opengraph-image' for grep-locality with the existing webhook precedent.
- src/inngest/client.ts: explicit eventKey + signingKey from process.env (no behavior change; SDK was already auto-detecting).
- src/app/api/inngest/route.ts: doc comment explaining the auth contract (signature-based via INNGEST_SIGNING_KEY, not cookie-based).

Pre-merge requirement: confirm INNGEST_EVENT_KEY and INNGEST_SIGNING_KEY are set in Vercel Production env vars (should already be present from the earlier Vercel-Inngest integration setup).

Post-merge actions (separate from this PR):
1. Delete the broken auto-registered app in Inngest dashboard (currently shows 'Unattached syncs' pointing at a stale Vercel preview URL).
2. 'Sync new app' in Inngest dashboard with serve URL: https://templestuart.com/api/inngest
3. Verify all 6 functions register: healthCheck, ecfrIngest, uscodeIngest, fedregIngest, irbIngest, embedPending.
4. Crons begin firing on schedule. First-fire backfill populates regulatory_documents + regulatory_document_chunks. embedPending then embeds at next 6-hour cron mark.