### PR TITLE
PR-Ops-2a-fix1: verify-chain endpoint contract normalization

### DIFF
--- a/src/app/api/audit-log/verify-chain/route.ts
+++ b/src/app/api/audit-log/verify-chain/route.ts
@@ -31,12 +31,30 @@ export async function POST() {
       },
     });
 
+    // Response contract emits BOTH the researcher-flavored fields used by
+    // diagnostic tooling (is_valid, total_rows, break_points, notes) AND the
+    // UI-flavored fields consumed by section components (ok, rows_checked,
+    // message). Single source of truth so consumers don't drift from the
+    // producer. SectionK_AuditTail and the future-fixed SectionI_AuditTail
+    // both read the UI-flavored fields.
+    const ui_message = result.is_valid
+      ? undefined
+      : result.notes[0] ?? (
+          result.break_points.length > 0
+            ? `${result.break_points.length} break point(s) — see /api/audit-log/verify-chain for details`
+            : 'chain invalid (no diagnostic notes available)'
+        );
+
     const serialized = {
       ...result,
       break_points: result.break_points.map((bp) => ({
         ...bp,
         sequence_number: bp.sequence_number.toString(),
       })),
+      // UI-flavored contract:
+      ok: result.is_valid,
+      rows_checked: result.total_rows,
+      message: ui_message,
     };
 
     return NextResponse.json(serialized);


### PR DESCRIPTION
Extends /api/audit-log/verify-chain response to emit both the researcher-flavored fields (is_valid, total_rows, break_points, notes) AND UI-flavored fields (ok, rows_checked, message) in the same payload. Single source of truth at the producer; consumers no longer drift.

Background:
  SectionK_AuditTail (PR-Ops-2a) and SectionI_AuditTail (existing
  compliance) both define VerifyResult as { ok, rows_checked, message }
  but the endpoint emitted { is_valid, total_rows, break_points, notes }.
  The components rendered "chain INVALID · see audit log" on every
  verification regardless of actual chain state because verifyResult.ok
  resolved to undefined.

  The latent bug existed in SectionI but was masked by a separate
  GET-vs-POST defect (the request never landed). When PR-Ops-2a fixed
  the method to POST in SectionK, the contract mismatch surfaced.

Diagnosis confirmed:
  - Smoke test on /operations/audit-log returned "chain INVALID"
  - Recon read of verifyAuditChain.ts + verify-chain/route.ts traced the field-name mismatch between producer and consumer
  - Chain integrity itself was never in question (writeAuditLog and the hash chain unchanged across PR-Ops-1 and PR-Ops-1.5)

Fix:
  Add ok = result.is_valid, rows_checked = result.total_rows, and a
  derived message field that surfaces notes[0] when present, else a
  break-point count summary, else a generic invalidation message.
  Backward compatible -- researcher fields remain in the response.

Design note (institutional):
  When two consumers disagree with a producer, the producer is wrong.
  Fixing at the endpoint normalizes the contract once and prevents
  future component drift. Bridgewater principle applied.

Verification:
  - tsc --noEmit: exit 0, zero errors
  - Single file changed, +18/-0 lines
  - Researcher contract preserved (is_valid, break_points, notes still emitted); diagnostic tooling unaffected.

Compliance side note:
  SectionI_AuditTail still has its GET-vs-POST defect (calls verify-chain
  with default GET; endpoint requires POST). NOT fixed in this PR.
  When that compliance bug is fixed in a separate compliance-thread PR,
  SectionI will work correctly without further changes -- the contract
  mismatch is already resolved here.

Smoke test plan post-merge:
  - Navigate to templestuart.com/operations/audit-log
  - Click "verify chain"
  - Expect: green "chain valid · N rows checked" banner
  - If still red: real chain corruption -- stop and investigate