### PR TITLE
PR-Ops-2a-fix2: prefix filter + bounded identity-bar retry

### DIFF
--- a/src/app/api/audit-log/route.ts
+++ b/src/app/api/audit-log/route.ts
@@ -1,6 +1,53 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { Prisma, AuditActionType } from '@prisma/client';
 import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
+
+/**
+ * Subsystem prefix → enum value list. Maintained explicitly because Prisma's
+ * `startsWith` filter does not work on enum columns (Postgres enums are not
+ * text-pattern-comparable). When new operations_* AuditActionType values are
+ * added in future PRs, append them here.
+ *
+ * The map is keyed by the prefix string the caller passes (?prefix=operations_).
+ * To extend to other subsystems, add entries — e.g., regulatory_, embedding_.
+ */
+const SUBSYSTEM_ACTION_TYPES: Record<string, AuditActionType[]> = {
+  operations_: [
+    // PR-Ops-1
+    'operations_project_created',
+    'operations_project_updated',
+    'operations_project_status_changed',
+    'operations_project_deleted',
+    'operations_project_task_created',
+    'operations_project_task_updated',
+    'operations_project_task_status_changed',
+    'operations_project_task_completed',
+    'operations_project_task_deleted',
+    'operations_project_dependency_added',
+    'operations_project_dependency_removed',
+    'operations_routine_created',
+    'operations_routine_updated',
+    'operations_routine_deactivated',
+    'operations_routine_deleted',
+    'operations_routine_completed',
+    'operations_routine_missed',
+    'operations_issue_logged',
+    'operations_issue_updated',
+    'operations_issue_status_changed',
+    'operations_issue_resolved',
+    'operations_issue_deleted',
+    'operations_vendor_added',
+    'operations_vendor_updated',
+    'operations_vendor_deactivated',
+    'operations_vendor_deleted',
+    'operations_priority_recomputed',
+    // PR-Ops-1.5
+    'operations_north_star_created',
+    'operations_north_star_updated',
+    'operations_north_star_reviewed',
+  ],
+};
 
 export async function GET(request: NextRequest) {
   try {
@@ -19,20 +66,34 @@ export async function GET(request: NextRequest) {
 
     const limit = Math.min(Math.max(parseInt(limitParam || '100', 10) || 100, 1), 500);
 
-    const where: Record<string, unknown> = {};
+    // Strongly typed where clause prevents the class of bug PR-Ops-2a-fix2 fixes:
+    // the previous Record<string, unknown> typing accepted a startsWith filter on
+    // an enum column at compile time, which Prisma rejected at runtime once
+    // operations_* rows existed and the filter was actually evaluated.
+    const where: Prisma.audit_logWhereInput = {};
+
     if (actorUserId) where.actor_user_id = actorUserId;
-    // action_type exact match wins over prefix; only one applies.
+
+    // action_type exact match wins over prefix; only one filter applies.
+    // Prefix lookups resolve to a static `in` list of enum values — see
+    // SUBSYSTEM_ACTION_TYPES above. Prefix values not in the map return
+    // an empty result set (rather than 400) for forward-compat.
     if (actionType) {
-      where.action_type = actionType;
+      where.action_type = actionType as AuditActionType;
     } else if (prefix) {
-      where.action_type = { startsWith: prefix };
+      const list = SUBSYSTEM_ACTION_TYPES[prefix];
+      if (!list || list.length === 0) {
+        return NextResponse.json({ count: 0, rows: [] });
+      }
+      where.action_type = { in: list };
     }
+
     if (targetTable) where.target_table = targetTable;
     if (targetId) where.target_id = targetId;
     if (after || before) {
       where.created_at = {};
-      if (after) (where.created_at as Record<string, unknown>).gte = new Date(after);
-      if (before) (where.created_at as Record<string, unknown>).lte = new Date(before);
+      if (after) where.created_at.gte = new Date(after);
+      if (before) where.created_at.lte = new Date(before);
     }
 
     const rows = await prisma.audit_log.findMany({

--- a/src/components/workbench/operations/IdentityBar.tsx
+++ b/src/components/workbench/operations/IdentityBar.tsx
@@ -5,25 +5,53 @@ import EntitySelectorStrip from './EntitySelector';
 
 const BUILD_SHA = (process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA ?? 'dev').slice(0, 8);
 
+const REFRESH_INTERVAL_MS = 15_000;
+const MAX_CONSECUTIVE_FAILURES = 3;
+
 export default function OperationsIdentityBar() {
   const [auditTailHash, setAuditTailHash] = useState<string | null>(null);
+  const [tailError, setTailError] = useState<string | null>(null);
 
   useEffect(() => {
+    let cancelled = false;
+    let intervalId: ReturnType<typeof setInterval> | null = null;
+    let consecutiveFailures = 0;
+
     const fetchTail = async () => {
       try {
         const res = await fetch('/api/audit-log?prefix=operations_&limit=1');
-        if (res.ok) {
-          const body = await res.json();
-          const tail = body?.rows?.[0]?.content_hash ?? null;
-          setAuditTailHash(tail ? String(tail).slice(0, 8) : null);
+        if (!res.ok) {
+          throw new Error(`HTTP ${res.status}`);
         }
-      } catch {
-        // silent — bar still renders without tail
+        if (cancelled) return;
+        const body = await res.json();
+        const tail = body?.rows?.[0]?.content_hash ?? null;
+        setAuditTailHash(tail ? String(tail).slice(0, 8) : null);
+        setTailError(null);
+        consecutiveFailures = 0;
+      } catch (err) {
+        if (cancelled) return;
+        consecutiveFailures += 1;
+        if (consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
+          setTailError('tail unavailable');
+          if (intervalId !== null) {
+            clearInterval(intervalId);
+            intervalId = null;
+          }
+          // Surfaced to the bar; no silent infinite retry.
+          // eslint-disable-next-line no-console
+          console.warn('[OperationsIdentityBar] tail fetch failed 3x; halting poll');
+        }
       }
     };
+
     fetchTail();
-    const id = setInterval(fetchTail, 15000);
-    return () => clearInterval(id);
+    intervalId = setInterval(fetchTail, REFRESH_INTERVAL_MS);
+
+    return () => {
+      cancelled = true;
+      if (intervalId !== null) clearInterval(intervalId);
+    };
   }, []);
 
   return (
@@ -35,6 +63,11 @@ export default function OperationsIdentityBar() {
           {auditTailHash && (
             <span title="Operations audit log tail hash (last 8 chars of latest content_hash, filtered to operations_*)">
               tail:{auditTailHash}
+            </span>
+          )}
+          {tailError && (
+            <span className="text-amber-700" title="audit-log tail fetch failed; poll halted after 3 failures">
+              tail: {tailError}
             </span>
           )}
         </div>


### PR DESCRIPTION
Two coordinated fixes for issues exposed when the first operations_* audit row landed in production after PR-Ops-2b shipped.

Background:
  /api/audit-log?prefix=operations_ returned 500 on every request
  once an operations_* row existed in audit_log. Root cause: the
  route used `where.action_type = { startsWith: prefix }` against an
  enum column. Prisma's startsWith filter is for String columns;
  Postgres enums are strict-equality types. The bug was hidden by
  two compounding factors:
    (1) The where clause was typed as Record<string, unknown>, which
        accepted the invalid filter shape at compile time.
    (2) IdentityBar.tsx silently swallowed all fetch failures via
        `catch {}`, masking the 500s for the duration the audit
        tail was empty (no operations_* rows existed pre-PR-Ops-2b).

When the first North Star save created the first operations_* audit row, the prefix filter actually executed against the row, Prisma rejected the enum-startsWith combination, and the endpoint started 500-ing. The IdentityBar polled it every 15 seconds, generating continuous 500s in production without surfacing the failure to the user.

Fix 1: typed Prisma filter with static enum map
  - SUBSYSTEM_ACTION_TYPES static map: prefix string → list of AuditActionType enum values. Initial entry covers all 30 operations_* values (27 from PR-Ops-1 + 3 from PR-Ops-1.5). Future operations_* additions append here.
  - where clause typed as Prisma.audit_logWhereInput. Compile-time safety prevents this class of bug from recurring.
  - Unknown/empty prefix returns { count: 0, rows: [] } with 200, not 500. Graceful degradation.
  - action_type exact-match precedence over prefix preserved.

Fix 2: bounded retry on IdentityBar tail fetch
  - 3 consecutive failures halt the poll interval.
  - Failure surfaces visibly as amber "tail: tail unavailable" in the bar, not silent black-hole.
  - Successful fetch resets the failure counter — transient failures recover without halting.
  - One-time console.warn on poll halt for debug visibility.
  - Same defensive pattern can be applied to SectionK_AuditTail in a future PR; not in scope for this fix.

Why both fixes ship together:
  The IdentityBar bug is the same class of problem (silent failure
  pattern) that hid the original prefix bug. Fixing one without the
  other means the next failure mode also gets buried. The two
  changes are orthogonal but reinforcing: the route fix makes the
  happy path work; the IdentityBar fix makes future failures
  surface instead of hide.

Verification:
  - tsc --noEmit: exit 0, zero errors
  - The Prisma.audit_logWhereInput type now flows through the where.created_at.gte/lte assignments, removing the prior Record<string, unknown> casts.
  - 30 operations_* enum values verified against schema.prisma AuditActionType definition (27 PR-Ops-1 + 3 PR-Ops-1.5).

Smoke test plan post-merge:
  - GET /api/audit-log?prefix=operations_&limit=1 returns { count: 1, rows: [...] } with the operations_north_star_created row visible.
  - /operations identity bar shows tail:<8 hex> for the first time (PR-Ops-2b created the first operations_* row; this PR makes the bar able to fetch it).
  - /operations/audit-log Section K shows the row.

Rollback: pure code change, no schema. Revert by reverting the merge commit. The audit_log endpoint reverts to its prior 500ing state for prefix queries, but action_type exact-match queries continue working. No data loss.