### PR TITLE
PR-Ops-2a: Operations workbench shell

### DIFF
--- a/src/app/api/audit-log/route.ts
+++ b/src/app/api/audit-log/route.ts
@@ -10,6 +10,7 @@ export async function GET(request: NextRequest) {
     const { searchParams } = new URL(request.url);
     const actorUserId = searchParams.get('actor_user_id');
     const actionType = searchParams.get('action_type');
+    const prefix = searchParams.get('prefix');
     const targetTable = searchParams.get('target_table');
     const targetId = searchParams.get('target_id');
     const after = searchParams.get('after');
@@ -20,7 +21,12 @@ export async function GET(request: NextRequest) {
 
     const where: Record<string, unknown> = {};
     if (actorUserId) where.actor_user_id = actorUserId;
-    if (actionType) where.action_type = actionType;
+    // action_type exact match wins over prefix; only one applies.
+    if (actionType) {
+      where.action_type = actionType;
+    } else if (prefix) {
+      where.action_type = { startsWith: prefix };
+    }
     if (targetTable) where.target_table = targetTable;
     if (targetId) where.target_id = targetId;
     if (after || before) {

--- a/src/app/operations/audit-log/page.tsx
+++ b/src/app/operations/audit-log/page.tsx
@@ -1,0 +1,13 @@
+/**
+ * src/app/operations/audit-log/page.tsx
+ *
+ * Section K · Audit Tail — operations-filtered hash-chained audit log
+ * with verify-chain control. The only Operations sub-tab in PR-Ops-2a
+ * that ships with real, working content (besides the chrome itself).
+ */
+
+import SectionK_AuditTail from '@/components/workbench/operations/SectionK_AuditTail';
+
+export default function OperationsAuditLogPage() {
+  return <SectionK_AuditTail />;
+}

--- a/src/app/operations/content/page.tsx
+++ b/src/app/operations/content/page.tsx
@@ -1,0 +1,5 @@
+import PlaceholderCard from '@/components/workbench/operations/PlaceholderCard';
+
+export default function OperationsContentPage() {
+  return <PlaceholderCard letter="G" title="CONTENT PRODUCTION" unbuiltLabel="UNBUILT · PR-Ops-8" />;
+}

--- a/src/app/operations/issues/page.tsx
+++ b/src/app/operations/issues/page.tsx
@@ -1,0 +1,5 @@
+import PlaceholderCard from '@/components/workbench/operations/PlaceholderCard';
+
+export default function OperationsIssuesPage() {
+  return <PlaceholderCard letter="J" title="ISSUE LOG" unbuiltLabel="UNBUILT · PR-Ops-6" />;
+}

--- a/src/app/operations/layout.tsx
+++ b/src/app/operations/layout.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import AppLayout from '@/components/ui/AppLayout';
+import OperationsIdentityBar from '@/components/workbench/operations/IdentityBar';
+import SubNav, { type SubNavTab } from '@/components/workbench/operations/SubNav';
+import { OperationsEntityProvider } from '@/components/workbench/operations/EntitySelector';
+
+const OPERATIONS_TABS: SubNavTab[] = [
+  { label: 'Daily Plan', href: '/operations', exact: true },
+  { label: 'Projects', href: '/operations/projects' },
+  { label: 'Routines', href: '/operations/routines' },
+  { label: 'Roadmap', href: '/operations/roadmap' },
+  { label: 'Content', href: '/operations/content' },
+  { label: 'Travel', href: '/operations/travel' },
+  { label: 'Money', href: '/operations/money' },
+  { label: 'Issue Log', href: '/operations/issues' },
+  { label: 'Audit Tail', href: '/operations/audit-log' },
+];
+
+export default function OperationsLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <AppLayout>
+      <OperationsEntityProvider>
+        <OperationsIdentityBar />
+        <SubNav tabs={OPERATIONS_TABS} />
+        <div className="max-w-[1600px] mx-auto px-6 py-4 space-y-3">{children}</div>
+      </OperationsEntityProvider>
+    </AppLayout>
+  );
+}

--- a/src/app/operations/money/page.tsx
+++ b/src/app/operations/money/page.tsx
@@ -1,0 +1,5 @@
+import PlaceholderCard from '@/components/workbench/operations/PlaceholderCard';
+
+export default function OperationsMoneyPage() {
+  return <PlaceholderCard letter="I" title="MONEY" unbuiltLabel="UNBUILT · PR-Ops-10" />;
+}

--- a/src/app/operations/page.tsx
+++ b/src/app/operations/page.tsx
@@ -1,36 +1,21 @@
 /**
  * src/app/operations/page.tsx
  *
- * Operations tab — daily plan, project backlog, priority engine,
- * routines, issue log, content production, travel project.
+ * Daily Plan — Operations home. Renders Section B (North Star) and
+ * Section C (Today's Decision) as placeholders. Real wiring lands in
+ * later PRs (PR-Ops-2b for North Star, PR-Ops-4 for Today's Decision).
  *
- * Currently a placeholder shell. Real sections ship in PR-Ops-1+.
+ * Chrome (identity bar + sub-nav) is provided by the parent
+ * src/app/operations/layout.tsx.
  */
 
-export default function OperationsPage() {
+import PlaceholderCard from '@/components/workbench/operations/PlaceholderCard';
+
+export default function OperationsDailyPlanPage() {
   return (
-    <main className="min-h-screen bg-bg-primary">
-      <div className="max-w-7xl mx-auto px-6 py-6">
-        <div className="border border-border bg-white">
-          <div className="bg-brand-purple text-white px-4 py-2 text-sm font-semibold tracking-wider uppercase">
-            Operations · Daily Plan + Priority Engine
-          </div>
-          <div className="p-8 text-center">
-            <div className="text-text-muted text-sm uppercase tracking-wider mb-2">
-              Under Construction
-            </div>
-            <p className="text-text-secondary text-sm max-w-2xl mx-auto leading-relaxed">
-              Personal operating system. Project backlog with Bridgewater
-              5-step scoping. Citadel-style ranked decision queue. Bridgewater
-              Issue Log. Routine tracker with fail-loud miss detection.
-              Content production workspace. 6-month travel project module.
-            </p>
-            <p className="text-text-muted text-xs mt-4">
-              Ships across PR-Ops-1 through PR-Ops-N.
-            </p>
-          </div>
-        </div>
-      </div>
-    </main>
+    <>
+      <PlaceholderCard letter="B" title="NORTH STAR" unbuiltLabel="UNBUILT · PR-Ops-2b" />
+      <PlaceholderCard letter="C" title="TODAY'S DECISION" unbuiltLabel="UNBUILT · PR-Ops-4" />
+    </>
   );
 }

--- a/src/app/operations/projects/page.tsx
+++ b/src/app/operations/projects/page.tsx
@@ -1,0 +1,5 @@
+import PlaceholderCard from '@/components/workbench/operations/PlaceholderCard';
+
+export default function OperationsProjectsPage() {
+  return <PlaceholderCard letter="D" title="PROJECTS" unbuiltLabel="UNBUILT · PR-Ops-3" />;
+}

--- a/src/app/operations/roadmap/page.tsx
+++ b/src/app/operations/roadmap/page.tsx
@@ -1,0 +1,5 @@
+import PlaceholderCard from '@/components/workbench/operations/PlaceholderCard';
+
+export default function OperationsRoadmapPage() {
+  return <PlaceholderCard letter="F" title="ROADMAP" unbuiltLabel="UNBUILT · PR-Ops-7" />;
+}

--- a/src/app/operations/routines/page.tsx
+++ b/src/app/operations/routines/page.tsx
@@ -1,0 +1,5 @@
+import PlaceholderCard from '@/components/workbench/operations/PlaceholderCard';
+
+export default function OperationsRoutinesPage() {
+  return <PlaceholderCard letter="E" title="ROUTINES" unbuiltLabel="UNBUILT · PR-Ops-5" />;
+}

--- a/src/app/operations/travel/page.tsx
+++ b/src/app/operations/travel/page.tsx
@@ -1,0 +1,5 @@
+import PlaceholderCard from '@/components/workbench/operations/PlaceholderCard';
+
+export default function OperationsTravelPage() {
+  return <PlaceholderCard letter="H" title="TRAVEL PROJECT" unbuiltLabel="UNBUILT · PR-Ops-9" />;
+}

--- a/src/components/workbench/operations/EntitySelector.tsx
+++ b/src/components/workbench/operations/EntitySelector.tsx
@@ -1,0 +1,129 @@
+'use client';
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from 'react';
+
+export interface Entity {
+  id: string;
+  name: string;
+  entity_type: string;
+  is_default: boolean;
+}
+
+export interface EntityContext {
+  entities: Entity[];
+  selectedEntityId: string | null;
+  setSelectedEntityId: (id: string | null) => void;
+  selectedEntity: Entity | null;
+}
+
+const STORAGE_KEY = 'operations-entity-id';
+
+export const OperationsEntityContext = createContext<EntityContext | null>(null);
+
+export function useOperationsEntity(): EntityContext {
+  const ctx = useContext(OperationsEntityContext);
+  if (!ctx) {
+    throw new Error('useOperationsEntity must be used within OperationsEntityProvider');
+  }
+  return ctx;
+}
+
+export function OperationsEntityProvider({ children }: { children: ReactNode }) {
+  const [entities, setEntities] = useState<Entity[]>([]);
+  const [selectedEntityId, setSelectedEntityIdState] = useState<string | null>(() => {
+    try {
+      if (typeof window !== 'undefined') {
+        const saved = localStorage.getItem(STORAGE_KEY);
+        if (saved !== null) return saved === 'null' ? null : saved;
+      }
+    } catch {}
+    return null;
+  });
+
+  const setSelectedEntityId = useCallback((id: string | null) => {
+    setSelectedEntityIdState(id);
+    try {
+      localStorage.setItem(STORAGE_KEY, id === null ? 'null' : id);
+    } catch {}
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    const fetchEntities = async () => {
+      try {
+        const res = await fetch('/api/entities');
+        if (!res.ok) return;
+        const data = await res.json();
+        if (cancelled) return;
+        const list: Entity[] = data?.entities ?? [];
+        setEntities(list);
+
+        // Apply is_default only when the user has never expressed a preference.
+        const hasStoredPreference =
+          typeof window !== 'undefined' && localStorage.getItem(STORAGE_KEY) !== null;
+        if (!hasStoredPreference && selectedEntityId === null) {
+          const def = list.find((e) => e.is_default);
+          if (def) setSelectedEntityId(def.id);
+        }
+      } catch {
+        // silent — UI still renders with no entities
+      }
+    };
+    fetchEntities();
+    return () => {
+      cancelled = true;
+    };
+    // selectedEntityId is intentionally not in deps: we only want the
+    // is_default fallback to run once on initial entity load. Subsequent
+    // user selections are persisted by setSelectedEntityId itself.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const selectedEntity = entities.find((e) => e.id === selectedEntityId) ?? null;
+
+  return (
+    <OperationsEntityContext.Provider
+      value={{ entities, selectedEntityId, setSelectedEntityId, selectedEntity }}
+    >
+      {children}
+    </OperationsEntityContext.Provider>
+  );
+}
+
+export default function EntitySelectorStrip() {
+  const { entities, selectedEntityId, setSelectedEntityId } = useOperationsEntity();
+
+  const activeClass =
+    'px-2 py-1 text-xs font-mono border-b-2 border-brand-purple text-brand-purple';
+  const inactiveClass =
+    'px-2 py-1 text-xs font-mono border-b-2 border-transparent text-text-muted hover:text-text-primary';
+
+  return (
+    <div className="flex items-center gap-1">
+      <button
+        type="button"
+        onClick={() => setSelectedEntityId(null)}
+        className={selectedEntityId === null ? activeClass : inactiveClass}
+      >
+        All
+      </button>
+      {entities.map((e) => (
+        <button
+          key={e.id}
+          type="button"
+          onClick={() => setSelectedEntityId(e.id)}
+          className={selectedEntityId === e.id ? activeClass : inactiveClass}
+        >
+          {e.name}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/components/workbench/operations/IdentityBar.tsx
+++ b/src/components/workbench/operations/IdentityBar.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import EntitySelectorStrip from './EntitySelector';
+
+const BUILD_SHA = (process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA ?? 'dev').slice(0, 8);
+
+export default function OperationsIdentityBar() {
+  const [auditTailHash, setAuditTailHash] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchTail = async () => {
+      try {
+        const res = await fetch('/api/audit-log?prefix=operations_&limit=1');
+        if (res.ok) {
+          const body = await res.json();
+          const tail = body?.rows?.[0]?.content_hash ?? null;
+          setAuditTailHash(tail ? String(tail).slice(0, 8) : null);
+        }
+      } catch {
+        // silent — bar still renders without tail
+      }
+    };
+    fetchTail();
+    const id = setInterval(fetchTail, 15000);
+    return () => clearInterval(id);
+  }, []);
+
+  return (
+    <div className="sticky top-0 z-30 bg-white border-b border-border shadow-sm">
+      <div className="max-w-[1600px] mx-auto px-4 py-2 flex items-center justify-between text-xs font-mono text-text-secondary">
+        <div className="flex items-center gap-4">
+          <span className="font-bold text-text-primary tracking-wide">OPERATIONS</span>
+          <span>build:{BUILD_SHA}</span>
+          {auditTailHash && (
+            <span title="Operations audit log tail hash (last 8 chars of latest content_hash, filtered to operations_*)">
+              tail:{auditTailHash}
+            </span>
+          )}
+        </div>
+        <div className="flex items-center gap-3">
+          <EntitySelectorStrip />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/workbench/operations/PlaceholderCard.tsx
+++ b/src/components/workbench/operations/PlaceholderCard.tsx
@@ -1,0 +1,33 @@
+import type { ReactNode } from 'react';
+
+export interface PlaceholderCardProps {
+  letter: string;
+  title: string;
+  unbuiltLabel: string;
+  children?: ReactNode;
+}
+
+export default function PlaceholderCard({
+  letter,
+  title,
+  unbuiltLabel,
+  children,
+}: PlaceholderCardProps) {
+  return (
+    <section className="bg-white rounded border border-border shadow-sm p-5">
+      <div className="flex items-center justify-between mb-3">
+        <h2 className="font-mono text-sm font-bold tracking-wide text-text-primary">
+          {letter} · {title}
+        </h2>
+        <span className="text-xs font-mono text-amber-700 bg-amber-50 border border-amber-200 px-2 py-0.5 rounded">
+          {unbuiltLabel}
+        </span>
+      </div>
+      {children ? (
+        <div className="text-xs font-mono text-text-muted">{children}</div>
+      ) : (
+        <div className="text-xs font-mono text-text-muted">section pending implementation</div>
+      )}
+    </section>
+  );
+}

--- a/src/components/workbench/operations/SectionK_AuditTail.tsx
+++ b/src/components/workbench/operations/SectionK_AuditTail.tsx
@@ -1,0 +1,158 @@
+/**
+ * src/components/workbench/operations/SectionK_AuditTail.tsx
+ *
+ * Operations-filtered audit tail. Mirrors SectionI_AuditTail but:
+ *  - fetches with ?prefix=operations_ to scope to the Operations subsystem
+ *  - calls verify-chain via POST (matches the endpoint contract)
+ *  - reads body.rows only (current API response shape)
+ */
+
+'use client';
+
+import { useEffect, useState } from 'react';
+
+interface AuditRow {
+  id: string;
+  created_at: string;
+  actor_type: string;
+  action_type: string;
+  action_description: string;
+  target_table: string | null;
+  target_id: string | null;
+  prev_hash: string;
+  content_hash: string;
+}
+
+interface VerifyResult {
+  ok: boolean;
+  rows_checked: number;
+  message?: string;
+}
+
+function shortHash(h: string | null): string {
+  if (!h) return '—';
+  return h.length > 12 ? `${h.slice(0, 6)}…${h.slice(-4)}` : h;
+}
+
+function relTime(iso: string): string {
+  const ms = Date.now() - new Date(iso).getTime();
+  if (ms < 60_000) return `${Math.floor(ms / 1000)}s ago`;
+  if (ms < 3_600_000) return `${Math.floor(ms / 60_000)}m ago`;
+  if (ms < 86_400_000) return `${Math.floor(ms / 3_600_000)}h ago`;
+  return `${Math.floor(ms / 86_400_000)}d ago`;
+}
+
+export default function SectionK_AuditTail() {
+  const [rows, setRows] = useState<AuditRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [verifying, setVerifying] = useState(false);
+  const [verifyResult, setVerifyResult] = useState<VerifyResult | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const fetchData = async () => {
+      try {
+        const res = await fetch('/api/audit-log?prefix=operations_&limit=50');
+        if (!cancelled && res.ok) {
+          const body = await res.json();
+          setRows(body?.rows ?? []);
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+    fetchData();
+    const id = setInterval(fetchData, 10000);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, []);
+
+  const verifyChain = async () => {
+    setVerifying(true);
+    setVerifyResult(null);
+    try {
+      const res = await fetch('/api/audit-log/verify-chain', { method: 'POST' });
+      if (res.ok) {
+        setVerifyResult(await res.json());
+      } else {
+        setVerifyResult({ ok: false, rows_checked: 0, message: `request failed (${res.status})` });
+      }
+    } finally {
+      setVerifying(false);
+    }
+  };
+
+  return (
+    <section className="bg-white rounded border border-border shadow-sm p-5">
+      <div className="flex items-center justify-between mb-3">
+        <h2 className="font-mono text-sm font-bold tracking-wide text-text-primary">
+          K · AUDIT TAIL
+        </h2>
+        <div className="flex items-center gap-3 text-xs font-mono">
+          <span className="text-text-muted">refresh 10s</span>
+          <button
+            onClick={verifyChain}
+            disabled={verifying}
+            className="px-2 py-1 border border-border rounded hover:bg-bg-row disabled:opacity-50"
+          >
+            {verifying ? 'verifying…' : 'verify chain'}
+          </button>
+        </div>
+      </div>
+
+      {verifyResult && (
+        <div
+          className={`text-xs font-mono mb-3 px-3 py-2 rounded border ${
+            verifyResult.ok
+              ? 'bg-green-50 border-green-200 text-green-800'
+              : 'bg-red-50 border-red-200 text-red-800'
+          }`}
+        >
+          {verifyResult.ok
+            ? `chain valid · ${verifyResult.rows_checked} rows checked`
+            : `chain INVALID · ${verifyResult.message ?? 'see audit log'}`}
+        </div>
+      )}
+
+      {loading ? (
+        <div className="text-xs font-mono text-text-muted">loading…</div>
+      ) : rows.length > 0 ? (
+        <div className="text-xs font-mono max-h-96 overflow-y-auto">
+          <table className="w-full">
+            <thead className="sticky top-0 bg-white">
+              <tr className="text-text-faint uppercase tracking-wide">
+                <th className="text-left pb-1 w-20">when</th>
+                <th className="text-left pb-1">action</th>
+                <th className="text-left pb-1 w-24">target</th>
+                <th className="text-left pb-1 w-28">prev_hash</th>
+                <th className="text-left pb-1 w-28">this_hash</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((r) => (
+                <tr key={r.id} className="border-t border-border-light">
+                  <td className="py-1 text-text-muted">{relTime(r.created_at)}</td>
+                  <td className="py-1 text-text-primary">
+                    <div className="font-bold">{r.action_type}</div>
+                    <div className="text-text-muted truncate max-w-md">
+                      {r.action_description}
+                    </div>
+                  </td>
+                  <td className="py-1 text-text-muted truncate">
+                    {r.target_table ?? '—'}
+                  </td>
+                  <td className="py-1 text-text-faint">{shortHash(r.prev_hash)}</td>
+                  <td className="py-1 text-text-faint">{shortHash(r.content_hash)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ) : (
+        <div className="text-xs font-mono text-text-muted">no operations audit entries yet</div>
+      )}
+    </section>
+  );
+}

--- a/src/components/workbench/operations/SubNav.tsx
+++ b/src/components/workbench/operations/SubNav.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+import Link from 'next/link';
+
+export type SubNavTab = {
+  label: string;
+  href: string;
+  exact?: boolean;
+  disabled?: boolean;
+};
+
+export default function SubNav({ tabs }: { tabs: SubNavTab[] }) {
+  const pathname = usePathname();
+
+  const isActive = (tab: SubNavTab): boolean => {
+    if (tab.disabled) return false;
+    if (tab.exact) return pathname === tab.href;
+    return pathname?.startsWith(tab.href) ?? false;
+  };
+
+  return (
+    <div className="border-b border-border bg-white">
+      <div className="max-w-[1600px] mx-auto px-4">
+        <nav className="flex items-center gap-1 -mb-px">
+          {tabs.map((tab) => {
+            if (tab.disabled) {
+              return (
+                <span
+                  key={tab.label}
+                  className="px-3 py-2 text-terminal-sm font-mono text-text-faint cursor-default"
+                >
+                  {tab.label}
+                </span>
+              );
+            }
+            const active = isActive(tab);
+            return (
+              <Link
+                key={tab.label}
+                href={tab.href}
+                className={
+                  active
+                    ? 'px-3 py-2 text-terminal-sm font-mono transition-colors border-b-2 border-brand-purple text-brand-purple font-medium'
+                    : 'px-3 py-2 text-terminal-sm font-mono transition-colors border-b-2 border-transparent text-text-muted hover:text-text-primary hover:border-border'
+                }
+              >
+                {tab.label}
+              </Link>
+            );
+          })}
+        </nav>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Ships the Operations tab's institutional chrome and routes. Schema-only PRs (PR-Ops-1 + PR-Ops-1.5) gave us the data spine; this PR makes the surface visible. North Star reader/editor lands in PR-Ops-2b.

New chrome components (src/components/workbench/operations/):
  EntitySelector.tsx       React context + 4-button strip
                           (All/Personal/Business/Trading), localStorage
                           persistence at key 'operations-entity-id',
                           defaults to entities.is_default on first load
  SubNav.tsx               Parameterized sub-tab strip; takes tabs prop;
                           max-w-[1600px] (compliance has a width
                           inconsistency we are not propagating)
  IdentityBar.tsx          Operations-scoped identity bar; pulls
                           audit-log tail filtered to operations_*
                           prefix; refreshes every 15s; houses
                           EntitySelectorStrip on the right
  PlaceholderCard.tsx      Shared "Section X · TITLE · UNBUILT" card
                           chrome; server component
  SectionK_AuditTail.tsx   Operations-filtered hash-chained audit tail;
                           verify-chain via POST (compliance has a
                           latent GET-vs-POST bug — fixed at source for
                           this variant; compliance bug logged for
                           later cleanup)

New routes (src/app/operations/):
  layout.tsx               Wraps AppLayout + EntityProvider +
                           IdentityBar + SubNav; nested layout pattern
  page.tsx                 Daily Plan home; placeholders for B (North
                           Star, PR-Ops-2b) and C (Today's Decision,
                           PR-Ops-4)
  projects/page.tsx        D — PROJECTS (PR-Ops-3)
  routines/page.tsx        E — ROUTINES (PR-Ops-5)
  roadmap/page.tsx         F — ROADMAP (PR-Ops-7)
  content/page.tsx         G — CONTENT PRODUCTION (PR-Ops-8)
  travel/page.tsx          H — TRAVEL PROJECT (PR-Ops-9)
  money/page.tsx           I — MONEY (PR-Ops-10)
  issues/page.tsx          J — ISSUE LOG (PR-Ops-6)
  audit-log/page.tsx       K — AUDIT TAIL (REAL — only sub-tab with
                           live content besides chrome)

API extension:
  /api/audit-log           Adds optional ?prefix=... filter using
                           Prisma startsWith. action_type exact match
                           wins over prefix when both passed (documented
                           in code comment).

Design decisions (institutional grade):
  - Entity selection persisted client-side in localStorage, NOT schema: it is view state (UI preference), not domain state (auditable record). Renaissance / Citadel both keep workstation view preferences client-side; schema is reserved for things that need audit trails. Pattern follows ConvergenceIntelligence.tsx precedent (lazy useState init, SSR guard, try/catch wrap, JSON persistence, namespaced key).
  - Operations identity bar shows OPERATIONS-filtered audit tail (not global). Each subsystem (compliance, operations) gets a tail of its own integrity. Matches Citadel ops dashboard pattern of desk-level audit visibility, not firm-wide.
  - SubNav is a NEW parameterized component, not a refactor of the existing OpsSubNav. Compliance migration to it is a separate compliance-thread PR. Zero compliance file modifications in this PR.
  - Hard-delete-with-audit-capture philosophy from PR-Ops-1 carries through: the audit_log itself remains the SSOT for historical state.

Bugs filed (NOT fixed in this PR):
  - SectionI_AuditTail.tsx (compliance) calls /api/audit-log/verify-chain with default GET; endpoint expects POST. Will likely 405 on click. Reproduced in pre-existing audit, will land in operations_issue_log_entries once that surface ships in PR-Ops-6.

Verification:
  - tsc --noEmit: exit 0, zero errors
  - prisma generate: no-op (no schema changes)
  - All compliance files (src/components/ops/, src/components/workbench/ SectionA-J, src/app/compliance/**) UNCHANGED. Compliance renders identically post-PR.

Rollback: pure additive PR (one endpoint extension is the only mod to pre-existing code; one /operations/page.tsx overwrite replaces a 36-line placeholder). Revert by reverting the merge commit.