### PR TITLE
Fix chunker: token-aware splitting across all four ingestion parsers

### DIFF
--- a/src/lib/corpus/ingest/chunker.ts
+++ b/src/lib/corpus/ingest/chunker.ts
@@ -1,0 +1,225 @@
+/**
+ * src/lib/corpus/ingest/chunker.ts
+ *
+ * Recursive structure-aware text splitter for the regulatory corpus.
+ *
+ * Algorithm (per architecture doc § 1.2):
+ *   1. If input <= target tokens, return as single chunk
+ *   2. Split on paragraph boundaries (\n\n), pack paragraphs until
+ *      target reached
+ *   3. If a single paragraph exceeds target, split on sentence
+ *      boundaries (matching . ! ? followed by whitespace)
+ *   4. If a single sentence exceeds target, fall back to character-
+ *      count splitting at target boundary
+ *   5. Apply overlap by prepending last N chars of previous chunk
+ *      to next (preserves context across chunk boundaries for
+ *      retrieval quality)
+ *
+ * Defaults match architecture doc institutional defaults:
+ *   target = 1500 tokens (well within doc's 500-2000 window)
+ *   overlap = 200 tokens
+ *
+ * Token estimation uses the canonical char-length / 4 approximation
+ * (consistent with parser-side estimates and conservative vs. real
+ * BPE tokenization, leaving headroom under Voyage's 32K per-input cap).
+ *
+ * Reference: docs/architecture/discovery-engine-institutional-grade.md § 1.2
+ */
+
+import type { ParsedChunk } from './types';
+
+const DEFAULT_TARGET_TOKENS = 1500;
+const DEFAULT_OVERLAP_TOKENS = 200;
+const TOKENS_PER_CHAR = 0.25; // i.e. 4 chars per token
+
+function estimateTokens(text: string): number {
+  return Math.ceil(text.length * TOKENS_PER_CHAR);
+}
+
+function tokensToChars(tokens: number): number {
+  return Math.ceil(tokens / TOKENS_PER_CHAR);
+}
+
+/**
+ * Split text on paragraph boundaries. Empty paragraphs are dropped.
+ */
+function splitParagraphs(text: string): string[] {
+  return text
+    .split(/\n\s*\n/)
+    .map((p) => p.trim())
+    .filter((p) => p.length > 0);
+}
+
+/**
+ * Split a single paragraph on sentence boundaries. Conservative regex:
+ * matches . ! ? followed by whitespace and a capital letter (avoids
+ * false splits on abbreviations like "U.S.C.").
+ *
+ * If no sentence boundaries found, returns the whole paragraph as
+ * one element.
+ */
+function splitSentences(paragraph: string): string[] {
+  const sentences: string[] = [];
+  const matches = paragraph.split(/(?<=[.!?])\s+(?=[A-Z])/);
+  for (const m of matches) {
+    const trimmed = m.trim();
+    if (trimmed.length > 0) sentences.push(trimmed);
+  }
+  return sentences.length > 0 ? sentences : [paragraph];
+}
+
+/**
+ * Hard character-count split. Final fallback when a single sentence
+ * exceeds target. Splits at exact character boundaries with no
+ * semantic awareness — only invoked for pathological inputs.
+ */
+function splitByChars(text: string, maxChars: number): string[] {
+  const out: string[] = [];
+  for (let i = 0; i < text.length; i += maxChars) {
+    out.push(text.slice(i, i + maxChars));
+  }
+  return out;
+}
+
+/**
+ * Pack a list of segments into chunks of <= target tokens each.
+ * Each segment must already fit within target on its own.
+ */
+function packSegments(segments: string[], targetTokens: number): string[] {
+  const chunks: string[] = [];
+  let current: string[] = [];
+  let currentTokens = 0;
+
+  for (const seg of segments) {
+    const segTokens = estimateTokens(seg);
+    if (currentTokens + segTokens <= targetTokens) {
+      current.push(seg);
+      currentTokens += segTokens;
+    } else {
+      if (current.length > 0) {
+        chunks.push(current.join('\n\n'));
+      }
+      current = [seg];
+      currentTokens = segTokens;
+    }
+  }
+
+  if (current.length > 0) {
+    chunks.push(current.join('\n\n'));
+  }
+
+  return chunks;
+}
+
+/**
+ * Apply overlap by prepending last N chars of previous chunk to next.
+ * First chunk has no prefix.
+ */
+function applyOverlap(chunks: string[], overlapChars: number): string[] {
+  if (chunks.length <= 1 || overlapChars <= 0) return chunks;
+
+  const out: string[] = [chunks[0]];
+  for (let i = 1; i < chunks.length; i++) {
+    const prev = chunks[i - 1];
+    const overlap = prev.slice(Math.max(0, prev.length - overlapChars));
+    out.push(`${overlap}\n\n${chunks[i]}`);
+  }
+  return out;
+}
+
+/**
+ * Recursively split text into chunks of <= target tokens.
+ *
+ * Pipeline:
+ *   - If text fits, return single chunk
+ *   - Split on paragraphs, recurse on any paragraph > target
+ *   - Split oversized paragraphs on sentences, recurse on any
+ *     sentence > target
+ *   - Split oversized sentences by character count
+ *   - Pack resulting segments into target-sized chunks
+ *   - Apply overlap
+ */
+function recursiveSplit(text: string, targetTokens: number): string[] {
+  if (estimateTokens(text) <= targetTokens) {
+    return [text];
+  }
+
+  const targetChars = tokensToChars(targetTokens);
+  const segments: string[] = [];
+
+  for (const para of splitParagraphs(text)) {
+    if (estimateTokens(para) <= targetTokens) {
+      segments.push(para);
+      continue;
+    }
+    // Paragraph too big — try sentence split
+    for (const sent of splitSentences(para)) {
+      if (estimateTokens(sent) <= targetTokens) {
+        segments.push(sent);
+      } else {
+        // Sentence too big — character fallback
+        for (const piece of splitByChars(sent, targetChars)) {
+          segments.push(piece);
+        }
+      }
+    }
+  }
+
+  return packSegments(segments, targetTokens);
+}
+
+export interface ChunkOptions {
+  targetTokens?: number;
+  overlapTokens?: number;
+  /** Base structural path (chunks get suffixed with #chunk-N/Total) */
+  structuralPath: string;
+  /** Base pinpoint (chunks get suffixed similarly if needed) */
+  pinpoint?: string | null;
+}
+
+/**
+ * Chunk a body of text into properly-sized ParsedChunk[].
+ *
+ * Always emits at least one chunk (empty input returns one empty chunk —
+ * caller should guard against empty bodies upstream if that matters).
+ *
+ * For inputs that fit in one chunk: returns one ParsedChunk with the
+ * caller's structural_path/pinpoint unchanged.
+ *
+ * For inputs requiring splitting: emits N chunks with
+ *   ordinal: 0..N-1
+ *   structural_path: `${base}#chunk-${i+1}/${N}`
+ *   pinpoint: `${base}#chunk-${i+1}/${N}` (only suffixed when split occurs)
+ */
+export function chunkText(
+  text: string,
+  opts: ChunkOptions
+): ParsedChunk[] {
+  const targetTokens = opts.targetTokens ?? DEFAULT_TARGET_TOKENS;
+  const overlapTokens = opts.overlapTokens ?? DEFAULT_OVERLAP_TOKENS;
+  const overlapChars = tokensToChars(overlapTokens);
+
+  const rawChunks = recursiveSplit(text, targetTokens);
+  const withOverlap = applyOverlap(rawChunks, overlapChars);
+  const total = withOverlap.length;
+
+  return withOverlap.map((chunkBody, i) => {
+    const isSplit = total > 1;
+    const suffix = isSplit ? `#chunk-${i + 1}/${total}` : '';
+    return {
+      ordinal: i,
+      structural_path: `${opts.structuralPath}${suffix}`,
+      pinpoint: opts.pinpoint
+        ? `${opts.pinpoint}${suffix}`
+        : (suffix || null),
+      text: chunkBody,
+      token_count: estimateTokens(chunkBody),
+    };
+  });
+}
+
+/**
+ * Re-export for callers that want to estimate without invoking the
+ * full splitter.
+ */
+export { estimateTokens };

--- a/src/lib/corpus/ingest/ecfr-parse.ts
+++ b/src/lib/corpus/ingest/ecfr-parse.ts
@@ -20,7 +20,8 @@
  */
 
 import { XMLParser } from 'fast-xml-parser';
-import type { ParsedDocument, ParsedChunk } from './types';
+import type { ParsedDocument } from './types';
+import { chunkText } from './chunker';
 
 const parser = new XMLParser({
   ignoreAttributes: false,
@@ -84,15 +85,6 @@ function extractText(node: unknown): string {
 }
 
 /**
- * Approximate token count: ~4 characters per token for English prose.
- * A more precise tokenizer (tiktoken) would be used in PR-J for embedding
- * cost calculation; here we just need an order-of-magnitude estimate.
- */
-function estimateTokens(text: string): number {
-  return Math.ceil(text.length / 4);
-}
-
-/**
  * Parse one title's XML payload into ParsedDocument[] (one per DIV5).
  *
  * @param xmlBuffer raw XML bytes from fetchTitleXml
@@ -130,20 +122,12 @@ export function parseTitleToDocuments(
     const structuralPath = `CFR/${titleNumber}/${sectionNumber}`;
     const pinpoint = `§ ${sectionNumber}`;
 
-    const chunk: ParsedChunk = {
-      ordinal: 0,
-      structural_path: structuralPath,
-      pinpoint,
-      text: bodyText,
-      token_count: estimateTokens(bodyText),
-    };
-
     documents.push({
       citation_key: citationKey,
       title: head || `CFR Title ${titleNumber} § ${sectionNumber}`,
       effective_date: effectiveDate,
       structural_path: structuralPath,
-      chunks: [chunk],
+      chunks: chunkText(bodyText, { structuralPath, pinpoint }),
       metadata: {
         section_type: sectionType,
         section_number: sectionNumber,

--- a/src/lib/corpus/ingest/fedreg-parse.ts
+++ b/src/lib/corpus/ingest/fedreg-parse.ts
@@ -16,8 +16,9 @@
  * Reference: docs/architecture/discovery-engine-institutional-grade.md § 1.2
  */
 
-import type { ParsedDocument, ParsedChunk } from './types';
+import type { ParsedDocument } from './types';
 import type { FedregDocumentDetail } from './fedreg-fetch';
+import { chunkText } from './chunker';
 
 /**
  * Map FR API's `type` field to our doc_type free-text values.
@@ -40,10 +41,6 @@ export function mapFedregTypeToDocType(frType: string): string {
       // new type, this branch logs it via the actual string in metadata.
       return 'agency_notice';
   }
-}
-
-function estimateTokens(text: string): number {
-  return Math.ceil(text.length / 4);
 }
 
 /**
@@ -74,20 +71,12 @@ export function parseFedregDocument(
   // publication_date (notices and immediately-effective documents).
   const effectiveDate = detail.effective_on ?? publicationDate;
 
-  const chunk: ParsedChunk = {
-    ordinal: 0,
-    structural_path: structuralPath,
-    pinpoint,
-    text: rawText.trim(),
-    token_count: estimateTokens(rawText),
-  };
-
   return {
     citation_key: citationKey,
     title: detail.title,
     effective_date: effectiveDate,
     structural_path: structuralPath,
-    chunks: [chunk],
+    chunks: chunkText(rawText.trim(), { structuralPath, pinpoint }),
     metadata: {
       fr_type: detail.type,
       fr_document_number: documentNumber,

--- a/src/lib/corpus/ingest/irb-parse.ts
+++ b/src/lib/corpus/ingest/irb-parse.ts
@@ -28,7 +28,8 @@
  */
 
 import * as cheerio from 'cheerio';
-import type { ParsedDocument, ParsedChunk } from './types';
+import type { ParsedDocument } from './types';
+import { chunkText } from './chunker';
 
 /**
  * Map a citation-key prefix to our free-text doc_type values.
@@ -56,10 +57,6 @@ export function mapCitationToDocType(citationKey: string): string {
  */
 function normalizeCitation(anchor: string): string {
   return anchor.replace(/[._]/g, '-').toUpperCase();
-}
-
-function estimateTokens(text: string): number {
-  return Math.ceil(text.length / 4);
 }
 
 /**
@@ -151,14 +148,6 @@ export function parseIrbIssue(
     const docType = mapCitationToDocType(citationKey);
     const structuralPath = `IRB/${issueId}/${citationKey}`;
 
-    const chunk: ParsedChunk = {
-      ordinal: 0,
-      structural_path: structuralPath,
-      pinpoint: citationKey,
-      text: bodyText,
-      token_count: estimateTokens(bodyText),
-    };
-
     const title = headingText || `${citationKey} (IRB ${issueId})`;
 
     documents.push({
@@ -166,7 +155,10 @@ export function parseIrbIssue(
       title,
       effective_date: publicationDate,
       structural_path: structuralPath,
-      chunks: [chunk],
+      chunks: chunkText(bodyText, {
+        structuralPath,
+        pinpoint: citationKey,
+      }),
       metadata: {
         irb_issue_id: issueId,
         irb_publication_date: publicationDate,

--- a/src/lib/corpus/ingest/uscode-parse.ts
+++ b/src/lib/corpus/ingest/uscode-parse.ts
@@ -28,7 +28,8 @@
  */
 
 import { XMLParser } from 'fast-xml-parser';
-import type { ParsedDocument, ParsedChunk } from './types';
+import type { ParsedDocument } from './types';
+import { chunkText } from './chunker';
 
 const parser = new XMLParser({
   ignoreAttributes: false,
@@ -88,13 +89,6 @@ function extractText(node: unknown): string {
     }
   }
   return parts.join(' ').replace(/\s+/g, ' ').trim();
-}
-
-/**
- * Approximate token count for chunk size estimation.
- */
-function estimateTokens(text: string): number {
-  return Math.ceil(text.length / 4);
 }
 
 /**
@@ -159,14 +153,6 @@ export function parseUscTitleToDocuments(
     const structuralPath = `USC/${titleNumber}/${sectionId}`;
     const pinpoint = num || `§ ${sectionId}`;
 
-    const chunk: ParsedChunk = {
-      ordinal: 0,
-      structural_path: structuralPath,
-      pinpoint,
-      text: bodyText,
-      token_count: estimateTokens(bodyText),
-    };
-
     const title = heading
       ? `${pinpoint} ${heading}`
       : `USC Title ${titleNumber} ${pinpoint}`;
@@ -176,7 +162,7 @@ export function parseUscTitleToDocuments(
       title,
       effective_date: effectiveDate,
       structural_path: structuralPath,
-      chunks: [chunk],
+      chunks: chunkText(bodyText, { structuralPath, pinpoint }),
       metadata: {
         section_id: sectionId,
         title_number: titleNumber,


### PR DESCRIPTION
Systemic bug across PR-G/H/I/J: every parser produced "one document = one chunk" with no size-bound splitting. Result: regulatory_document_chunks contained chunks averaging 4,224 tokens with p99 of 38,298 and max of 345,745. Voyage embedding API rejects inputs >32K tokens per chunk and batches >320K tokens total.

Architecture doc § 1.2 specifies semantic chunking with 1,200-token target and 200-token overlap. Implementation chose 1,500 tokens for slightly more retrieval context within the spec's 500-2000 window.

Algorithm (recursive structure-aware splitting):
  1. If input <= target tokens, return as single chunk
  2. Split on paragraph boundaries (\n\n)
  3. Pack paragraphs into chunks <= target
  4. If single paragraph too large, split on sentence boundaries
  5. If single sentence too large, fall back to character split
  6. Apply 200-token overlap between adjacent chunks for retrieval quality across boundaries

Files:
- src/lib/corpus/ingest/chunker.ts (new): ~225 lines. Pure TypeScript, no external deps. Custom implementation rather than LangChain RecursiveCharacterTextSplitter — avoids 5MB+ of transitive deps and gives explicit behavioral control over a ~50-line algorithm.
- src/lib/corpus/ingest/ecfr-parse.ts: chunk emission replaced with chunkText() call. Worst offender (avg 14,652 tokens, max 345,745).
- src/lib/corpus/ingest/uscode-parse.ts: same shape change.
- src/lib/corpus/ingest/fedreg-parse.ts: same shape change. (avg 3,772 tokens, max 70,960 — also exceeds Voyage caps.)
- src/lib/corpus/ingest/irb-parse.ts: same shape change.

No DB schema changes. No persist-layer changes. No embedding worker changes. ParsedChunk[] is already the type used downstream.

Post-merge action plan:
  1. TRUNCATE regulatory_document_chunks, regulatory_documents RESTART IDENTITY CASCADE; — none of the 6,549 existing chunks are embedded yet (Voyage rejected them all), so no data loss.
  2. Manually invoke fedreg-ingest-hourly and ecfr-ingest-daily to re-fetch and re-chunk with proper sizing.
  3. Voyage embedding worker fires at next 6-hour cron mark with properly-sized chunks. Expected first-run cost: under $1.
  4. Section H of workbench upgrades to true semantic search across the federal corpus.

Reference: docs/architecture/discovery-engine-institutional-grade.md § 1.2