### PR TITLE
PR-Ops-2b: North Star reader/editor + write API

### DIFF
--- a/src/app/api/operations/north-star/review/route.ts
+++ b/src/app/api/operations/north-star/review/route.ts
@@ -1,0 +1,83 @@
+/**
+ * /api/operations/north-star/review
+ *
+ * POST — record a review-without-edit attestation. Updates only
+ *        last_reviewed_at to NOW() and recomputes next_review_at as
+ *        last_reviewed_at + review_cadence_days. Hash-chains an audit
+ *        entry with action_type operations_north_star_reviewed.
+ *
+ * Distinct from POST /api/operations/north-star (which records edits).
+ * Bridgewater convention: "I read this and it still holds" is its own
+ * audit-evidentiary event, separate from content changes. SOC 2 evidence-
+ * of-review controls work this way.
+ */
+
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { writeAuditLog } from '@/lib/audit/writeAuditLog';
+
+export async function POST() {
+  try {
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const user = await prisma.users.findFirst({
+      where: { email: { equals: userEmail, mode: 'insensitive' } },
+    });
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+
+    const existing = await prisma.operations_north_star.findUnique({
+      where: { user_id: user.id },
+    });
+    if (!existing) {
+      return NextResponse.json(
+        { error: 'No north star to review', message: 'create one first via POST /api/operations/north-star' },
+        { status: 404 }
+      );
+    }
+
+    const now = new Date();
+    const nextReview = new Date(now.getTime() + existing.review_cadence_days * 24 * 60 * 60 * 1000);
+
+    const northStar = await prisma.operations_north_star.update({
+      where: { user_id: user.id },
+      data: {
+        last_reviewed_at: now,
+        next_review_at: nextReview,
+      },
+    });
+
+    await writeAuditLog({
+      actor: {
+        user_id: user.id,
+        email: userEmail,
+        type: 'human_user',
+      },
+      action: {
+        type: 'operations_north_star_reviewed',
+        description: `Reviewed north star (no content change) for ${userEmail}; next review due ${nextReview.toISOString()}`,
+      },
+      target: {
+        table: 'operations_north_star',
+        id: northStar.id,
+      },
+      payload: {
+        before: existing,
+        after: northStar,
+        metadata: {
+          review_cadence_days: existing.review_cadence_days,
+          previous_review_at: existing.last_reviewed_at?.toISOString() ?? null,
+        },
+      },
+    });
+
+    return NextResponse.json({ northStar });
+  } catch (error) {
+    console.error('[North Star Review]', error);
+    return NextResponse.json(
+      { error: 'Failed to record review', message: error instanceof Error ? error.message : 'unknown' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/operations/north-star/route.ts
+++ b/src/app/api/operations/north-star/route.ts
@@ -1,0 +1,140 @@
+/**
+ * /api/operations/north-star
+ *
+ * GET  — return the current user's operations_north_star row, or null if absent.
+ *        No audit write (read-only).
+ *
+ * POST — upsert the current user's row from the request body. Hash-chains
+ *        an audit_log entry for the create or update event.
+ *
+ * Pattern mirrors src/app/api/discovery/profile/route.ts: inline auth,
+ * inline user lookup, sequential prisma + writeAuditLog awaits (NOT
+ * transactional — matches existing convention; partial-failure tolerance
+ * relies on writeAuditLog's internal P2034/P2024 retry).
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { writeAuditLog } from '@/lib/audit/writeAuditLog';
+
+export async function GET() {
+  try {
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const user = await prisma.users.findFirst({
+      where: { email: { equals: userEmail, mode: 'insensitive' } },
+    });
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+
+    const northStar = await prisma.operations_north_star.findUnique({
+      where: { user_id: user.id },
+    });
+
+    return NextResponse.json({ northStar });
+  } catch (error) {
+    console.error('[North Star GET]', error);
+    return NextResponse.json(
+      { error: 'Failed to load north star', message: error instanceof Error ? error.message : 'unknown' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const user = await prisma.users.findFirst({
+      where: { email: { equals: userEmail, mode: 'insensitive' } },
+    });
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+
+    const body = await request.json();
+
+    // Validation: review_cadence_days must be positive (DB CHECK constraint).
+    // Strings normalize empty → null. core_values must be a string array.
+    const review_cadence_days =
+      typeof body.review_cadence_days === 'number' ? body.review_cadence_days : 90;
+    if (review_cadence_days <= 0) {
+      return NextResponse.json(
+        { error: 'Validation', field: 'review_cadence_days', message: 'must be positive' },
+        { status: 400 }
+      );
+    }
+
+    if (body.core_values !== undefined && !Array.isArray(body.core_values)) {
+      return NextResponse.json(
+        { error: 'Validation', field: 'core_values', message: 'must be an array of strings' },
+        { status: 400 }
+      );
+    }
+
+    const norm = (v: unknown): string | null => {
+      if (typeof v !== 'string') return null;
+      const t = v.trim();
+      return t.length > 0 ? t : null;
+    };
+
+    const data = {
+      mission_statement: norm(body.mission_statement),
+      life_stage: norm(body.life_stage),
+      core_values: Array.isArray(body.core_values)
+        ? body.core_values.filter((s: unknown): s is string => typeof s === 'string' && s.trim().length > 0)
+        : [],
+      guiding_principles: norm(body.guiding_principles),
+      one_year_target: norm(body.one_year_target),
+      three_year_target: norm(body.three_year_target),
+      current_location_label: norm(body.current_location_label),
+      current_timezone: norm(body.current_timezone) ?? 'America/Los_Angeles',
+      review_cadence_days,
+    };
+
+    const existing = await prisma.operations_north_star.findUnique({
+      where: { user_id: user.id },
+    });
+    const isCreate = !existing;
+
+    const northStar = await prisma.operations_north_star.upsert({
+      where: { user_id: user.id },
+      create: {
+        user_id: user.id,
+        created_by: userEmail,
+        ...data,
+      },
+      update: data,
+    });
+
+    await writeAuditLog({
+      actor: {
+        user_id: user.id,
+        email: userEmail,
+        type: 'human_user',
+      },
+      action: {
+        type: isCreate ? 'operations_north_star_created' : 'operations_north_star_updated',
+        description: isCreate
+          ? `Created north star for ${userEmail}`
+          : `Updated north star for ${userEmail}`,
+      },
+      target: {
+        table: 'operations_north_star',
+        id: northStar.id,
+      },
+      payload: {
+        before: existing ?? undefined,
+        after: northStar,
+      },
+    });
+
+    return NextResponse.json({ northStar, isCreate }, { status: isCreate ? 201 : 200 });
+  } catch (error) {
+    console.error('[North Star POST]', error);
+    return NextResponse.json(
+      { error: 'Failed to save north star', message: error instanceof Error ? error.message : 'unknown' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/operations/page.tsx
+++ b/src/app/operations/page.tsx
@@ -10,11 +10,12 @@
  */
 
 import PlaceholderCard from '@/components/workbench/operations/PlaceholderCard';
+import SectionB_NorthStar from '@/components/workbench/operations/SectionB_NorthStar';
 
 export default function OperationsDailyPlanPage() {
   return (
     <>
-      <PlaceholderCard letter="B" title="NORTH STAR" unbuiltLabel="UNBUILT · PR-Ops-2b" />
+      <SectionB_NorthStar />
       <PlaceholderCard letter="C" title="TODAY'S DECISION" unbuiltLabel="UNBUILT · PR-Ops-4" />
     </>
   );

--- a/src/components/workbench/operations/SectionB_NorthStar.tsx
+++ b/src/components/workbench/operations/SectionB_NorthStar.tsx
@@ -1,0 +1,521 @@
+/**
+ * src/components/workbench/operations/SectionB_NorthStar.tsx
+ *
+ * Section B · North Star — per-user mission anchor with always-edit-mode form.
+ *
+ * Three render branches:
+ *   - Loading: section card with "loading north star…" body
+ *   - Empty (no row): section card with empty-state pitch + form populated
+ *     from defaults + "Save Your North Star" button
+ *   - Has row: section card showing display view by default, with an "edit"
+ *     toggle to enter form mode and an "I reviewed this — still holds"
+ *     button to record a review attestation
+ *
+ * Bridgewater convention: review-without-change is a distinct audit event
+ * (operations_north_star_reviewed) from a content edit (..._updated).
+ */
+
+'use client';
+
+import { useEffect, useState } from 'react';
+import type { NorthStar, NorthStarForm } from './types';
+import { DEFAULT_NORTH_STAR_FORM } from './types';
+
+function relTime(iso: string): string {
+  const ms = Date.now() - new Date(iso).getTime();
+  if (ms < 0) {
+    const future = -ms;
+    if (future < 3_600_000) return `in ${Math.ceil(future / 60_000)}m`;
+    if (future < 86_400_000) return `in ${Math.ceil(future / 3_600_000)}h`;
+    return `in ${Math.ceil(future / 86_400_000)}d`;
+  }
+  if (ms < 60_000) return `${Math.floor(ms / 1000)}s ago`;
+  if (ms < 3_600_000) return `${Math.floor(ms / 60_000)}m ago`;
+  if (ms < 86_400_000) return `${Math.floor(ms / 3_600_000)}h ago`;
+  return `${Math.floor(ms / 86_400_000)}d ago`;
+}
+
+function daysUntil(iso: string | null): number | null {
+  if (!iso) return null;
+  const ms = new Date(iso).getTime() - Date.now();
+  return Math.ceil(ms / 86_400_000);
+}
+
+function toForm(ns: NorthStar): NorthStarForm {
+  return {
+    mission_statement: ns.mission_statement ?? '',
+    life_stage: ns.life_stage ?? '',
+    core_values: ns.core_values,
+    guiding_principles: ns.guiding_principles ?? '',
+    one_year_target: ns.one_year_target ?? '',
+    three_year_target: ns.three_year_target ?? '',
+    current_location_label: ns.current_location_label ?? '',
+    current_timezone: ns.current_timezone,
+    review_cadence_days: ns.review_cadence_days,
+  };
+}
+
+export default function SectionB_NorthStar() {
+  const [northStar, setNorthStar] = useState<NorthStar | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [editing, setEditing] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [reviewing, setReviewing] = useState(false);
+  const [form, setForm] = useState<NorthStarForm>(DEFAULT_NORTH_STAR_FORM);
+  const [coreValueInput, setCoreValueInput] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const fetchData = async () => {
+      try {
+        const res = await fetch('/api/operations/north-star');
+        if (!cancelled && res.ok) {
+          const body = await res.json();
+          const ns: NorthStar | null = body?.northStar ?? null;
+          setNorthStar(ns);
+          if (ns) {
+            setForm(toForm(ns));
+            setEditing(false);
+          } else {
+            setForm(DEFAULT_NORTH_STAR_FORM);
+            setEditing(true);
+          }
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+    fetchData();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!successMessage) return;
+    const t = setTimeout(() => setSuccessMessage(null), 3000);
+    return () => clearTimeout(t);
+  }, [successMessage]);
+
+  const addCoreValue = () => {
+    const v = coreValueInput.trim();
+    if (!v) return;
+    if (form.core_values.includes(v)) {
+      setCoreValueInput('');
+      return;
+    }
+    setForm({ ...form, core_values: [...form.core_values, v] });
+    setCoreValueInput('');
+  };
+
+  const removeCoreValue = (v: string) => {
+    setForm({ ...form, core_values: form.core_values.filter((x) => x !== v) });
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/operations/north-star', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(form),
+      });
+      const body = await res.json();
+      if (!res.ok) {
+        setError(body?.message ?? body?.error ?? 'failed to save');
+        return;
+      }
+      setNorthStar(body.northStar);
+      setForm(toForm(body.northStar));
+      setEditing(false);
+      setSuccessMessage(body.isCreate ? 'north star saved' : 'north star updated');
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'failed to save');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleReview = async () => {
+    if (!northStar) return;
+    setReviewing(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/operations/north-star/review', { method: 'POST' });
+      const body = await res.json();
+      if (!res.ok) {
+        setError(body?.message ?? body?.error ?? 'failed to record review');
+        return;
+      }
+      setNorthStar(body.northStar);
+      setForm(toForm(body.northStar));
+      setSuccessMessage('review recorded');
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'failed to record review');
+    } finally {
+      setReviewing(false);
+    }
+  };
+
+  const handleCancelEdit = () => {
+    if (northStar) {
+      setForm(toForm(northStar));
+      setEditing(false);
+    }
+    setError(null);
+  };
+
+  return (
+    <section className="bg-white rounded border border-border shadow-sm p-5">
+      <div className="flex items-center justify-between mb-3">
+        <h2 className="font-mono text-sm font-bold tracking-wide text-text-primary">
+          B · NORTH STAR
+        </h2>
+        <div className="flex items-center gap-3 text-xs font-mono">
+          {northStar && !editing && (
+            <>
+              <button
+                type="button"
+                onClick={handleReview}
+                disabled={reviewing}
+                className="px-2 py-1 border border-border rounded hover:bg-bg-row disabled:opacity-50"
+                title="Record a review-without-edit attestation"
+              >
+                {reviewing ? 'recording…' : 'I reviewed — still holds'}
+              </button>
+              <button
+                type="button"
+                onClick={() => setEditing(true)}
+                className="px-2 py-1 border border-border rounded hover:bg-bg-row"
+              >
+                edit
+              </button>
+            </>
+          )}
+        </div>
+      </div>
+
+      {error && (
+        <div className="text-xs font-mono mb-3 px-3 py-2 rounded border bg-red-50 border-red-200 text-red-800">
+          {error}
+        </div>
+      )}
+      {successMessage && (
+        <div className="text-xs font-mono mb-3 px-3 py-2 rounded border bg-green-50 border-green-200 text-green-800">
+          {successMessage}
+        </div>
+      )}
+
+      {loading ? (
+        <div className="text-xs font-mono text-text-muted">loading north star…</div>
+      ) : editing ? (
+        <NorthStarEditor
+          form={form}
+          setForm={setForm}
+          coreValueInput={coreValueInput}
+          setCoreValueInput={setCoreValueInput}
+          addCoreValue={addCoreValue}
+          removeCoreValue={removeCoreValue}
+          saving={saving}
+          onSave={handleSave}
+          onCancel={northStar ? handleCancelEdit : undefined}
+        />
+      ) : northStar ? (
+        <NorthStarDisplay northStar={northStar} />
+      ) : (
+        <div className="text-xs font-mono text-text-muted">no north star yet — entering edit mode…</div>
+      )}
+    </section>
+  );
+}
+
+function NorthStarDisplay({ northStar }: { northStar: NorthStar }) {
+  const daysToReview = daysUntil(northStar.next_review_at);
+  return (
+    <div className="space-y-4 text-xs font-mono">
+      {northStar.mission_statement ? (
+        <div>
+          <div className="text-text-faint uppercase tracking-wide mb-1">mission</div>
+          <div className="text-text-primary text-sm whitespace-pre-wrap">
+            {northStar.mission_statement}
+          </div>
+        </div>
+      ) : (
+        <div className="text-text-muted italic">no mission statement set</div>
+      )}
+
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          <div className="text-text-faint uppercase tracking-wide mb-1">life stage</div>
+          <div className="text-text-primary">{northStar.life_stage ?? '—'}</div>
+        </div>
+        <div>
+          <div className="text-text-faint uppercase tracking-wide mb-1">location · timezone</div>
+          <div className="text-text-primary">
+            {northStar.current_location_label ?? '—'} · {northStar.current_timezone}
+          </div>
+        </div>
+      </div>
+
+      <div>
+        <div className="text-text-faint uppercase tracking-wide mb-1">core values</div>
+        {northStar.core_values.length > 0 ? (
+          <div className="flex flex-wrap gap-1">
+            {northStar.core_values.map((v) => (
+              <span
+                key={v}
+                className="px-2 py-0.5 border border-border rounded bg-bg-row text-text-primary"
+              >
+                {v}
+              </span>
+            ))}
+          </div>
+        ) : (
+          <div className="text-text-muted">—</div>
+        )}
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          <div className="text-text-faint uppercase tracking-wide mb-1">1-year target</div>
+          <div className="text-text-primary whitespace-pre-wrap">
+            {northStar.one_year_target ?? '—'}
+          </div>
+        </div>
+        <div>
+          <div className="text-text-faint uppercase tracking-wide mb-1">3-year target</div>
+          <div className="text-text-primary whitespace-pre-wrap">
+            {northStar.three_year_target ?? '—'}
+          </div>
+        </div>
+      </div>
+
+      {northStar.guiding_principles && (
+        <div>
+          <div className="text-text-faint uppercase tracking-wide mb-1">guiding principles</div>
+          <div className="text-text-primary whitespace-pre-wrap">{northStar.guiding_principles}</div>
+        </div>
+      )}
+
+      <div className="flex items-center gap-4 pt-2 border-t border-border-light text-text-muted">
+        <span>
+          last reviewed:{' '}
+          {northStar.last_reviewed_at ? relTime(northStar.last_reviewed_at) : 'never'}
+        </span>
+        <span>
+          cadence: every {northStar.review_cadence_days}d
+        </span>
+        {daysToReview !== null && (
+          <span
+            className={
+              daysToReview < 0
+                ? 'text-red-700'
+                : daysToReview <= 7
+                ? 'text-amber-700'
+                : 'text-text-muted'
+            }
+          >
+            {daysToReview < 0
+              ? `review overdue by ${-daysToReview}d`
+              : daysToReview === 0
+              ? 'review due today'
+              : `review due in ${daysToReview}d`}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+interface EditorProps {
+  form: NorthStarForm;
+  setForm: (f: NorthStarForm) => void;
+  coreValueInput: string;
+  setCoreValueInput: (s: string) => void;
+  addCoreValue: () => void;
+  removeCoreValue: (v: string) => void;
+  saving: boolean;
+  onSave: () => void;
+  onCancel?: () => void;
+}
+
+function NorthStarEditor({
+  form,
+  setForm,
+  coreValueInput,
+  setCoreValueInput,
+  addCoreValue,
+  removeCoreValue,
+  saving,
+  onSave,
+  onCancel,
+}: EditorProps) {
+  const labelClass = 'text-text-faint uppercase tracking-wide mb-1 text-xs font-mono';
+  const inputClass =
+    'w-full px-2 py-1 border border-border rounded text-xs font-mono text-text-primary focus:outline-none focus:border-brand-purple';
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <div className={labelClass}>mission statement</div>
+        <textarea
+          value={form.mission_statement}
+          onChange={(e) => setForm({ ...form, mission_statement: e.target.value })}
+          rows={2}
+          className={inputClass}
+          placeholder="why are you doing this work?"
+        />
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          <div className={labelClass}>life stage</div>
+          <input
+            type="text"
+            value={form.life_stage}
+            onChange={(e) => setForm({ ...form, life_stage: e.target.value })}
+            className={inputClass}
+            placeholder="building / scaling / transitioning"
+          />
+        </div>
+        <div>
+          <div className={labelClass}>review cadence (days)</div>
+          <input
+            type="number"
+            min={1}
+            value={form.review_cadence_days}
+            onChange={(e) =>
+              setForm({ ...form, review_cadence_days: parseInt(e.target.value, 10) || 90 })
+            }
+            className={inputClass}
+          />
+        </div>
+      </div>
+
+      <div>
+        <div className={labelClass}>core values</div>
+        <div className="flex flex-wrap gap-1 mb-2">
+          {form.core_values.map((v) => (
+            <span
+              key={v}
+              className="px-2 py-0.5 border border-border rounded bg-bg-row text-text-primary text-xs font-mono inline-flex items-center gap-1"
+            >
+              {v}
+              <button
+                type="button"
+                onClick={() => removeCoreValue(v)}
+                className="text-text-muted hover:text-red-700"
+                aria-label={`Remove ${v}`}
+              >
+                ×
+              </button>
+            </span>
+          ))}
+        </div>
+        <div className="flex gap-2">
+          <input
+            type="text"
+            value={coreValueInput}
+            onChange={(e) => setCoreValueInput(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                addCoreValue();
+              }
+            }}
+            className={inputClass}
+            placeholder="add a value (press Enter)"
+          />
+          <button
+            type="button"
+            onClick={addCoreValue}
+            className="px-3 py-1 border border-border rounded text-xs font-mono hover:bg-bg-row"
+          >
+            add
+          </button>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          <div className={labelClass}>1-year target</div>
+          <textarea
+            value={form.one_year_target}
+            onChange={(e) => setForm({ ...form, one_year_target: e.target.value })}
+            rows={2}
+            className={inputClass}
+            placeholder="where do you want to be in 12 months?"
+          />
+        </div>
+        <div>
+          <div className={labelClass}>3-year target</div>
+          <textarea
+            value={form.three_year_target}
+            onChange={(e) => setForm({ ...form, three_year_target: e.target.value })}
+            rows={2}
+            className={inputClass}
+            placeholder="where do you want to be in 3 years?"
+          />
+        </div>
+      </div>
+
+      <div>
+        <div className={labelClass}>guiding principles</div>
+        <textarea
+          value={form.guiding_principles}
+          onChange={(e) => setForm({ ...form, guiding_principles: e.target.value })}
+          rows={4}
+          className={inputClass}
+          placeholder="long-form principles you want to anchor decisions to"
+        />
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          <div className={labelClass}>location label</div>
+          <input
+            type="text"
+            value={form.current_location_label}
+            onChange={(e) => setForm({ ...form, current_location_label: e.target.value })}
+            className={inputClass}
+            placeholder="Los Angeles, CA"
+          />
+        </div>
+        <div>
+          <div className={labelClass}>timezone (IANA)</div>
+          <input
+            type="text"
+            value={form.current_timezone}
+            onChange={(e) => setForm({ ...form, current_timezone: e.target.value })}
+            className={inputClass}
+            placeholder="America/Los_Angeles"
+          />
+        </div>
+      </div>
+
+      <div className="flex items-center gap-2 pt-2 border-t border-border-light">
+        <button
+          type="button"
+          onClick={onSave}
+          disabled={saving}
+          className="px-3 py-1 border border-brand-purple bg-brand-purple text-white rounded text-xs font-mono hover:opacity-90 disabled:opacity-50"
+        >
+          {saving ? 'saving…' : 'save north star'}
+        </button>
+        {onCancel && (
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={saving}
+            className="px-3 py-1 border border-border rounded text-xs font-mono hover:bg-bg-row disabled:opacity-50"
+          >
+            cancel
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/workbench/operations/types.ts
+++ b/src/components/workbench/operations/types.ts
@@ -1,0 +1,57 @@
+/**
+ * Shared types for the Operations workbench.
+ *
+ * NorthStar mirrors the operations_north_star Prisma model 1:1 with two
+ * adjustments: timestamps are serialized as ISO strings over the wire
+ * (since JSON.stringify on Date produces ISO), and the row is nullable
+ * (the API returns null when no row exists for the user yet).
+ */
+
+export interface NorthStar {
+  id: string;
+  user_id: string;
+  mission_statement: string | null;
+  life_stage: string | null;
+  core_values: string[];
+  guiding_principles: string | null;
+  one_year_target: string | null;
+  three_year_target: string | null;
+  current_location_label: string | null;
+  current_timezone: string;
+  review_cadence_days: number;
+  last_reviewed_at: string | null;
+  next_review_at: string | null;
+  created_at: string;
+  updated_at: string;
+  created_by: string | null;
+}
+
+/**
+ * Form-side shape: same as NorthStar but without server-managed fields
+ * (id, user_id, timestamps, created_by). Nullable fields become empty
+ * string for form binding, then are coerced back to null on submit when
+ * empty.
+ */
+export interface NorthStarForm {
+  mission_statement: string;
+  life_stage: string;
+  core_values: string[];
+  guiding_principles: string;
+  one_year_target: string;
+  three_year_target: string;
+  current_location_label: string;
+  current_timezone: string;
+  review_cadence_days: number;
+}
+
+export const DEFAULT_NORTH_STAR_FORM: NorthStarForm = {
+  mission_statement: '',
+  life_stage: '',
+  core_values: [],
+  guiding_principles: '',
+  one_year_target: '',
+  three_year_target: '',
+  current_location_label: '',
+  current_timezone: 'America/Los_Angeles',
+  review_cadence_days: 90,
+};


### PR DESCRIPTION
Ships the first user-facing write surface in the Operations tab. Exercises the full PR-Audit-Hash-Input audit infrastructure end-to- end: every save and every review attestation hash-chains into audit_log via writeAuditLog with content-verifiable hash_input.

New endpoints:
  GET  /api/operations/north-star          Read user's row or null
  POST /api/operations/north-star          Upsert; audits as
                                           operations_north_star_created
                                           or _updated
  POST /api/operations/north-star/review   Review-without-edit
                                           attestation; audits as
                                           operations_north_star_reviewed

New types module:
  src/components/workbench/operations/types.ts — NorthStar (16-field
  mirror of operations_north_star Prisma model with ISO timestamps),
  NorthStarForm (form-side shape excluding server-managed fields),
  DEFAULT_NORTH_STAR_FORM (institutional defaults: America/Los_Angeles
  timezone, 90-day Bridgewater quarterly review cadence).

New component:
  SectionB_NorthStar — three render branches:
    * Loading: section card with "loading north star…"
    * Empty: auto-enters edit mode with default form values, save creates first row
    * Has row: display view with two action buttons — "I reviewed — still holds" (review-without-edit attestation) and "edit" (toggle to form mode) Display view shows mission, life stage, location/timezone, core values badges, 1yr/3yr targets, guiding principles, last-reviewed relative time, cadence, days-until-next-review with red/amber/muted color coding for overdue/imminent/comfortable. Editor uses always-edit-mode pattern (no toggle within); save POSTs and exits edit mode on success.

Page wiring:
  src/app/operations/page.tsx — replaces Section B placeholder with
  <SectionB_NorthStar />. Section C (Today's Decision) stays
  placeholder until PR-Ops-4.

Pattern conventions (institutional):
  - Audit-write follows discovery/profile/route.ts precedent: inline auth via getVerifiedEmail(), inline user lookup via prisma.users.findFirst, sequential prisma+writeAuditLog awaits (NOT transactional — relies on writeAuditLog's internal P2034/ P2024 retry for partial-failure tolerance, matching codebase convention; future PR-Audit-Atomicity could harden this systemwide).
  - Validation gates fire BEFORE DB lookups (review_cadence_days > 0, core_values is array) — saves a roundtrip on bad input, matches compliance/profile validation ordering.
  - norm() helper coerces empty strings to null for nullable text columns.
  - core_values array filter strips empty strings AND non-strings defensively.
  - Review endpoint computes next_review_at as last_reviewed_at + cadence_days * 86400000ms. TIMESTAMPTZ is absolute time; DST is handled at the timezone-display layer, not here.
  - Audit metadata on review captures previous_review_at — lets future replay reconstruct exactly when prior review happened, even though the new value clobbers the old.
  - Bridgewater convention: review-without-change is a distinct audit-evidentiary event from a content edit. SOC 2 evidence-of- review controls work this way.

Verification:
  - prisma generate: no schema changes (operations_north_star landed in PR-Ops-1.5)
  - tsc --noEmit: exit 0, zero errors
  - All operations_north_star_{created,updated,reviewed} action types were added to AuditActionType in PR-Ops-1.5; no enum work needed.

Smoke test plan post-merge:
  1. Navigate to /operations
  2. Section B renders empty-state form (no row exists for user)
  3. Fill in mission_statement, save
  4. Card flips to display view with mission visible
  5. Click "I reviewed — still holds" — banner says "review recorded"
  6. Refresh page — last reviewed shows "0s ago" or similar
  7. /operations/audit-log shows 2 new operations_* events: operations_north_star_created and operations_north_star_reviewed
  8. Identity bar tail: hash now populated (was empty pre-PR)
  9. Verify chain: green, with content_verified count > 0

Rollback: pure additive PR. Revert by reverting the merge commit. Cancels render of SectionB_NorthStar; placeholder returns. No data loss; existing operations_north_star rows persist (orphan from UI perspective, fully readable via psql or future re-deploy).