### PR TITLE
PR-Ops-3b: tasks (Bridgewater step 5) — CRUD + inside-ProjectRow rend…

### DIFF
--- a/src/app/api/operations/projects/[id]/tasks/[taskId]/route.ts
+++ b/src/app/api/operations/projects/[id]/tasks/[taskId]/route.ts
@@ -1,0 +1,308 @@
+/**
+ * /api/operations/projects/[id]/tasks/[taskId]
+ *
+ * GET    — return one task. 404 if not found, not owned, OR taskId not
+ *          under projectId (defensive: taskIds are UUIDs but verifying
+ *          parentage prevents cross-project leakage).
+ * PATCH  — update writable fields. Status transitions discriminate audits:
+ *            * Transition to 'completed' → operations_project_task_completed
+ *              (regardless of from-state); also writes completed_at = NOW()
+ *              if it isn't being explicitly set in the same patch.
+ *            * Other status changes → operations_project_task_status_changed
+ *            * Non-status content changes → operations_project_task_updated
+ *          (Bridgewater convention: completion is its own evidentiary class.)
+ * DELETE — hard delete with full payload_before. Audits
+ *          operations_project_task_deleted.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { Prisma, OperationsTaskStatus } from '@prisma/client';
+import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { writeAuditLog } from '@/lib/audit/writeAuditLog';
+
+const VALID_STATUSES: OperationsTaskStatus[] = [
+  'open',
+  'in_progress',
+  'blocked',
+  'completed',
+  'cancelled',
+];
+
+async function loadAuthorizedTask(taskId: string, projectId: string, userId: string) {
+  return prisma.operations_project_tasks.findFirst({
+    where: { id: taskId, project_id: projectId, user_id: userId },
+  });
+}
+
+async function loadAuthorizedProject(projectId: string, userId: string) {
+  return prisma.operations_projects.findFirst({
+    where: { id: projectId, user_id: userId },
+  });
+}
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string; taskId: string }> }
+) {
+  try {
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const user = await prisma.users.findFirst({
+      where: { email: { equals: userEmail, mode: 'insensitive' } },
+    });
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+
+    const { id: projectId, taskId } = await params;
+    const task = await loadAuthorizedTask(taskId, projectId, user.id);
+    if (!task) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+
+    return NextResponse.json({ task });
+  } catch (error) {
+    console.error('[Task GET]', error);
+    return NextResponse.json(
+      { error: 'Failed to load task', message: error instanceof Error ? error.message : 'unknown' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string; taskId: string }> }
+) {
+  try {
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const user = await prisma.users.findFirst({
+      where: { email: { equals: userEmail, mode: 'insensitive' } },
+    });
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+
+    const { id: projectId, taskId } = await params;
+    const existing = await loadAuthorizedTask(taskId, projectId, user.id);
+    if (!existing) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+
+    const project = await loadAuthorizedProject(projectId, user.id);
+    if (!project) return NextResponse.json({ error: 'Project not found' }, { status: 404 });
+
+    const body = await request.json();
+
+    const data: Prisma.operations_project_tasksUpdateInput = {};
+
+    const trimNonEmpty = (v: unknown): string | null => {
+      if (typeof v !== 'string') return null;
+      const t = v.trim();
+      return t.length > 0 ? t : null;
+    };
+
+    if (body.title !== undefined) {
+      const t = trimNonEmpty(body.title);
+      if (t === null || t.length > 500) {
+        return NextResponse.json(
+          { error: 'Validation', field: 'title', message: 'required, max 500 chars' },
+          { status: 400 }
+        );
+      }
+      data.title = t;
+    }
+
+    if (body.description !== undefined) {
+      data.description = trimNonEmpty(body.description);
+    }
+
+    if (body.unblocks_label !== undefined) {
+      data.unblocks_label = trimNonEmpty(body.unblocks_label);
+    }
+
+    if (body.deadline !== undefined) {
+      data.deadline =
+        typeof body.deadline === 'string' && body.deadline.length > 0
+          ? new Date(body.deadline)
+          : null;
+    }
+
+    if (body.estimated_minutes !== undefined) {
+      const v = body.estimated_minutes;
+      if (v === null || v === '') {
+        data.estimated_minutes = null;
+      } else {
+        const n = Number(v);
+        if (!Number.isFinite(n) || n < 0) {
+          return NextResponse.json(
+            { error: 'Validation', field: 'estimated_minutes', message: 'must be a non-negative number' },
+            { status: 400 }
+          );
+        }
+        data.estimated_minutes = n;
+      }
+    }
+
+    if (body.estimated_cost_usd !== undefined) {
+      const v = body.estimated_cost_usd;
+      if (v === null || v === '') {
+        data.estimated_cost_usd = null;
+      } else if (typeof v === 'string' && v.trim().length > 0) {
+        data.estimated_cost_usd = new Prisma.Decimal(v.trim());
+      } else if (typeof v === 'number') {
+        data.estimated_cost_usd = new Prisma.Decimal(v);
+      }
+    }
+
+    if (body.display_order !== undefined) {
+      const n = Number(body.display_order);
+      if (!Number.isFinite(n)) {
+        return NextResponse.json(
+          { error: 'Validation', field: 'display_order', message: 'must be a number' },
+          { status: 400 }
+        );
+      }
+      data.display_order = Math.trunc(n);
+    }
+
+    // Status transitions: completion vs. status change vs. content edit.
+    let statusTransition: { from: OperationsTaskStatus; to: OperationsTaskStatus } | null = null;
+    let isCompletion = false;
+    if (body.status !== undefined) {
+      const incoming = body.status as OperationsTaskStatus;
+      if (!VALID_STATUSES.includes(incoming)) {
+        return NextResponse.json(
+          { error: 'Validation', field: 'status', message: 'invalid status value' },
+          { status: 400 }
+        );
+      }
+      if (incoming !== existing.status) {
+        statusTransition = { from: existing.status, to: incoming };
+        if (incoming === 'completed') {
+          isCompletion = true;
+          // Auto-set completed_at if not explicitly being patched in the same call.
+          if (body.completed_at === undefined) {
+            data.completed_at = new Date();
+          }
+        }
+        if (existing.status === 'completed' && incoming !== 'completed') {
+          // Reverting from completed — clear completed_at unless explicitly patched.
+          if (body.completed_at === undefined) {
+            data.completed_at = null;
+          }
+        }
+      }
+      data.status = incoming;
+    }
+
+    if (body.completed_at !== undefined) {
+      data.completed_at =
+        typeof body.completed_at === 'string' && body.completed_at.length > 0
+          ? new Date(body.completed_at)
+          : null;
+    }
+
+    const task = await prisma.operations_project_tasks.update({
+      where: { id: taskId },
+      data,
+    });
+
+    let actionType: 'operations_project_task_completed' | 'operations_project_task_status_changed' | 'operations_project_task_updated';
+    let description: string;
+
+    if (isCompletion) {
+      actionType = 'operations_project_task_completed';
+      description = `Completed task "${existing.title}" in project "${project.title}"`;
+    } else if (statusTransition) {
+      actionType = 'operations_project_task_status_changed';
+      description = `Task "${existing.title}" status: ${statusTransition.from} → ${statusTransition.to}`;
+    } else {
+      actionType = 'operations_project_task_updated';
+      description = `Updated task "${existing.title}" in project "${project.title}"`;
+    }
+
+    await writeAuditLog({
+      actor: {
+        user_id: user.id,
+        email: userEmail,
+        type: 'human_user',
+      },
+      action: {
+        type: actionType,
+        description,
+      },
+      target: {
+        table: 'operations_project_tasks',
+        id: task.id,
+      },
+      payload: {
+        before: existing,
+        after: task,
+        metadata: {
+          project_id: projectId,
+          project_title: project.title,
+          ...(statusTransition && { status_from: statusTransition.from, status_to: statusTransition.to }),
+        },
+      },
+    });
+
+    return NextResponse.json({ task });
+  } catch (error) {
+    console.error('[Task PATCH]', error);
+    return NextResponse.json(
+      { error: 'Failed to update task', message: error instanceof Error ? error.message : 'unknown' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string; taskId: string }> }
+) {
+  try {
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const user = await prisma.users.findFirst({
+      where: { email: { equals: userEmail, mode: 'insensitive' } },
+    });
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+
+    const { id: projectId, taskId } = await params;
+    const existing = await loadAuthorizedTask(taskId, projectId, user.id);
+    if (!existing) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+
+    const project = await loadAuthorizedProject(projectId, user.id);
+
+    await prisma.operations_project_tasks.delete({ where: { id: taskId } });
+
+    await writeAuditLog({
+      actor: {
+        user_id: user.id,
+        email: userEmail,
+        type: 'human_user',
+      },
+      action: {
+        type: 'operations_project_task_deleted',
+        description: `Deleted task "${existing.title}" from project "${project?.title ?? projectId}"`,
+      },
+      target: {
+        table: 'operations_project_tasks',
+        id: existing.id,
+      },
+      payload: {
+        before: existing,
+        metadata: {
+          project_id: projectId,
+          project_title: project?.title ?? null,
+        },
+      },
+    });
+
+    return NextResponse.json({ deleted: true, id: existing.id });
+  } catch (error) {
+    console.error('[Task DELETE]', error);
+    return NextResponse.json(
+      { error: 'Failed to delete task', message: error instanceof Error ? error.message : 'unknown' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/operations/projects/[id]/tasks/route.ts
+++ b/src/app/api/operations/projects/[id]/tasks/route.ts
@@ -1,0 +1,216 @@
+/**
+ * /api/operations/projects/[id]/tasks
+ *
+ * GET  — list this project's tasks. Sorted by status priority (open/
+ *        in_progress first, then blocked, then completed/cancelled),
+ *        then display_order ASC, then deadline ASC NULLS LAST.
+ *        No audit (read-only).
+ *
+ * POST — create a task. Server inherits entity_id from parent project
+ *        (β-1: tasks denormalize entity_id for index speed; never
+ *        independently chosen). Computes display_order = max+1 from
+ *        existing siblings (α-1: documented race-acceptance — two
+ *        simultaneous POSTs can collide on display_order; acceptable
+ *        for single-user system, resolvable via PATCH).
+ *        Audits operations_project_task_created with metadata.project_id
+ *        and project_title for replay context.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { Prisma, OperationsTaskStatus } from '@prisma/client';
+import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { writeAuditLog } from '@/lib/audit/writeAuditLog';
+
+const STATUS_ORDER: Record<OperationsTaskStatus, number> = {
+  open: 0,
+  in_progress: 1,
+  blocked: 2,
+  completed: 3,
+  cancelled: 4,
+};
+
+async function loadAuthorizedProject(projectId: string, userId: string) {
+  return prisma.operations_projects.findFirst({
+    where: { id: projectId, user_id: userId },
+  });
+}
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const user = await prisma.users.findFirst({
+      where: { email: { equals: userEmail, mode: 'insensitive' } },
+    });
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+
+    const { id: projectId } = await params;
+    const project = await loadAuthorizedProject(projectId, user.id);
+    if (!project) return NextResponse.json({ error: 'Project not found' }, { status: 404 });
+
+    const tasks = await prisma.operations_project_tasks.findMany({
+      where: { project_id: projectId },
+      orderBy: [
+        { display_order: 'asc' },
+        { deadline: { sort: 'asc', nulls: 'last' } },
+        { updated_at: 'desc' },
+      ],
+    });
+
+    // Status-priority sort layered on top of display_order.
+    const sorted = tasks.slice().sort((a, b) => {
+      const sa = STATUS_ORDER[a.status];
+      const sb = STATUS_ORDER[b.status];
+      if (sa !== sb) return sa - sb;
+      return 0;
+    });
+
+    return NextResponse.json({ tasks: sorted });
+  } catch (error) {
+    console.error('[Tasks GET]', error);
+    return NextResponse.json(
+      { error: 'Failed to load tasks', message: error instanceof Error ? error.message : 'unknown' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const user = await prisma.users.findFirst({
+      where: { email: { equals: userEmail, mode: 'insensitive' } },
+    });
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+
+    const { id: projectId } = await params;
+    const project = await loadAuthorizedProject(projectId, user.id);
+    if (!project) return NextResponse.json({ error: 'Project not found' }, { status: 404 });
+
+    const body = await request.json();
+
+    const requireString = (v: unknown, field: string, max?: number): string | NextResponse => {
+      if (typeof v !== 'string' || v.trim().length === 0) {
+        return NextResponse.json(
+          { error: 'Validation', field, message: `${field} is required` },
+          { status: 400 }
+        );
+      }
+      const trimmed = v.trim();
+      if (max && trimmed.length > max) {
+        return NextResponse.json(
+          { error: 'Validation', field, message: `${field} exceeds ${max} characters` },
+          { status: 400 }
+        );
+      }
+      return trimmed;
+    };
+
+    const title = requireString(body.title, 'title', 500);
+    if (title instanceof NextResponse) return title;
+
+    const trimNullable = (v: unknown): string | null => {
+      if (typeof v !== 'string') return null;
+      const t = v.trim();
+      return t.length > 0 ? t : null;
+    };
+
+    const description = trimNullable(body.description);
+    const unblocks_label = trimNullable(body.unblocks_label);
+
+    const deadline =
+      typeof body.deadline === 'string' && body.deadline.length > 0
+        ? new Date(body.deadline)
+        : null;
+
+    let estimated_minutes: number | null = null;
+    if (body.estimated_minutes !== undefined && body.estimated_minutes !== null && body.estimated_minutes !== '') {
+      const n = Number(body.estimated_minutes);
+      if (!Number.isFinite(n) || n < 0) {
+        return NextResponse.json(
+          { error: 'Validation', field: 'estimated_minutes', message: 'must be a non-negative number' },
+          { status: 400 }
+        );
+      }
+      estimated_minutes = n;
+    }
+
+    let estimated_cost_usd: Prisma.Decimal | null = null;
+    if (typeof body.estimated_cost_usd === 'string' && body.estimated_cost_usd.trim().length > 0) {
+      estimated_cost_usd = new Prisma.Decimal(body.estimated_cost_usd.trim());
+    } else if (typeof body.estimated_cost_usd === 'number') {
+      estimated_cost_usd = new Prisma.Decimal(body.estimated_cost_usd);
+    }
+
+    // α-1: server-computed display_order = max(existing) + 1.
+    // Race-acceptance asterisk: two simultaneous POSTs against the same
+    // project can read the same max and collide. Acceptable for single-
+    // user system; resolvable via PATCH on display_order. Future reorder
+    // UI is the canonical fix path.
+    const last = await prisma.operations_project_tasks.findFirst({
+      where: { project_id: projectId },
+      orderBy: { display_order: 'desc' },
+      select: { display_order: true },
+    });
+    const display_order = last ? last.display_order + 1 : 0;
+
+    // β-1: entity_id inherited from parent project.
+    const task = await prisma.operations_project_tasks.create({
+      data: {
+        project_id: projectId,
+        user_id: user.id,
+        entity_id: project.entity_id,
+        title,
+        description,
+        unblocks_label,
+        deadline,
+        estimated_minutes,
+        estimated_cost_usd,
+        display_order,
+        created_by: userEmail,
+      },
+    });
+
+    await writeAuditLog({
+      actor: {
+        user_id: user.id,
+        email: userEmail,
+        type: 'human_user',
+      },
+      action: {
+        type: 'operations_project_task_created',
+        description: `Created task "${title}" in project "${project.title}"`,
+      },
+      target: {
+        table: 'operations_project_tasks',
+        id: task.id,
+      },
+      payload: {
+        after: task,
+        metadata: {
+          project_id: projectId,
+          project_title: project.title,
+          entity_id: project.entity_id,
+        },
+      },
+    });
+
+    return NextResponse.json({ task, isCreate: true }, { status: 201 });
+  } catch (error) {
+    console.error('[Tasks POST]', error);
+    return NextResponse.json(
+      { error: 'Failed to create task', message: error instanceof Error ? error.message : 'unknown' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/components/workbench/operations/projects/ProjectRow.tsx
+++ b/src/components/workbench/operations/projects/ProjectRow.tsx
@@ -19,6 +19,7 @@
 import { useState } from 'react';
 import type { Project, ProjectForm, ProjectStatus } from './types';
 import { STATUS_LABELS, STATUS_PILL_CLASSES } from './types';
+import TaskList from './TaskList';
 
 interface Entity {
   id: string;
@@ -169,6 +170,10 @@ export default function ProjectRow({ project, entities, onUpdate, onDelete }: Pr
           <div>
             <div className={labelClass}>4 · design</div>
             <div className="text-text-primary whitespace-pre-wrap">{project.design}</div>
+          </div>
+          <div className="pt-2 border-t border-border-light">
+            <div className={labelClass}>5 · execute (tasks)</div>
+            <TaskList projectId={project.id} />
           </div>
           <div className="grid grid-cols-2 gap-4 pt-2 border-t border-border-light">
             <div>

--- a/src/components/workbench/operations/projects/TaskList.tsx
+++ b/src/components/workbench/operations/projects/TaskList.tsx
@@ -1,0 +1,234 @@
+/**
+ * TaskList — renders the tasks for a single project.
+ *
+ * Self-fetches via GET /api/operations/projects/[projectId]/tasks on mount
+ * and on any onUpdate/onDelete callback from a TaskRow. Self-contained:
+ * the parent ProjectRow just renders <TaskList projectId={...} /> and never
+ * needs to know about task state.
+ *
+ * "+ add task" affordance toggles an inline create form ABOVE the task list.
+ * Bridgewater step-5 framing: this is the execute layer; the project's
+ * scoping fields are read above this in the parent ProjectRow.
+ */
+
+'use client';
+
+import { useEffect, useState } from 'react';
+import TaskRow from './TaskRow';
+import type { Task, TaskForm } from './types';
+import { DEFAULT_TASK_FORM } from './types';
+
+interface Props {
+  projectId: string;
+}
+
+export default function TaskList({ projectId }: Props) {
+  const [tasks, setTasks] = useState<Task[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [showCreate, setShowCreate] = useState(false);
+  const [createForm, setCreateForm] = useState<TaskForm>(DEFAULT_TASK_FORM);
+  const [createSaving, setCreateSaving] = useState(false);
+  const [createError, setCreateError] = useState<string | null>(null);
+
+  const fetchTasks = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/operations/projects/${projectId}/tasks`);
+      const body = await res.json();
+      if (!res.ok) {
+        setError(body?.message ?? body?.error ?? 'failed to load tasks');
+        setTasks([]);
+        return;
+      }
+      setTasks(body.tasks ?? []);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'failed to load tasks');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchTasks();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [projectId]);
+
+  const startCreate = () => {
+    setCreateForm(DEFAULT_TASK_FORM);
+    setCreateError(null);
+    setShowCreate(true);
+  };
+
+  const cancelCreate = () => {
+    setShowCreate(false);
+    setCreateForm(DEFAULT_TASK_FORM);
+    setCreateError(null);
+  };
+
+  const handleCreate = async () => {
+    setCreateSaving(true);
+    setCreateError(null);
+    try {
+      const res = await fetch(`/api/operations/projects/${projectId}/tasks`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(createForm),
+      });
+      const body = await res.json();
+      if (!res.ok) {
+        setCreateError(body?.message ?? body?.error ?? 'failed to create');
+        return;
+      }
+      cancelCreate();
+      fetchTasks();
+    } catch (e) {
+      setCreateError(e instanceof Error ? e.message : 'failed to create');
+    } finally {
+      setCreateSaving(false);
+    }
+  };
+
+  const inputClass =
+    'w-full px-2 py-1 border border-border rounded text-xs font-mono text-text-primary focus:outline-none focus:border-brand-purple';
+  const labelClass = 'text-text-faint uppercase tracking-wide mb-1 text-xs font-mono';
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <div className="text-xs font-mono text-text-muted">
+          {tasks.length} {tasks.length === 1 ? 'task' : 'tasks'}
+        </div>
+        {!showCreate && (
+          <button
+            type="button"
+            onClick={(e) => { e.stopPropagation(); startCreate(); }}
+            className="px-2 py-1 border border-brand-purple bg-brand-purple text-white rounded text-xs font-mono hover:opacity-90"
+          >
+            + add task
+          </button>
+        )}
+      </div>
+
+      {error && (
+        <div className="text-xs font-mono px-3 py-2 rounded border bg-red-50 border-red-200 text-red-800">
+          {error}
+        </div>
+      )}
+
+      {showCreate && (
+        <div className="border border-brand-purple rounded p-3 bg-purple-50/30 text-xs font-mono space-y-3">
+          <div className="font-bold text-text-primary">new task</div>
+          {createError && (
+            <div className="px-3 py-2 rounded border bg-red-50 border-red-200 text-red-800">
+              {createError}
+            </div>
+          )}
+          <div>
+            <div className={labelClass}>title</div>
+            <input
+              type="text"
+              value={createForm.title}
+              onChange={(e) => setCreateForm({ ...createForm, title: e.target.value })}
+              className={inputClass}
+              maxLength={500}
+              placeholder="what is the atomic unit of work?"
+            />
+          </div>
+          <div>
+            <div className={labelClass}>description (optional)</div>
+            <textarea
+              value={createForm.description}
+              onChange={(e) => setCreateForm({ ...createForm, description: e.target.value })}
+              rows={2}
+              className={inputClass}
+              placeholder="more detail if the title isn't enough"
+            />
+          </div>
+          <div>
+            <div className={labelClass}>unblocks (optional — rationale for priority engine)</div>
+            <textarea
+              value={createForm.unblocks_label}
+              onChange={(e) => setCreateForm({ ...createForm, unblocks_label: e.target.value })}
+              rows={2}
+              className={inputClass}
+              placeholder="what does completing this unblock?"
+            />
+          </div>
+          <div className="grid grid-cols-3 gap-3">
+            <div>
+              <div className={labelClass}>deadline (optional)</div>
+              <input
+                type="date"
+                value={createForm.deadline}
+                onChange={(e) => setCreateForm({ ...createForm, deadline: e.target.value })}
+                className={inputClass}
+              />
+            </div>
+            <div>
+              <div className={labelClass}>est. minutes (optional)</div>
+              <input
+                type="number"
+                min={0}
+                value={createForm.estimated_minutes}
+                onChange={(e) => setCreateForm({ ...createForm, estimated_minutes: e.target.value })}
+                className={inputClass}
+              />
+            </div>
+            <div>
+              <div className={labelClass}>est. cost usd (optional)</div>
+              <input
+                type="text"
+                value={createForm.estimated_cost_usd}
+                onChange={(e) => setCreateForm({ ...createForm, estimated_cost_usd: e.target.value })}
+                className={inputClass}
+                placeholder="0.00"
+              />
+            </div>
+          </div>
+          <div className="flex items-center gap-2 pt-2 border-t border-border-light">
+            <button
+              type="button"
+              onClick={handleCreate}
+              disabled={createSaving}
+              className="px-3 py-1 border border-brand-purple bg-brand-purple text-white rounded hover:opacity-90 disabled:opacity-50"
+            >
+              {createSaving ? 'creating…' : 'create task'}
+            </button>
+            <button
+              type="button"
+              onClick={cancelCreate}
+              disabled={createSaving}
+              className="px-3 py-1 border border-border rounded hover:bg-bg-row disabled:opacity-50"
+            >
+              cancel
+            </button>
+          </div>
+        </div>
+      )}
+
+      {loading ? (
+        <div className="text-xs font-mono text-text-muted">loading tasks…</div>
+      ) : tasks.length === 0 ? (
+        <div className="text-xs font-mono text-text-muted italic">
+          no tasks yet — click "+ add task" to break this project down into atomic execution units.
+        </div>
+      ) : (
+        <div className="space-y-1.5">
+          {tasks.map((t, i) => (
+            <TaskRow
+              key={t.id}
+              task={t}
+              projectId={projectId}
+              index={i + 1}
+              onUpdate={fetchTasks}
+              onDelete={fetchTasks}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/workbench/operations/projects/TaskRow.tsx
+++ b/src/components/workbench/operations/projects/TaskRow.tsx
@@ -1,0 +1,361 @@
+/**
+ * TaskRow — single task in a project's task list.
+ *
+ * Three modes (mirrors ProjectRow's pattern at task scale):
+ *   1. Compact: index + title + status pill + deadline + "complete" quick action
+ *   2. Expanded: + description + unblocks_label + estimates + completed_at
+ *   3. Edit: inline form for all writable fields
+ *
+ * Click row body → toggle expand. "complete" quick-action button (when status
+ * !== 'completed') → single-click sets status to 'completed', server writes
+ * operations_project_task_completed audit + completed_at timestamp.
+ */
+
+'use client';
+
+import { useState } from 'react';
+import type { Task, TaskForm, TaskStatus } from './types';
+import { TASK_STATUS_LABELS, TASK_STATUS_PILL_CLASSES } from './types';
+
+interface Props {
+  task: Task;
+  projectId: string;
+  index: number; // 1-based display index
+  onUpdate: () => void;
+  onDelete: () => void;
+}
+
+const STATUS_OPTIONS: TaskStatus[] = [
+  'open',
+  'in_progress',
+  'blocked',
+  'completed',
+  'cancelled',
+];
+
+function taskToForm(t: Task): TaskForm {
+  return {
+    title: t.title,
+    description: t.description ?? '',
+    status: t.status,
+    estimated_minutes: t.estimated_minutes !== null ? String(t.estimated_minutes) : '',
+    estimated_cost_usd: t.estimated_cost_usd ?? '',
+    deadline: t.deadline ? t.deadline.slice(0, 10) : '',
+    unblocks_label: t.unblocks_label ?? '',
+  };
+}
+
+function formatDate(iso: string | null): string {
+  if (!iso) return '—';
+  return new Date(iso).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+}
+
+export default function TaskRow({ task, projectId, index, onUpdate, onDelete }: Props) {
+  const [expanded, setExpanded] = useState(false);
+  const [editing, setEditing] = useState(false);
+  const [form, setForm] = useState<TaskForm>(() => taskToForm(task));
+  const [saving, setSaving] = useState(false);
+  const [completing, setCompleting] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const enterEdit = () => {
+    setForm(taskToForm(task));
+    setEditing(true);
+    setError(null);
+  };
+
+  const cancelEdit = () => {
+    setForm(taskToForm(task));
+    setEditing(false);
+    setError(null);
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    setError(null);
+    try {
+      const res = await fetch(
+        `/api/operations/projects/${projectId}/tasks/${task.id}`,
+        {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(form),
+        }
+      );
+      const body = await res.json();
+      if (!res.ok) {
+        setError(body?.message ?? body?.error ?? 'failed to save');
+        return;
+      }
+      setEditing(false);
+      onUpdate();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'failed to save');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleQuickComplete = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setCompleting(true);
+    setError(null);
+    try {
+      const res = await fetch(
+        `/api/operations/projects/${projectId}/tasks/${task.id}`,
+        {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ status: 'completed' }),
+        }
+      );
+      const body = await res.json();
+      if (!res.ok) {
+        setError(body?.message ?? body?.error ?? 'failed to complete');
+        return;
+      }
+      onUpdate();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'failed to complete');
+    } finally {
+      setCompleting(false);
+    }
+  };
+
+  const handleDelete = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (!confirm(`Delete task "${task.title}"?`)) return;
+    setDeleting(true);
+    setError(null);
+    try {
+      const res = await fetch(
+        `/api/operations/projects/${projectId}/tasks/${task.id}`,
+        { method: 'DELETE' }
+      );
+      const body = await res.json();
+      if (!res.ok) {
+        setError(body?.message ?? body?.error ?? 'failed to delete');
+        return;
+      }
+      onDelete();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'failed to delete');
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  const inputClass =
+    'w-full px-2 py-1 border border-border rounded text-xs font-mono text-text-primary focus:outline-none focus:border-brand-purple';
+  const labelClass = 'text-text-faint uppercase tracking-wide mb-1 text-xs font-mono';
+  const pillClass = `inline-block px-2 py-0.5 border rounded text-xs font-mono ${TASK_STATUS_PILL_CLASSES[task.status]}`;
+
+  return (
+    <div className="border border-border-light rounded bg-white">
+      <div
+        className="flex items-center justify-between px-3 py-1.5 cursor-pointer hover:bg-bg-row text-xs font-mono"
+        onClick={() => !editing && setExpanded((x) => !x)}
+      >
+        <div className="flex items-center gap-2 min-w-0 flex-1">
+          <span className="text-text-faint shrink-0 w-6 text-right">{index}.</span>
+          <span className="text-text-faint">{expanded ? '▾' : '▸'}</span>
+          <span
+            className={
+              task.status === 'completed' || task.status === 'cancelled'
+                ? 'text-text-muted line-through truncate'
+                : 'text-text-primary truncate'
+            }
+          >
+            {task.title}
+          </span>
+          <span className={pillClass}>{TASK_STATUS_LABELS[task.status]}</span>
+          {task.deadline && (
+            <span className="text-text-muted">due {formatDate(task.deadline)}</span>
+          )}
+        </div>
+        <div className="flex items-center gap-2 shrink-0">
+          {task.status !== 'completed' && task.status !== 'cancelled' && (
+            <button
+              type="button"
+              onClick={handleQuickComplete}
+              disabled={completing}
+              className="px-2 py-0.5 border border-green-300 text-green-800 rounded hover:bg-green-50 disabled:opacity-50 text-xs font-mono"
+              title="Mark task as completed"
+            >
+              {completing ? '…' : '✓ complete'}
+            </button>
+          )}
+        </div>
+      </div>
+
+      {expanded && !editing && (
+        <div className="px-4 py-2 border-t border-border-light text-xs font-mono space-y-2">
+          {error && (
+            <div className="px-3 py-2 rounded border bg-red-50 border-red-200 text-red-800">
+              {error}
+            </div>
+          )}
+          {task.description ? (
+            <div>
+              <div className={labelClass}>description</div>
+              <div className="text-text-primary whitespace-pre-wrap">{task.description}</div>
+            </div>
+          ) : (
+            <div className="text-text-muted italic">no description</div>
+          )}
+
+          {task.unblocks_label && (
+            <div>
+              <div className={labelClass}>unblocks</div>
+              <div className="text-text-primary whitespace-pre-wrap">{task.unblocks_label}</div>
+            </div>
+          )}
+
+          <div className="grid grid-cols-3 gap-3 pt-2 border-t border-border-light">
+            <div>
+              <div className={labelClass}>est. minutes</div>
+              <div className="text-text-primary">{task.estimated_minutes ?? '—'}</div>
+            </div>
+            <div>
+              <div className={labelClass}>est. cost (usd)</div>
+              <div className="text-text-primary">{task.estimated_cost_usd ?? '—'}</div>
+            </div>
+            <div>
+              <div className={labelClass}>completed at</div>
+              <div className="text-text-primary">{formatDate(task.completed_at)}</div>
+            </div>
+          </div>
+
+          <div className="flex items-center gap-2 pt-2 border-t border-border-light">
+            <button
+              type="button"
+              onClick={(e) => { e.stopPropagation(); enterEdit(); }}
+              className="px-2 py-1 border border-border rounded hover:bg-bg-row"
+            >
+              edit
+            </button>
+            <button
+              type="button"
+              onClick={handleDelete}
+              disabled={deleting}
+              className="px-2 py-1 border border-red-300 text-red-700 rounded hover:bg-red-50 disabled:opacity-50"
+            >
+              {deleting ? 'deleting…' : 'delete'}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {editing && (
+        <div className="px-4 py-3 border-t border-border-light text-xs font-mono space-y-3">
+          {error && (
+            <div className="px-3 py-2 rounded border bg-red-50 border-red-200 text-red-800">
+              {error}
+            </div>
+          )}
+
+          <div className="grid grid-cols-2 gap-3">
+            <div className="col-span-2">
+              <div className={labelClass}>title</div>
+              <input
+                type="text"
+                value={form.title}
+                onChange={(e) => setForm({ ...form, title: e.target.value })}
+                className={inputClass}
+                maxLength={500}
+              />
+            </div>
+            <div>
+              <div className={labelClass}>status</div>
+              <select
+                value={form.status}
+                onChange={(e) => setForm({ ...form, status: e.target.value as TaskStatus })}
+                className={inputClass}
+              >
+                {STATUS_OPTIONS.map((s) => (
+                  <option key={s} value={s}>
+                    {TASK_STATUS_LABELS[s]}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <div className={labelClass}>deadline</div>
+              <input
+                type="date"
+                value={form.deadline}
+                onChange={(e) => setForm({ ...form, deadline: e.target.value })}
+                className={inputClass}
+              />
+            </div>
+          </div>
+
+          <div>
+            <div className={labelClass}>description</div>
+            <textarea
+              value={form.description}
+              onChange={(e) => setForm({ ...form, description: e.target.value })}
+              rows={3}
+              className={inputClass}
+              placeholder="what does this task entail?"
+            />
+          </div>
+
+          <div>
+            <div className={labelClass}>unblocks (rationale for priority engine)</div>
+            <textarea
+              value={form.unblocks_label}
+              onChange={(e) => setForm({ ...form, unblocks_label: e.target.value })}
+              rows={2}
+              className={inputClass}
+              placeholder="what does completing this unblock? — fed to the priority ranker (PR-Ops-4)"
+            />
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <div className={labelClass}>est. minutes</div>
+              <input
+                type="number"
+                min={0}
+                value={form.estimated_minutes}
+                onChange={(e) => setForm({ ...form, estimated_minutes: e.target.value })}
+                className={inputClass}
+              />
+            </div>
+            <div>
+              <div className={labelClass}>est. cost (usd)</div>
+              <input
+                type="text"
+                value={form.estimated_cost_usd}
+                onChange={(e) => setForm({ ...form, estimated_cost_usd: e.target.value })}
+                className={inputClass}
+                placeholder="0.00"
+              />
+            </div>
+          </div>
+
+          <div className="flex items-center gap-2 pt-2 border-t border-border-light">
+            <button
+              type="button"
+              onClick={handleSave}
+              disabled={saving}
+              className="px-3 py-1 border border-brand-purple bg-brand-purple text-white rounded hover:opacity-90 disabled:opacity-50"
+            >
+              {saving ? 'saving…' : 'save'}
+            </button>
+            <button
+              type="button"
+              onClick={cancelEdit}
+              disabled={saving}
+              className="px-3 py-1 border border-border rounded hover:bg-bg-row disabled:opacity-50"
+            >
+              cancel
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/workbench/operations/projects/types.ts
+++ b/src/components/workbench/operations/projects/types.ts
@@ -94,3 +94,84 @@ export const STATUS_PILL_CLASSES: Record<ProjectStatus, string> = {
   cancelled: 'bg-gray-50 text-gray-500 border-gray-200',
   archived: 'bg-gray-50 text-gray-400 border-gray-200',
 };
+
+/**
+ * ============================================================================
+ * Tasks (PR-Ops-3b) — Step 5 of Bridgewater scoping. Atomic execution units
+ * inside a project. Each task lives in operations_project_tasks with FK CASCADE
+ * to its parent project. entity_id is server-inherited from the parent project
+ * (denormalized for index speed; never independently chosen).
+ * ============================================================================
+ */
+
+export type TaskStatus =
+  | 'open'
+  | 'in_progress'
+  | 'blocked'
+  | 'completed'
+  | 'cancelled';
+
+export interface Task {
+  id: string;
+  project_id: string;
+  user_id: string;
+  entity_id: string;
+  title: string;
+  description: string | null;
+  status: TaskStatus;
+  estimated_minutes: number | null;
+  estimated_cost_usd: string | null;
+  deadline: string | null;
+  priority_score: string | null;
+  priority_inputs_hash: string | null;
+  priority_computed_at: string | null;
+  priority_rationale: string | null;
+  unblocks_label: string | null;
+  display_order: number;
+  completed_at: string | null;
+  created_at: string;
+  updated_at: string;
+  created_by: string | null;
+}
+
+/**
+ * Form-side shape for task editing. Excludes server-managed fields
+ * (id, project_id, user_id, entity_id, timestamps, priority_*, completed_at,
+ * created_by, display_order). entity_id is inherited server-side from the
+ * parent project; the client never sets it.
+ */
+export interface TaskForm {
+  title: string;
+  description: string;
+  status: TaskStatus;
+  estimated_minutes: string;        // string for input binding
+  estimated_cost_usd: string;       // string for decimal fidelity
+  deadline: string;                 // ISO date (yyyy-mm-dd) or empty
+  unblocks_label: string;
+}
+
+export const DEFAULT_TASK_FORM: TaskForm = {
+  title: '',
+  description: '',
+  status: 'open',
+  estimated_minutes: '',
+  estimated_cost_usd: '',
+  deadline: '',
+  unblocks_label: '',
+};
+
+export const TASK_STATUS_LABELS: Record<TaskStatus, string> = {
+  open: 'open',
+  in_progress: 'in progress',
+  blocked: 'blocked',
+  completed: 'completed',
+  cancelled: 'cancelled',
+};
+
+export const TASK_STATUS_PILL_CLASSES: Record<TaskStatus, string> = {
+  open: 'bg-gray-100 text-gray-700 border-gray-300',
+  in_progress: 'bg-blue-50 text-blue-800 border-blue-300',
+  blocked: 'bg-amber-50 text-amber-800 border-amber-300',
+  completed: 'bg-green-50 text-green-800 border-green-300',
+  cancelled: 'bg-gray-50 text-gray-500 border-gray-200',
+};


### PR DESCRIPTION
…ering

Ships the task layer of the projects/tasks/dependencies trio. Tasks live inside their parent project's expanded view (option α: tasks are atomic units OF a project; the UI mirrors the structural truth). Dependency graph + cycle detection ships in PR-Ops-3c.

New endpoints (under /api/operations/projects/[id]/tasks/):

  GET    /api/operations/projects/[id]/tasks
    List this project's tasks. Sorted by status priority (open/
    in_progress first), then display_order ASC, then deadline ASC
    NULLS LAST.

  POST   /api/operations/projects/[id]/tasks
    Create a task. Architectural decisions:
      - β-1: server inherits entity_id from parent project. Tasks
        denormalize entity_id for index speed; never independently
        chosen. Client never sets entity_id. Architectural invariant
        baked into server, not validated on the wire.
      - α-1: server-computed display_order = max(siblings)+1, or 0
        if no siblings. Documented race-acceptance for two
        simultaneous POSTs (acceptable for single-user system,
        resolvable via PATCH on display_order). Future reorder UI is
        the canonical fix path.
    Audits operations_project_task_created with metadata.project_id
    and project_title for replay context.

  GET    /api/operations/projects/[id]/tasks/[taskId]
    Detail. Defensive parentage check (taskId must belong to
    projectId AND be owned by the user) prevents cross-project
    leakage. 404 on any failure.

  PATCH  /api/operations/projects/[id]/tasks/[taskId]
    Update writable fields. Three-way audit discrimination:
      - Transition to 'completed' → operations_project_task_completed (regardless of from-state). Auto-sets completed_at = NOW() if not explicitly patched. Bridgewater convention: completion is its own evidentiary class, distinct from generic status changes.
      - Other status transitions → operations_project_task_status_changed with payload metadata.status_from/status_to for replay. - Non-status content edits → operations_project_task_updated Auto-clears completed_at on transition FROM completed. PATCH builds data field-by-field — never spreads body.

  DELETE /api/operations/projects/[id]/tasks/[taskId]
    Hard delete. Full payload_before captured for replay. Audits operations_project_task_deleted with project context.

Types module (types.ts append):
  - Task (20-field 1:1 mirror of operations_project_tasks)
  - TaskStatus (5-value union matching OperationsTaskStatus enum)
  - TaskForm (writable fields only — excludes server-managed: display_order, entity_id, priority_*, completed_at, project_id, user_id, timestamps)
  - DEFAULT_TASK_FORM with status='open'
  - TASK_STATUS_LABELS / TASK_STATUS_PILL_CLASSES (display metadata)

New components:
  TaskRow.tsx — three-mode row matching ProjectRow's pattern at task
    scale. Compact: 1-based index + title + status pill + deadline + "✓ complete" quick-action button (visible when status is not already completed/cancelled). Expanded: + description + unblocks_label + estimates + completed_at. Edit: inline form for all writable fields including unblocks_label (γ-1: shipped now even though priority engine consumes it later, so users don't need a re-edit pass when PR-Ops-4 ships). Strikethrough rendering on completed/cancelled titles. e.stopPropagation() on every action button to prevent the row's expand-toggle from firing.

  TaskList.tsx — self-contained component that takes a projectId,
    fetches its tasks, and manages create/refresh state. ProjectRow just renders <TaskList projectId={...} /> and never needs to know about task state. "+ add task" toggles inline create form above the list; empty-state framing reinforces "atomic execution units" (Bridgewater language).

ProjectRow modification:
  Single new import line + single new "5 · execute (tasks)" block
  inserted between "4 · design" and the est minutes/cost grid.
  The expand toggle continues to work; tasks are part of the
  expanded body. No other ProjectRow changes.

Pattern conventions (institutional, mirroring PR-Ops-3a):
  - All endpoints follow operations/north-star/route.ts + operations/projects/route.ts auth precedent: inline getVerifiedEmail(), inline prisma.users.findFirst, sequential prisma + writeAuditLog awaits (NOT transactional — matches codebase convention).
  - loadAuthorizedTask helper deduplicates the (taskId + projectId
    + userId) check across GET/PATCH/DELETE.
  - Where clauses typed via Prisma.operations_project_tasksWhereInput / Prisma.operations_project_tasksUpdateInput. The Record<string, unknown> typing pattern that caused the PR-Ops-2a-fix2 bug is avoided everywhere.
  - Status discrimination at action_type level (not just description level): future audit replay tooling can answer "how many tasks did I complete in March?" with a single WHERE action_type = 'operations_project_task_completed' query across all projects, no description parsing.
  - completed_at auto-management: server timestamps on transition to completed, clears on transition away from completed; both overridable via explicit completed_at body field.

Verification:
  - prisma generate: no schema changes (operations_project_tasks landed in PR-Ops-1)
  - tsc --noEmit: exit 0, zero errors
  - All 5 task audit action types verified present in AuditActionType (PR-Ops-1) and in SUBSYSTEM_ACTION_TYPES static map at /api/audit-log/route.ts (PR-Ops-2a-fix2).

Smoke test plan post-merge:
  1. Navigate to /operations/projects, click any existing project row to expand.
  2. New "5 · execute (tasks)" section visible below "4 · design", with empty-state ("no tasks yet — click + add task to break this project down into atomic execution units")
  3. Click "+ add task" → inline create form appears.
  4. Fill in title (e.g., "Audit current trade pipeline integrity score weights"), optional description, deadline, estimated minutes/cost, unblocks_label. Click create task.
  5. Form collapses, task appears in list with index "1.", status pill "open", quick-action "✓ complete" button visible.
  6. Click row body → task expands showing description, unblocks, estimates, completed_at "—".
  7. Click "✓ complete" — task title strikes through, status pill turns green "completed", quick-action button disappears.
  8. /operations/audit-log Section K shows two new rows: operations_project_task_created and operations_project_task_completed (NOT _status_changed — completion has its own evidentiary class).
  9. Click row to expand again — completed_at now shows a real date.
 10. Edit the task: change status back to "open" via the dropdown, save. completed_at clears in the display. Audit log gets a third row: operations_project_task_status_changed (NOT _completed; the inverse transition is generic).

Rollback: pure additive PR. Revert by reverting the merge commit. Cancels the TaskList rendering inside ProjectRow; projects show without their task list. No data loss; existing operations_project_tasks rows persist (orphan from UI perspective, fully readable via psql).

Known scope deferrals (intentional, not bugs):
  - Task reorder UI (drag-drop or up/down arrows): defer to future PR; current α-1 race-accept relies on user PATCHing display_order directly via console fetch if collision is observed.
  - Dependencies + cycle detection: PR-Ops-3c.
  - Priority scoring (priority_score + priority_rationale): PR-Ops-4.
  - Bulk task operations (bulk-complete, bulk-status-change): defer.