### PR TITLE
Fix audit_log deadlock: retry on Postgres serialization_failure

### DIFF
--- a/src/lib/audit/writeAuditLog.ts
+++ b/src/lib/audit/writeAuditLog.ts
@@ -1,6 +1,31 @@
-import { AuditActorType, AuditActionType, audit_log } from '@prisma/client';
+import { Prisma, AuditActorType, AuditActionType, audit_log } from '@prisma/client';
 import { createHash } from 'crypto';
 import { prisma } from '@/lib/prisma';
+
+const MAX_RETRY_ATTEMPTS = 5;
+
+/**
+ * Postgres serializable isolation will abort one of two concurrent
+ * writers with code 40001 (Prisma maps this to P2034). P2024 covers
+ * transaction-acquire timeouts under heavy contention. Both are safe
+ * to retry — the hash chain re-reads the latest prev_hash inside the
+ * retried transaction, so retries naturally resolve the race.
+ */
+function isRetryableError(err: unknown): boolean {
+  return (
+    err instanceof Prisma.PrismaClientKnownRequestError &&
+    (err.code === 'P2034' || err.code === 'P2024')
+  );
+}
+
+/**
+ * Exponential backoff with ±50% jitter to avoid thundering-herd
+ * resync on multiple concurrent retriers. Floor at 10ms.
+ */
+function sleepWithJitter(baseMs: number): Promise<void> {
+  const jitter = baseMs * (Math.random() - 0.5);
+  return new Promise((r) => setTimeout(r, Math.max(10, baseMs + jitter)));
+}
 
 export interface WriteAuditLogInput {
   actor: {
@@ -28,64 +53,90 @@ export interface WriteAuditLogInput {
 }
 
 export async function writeAuditLog(input: WriteAuditLogInput): Promise<audit_log> {
-  if (input.request_id) {
-    const existing = await prisma.audit_log.findFirst({
-      where: { request_id: input.request_id },
-    });
-    if (existing) return existing;
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt < MAX_RETRY_ATTEMPTS; attempt++) {
+    try {
+      return await prisma.$transaction(
+        async (tx) => {
+          // Idempotency check INSIDE the transaction so the lookup
+          // shares a snapshot with the subsequent insert. Prevents
+          // double-write races when a retry coincides with another
+          // writer's commit.
+          if (input.request_id) {
+            const existing = await tx.audit_log.findFirst({
+              where: { request_id: input.request_id },
+            });
+            if (existing) return existing;
+          }
+
+          const prev = await tx.audit_log.findFirst({
+            orderBy: { sequence_number: 'desc' },
+          });
+
+          if (!prev) {
+            throw new Error(
+              'audit_log has no rows — genesis row missing. ' +
+                'PR-C migration should have inserted the genesis row.'
+            );
+          }
+
+          const content = JSON.stringify({
+            prev_hash: prev.content_hash,
+            actor_user_id: input.actor.user_id ?? null,
+            actor_email: input.actor.email ?? null,
+            actor_type: input.actor.type,
+            action_type: input.action.type,
+            action_description: input.action.description,
+            target_table: input.target.table,
+            target_id: input.target.id ?? null,
+            payload_before: input.payload?.before ?? null,
+            payload_after: input.payload?.after ?? null,
+            payload_metadata: input.payload?.metadata ?? null,
+            request_id: input.request_id ?? null,
+          });
+
+          const content_hash = createHash('sha256').update(content).digest('hex');
+
+          return await tx.audit_log.create({
+            data: {
+              prev_hash: prev.content_hash,
+              content_hash,
+              actor_user_id: input.actor.user_id ?? null,
+              actor_email: input.actor.email ?? null,
+              actor_type: input.actor.type,
+              actor_session_id: input.actor.session_id ?? null,
+              actor_ip: input.actor.ip ?? null,
+              action_type: input.action.type,
+              action_description: input.action.description,
+              target_table: input.target.table,
+              target_id: input.target.id ?? null,
+              payload_before: input.payload?.before ?? undefined,
+              payload_after: input.payload?.after ?? undefined,
+              payload_metadata: input.payload?.metadata ?? undefined,
+              request_id: input.request_id ?? null,
+              user_agent: input.user_agent ?? null,
+            },
+          });
+        },
+        { isolationLevel: 'Serializable' }
+      );
+    } catch (err) {
+      lastError = err;
+      if (isRetryableError(err) && attempt < MAX_RETRY_ATTEMPTS - 1) {
+        const backoff = 50 * Math.pow(2, attempt);
+        console.warn(
+          `[writeAuditLog] retry attempt ${attempt + 1}/${MAX_RETRY_ATTEMPTS} ` +
+            `due to ${(err as Prisma.PrismaClientKnownRequestError).code}`
+        );
+        await sleepWithJitter(backoff);
+        continue;
+      }
+      throw err;
+    }
   }
 
-  return await prisma.$transaction(
-    async (tx) => {
-      const prev = await tx.audit_log.findFirst({
-        orderBy: { sequence_number: 'desc' },
-      });
-
-      if (!prev) {
-        throw new Error(
-          'audit_log has no rows — genesis row missing. ' +
-            'PR-C migration should have inserted the genesis row.'
-        );
-      }
-
-      const content = JSON.stringify({
-        prev_hash: prev.content_hash,
-        actor_user_id: input.actor.user_id ?? null,
-        actor_email: input.actor.email ?? null,
-        actor_type: input.actor.type,
-        action_type: input.action.type,
-        action_description: input.action.description,
-        target_table: input.target.table,
-        target_id: input.target.id ?? null,
-        payload_before: input.payload?.before ?? null,
-        payload_after: input.payload?.after ?? null,
-        payload_metadata: input.payload?.metadata ?? null,
-        request_id: input.request_id ?? null,
-      });
-
-      const content_hash = createHash('sha256').update(content).digest('hex');
-
-      return await tx.audit_log.create({
-        data: {
-          prev_hash: prev.content_hash,
-          content_hash,
-          actor_user_id: input.actor.user_id ?? null,
-          actor_email: input.actor.email ?? null,
-          actor_type: input.actor.type,
-          actor_session_id: input.actor.session_id ?? null,
-          actor_ip: input.actor.ip ?? null,
-          action_type: input.action.type,
-          action_description: input.action.description,
-          target_table: input.target.table,
-          target_id: input.target.id ?? null,
-          payload_before: input.payload?.before ?? undefined,
-          payload_after: input.payload?.after ?? undefined,
-          payload_metadata: input.payload?.metadata ?? undefined,
-          request_id: input.request_id ?? null,
-          user_agent: input.user_agent ?? null,
-        },
-      });
-    },
-    { isolationLevel: 'Serializable' }
-  );
+  // Unreachable in practice — the loop either returns on success or
+  // throws on the final attempt. Kept for TS exhaustiveness.
+  throw lastError;
 }


### PR DESCRIPTION
writeAuditLog runs in a serializable Postgres transaction to enforce hash-chain integrity (genesis-derived prev_hash + content_hash chain across all audit events for SOC 2 / regulator auditability). Under concurrent load — multiple ingestion workers writing audit events in parallel, plus the Voyage embedding worker writing per-batch entries — two writers reading the same prev_hash simultaneously cause Postgres to abort one with serialization_failure (40001 / Prisma P2034).

Discovered when Voyage embedding worker died at 849 successful chunks with: "Invalid prisma.audit_log.create() invocation: Transaction failed due to a write conflict or a deadlock. Please retry your transaction."

This is the standard Postgres serializable-isolation idiom: the docs explicitly state "applications using this isolation level must be prepared to retry transactions due to serialization failures."

Fix:

1. Wrap the prisma.$transaction call in a 5-attempt retry loop with exponential backoff + jitter (50, 100, 200, 400, 800 ms ± 50%). Cumulative max wait ~1.5s before final re-throw.

2. Retry only on PrismaClientKnownRequestError with codes:
   - P2034: transaction conflict / deadlock
   - P2024: connection-pool timeout (also transient) All other errors re-thrown immediately.

3. Move request_id idempotency check INSIDE the transaction. Previously it ran outside the $transaction call, creating a race between retry loop iterations and concurrent writers committing the same request_id. Moving it inside makes the entire operation a single serializable read-then-conditional-insert.

4. Add console.warn on each retry attempt for operational observability (visible in Vercel + Inngest logs). Not audit_log itself to avoid recursion potential.

No schema changes. No call-site changes — all callers (ingestion workers, embedding worker, future workers) benefit transparently.

Imports Prisma.PrismaClientKnownRequestError from @prisma/client for type-safe error code matching. First file in the codebase to use this pattern. Worth adopting more broadly later if other hot-path operations need similar treatment.

Reference: PostgreSQL docs on serializable isolation https://www.postgresql.org/docs/current/transaction-iso.html#XACT-SERIALIZABLE