### PR TITLE
PR-Ops-1.5: Operations North Star table

### DIFF
--- a/prisma/migrations/20260508000000_pr_ops_1_5_north_star/migration.sql
+++ b/prisma/migrations/20260508000000_pr_ops_1_5_north_star/migration.sql
@@ -1,0 +1,87 @@
+-- =============================================================================
+-- PR-Ops-1.5: Operations North Star
+-- =============================================================================
+-- Adds the per-user mission anchor table for the Operations tab. One row per
+-- user, edited frequently, hash-chained into audit_log on every mutation.
+--
+-- Single new table: operations_north_star
+-- Three new AuditActionType values: operations_north_star_{created,updated,reviewed}
+--
+-- Naming and conventions follow PR-Ops-1 / PR-K precedent:
+--   - Identifiers unquoted snake_case lowercase
+--   - Enum types double-quoted PascalCase
+--   - TIMESTAMPTZ for all timestamps
+--   - id UUID PRIMARY KEY DEFAULT gen_random_uuid()
+--   - Cross-domain FKs (user_id) declared without Prisma @relation back-edges
+--     in the schema layer (matches the missions / operations_* convention)
+--
+-- ALTER TYPE ADD VALUE intentionally NOT wrapped in BEGIN/COMMIT per the
+-- PR-G/PR-K convention (Postgres driver edge cases on enum-extension inside
+-- explicit transactions).
+-- =============================================================================
+
+-- PART 1: Table
+BEGIN;
+
+CREATE TABLE operations_north_star (
+  id                        UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id                   TEXT NOT NULL,
+  mission_statement         TEXT,
+  life_stage                VARCHAR(50),
+  core_values               TEXT[] NOT NULL DEFAULT '{}',
+  guiding_principles        TEXT,
+  one_year_target           TEXT,
+  three_year_target         TEXT,
+  current_location_label    VARCHAR(200),
+  current_timezone          VARCHAR(64) NOT NULL DEFAULT 'America/Los_Angeles',
+  review_cadence_days       INTEGER NOT NULL DEFAULT 90,
+  last_reviewed_at          TIMESTAMPTZ,
+  next_review_at            TIMESTAMPTZ,
+  created_at                TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at                TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  created_by                TEXT,
+  CONSTRAINT operations_north_star_user_id_fkey
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE ON UPDATE NO ACTION,
+  CONSTRAINT operations_north_star_user_id_key
+    UNIQUE (user_id),
+  CONSTRAINT operations_north_star_review_cadence_positive
+    CHECK (review_cadence_days > 0)
+);
+
+-- The user_id UNIQUE constraint already creates a btree index on user_id;
+-- only the next-review staleness index is added here.
+CREATE INDEX operations_north_star_next_review_idx
+  ON operations_north_star (next_review_at);
+
+COMMENT ON TABLE operations_north_star IS
+  'Per-user mission anchor. One row per user; mutations hash-chain into '
+  'audit_log via operations_north_star_updated/created/reviewed action types. '
+  'Row is never deleted; "clearing" the north star means editing fields to empty.';
+COMMENT ON COLUMN operations_north_star.life_stage IS
+  'Free-text life-stage label chosen by the user (e.g. "building", "scaling", '
+  '"transitioning"). Deliberately not enum-typed: subjective field, no fixed taxonomy.';
+COMMENT ON COLUMN operations_north_star.core_values IS
+  'Ordered list of self-selected core values. Mirrors framework_mappings precedent.';
+COMMENT ON COLUMN operations_north_star.review_cadence_days IS
+  'Days between scheduled reviews. Default 90 = Bridgewater quarterly principle '
+  'review cycle. Citadel-style monthly = 30. CHECK > 0 prevents disabling reviews.';
+COMMENT ON COLUMN operations_north_star.last_reviewed_at IS
+  'When the user last attested "I read this and it still holds." Distinct from '
+  'updated_at, which captures any field change. NULL until first review.';
+COMMENT ON COLUMN operations_north_star.next_review_at IS
+  'Materialized in app code as last_reviewed_at + review_cadence_days. '
+  'Index-backed staleness detection.';
+COMMENT ON COLUMN operations_north_star.current_timezone IS
+  'IANA timezone, drives "Today" computation in the Daily Plan section. '
+  'Default America/Los_Angeles matches operations_routines convention.';
+
+COMMIT;
+
+-- =============================================================================
+-- PART 2: AuditActionType enum extensions (must run outside transaction)
+-- IF NOT EXISTS guards make this idempotent.
+-- =============================================================================
+
+ALTER TYPE "AuditActionType" ADD VALUE IF NOT EXISTS 'operations_north_star_created';
+ALTER TYPE "AuditActionType" ADD VALUE IF NOT EXISTS 'operations_north_star_updated';
+ALTER TYPE "AuditActionType" ADD VALUE IF NOT EXISTS 'operations_north_star_reviewed';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -475,6 +475,7 @@ model users {
   missions                missions[]
   accountable_tasks       compliance_tasks[]       @relation("task_accountable")
   user_profile            user_profiles?
+  operations_north_star   operations_north_star?
   discovery_runs          discovery_runs[]
 }
 
@@ -2056,6 +2057,9 @@ enum AuditActionType {
   operations_vendor_deactivated
   operations_vendor_deleted
   operations_priority_recomputed
+  operations_north_star_created
+  operations_north_star_updated
+  operations_north_star_reviewed
   system_other
 }
 
@@ -2718,4 +2722,37 @@ model operations_vendor_directory {
   @@index([next_due_date])
   @@index([chart_account_id])
   @@map("operations_vendor_directory")
+}
+
+// =============================================================================
+// PR-Ops-1.5: Operations North Star
+// =============================================================================
+// Per-user mission anchor. One row per user (UNIQUE on user_id). Bound to
+// users(id) with Cascade delete -- matches user_profiles precedent for
+// personal-data tables. Mutations hash-chain into the shared audit_log via
+// operations_north_star_{created,updated,reviewed} action types.
+// =============================================================================
+
+model operations_north_star {
+  id                       String     @id @default(uuid()) @db.Uuid
+  user_id                  String     @unique
+  mission_statement        String?    @db.Text
+  life_stage               String?    @db.VarChar(50)
+  core_values              String[]   @default([])
+  guiding_principles       String?    @db.Text
+  one_year_target          String?    @db.Text
+  three_year_target        String?    @db.Text
+  current_location_label   String?    @db.VarChar(200)
+  current_timezone         String     @default("America/Los_Angeles") @db.VarChar(64)
+  review_cadence_days      Int        @default(90)
+  last_reviewed_at         DateTime?  @db.Timestamptz(6)
+  next_review_at           DateTime?  @db.Timestamptz(6)
+  created_at               DateTime   @default(now()) @db.Timestamptz(6)
+  updated_at               DateTime   @updatedAt @db.Timestamptz(6)
+  created_by               String?
+
+  user                     users      @relation(fields: [user_id], references: [id], onDelete: Cascade)
+
+  @@index([next_review_at])
+  @@map("operations_north_star")
 }


### PR DESCRIPTION
Adds operations_north_star: a per-user mission anchor table for the Operations tab. One row per user (UNIQUE on user_id). Mutations hash-chain into the shared audit_log via three new AuditActionType values: operations_north_star_{created,updated,reviewed}.

Schema:
  - id UUID PK
  - user_id TEXT UNIQUE, FK to users(id) ON DELETE CASCADE
  - mission_statement, life_stage, core_values (TEXT[]), guiding_principles
  - one_year_target, three_year_target (Bridgewater 1yr/3yr horizon convention)
  - current_location_label, current_timezone (default America/Los_Angeles)
  - review_cadence_days (default 90 = Bridgewater quarterly principle review)
  - last_reviewed_at, next_review_at (materialized in app code)
  - created_at, updated_at, created_by
  - CHECK (review_cadence_days > 0) prevents disabling reviews
  - INDEX on next_review_at for staleness detection

Design notes:
  - life_stage is VARCHAR not enum: subjective field, no fixed taxonomy (Renaissance principle: don't constrain user-subjective fields with rigid taxonomy until usage justifies one)
  - core_values follows the framework_mappings TEXT[] precedent
  - 1yr/3yr horizon split rather than generic horizons[] -- structure visible in schema, expandable to operations_horizons table later
  - No is_active or soft-delete: row is permanent; audit_log captures every revision (consistent with PR-Ops-1's hard-delete-with-audit philosophy for operations_*)
  - last_reviewed_at distinct from updated_at: review-without-change is its own audit-evidentiary event (operations_north_star_reviewed action type), separate from content edits (operations_north_star_updated)
  - users <-> operations_north_star uses full @relation with Cascade, matching the user_profiles precedent for personal-data tables; differs from PR-Ops-1's bare-FK convention because that referenced long-lived org/bookkeeping records (entities, chart_of_accounts), while this is tightly user-bound personal data

Verification:
  - prisma validate: passed (Prisma 5.22.0)
  - prisma generate: client generated successfully
  - tsc --noEmit: exit 0, zero errors

Rollback: additive migration (no drops, no alters to existing tables). Revert by reverting the merge commit; the 3 enum values added to AuditActionType remain harmless if unreferenced.