### PR TITLE
PR-Ops-3a: project backlog CRUD + Section D

### DIFF
--- a/src/app/api/operations/projects/[id]/route.ts
+++ b/src/app/api/operations/projects/[id]/route.ts
@@ -1,0 +1,262 @@
+/**
+ * /api/operations/projects/[id]
+ *
+ * GET    — return one project (404 if not found or not owned). No audit.
+ * PATCH  — update writable fields. Status changes audit-discriminate via
+ *          operations_project_status_changed; other content changes audit
+ *          as operations_project_updated. SOC 2 evidence-of-state-change
+ *          control: status transitions are evidentiarily distinct from
+ *          content edits.
+ * DELETE — hard delete. CASCADE removes tasks and dependencies. Full
+ *          payload_before captured in audit_log for replay.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { Prisma, ProjectStatus } from '@prisma/client';
+import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { writeAuditLog } from '@/lib/audit/writeAuditLog';
+
+const VALID_STATUSES: ProjectStatus[] = [
+  'not_started',
+  'in_progress',
+  'blocked',
+  'completed',
+  'cancelled',
+  'archived',
+];
+
+async function loadAuthorizedProject(projectId: string, userId: string) {
+  return prisma.operations_projects.findFirst({
+    where: { id: projectId, user_id: userId },
+  });
+}
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const user = await prisma.users.findFirst({
+      where: { email: { equals: userEmail, mode: 'insensitive' } },
+    });
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+
+    const { id } = await params;
+    const project = await loadAuthorizedProject(id, user.id);
+    if (!project) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+
+    return NextResponse.json({ project });
+  } catch (error) {
+    console.error('[Project GET]', error);
+    return NextResponse.json(
+      { error: 'Failed to load project', message: error instanceof Error ? error.message : 'unknown' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const user = await prisma.users.findFirst({
+      where: { email: { equals: userEmail, mode: 'insensitive' } },
+    });
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+
+    const { id } = await params;
+    const existing = await loadAuthorizedProject(id, user.id);
+    if (!existing) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+
+    const body = await request.json();
+
+    // Build the patch object explicitly — never trust body keys to flow through.
+    const data: Prisma.operations_projectsUpdateInput = {};
+
+    const trimNonEmpty = (v: unknown): string | null => {
+      if (typeof v !== 'string') return null;
+      const t = v.trim();
+      return t.length > 0 ? t : null;
+    };
+
+    if (body.title !== undefined) {
+      const t = trimNonEmpty(body.title);
+      if (t === null || t.length > 500) {
+        return NextResponse.json(
+          { error: 'Validation', field: 'title', message: 'required, max 500 chars' },
+          { status: 400 }
+        );
+      }
+      // Uniqueness check on title change.
+      if (t !== existing.title) {
+        const dup = await prisma.operations_projects.findFirst({
+          where: { user_id: user.id, title: t, NOT: { id } },
+        });
+        if (dup) {
+          return NextResponse.json(
+            { error: 'Duplicate', field: 'title', message: 'a project with this title already exists' },
+            { status: 409 }
+          );
+        }
+      }
+      data.title = t;
+    }
+
+    for (const field of ['goal', 'problem', 'diagnosis', 'design'] as const) {
+      if (body[field] !== undefined) {
+        const t = trimNonEmpty(body[field]);
+        if (t === null) {
+          return NextResponse.json(
+            { error: 'Validation', field, message: `${field} cannot be empty` },
+            { status: 400 }
+          );
+        }
+        data[field] = t;
+      }
+    }
+
+    let statusChange: { from: ProjectStatus; to: ProjectStatus } | null = null;
+    if (body.status !== undefined) {
+      const incoming = body.status as ProjectStatus;
+      if (!VALID_STATUSES.includes(incoming)) {
+        return NextResponse.json(
+          { error: 'Validation', field: 'status', message: 'invalid status value' },
+          { status: 400 }
+        );
+      }
+      if (incoming !== existing.status) {
+        statusChange = { from: existing.status, to: incoming };
+      }
+      data.status = incoming;
+    }
+
+    if (body.target_completion_date !== undefined) {
+      data.target_completion_date =
+        typeof body.target_completion_date === 'string' && body.target_completion_date.length > 0
+          ? new Date(body.target_completion_date)
+          : null;
+    }
+
+    if (body.estimated_total_minutes !== undefined) {
+      const v = body.estimated_total_minutes;
+      if (v === null || v === '') {
+        data.estimated_total_minutes = null;
+      } else {
+        const n = Number(v);
+        if (!Number.isFinite(n) || n < 0) {
+          return NextResponse.json(
+            { error: 'Validation', field: 'estimated_total_minutes', message: 'must be a non-negative number' },
+            { status: 400 }
+          );
+        }
+        data.estimated_total_minutes = n;
+      }
+    }
+
+    if (body.estimated_total_cost_usd !== undefined) {
+      const v = body.estimated_total_cost_usd;
+      if (v === null || v === '') {
+        data.estimated_total_cost_usd = null;
+      } else if (typeof v === 'string' && v.trim().length > 0) {
+        data.estimated_total_cost_usd = new Prisma.Decimal(v.trim());
+      } else if (typeof v === 'number') {
+        data.estimated_total_cost_usd = new Prisma.Decimal(v);
+      }
+    }
+
+    const project = await prisma.operations_projects.update({
+      where: { id },
+      data,
+    });
+
+    // Status changes audit as a distinct evidentiary event.
+    await writeAuditLog({
+      actor: {
+        user_id: user.id,
+        email: userEmail,
+        type: 'human_user',
+      },
+      action: {
+        type: statusChange ? 'operations_project_status_changed' : 'operations_project_updated',
+        description: statusChange
+          ? `Project "${existing.title}" status: ${statusChange.from} → ${statusChange.to}`
+          : `Updated project "${existing.title}" for ${userEmail}`,
+      },
+      target: {
+        table: 'operations_projects',
+        id: project.id,
+      },
+      payload: {
+        before: existing,
+        after: project,
+        metadata: statusChange
+          ? { status_from: statusChange.from, status_to: statusChange.to }
+          : undefined,
+      },
+    });
+
+    return NextResponse.json({ project });
+  } catch (error) {
+    console.error('[Project PATCH]', error);
+    return NextResponse.json(
+      { error: 'Failed to update project', message: error instanceof Error ? error.message : 'unknown' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const user = await prisma.users.findFirst({
+      where: { email: { equals: userEmail, mode: 'insensitive' } },
+    });
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+
+    const { id } = await params;
+    const existing = await loadAuthorizedProject(id, user.id);
+    if (!existing) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+
+    await prisma.operations_projects.delete({ where: { id } });
+
+    await writeAuditLog({
+      actor: {
+        user_id: user.id,
+        email: userEmail,
+        type: 'human_user',
+      },
+      action: {
+        type: 'operations_project_deleted',
+        description: `Deleted project "${existing.title}" for ${userEmail}`,
+      },
+      target: {
+        table: 'operations_projects',
+        id: existing.id,
+      },
+      payload: {
+        before: existing,
+      },
+    });
+
+    return NextResponse.json({ deleted: true, id: existing.id });
+  } catch (error) {
+    console.error('[Project DELETE]', error);
+    return NextResponse.json(
+      { error: 'Failed to delete project', message: error instanceof Error ? error.message : 'unknown' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/operations/projects/route.ts
+++ b/src/app/api/operations/projects/route.ts
@@ -1,0 +1,239 @@
+/**
+ * /api/operations/projects
+ *
+ * GET  — list the user's projects, optionally filtered by ?entity_id=<uuid>.
+ *        Sorted by status priority (not_started/in_progress first), then
+ *        priority_score DESC NULLS LAST, then target_completion_date ASC.
+ *        No audit write (read-only).
+ *
+ * POST — create a project. Validates all 4 Bridgewater scoping fields
+ *        (goal, problem, diagnosis, design) non-empty server-side. Verifies
+ *        entity ownership before insert. Catches (user_id, title) unique
+ *        constraint pre-emptively for clean 409 error.
+ *        Audits operations_project_created.
+ *
+ * Pattern mirrors src/app/api/operations/north-star/route.ts. Sequential
+ * prisma + writeAuditLog awaits, NOT transactional (matches codebase
+ * convention; relies on writeAuditLog internal P2034/P2024 retry).
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { Prisma, ProjectStatus } from '@prisma/client';
+import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { writeAuditLog } from '@/lib/audit/writeAuditLog';
+
+/**
+ * Status sort key. not_started + in_progress surface first (active work);
+ * blocked next (needs attention); completed/cancelled/archived last.
+ * Used in the GET orderBy.
+ */
+const STATUS_ORDER: Record<ProjectStatus, number> = {
+  not_started: 0,
+  in_progress: 1,
+  blocked: 2,
+  completed: 3,
+  cancelled: 4,
+  archived: 5,
+};
+
+export async function GET(request: NextRequest) {
+  try {
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const user = await prisma.users.findFirst({
+      where: { email: { equals: userEmail, mode: 'insensitive' } },
+    });
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+
+    const { searchParams } = new URL(request.url);
+    const entityId = searchParams.get('entity_id');
+
+    const where: Prisma.operations_projectsWhereInput = { user_id: user.id };
+    if (entityId) {
+      // Verify entity ownership before filtering.
+      const entity = await prisma.entities.findFirst({
+        where: { id: entityId, userId: user.id },
+      });
+      if (!entity) {
+        return NextResponse.json(
+          { error: 'Entity not found or not owned' },
+          { status: 404 }
+        );
+      }
+      where.entity_id = entityId;
+    }
+
+    const projects = await prisma.operations_projects.findMany({
+      where,
+      orderBy: [
+        // Prisma can't sort by computed status_order without raw SQL; we sort
+        // server-side after fetch. Single-user backlogs are small (<200), so
+        // in-memory sort cost is negligible.
+        { priority_score: { sort: 'desc', nulls: 'last' } },
+        { target_completion_date: 'asc' },
+        { updated_at: 'desc' },
+      ],
+    });
+
+    // Status-priority sort layered on top of priority_score order.
+    const sorted = projects.slice().sort((a, b) => {
+      const sa = STATUS_ORDER[a.status];
+      const sb = STATUS_ORDER[b.status];
+      if (sa !== sb) return sa - sb;
+      // Within same status: preserve priority_score / target_date / updated_at order from Prisma.
+      return 0;
+    });
+
+    return NextResponse.json({ projects: sorted });
+  } catch (error) {
+    console.error('[Projects GET]', error);
+    return NextResponse.json(
+      { error: 'Failed to load projects', message: error instanceof Error ? error.message : 'unknown' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const user = await prisma.users.findFirst({
+      where: { email: { equals: userEmail, mode: 'insensitive' } },
+    });
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+
+    const body = await request.json();
+
+    // Validation gates — fire BEFORE DB lookups to save roundtrips.
+    const requireString = (v: unknown, field: string, max?: number): string | NextResponse => {
+      if (typeof v !== 'string' || v.trim().length === 0) {
+        return NextResponse.json(
+          { error: 'Validation', field, message: `${field} is required` },
+          { status: 400 }
+        );
+      }
+      const trimmed = v.trim();
+      if (max && trimmed.length > max) {
+        return NextResponse.json(
+          { error: 'Validation', field, message: `${field} exceeds ${max} characters` },
+          { status: 400 }
+        );
+      }
+      return trimmed;
+    };
+
+    const entity_id_raw = requireString(body.entity_id, 'entity_id');
+    if (entity_id_raw instanceof NextResponse) return entity_id_raw;
+    const title = requireString(body.title, 'title', 500);
+    if (title instanceof NextResponse) return title;
+    const goal = requireString(body.goal, 'goal');
+    if (goal instanceof NextResponse) return goal;
+    const problem = requireString(body.problem, 'problem');
+    if (problem instanceof NextResponse) return problem;
+    const diagnosis = requireString(body.diagnosis, 'diagnosis');
+    if (diagnosis instanceof NextResponse) return diagnosis;
+    const design = requireString(body.design, 'design');
+    if (design instanceof NextResponse) return design;
+
+    // Verify entity ownership.
+    const entity = await prisma.entities.findFirst({
+      where: { id: entity_id_raw, userId: user.id },
+    });
+    if (!entity) {
+      return NextResponse.json(
+        { error: 'Entity not found or not owned', field: 'entity_id' },
+        { status: 404 }
+      );
+    }
+
+    // Pre-emptive uniqueness check on (user_id, title) — cleaner UX than
+    // catching the Prisma P2002 error after the fact.
+    const duplicate = await prisma.operations_projects.findFirst({
+      where: { user_id: user.id, title },
+    });
+    if (duplicate) {
+      return NextResponse.json(
+        {
+          error: 'Duplicate',
+          field: 'title',
+          message: 'a project with this title already exists',
+        },
+        { status: 409 }
+      );
+    }
+
+    // Optional fields — coerce strings/numbers carefully.
+    const target_completion_date =
+      typeof body.target_completion_date === 'string' && body.target_completion_date.length > 0
+        ? new Date(body.target_completion_date)
+        : null;
+
+    const estimated_total_minutes =
+      body.estimated_total_minutes !== undefined &&
+      body.estimated_total_minutes !== null &&
+      body.estimated_total_minutes !== ''
+        ? Number(body.estimated_total_minutes)
+        : null;
+    if (estimated_total_minutes !== null && (!Number.isFinite(estimated_total_minutes) || estimated_total_minutes < 0)) {
+      return NextResponse.json(
+        { error: 'Validation', field: 'estimated_total_minutes', message: 'must be a non-negative integer' },
+        { status: 400 }
+      );
+    }
+
+    const estimated_total_cost_usd =
+      typeof body.estimated_total_cost_usd === 'string' && body.estimated_total_cost_usd.trim().length > 0
+        ? new Prisma.Decimal(body.estimated_total_cost_usd.trim())
+        : typeof body.estimated_total_cost_usd === 'number'
+        ? new Prisma.Decimal(body.estimated_total_cost_usd)
+        : null;
+
+    const project = await prisma.operations_projects.create({
+      data: {
+        user_id: user.id,
+        entity_id: entity_id_raw,
+        title,
+        goal,
+        problem,
+        diagnosis,
+        design,
+        target_completion_date,
+        estimated_total_minutes,
+        estimated_total_cost_usd,
+        created_by: userEmail,
+      },
+    });
+
+    await writeAuditLog({
+      actor: {
+        user_id: user.id,
+        email: userEmail,
+        type: 'human_user',
+      },
+      action: {
+        type: 'operations_project_created',
+        description: `Created project "${title}" for ${userEmail}`,
+      },
+      target: {
+        table: 'operations_projects',
+        id: project.id,
+      },
+      payload: {
+        after: project,
+        metadata: { entity_id: entity_id_raw },
+      },
+    });
+
+    return NextResponse.json({ project, isCreate: true }, { status: 201 });
+  } catch (error) {
+    console.error('[Projects POST]', error);
+    return NextResponse.json(
+      { error: 'Failed to create project', message: error instanceof Error ? error.message : 'unknown' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/operations/projects/page.tsx
+++ b/src/app/operations/projects/page.tsx
@@ -1,5 +1,13 @@
-import PlaceholderCard from '@/components/workbench/operations/PlaceholderCard';
+/**
+ * src/app/operations/projects/page.tsx
+ *
+ * Section D · Project Backlog — Bridgewater 5-step scoping list. Wired
+ * to <SectionD_ProjectBacklog/> in PR-Ops-3a. Tasks (step 5) ship in
+ * PR-Ops-3b; dependency graph in PR-Ops-3c.
+ */
+
+import SectionD_ProjectBacklog from '@/components/workbench/operations/SectionD_ProjectBacklog';
 
 export default function OperationsProjectsPage() {
-  return <PlaceholderCard letter="D" title="PROJECTS" unbuiltLabel="UNBUILT · PR-Ops-3" />;
+  return <SectionD_ProjectBacklog />;
 }

--- a/src/components/workbench/operations/SectionD_ProjectBacklog.tsx
+++ b/src/components/workbench/operations/SectionD_ProjectBacklog.tsx
@@ -1,0 +1,296 @@
+/**
+ * src/components/workbench/operations/SectionD_ProjectBacklog.tsx
+ *
+ * Section D · Project Backlog — entity-scoped list of operations_projects
+ * with full Bridgewater 5-step scoping (goal/problem/diagnosis/design)
+ * required on create. Step 5 (execute) = tasks, ships in PR-Ops-3b.
+ *
+ * Reads selectedEntityId from useOperationsEntity() context. Filters the
+ * project list fetch by ?entity_id when an entity is selected; passes
+ * nothing when "All" is selected (returns user's full backlog across all
+ * entities).
+ *
+ * "+ new project" affordance at the top right toggles an inline create
+ * form ABOVE the list (matches COA management table's add pattern).
+ */
+
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useOperationsEntity } from './EntitySelector';
+import ProjectRow from './projects/ProjectRow';
+import type { Project, ProjectForm } from './projects/types';
+import { DEFAULT_PROJECT_FORM } from './projects/types';
+
+interface Entity {
+  id: string;
+  name: string;
+  is_default?: boolean;
+}
+
+export default function SectionD_ProjectBacklog() {
+  const { entities, selectedEntityId } = useOperationsEntity();
+
+  const [projects, setProjects] = useState<Project[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [showCreate, setShowCreate] = useState(false);
+  const [createForm, setCreateForm] = useState<ProjectForm>(DEFAULT_PROJECT_FORM);
+  const [createSaving, setCreateSaving] = useState(false);
+  const [createError, setCreateError] = useState<string | null>(null);
+
+  const fetchProjects = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const url = selectedEntityId
+        ? `/api/operations/projects?entity_id=${encodeURIComponent(selectedEntityId)}`
+        : '/api/operations/projects';
+      const res = await fetch(url);
+      const body = await res.json();
+      if (!res.ok) {
+        setError(body?.message ?? body?.error ?? 'failed to load projects');
+        setProjects([]);
+        return;
+      }
+      setProjects(body.projects ?? []);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'failed to load projects');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchProjects();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedEntityId]);
+
+  const startCreate = () => {
+    // Default the new project's entity to the currently-selected one, or the
+    // first available entity if "All" is selected.
+    const initialEntity =
+      selectedEntityId ?? entities.find((e) => e.is_default)?.id ?? entities[0]?.id ?? '';
+    setCreateForm({ ...DEFAULT_PROJECT_FORM, entity_id: initialEntity });
+    setCreateError(null);
+    setShowCreate(true);
+  };
+
+  const cancelCreate = () => {
+    setShowCreate(false);
+    setCreateForm(DEFAULT_PROJECT_FORM);
+    setCreateError(null);
+  };
+
+  const handleCreate = async () => {
+    setCreateSaving(true);
+    setCreateError(null);
+    try {
+      const res = await fetch('/api/operations/projects', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(createForm),
+      });
+      const body = await res.json();
+      if (!res.ok) {
+        setCreateError(body?.message ?? body?.error ?? 'failed to create');
+        return;
+      }
+      cancelCreate();
+      fetchProjects();
+    } catch (e) {
+      setCreateError(e instanceof Error ? e.message : 'failed to create');
+    } finally {
+      setCreateSaving(false);
+    }
+  };
+
+  const inputClass =
+    'w-full px-2 py-1 border border-border rounded text-xs font-mono text-text-primary focus:outline-none focus:border-brand-purple';
+  const labelClass = 'text-text-faint uppercase tracking-wide mb-1 text-xs font-mono';
+
+  return (
+    <section className="bg-white rounded border border-border shadow-sm p-5">
+      <div className="flex items-center justify-between mb-3">
+        <h2 className="font-mono text-sm font-bold tracking-wide text-text-primary">
+          D · PROJECT BACKLOG
+        </h2>
+        <div className="flex items-center gap-3 text-xs font-mono">
+          <span className="text-text-muted">
+            {projects.length} {projects.length === 1 ? 'project' : 'projects'}
+          </span>
+          {!showCreate && (
+            <button
+              type="button"
+              onClick={startCreate}
+              disabled={entities.length === 0}
+              className="px-2 py-1 border border-brand-purple bg-brand-purple text-white rounded hover:opacity-90 disabled:opacity-50"
+            >
+              + new project
+            </button>
+          )}
+        </div>
+      </div>
+
+      {error && (
+        <div className="text-xs font-mono mb-3 px-3 py-2 rounded border bg-red-50 border-red-200 text-red-800">
+          {error}
+        </div>
+      )}
+
+      {showCreate && (
+        <div className="mb-4 border border-brand-purple rounded p-3 bg-purple-50/30 text-xs font-mono space-y-3">
+          <div className="font-bold text-text-primary">new project · 5-step scoping required</div>
+          {createError && (
+            <div className="px-3 py-2 rounded border bg-red-50 border-red-200 text-red-800">
+              {createError}
+            </div>
+          )}
+          <div className="grid grid-cols-2 gap-3">
+            <div className="col-span-2">
+              <div className={labelClass}>title</div>
+              <input
+                type="text"
+                value={createForm.title}
+                onChange={(e) => setCreateForm({ ...createForm, title: e.target.value })}
+                className={inputClass}
+                maxLength={500}
+                placeholder="short, distinctive, unique within your projects"
+              />
+            </div>
+            <div>
+              <div className={labelClass}>entity</div>
+              <select
+                value={createForm.entity_id}
+                onChange={(e) => setCreateForm({ ...createForm, entity_id: e.target.value })}
+                className={inputClass}
+              >
+                <option value="">— select —</option>
+                {entities.map((e) => (
+                  <option key={e.id} value={e.id}>
+                    {e.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <div className={labelClass}>target date (optional)</div>
+              <input
+                type="date"
+                value={createForm.target_completion_date}
+                onChange={(e) => setCreateForm({ ...createForm, target_completion_date: e.target.value })}
+                className={inputClass}
+              />
+            </div>
+          </div>
+
+          <div>
+            <div className={labelClass}>1 · goal — what success looks like</div>
+            <textarea
+              value={createForm.goal}
+              onChange={(e) => setCreateForm({ ...createForm, goal: e.target.value })}
+              rows={2}
+              className={inputClass}
+              placeholder="the specific outcome that means this project is done"
+            />
+          </div>
+          <div>
+            <div className={labelClass}>2 · problem — gap between current and goal</div>
+            <textarea
+              value={createForm.problem}
+              onChange={(e) => setCreateForm({ ...createForm, problem: e.target.value })}
+              rows={2}
+              className={inputClass}
+              placeholder="what's missing or broken right now"
+            />
+          </div>
+          <div>
+            <div className={labelClass}>3 · diagnosis — root cause</div>
+            <textarea
+              value={createForm.diagnosis}
+              onChange={(e) => setCreateForm({ ...createForm, diagnosis: e.target.value })}
+              rows={3}
+              className={inputClass}
+              placeholder="why the gap exists — go deeper than symptoms"
+            />
+          </div>
+          <div>
+            <div className={labelClass}>4 · design — the plan</div>
+            <textarea
+              value={createForm.design}
+              onChange={(e) => setCreateForm({ ...createForm, design: e.target.value })}
+              rows={3}
+              className={inputClass}
+              placeholder="the approach. tasks (step 5) come after this is locked."
+            />
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <div className={labelClass}>est. minutes (optional)</div>
+              <input
+                type="number"
+                min={0}
+                value={createForm.estimated_total_minutes}
+                onChange={(e) => setCreateForm({ ...createForm, estimated_total_minutes: e.target.value })}
+                className={inputClass}
+              />
+            </div>
+            <div>
+              <div className={labelClass}>est. cost usd (optional)</div>
+              <input
+                type="text"
+                value={createForm.estimated_total_cost_usd}
+                onChange={(e) => setCreateForm({ ...createForm, estimated_total_cost_usd: e.target.value })}
+                className={inputClass}
+                placeholder="0.00"
+              />
+            </div>
+          </div>
+
+          <div className="flex items-center gap-2 pt-2 border-t border-border-light">
+            <button
+              type="button"
+              onClick={handleCreate}
+              disabled={createSaving}
+              className="px-3 py-1 border border-brand-purple bg-brand-purple text-white rounded hover:opacity-90 disabled:opacity-50"
+            >
+              {createSaving ? 'creating…' : 'create project'}
+            </button>
+            <button
+              type="button"
+              onClick={cancelCreate}
+              disabled={createSaving}
+              className="px-3 py-1 border border-border rounded hover:bg-bg-row disabled:opacity-50"
+            >
+              cancel
+            </button>
+          </div>
+        </div>
+      )}
+
+      {loading ? (
+        <div className="text-xs font-mono text-text-muted">loading projects…</div>
+      ) : projects.length === 0 ? (
+        <div className="text-xs font-mono text-text-muted">
+          {selectedEntityId
+            ? 'no projects for this entity yet — click "+ new project" to scope your first one.'
+            : 'no projects yet — click "+ new project" to scope your first one.'}
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {projects.map((p) => (
+            <ProjectRow
+              key={p.id}
+              project={p}
+              entities={entities}
+              onUpdate={fetchProjects}
+              onDelete={fetchProjects}
+            />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/workbench/operations/projects/ProjectRow.tsx
+++ b/src/components/workbench/operations/projects/ProjectRow.tsx
@@ -1,0 +1,343 @@
+/**
+ * ProjectRow — single row in the Section D project list.
+ *
+ * Three modes, toggled by local state:
+ *   1. Compact (default): one line — title + status pill + target date
+ *   2. Expanded: compact line + 4 Bridgewater scoping fields readable
+ *   3. Edit: inline form covering all writable fields
+ *
+ * Click row body → toggle expand. "edit" button (in expanded view) → swap to
+ * edit mode. Save → PATCH → refetch parent (via onUpdate callback) → exit
+ * edit mode. Delete → confirmation prompt → DELETE → refetch parent.
+ *
+ * Pattern mirrors COAManagementTable's editingId sentinel + per-row form
+ * state, adapted for a card-style layout with long-form Text fields.
+ */
+
+'use client';
+
+import { useState } from 'react';
+import type { Project, ProjectForm, ProjectStatus } from './types';
+import { STATUS_LABELS, STATUS_PILL_CLASSES } from './types';
+
+interface Entity {
+  id: string;
+  name: string;
+}
+
+interface Props {
+  project: Project;
+  entities: Entity[];
+  onUpdate: () => void;
+  onDelete: () => void;
+}
+
+const STATUS_OPTIONS: ProjectStatus[] = [
+  'not_started',
+  'in_progress',
+  'blocked',
+  'completed',
+  'cancelled',
+  'archived',
+];
+
+function projectToForm(p: Project): ProjectForm {
+  return {
+    entity_id: p.entity_id,
+    title: p.title,
+    goal: p.goal,
+    problem: p.problem,
+    diagnosis: p.diagnosis,
+    design: p.design,
+    status: p.status,
+    target_completion_date: p.target_completion_date
+      ? p.target_completion_date.slice(0, 10)
+      : '',
+    estimated_total_minutes: p.estimated_total_minutes !== null ? String(p.estimated_total_minutes) : '',
+    estimated_total_cost_usd: p.estimated_total_cost_usd ?? '',
+  };
+}
+
+function formatTargetDate(iso: string | null): string {
+  if (!iso) return '—';
+  const d = new Date(iso);
+  return d.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+}
+
+function entityName(entities: Entity[], entityId: string): string {
+  return entities.find((e) => e.id === entityId)?.name ?? entityId;
+}
+
+export default function ProjectRow({ project, entities, onUpdate, onDelete }: Props) {
+  const [expanded, setExpanded] = useState(false);
+  const [editing, setEditing] = useState(false);
+  const [form, setForm] = useState<ProjectForm>(() => projectToForm(project));
+  const [saving, setSaving] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const enterEdit = () => {
+    setForm(projectToForm(project));
+    setEditing(true);
+    setError(null);
+  };
+
+  const cancelEdit = () => {
+    setForm(projectToForm(project));
+    setEditing(false);
+    setError(null);
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/operations/projects/${project.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(form),
+      });
+      const body = await res.json();
+      if (!res.ok) {
+        setError(body?.message ?? body?.error ?? 'failed to save');
+        return;
+      }
+      setEditing(false);
+      onUpdate();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'failed to save');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!confirm(`Delete project "${project.title}"? This will also delete its tasks and dependencies.`)) return;
+    setDeleting(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/operations/projects/${project.id}`, { method: 'DELETE' });
+      const body = await res.json();
+      if (!res.ok) {
+        setError(body?.message ?? body?.error ?? 'failed to delete');
+        return;
+      }
+      onDelete();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'failed to delete');
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  const inputClass =
+    'w-full px-2 py-1 border border-border rounded text-xs font-mono text-text-primary focus:outline-none focus:border-brand-purple';
+  const labelClass = 'text-text-faint uppercase tracking-wide mb-1 text-xs font-mono';
+  const pillClass = `inline-block px-2 py-0.5 border rounded text-xs font-mono ${STATUS_PILL_CLASSES[project.status]}`;
+
+  return (
+    <div className="border border-border rounded bg-white">
+      <div
+        className="flex items-center justify-between px-4 py-2 cursor-pointer hover:bg-bg-row text-xs font-mono"
+        onClick={() => !editing && setExpanded((x) => !x)}
+      >
+        <div className="flex items-center gap-3 min-w-0 flex-1">
+          <span className="text-text-faint">{expanded ? '▾' : '▸'}</span>
+          <span className="font-bold text-text-primary truncate">{project.title}</span>
+          <span className={pillClass}>{STATUS_LABELS[project.status]}</span>
+          <span className="text-text-muted">{entityName(entities, project.entity_id)}</span>
+        </div>
+        <div className="flex items-center gap-3 text-text-muted shrink-0">
+          <span>target: {formatTargetDate(project.target_completion_date)}</span>
+        </div>
+      </div>
+
+      {expanded && !editing && (
+        <div className="px-4 py-3 border-t border-border-light text-xs font-mono space-y-3">
+          <div>
+            <div className={labelClass}>1 · goal</div>
+            <div className="text-text-primary whitespace-pre-wrap">{project.goal}</div>
+          </div>
+          <div>
+            <div className={labelClass}>2 · problem</div>
+            <div className="text-text-primary whitespace-pre-wrap">{project.problem}</div>
+          </div>
+          <div>
+            <div className={labelClass}>3 · diagnosis</div>
+            <div className="text-text-primary whitespace-pre-wrap">{project.diagnosis}</div>
+          </div>
+          <div>
+            <div className={labelClass}>4 · design</div>
+            <div className="text-text-primary whitespace-pre-wrap">{project.design}</div>
+          </div>
+          <div className="grid grid-cols-2 gap-4 pt-2 border-t border-border-light">
+            <div>
+              <div className={labelClass}>est. minutes</div>
+              <div className="text-text-primary">{project.estimated_total_minutes ?? '—'}</div>
+            </div>
+            <div>
+              <div className={labelClass}>est. cost (usd)</div>
+              <div className="text-text-primary">{project.estimated_total_cost_usd ?? '—'}</div>
+            </div>
+          </div>
+          <div className="flex items-center gap-2 pt-2 border-t border-border-light">
+            <button
+              type="button"
+              onClick={enterEdit}
+              className="px-2 py-1 border border-border rounded hover:bg-bg-row"
+            >
+              edit
+            </button>
+            <button
+              type="button"
+              onClick={handleDelete}
+              disabled={deleting}
+              className="px-2 py-1 border border-red-300 text-red-700 rounded hover:bg-red-50 disabled:opacity-50"
+            >
+              {deleting ? 'deleting…' : 'delete'}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {editing && (
+        <div className="px-4 py-3 border-t border-border-light text-xs font-mono space-y-3">
+          {error && (
+            <div className="px-3 py-2 rounded border bg-red-50 border-red-200 text-red-800">
+              {error}
+            </div>
+          )}
+
+          <div className="grid grid-cols-2 gap-3">
+            <div className="col-span-2">
+              <div className={labelClass}>title</div>
+              <input
+                type="text"
+                value={form.title}
+                onChange={(e) => setForm({ ...form, title: e.target.value })}
+                className={inputClass}
+                maxLength={500}
+              />
+            </div>
+            <div>
+              <div className={labelClass}>entity</div>
+              <select
+                value={form.entity_id}
+                onChange={(e) => setForm({ ...form, entity_id: e.target.value })}
+                className={inputClass}
+              >
+                {entities.map((e) => (
+                  <option key={e.id} value={e.id}>
+                    {e.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <div className={labelClass}>status</div>
+              <select
+                value={form.status}
+                onChange={(e) => setForm({ ...form, status: e.target.value as ProjectStatus })}
+                className={inputClass}
+              >
+                {STATUS_OPTIONS.map((s) => (
+                  <option key={s} value={s}>
+                    {STATUS_LABELS[s]}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+
+          <div>
+            <div className={labelClass}>1 · goal — what success looks like</div>
+            <textarea
+              value={form.goal}
+              onChange={(e) => setForm({ ...form, goal: e.target.value })}
+              rows={2}
+              className={inputClass}
+            />
+          </div>
+          <div>
+            <div className={labelClass}>2 · problem — gap between current and goal</div>
+            <textarea
+              value={form.problem}
+              onChange={(e) => setForm({ ...form, problem: e.target.value })}
+              rows={2}
+              className={inputClass}
+            />
+          </div>
+          <div>
+            <div className={labelClass}>3 · diagnosis — root cause of the gap</div>
+            <textarea
+              value={form.diagnosis}
+              onChange={(e) => setForm({ ...form, diagnosis: e.target.value })}
+              rows={3}
+              className={inputClass}
+            />
+          </div>
+          <div>
+            <div className={labelClass}>4 · design — the plan</div>
+            <textarea
+              value={form.design}
+              onChange={(e) => setForm({ ...form, design: e.target.value })}
+              rows={3}
+              className={inputClass}
+            />
+          </div>
+
+          <div className="grid grid-cols-3 gap-3">
+            <div>
+              <div className={labelClass}>target date</div>
+              <input
+                type="date"
+                value={form.target_completion_date}
+                onChange={(e) => setForm({ ...form, target_completion_date: e.target.value })}
+                className={inputClass}
+              />
+            </div>
+            <div>
+              <div className={labelClass}>est. minutes</div>
+              <input
+                type="number"
+                min={0}
+                value={form.estimated_total_minutes}
+                onChange={(e) => setForm({ ...form, estimated_total_minutes: e.target.value })}
+                className={inputClass}
+              />
+            </div>
+            <div>
+              <div className={labelClass}>est. cost (usd)</div>
+              <input
+                type="text"
+                value={form.estimated_total_cost_usd}
+                onChange={(e) => setForm({ ...form, estimated_total_cost_usd: e.target.value })}
+                className={inputClass}
+                placeholder="0.00"
+              />
+            </div>
+          </div>
+
+          <div className="flex items-center gap-2 pt-2 border-t border-border-light">
+            <button
+              type="button"
+              onClick={handleSave}
+              disabled={saving}
+              className="px-3 py-1 border border-brand-purple bg-brand-purple text-white rounded hover:opacity-90 disabled:opacity-50"
+            >
+              {saving ? 'saving…' : 'save'}
+            </button>
+            <button
+              type="button"
+              onClick={cancelEdit}
+              disabled={saving}
+              className="px-3 py-1 border border-border rounded hover:bg-bg-row disabled:opacity-50"
+            >
+              cancel
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/workbench/operations/projects/types.ts
+++ b/src/components/workbench/operations/projects/types.ts
@@ -1,0 +1,96 @@
+/**
+ * Shared types for the Operations Projects surface (Section D).
+ *
+ * Project mirrors the operations_projects Prisma model 1:1. Bridgewater
+ * 5-step scoping fields (goal/problem/diagnosis/design) are required at
+ * the DB layer (NOT NULL), enforced server-side, and required in the
+ * form-side type below.
+ *
+ * The 5th step (execute) is the project's tasks, lives in a child table
+ * (operations_project_tasks), shipped in PR-Ops-3b.
+ */
+
+export type ProjectStatus =
+  | 'not_started'
+  | 'in_progress'
+  | 'blocked'
+  | 'completed'
+  | 'cancelled'
+  | 'archived';
+
+export interface Project {
+  id: string;
+  user_id: string;
+  entity_id: string;
+  title: string;
+  goal: string;
+  problem: string;
+  diagnosis: string;
+  design: string;
+  status: ProjectStatus;
+  target_completion_date: string | null;
+  estimated_total_minutes: number | null;
+  estimated_total_cost_usd: string | null;
+  priority_score: string | null;
+  priority_inputs_hash: string | null;
+  priority_computed_at: string | null;
+  priority_rationale: string | null;
+  created_at: string;
+  updated_at: string;
+  created_by: string | null;
+}
+
+/**
+ * Form-side shape: writable fields only.
+ *
+ * status is excluded from the create-form (server defaults to 'not_started')
+ * but writable on edit. The full ProjectForm includes status because the
+ * editor handles both create and edit. status changes audit-discriminate
+ * server-side via operations_project_status_changed (vs. plain _updated).
+ */
+export interface ProjectForm {
+  entity_id: string;
+  title: string;
+  goal: string;
+  problem: string;
+  diagnosis: string;
+  design: string;
+  status: ProjectStatus;
+  target_completion_date: string;          // ISO date (yyyy-mm-dd) or empty
+  estimated_total_minutes: string;         // string for input binding; coerced server-side
+  estimated_total_cost_usd: string;        // string for decimal fidelity
+}
+
+export const DEFAULT_PROJECT_FORM: ProjectForm = {
+  entity_id: '',
+  title: '',
+  goal: '',
+  problem: '',
+  diagnosis: '',
+  design: '',
+  status: 'not_started',
+  target_completion_date: '',
+  estimated_total_minutes: '',
+  estimated_total_cost_usd: '',
+};
+
+/**
+ * Display-side metadata for the status pill.
+ */
+export const STATUS_LABELS: Record<ProjectStatus, string> = {
+  not_started: 'not started',
+  in_progress: 'in progress',
+  blocked: 'blocked',
+  completed: 'completed',
+  cancelled: 'cancelled',
+  archived: 'archived',
+};
+
+export const STATUS_PILL_CLASSES: Record<ProjectStatus, string> = {
+  not_started: 'bg-gray-100 text-gray-700 border-gray-300',
+  in_progress: 'bg-blue-50 text-blue-800 border-blue-300',
+  blocked: 'bg-amber-50 text-amber-800 border-amber-300',
+  completed: 'bg-green-50 text-green-800 border-green-300',
+  cancelled: 'bg-gray-50 text-gray-500 border-gray-200',
+  archived: 'bg-gray-50 text-gray-400 border-gray-200',
+};


### PR DESCRIPTION
First user-facing surface for the Operations Project Backlog. Ships the project layer of the projects/tasks/dependencies trio (PR-Ops-3 sequence): full CRUD with audit on every mutation, entity-scoped list view, Bridgewater 5-step scoping enforced at every layer.

Tasks (step 5) ship in PR-Ops-3b. Dependency graph + cycle detection ships in PR-Ops-3c. Each PR is independently useful and reviewable.

New endpoints:
  GET    /api/operations/projects[?entity_id=...]
    List user's projects, optionally entity-scoped. Sorted by status
    priority (not_started/in_progress first, blocked next, then
    completed/cancelled/archived) layered on priority_score DESC,
    target_completion_date ASC, updated_at DESC.

  POST   /api/operations/projects
    Create. Validates: title (req, max 500), goal/problem/diagnosis/
    design (req, all four — DB enforces NOT NULL, server gates
    up-front for clean 400). Verifies entity ownership. Pre-emptive
    (user_id, title) uniqueness check returns 409 with field-targeted
    message. Audits operations_project_created.

  GET    /api/operations/projects/[id]
    Detail. 404 if not found OR not owned. No audit.

  PATCH  /api/operations/projects/[id]
    Update writable fields. Status changes audit-discriminate via
    operations_project_status_changed (SOC 2 evidence-of-state-change
    control: status transitions are evidentiarily distinct from
    content edits). Other content changes audit as
    operations_project_updated. Title-change uniqueness check
    excludes self via NOT: { id }.

  DELETE /api/operations/projects/[id]
    Hard delete. Full payload_before captured in audit_log for
    replay. CASCADE handles tasks/dependencies (none in 3a; future
    PRs will populate).

New types module:
  src/components/workbench/operations/projects/types.ts
    - Project (16-field 1:1 mirror of operations_projects Prisma model)
    - ProjectStatus (6-value union matching ProjectStatus enum)
    - ProjectForm (writable fields only; strings for input binding)
    - DEFAULT_PROJECT_FORM
    - STATUS_LABELS / STATUS_PILL_CLASSES (display metadata)

New components:
  ProjectRow.tsx — three-mode row (compact/expanded/edit). Click row
    to expand, "edit" button to swap to inline form, save → PATCH +
    refetch + exit edit, delete → confirm() prompt + DELETE + refetch.
    Pattern mirrors COAManagementTable's editingId sentinel adapted
    for card-style long-form Text fields.

  SectionD_ProjectBacklog.tsx — top-level section. Reads
    selectedEntityId from useOperationsEntity() context, refetches
    on entity change, "+ new project" toggles inline create form
    ABOVE the list. Empty state branches on filtered vs unfiltered.
    Project count in header reflects entity-filtered count.

Page wiring:
  src/app/operations/projects/page.tsx — replaces D placeholder with
  <SectionD_ProjectBacklog />.

Pattern conventions (institutional):
  - All endpoints follow discovery/profile/route.ts auth precedent: inline getVerifiedEmail(), inline prisma.users.findFirst lookup, sequential prisma + writeAuditLog awaits (NOT transactional — matches codebase convention; relies on writeAuditLog internal P2034/P2024 retry).
  - Entity ownership verified via prisma.entities.findFirst with userId match BEFORE any mutation. Mirrors journal-entries precedent.
  - Where clauses typed as Prisma.operations_projectsWhereInput / Prisma.operations_projectsUpdateInput. Type erasure (the Record<string, unknown> pattern) was the root cause of the PR-Ops-2a-fix2 prefix-filter bug; we don't repeat it.
  - PATCH builds data field-by-field from validated body keys. Never spreads body — extra keys (id, user_id, priority_score) cannot escalate via the wire.
  - Status changes audit-discriminate at action_type level, not just description level. Future audit replay tooling can filter by action_type IN ('operations_project_status_changed') for all status transitions across all projects without parsing descriptions.
  - Bridgewater 5-step scoping enforced at three layers: (a) DB CHECK / NOT NULL — goal/problem/diagnosis/design (b) server validation — empty trim rejected with 400 (c) UI labels — placeholders nudge correct content The schema doesn't permit shipping a half-scoped project.

Verification:
  - prisma generate: no schema changes (tables landed in PR-Ops-1)
  - tsc --noEmit: exit 0, zero errors
  - All 4 project audit action types (operations_project_created, _updated, _status_changed, _deleted) added in PR-Ops-1; verified present in current AuditActionType enum.

Smoke test plan post-merge:
  1. Navigate to /operations/projects
  2. Section D renders empty-state ("no projects yet — click + new project to scope your first one")
  3. Click "+ new project" — inline create form appears with all 5 scoping field placeholders
  4. Fill in title + goal + problem + diagnosis + design + entity
     + (optional) target date / minutes / cost. Click create project.
  5. Form collapses, project appears in list with status pill "not started", entity label, target date or "—".
  6. Click row — expands showing all 4 scoping fields readable.
  7. Click "edit" — inline form replaces display, all fields populated. Modify status to "in_progress", save.
  8. Card returns to expanded view, status pill updates to "in progress" (blue).
  9. Switch entity selector to a different entity — list updates to that entity's projects (or empty state).
 10. /operations/audit-log Section K shows two new rows: operations_project_created and operations_project_status_changed.

Rollback: pure additive PR. Revert by reverting the merge commit. Cancels render of SectionD_ProjectBacklog; placeholder returns. No data loss; existing operations_projects rows persist (orphan from UI perspective, fully readable via psql).

Known scope deferrals (intentional, not bugs):
  - Tasks: PR-Ops-3b
  - Dependencies + cycle detection: PR-Ops-3c
  - Priority scoring (priority_score / priority_rationale fields): PR-Ops-4 territory; surface readonly when present, no compute.
  - Linked issues display: PR-Ops-6 territory.