### PR TITLE
Fix embedding worker timeout: maxDuration 800s on Inngest route

### DIFF
--- a/src/app/api/inngest/route.ts
+++ b/src/app/api/inngest/route.ts
@@ -19,6 +19,21 @@ import { inngest } from '@/inngest/client';
 import { functions } from '@/inngest/functions';
 
 /**
+ * Vercel maxDuration: 800 seconds (13.3 min) — Pro plan ceiling.
+ *
+ * Required because the Voyage embedding worker
+ * (src/inngest/functions/embed-pending.ts) processes hundreds of
+ * batches in a single step.run, and the default Vercel timeout
+ * (10s) was killing it with FUNCTION_INVOCATION_TIMEOUT after
+ * partial completion.
+ *
+ * Stopgap. Proper fix is to refactor embed-pending.ts to use
+ * per-batch step.run so each invocation is bounded to ~5 sec.
+ * Tracked separately.
+ */
+export const maxDuration = 800;
+
+/**
  * Inngest webhook endpoint. Auth is signature-based via
  * INNGEST_SIGNING_KEY, NOT cookie-based. /api/inngest is in
  * middleware PUBLIC_PATHS to bypass the auth gate; serve() validates


### PR DESCRIPTION
Voyage embedding worker hit Vercel FUNCTION_INVOCATION_TIMEOUT during a 30+ minute run, killing the worker after 13,170 of ~31,000 chunks were successfully embedded. Vercel Pro plan default function timeout is short; the embed-pending function exceeds it because runEmbeddingPass() loops through hundreds of batches in a single step.run.

Quick fix: set maxDuration to 800 seconds (Vercel Pro ceiling) on the Inngest serve route. Each Vercel function invocation now has up to 13.3 min before timeout. Inngest's automatic retry will re-invoke for additional passes; embed-pending is idempotent (queries for embedding IS NULL) so re-runs cleanly resume from where prior runs left off.

Stopgap. The proper architectural fix is refactoring embed-pending.ts to use per-batch step.run so each Vercel invocation completes in ~5 seconds. That requires restructuring runEmbeddingPass to be batch-callable rather than loop-internal. Tracked as a separate PR.

After this merges:
  1. Re-invoke Voyage embedding worker from Inngest dashboard
  2. Worker resumes from chunk 13,171 onward
  3. Up to ~13 min per pass; Inngest re-invokes for additional passes until all chunks embedded
  4. Verify outcome='completed' in embedding_runs table

No schema changes. No call-site changes. Single config export added to src/app/api/inngest/route.ts.