### PR TITLE
PR-Ops-3c: dependencies + cycle detection — typed DAG over projects

### DIFF
--- a/src/app/api/operations/projects/[id]/dependencies/[depId]/route.ts
+++ b/src/app/api/operations/projects/[id]/dependencies/[depId]/route.ts
@@ -1,0 +1,94 @@
+/**
+ * /api/operations/projects/[id]/dependencies/[depId]
+ *
+ * DELETE — remove a dependency edge. Defensive parentage check:
+ *          depId must belong to projectId (defense against deleting
+ *          another project's dependency edge by guessing the depId).
+ *          Audits operations_project_dependency_removed with full
+ *          payload_before for replay.
+ *
+ * No GET or PATCH endpoints — dependency edges are immutable in the
+ * UI: the only operations are add (POST on parent route) and remove
+ * (this DELETE). Editing rationale would require remove+add pair,
+ * which the UI can compose if needed.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { writeAuditLog } from '@/lib/audit/writeAuditLog';
+
+async function loadAuthorizedProject(projectId: string, userId: string) {
+  return prisma.operations_projects.findFirst({
+    where: { id: projectId, user_id: userId },
+  });
+}
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string; depId: string }> }
+) {
+  try {
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const user = await prisma.users.findFirst({
+      where: { email: { equals: userEmail, mode: 'insensitive' } },
+    });
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+
+    const { id: projectId, depId } = await params;
+    const project = await loadAuthorizedProject(projectId, user.id);
+    if (!project) return NextResponse.json({ error: 'Project not found' }, { status: 404 });
+
+    // Defensive parentage: dependency must belong to this project.
+    const existing = await prisma.operations_project_dependencies.findFirst({
+      where: { id: depId, project_id: projectId },
+    });
+    if (!existing) {
+      return NextResponse.json({ error: 'Dependency not found' }, { status: 404 });
+    }
+
+    // Hydrate target title for audit description.
+    const target = await prisma.operations_projects.findFirst({
+      where: { id: existing.depends_on_project_id, user_id: user.id },
+      select: { title: true },
+    });
+
+    await prisma.operations_project_dependencies.delete({ where: { id: depId } });
+
+    await writeAuditLog({
+      actor: {
+        user_id: user.id,
+        email: userEmail,
+        type: 'human_user',
+      },
+      action: {
+        type: 'operations_project_dependency_removed',
+        description: `Removed: ${project.title} ${existing.dependency_type} ${target?.title ?? existing.depends_on_project_id}`,
+      },
+      target: {
+        table: 'operations_project_dependencies',
+        id: existing.id,
+      },
+      payload: {
+        before: existing,
+        metadata: {
+          source_project_id: projectId,
+          source_project_title: project.title,
+          target_project_id: existing.depends_on_project_id,
+          target_project_title: target?.title ?? null,
+          dependency_type: existing.dependency_type,
+        },
+      },
+    });
+
+    return NextResponse.json({ deleted: true, id: existing.id });
+  } catch (error) {
+    console.error('[Dependency DELETE]', error);
+    return NextResponse.json(
+      { error: 'Failed to delete dependency', message: error instanceof Error ? error.message : 'unknown' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/operations/projects/[id]/dependencies/route.ts
+++ b/src/app/api/operations/projects/[id]/dependencies/route.ts
@@ -1,0 +1,240 @@
+/**
+ * /api/operations/projects/[id]/dependencies
+ *
+ * GET  — return the project's incoming AND outgoing dependency edges,
+ *        hydrated with the other endpoint's title + status. Both
+ *        directions returned in one call to minimize roundtrips for
+ *        the row's expanded view.
+ *
+ *        Response shape:
+ *          {
+ *            outgoing: HydratedDependency[],   // edges where THIS project is the source
+ *            incoming: InverseDependency[],     // edges where THIS project is the target
+ *          }
+ *
+ *        outgoing[i].depends_on_project_title is what THIS project is "blocked by".
+ *        incoming[i].project_title is what THIS project "blocks" or "informs", etc.
+ *
+ * POST — create a dependency edge. Validates:
+ *          - body.depends_on_project_id is present and is a different project
+ *            (DB CHECK enforces too; defense-in-depth)
+ *          - both source and target projects are owned by the user
+ *          - (source, target, type) is unique (pre-emptive 409)
+ *          - if type === 'blocks', cycle detection over existing blocks edges
+ *            (β: only blocks counts; informs/derived_from skip cycle check)
+ *        Audits operations_project_dependency_added.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { Prisma, ProjectDependencyType } from '@prisma/client';
+import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { writeAuditLog } from '@/lib/audit/writeAuditLog';
+import { buildAdjacency, dfsHasCycle } from '@/lib/operations/cycleDetection';
+
+const VALID_TYPES: ProjectDependencyType[] = ['blocks', 'informs', 'derived_from'];
+
+async function loadAuthorizedProject(projectId: string, userId: string) {
+  return prisma.operations_projects.findFirst({
+    where: { id: projectId, user_id: userId },
+  });
+}
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const user = await prisma.users.findFirst({
+      where: { email: { equals: userEmail, mode: 'insensitive' } },
+    });
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+
+    const { id: projectId } = await params;
+    const project = await loadAuthorizedProject(projectId, user.id);
+    if (!project) return NextResponse.json({ error: 'Project not found' }, { status: 404 });
+
+    // Outgoing: this project is the source. Hydrate target.
+    const outgoingRaw = await prisma.operations_project_dependencies.findMany({
+      where: { project_id: projectId },
+      orderBy: [{ dependency_type: 'asc' }, { created_at: 'asc' }],
+    });
+    const outgoingTargetIds = outgoingRaw.map((d) => d.depends_on_project_id);
+    const outgoingTargets = outgoingTargetIds.length > 0
+      ? await prisma.operations_projects.findMany({
+          where: { id: { in: outgoingTargetIds }, user_id: user.id },
+          select: { id: true, title: true, status: true },
+        })
+      : [];
+    const outgoingTargetMap = new Map(outgoingTargets.map((p) => [p.id, p]));
+    const outgoing = outgoingRaw.map((d) => ({
+      ...d,
+      depends_on_project_title: outgoingTargetMap.get(d.depends_on_project_id)?.title ?? '(unknown)',
+      depends_on_project_status: outgoingTargetMap.get(d.depends_on_project_id)?.status ?? 'unknown',
+    }));
+
+    // Incoming: this project is the target. Hydrate source.
+    const incomingRaw = await prisma.operations_project_dependencies.findMany({
+      where: { depends_on_project_id: projectId },
+      orderBy: [{ dependency_type: 'asc' }, { created_at: 'asc' }],
+    });
+    const incomingSourceIds = incomingRaw.map((d) => d.project_id);
+    const incomingSources = incomingSourceIds.length > 0
+      ? await prisma.operations_projects.findMany({
+          where: { id: { in: incomingSourceIds }, user_id: user.id },
+          select: { id: true, title: true, status: true },
+        })
+      : [];
+    const incomingSourceMap = new Map(incomingSources.map((p) => [p.id, p]));
+    const incoming = incomingRaw.map((d) => ({
+      ...d,
+      project_title: incomingSourceMap.get(d.project_id)?.title ?? '(unknown)',
+      project_status: incomingSourceMap.get(d.project_id)?.status ?? 'unknown',
+    }));
+
+    return NextResponse.json({ outgoing, incoming });
+  } catch (error) {
+    console.error('[Dependencies GET]', error);
+    return NextResponse.json(
+      { error: 'Failed to load dependencies', message: error instanceof Error ? error.message : 'unknown' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const user = await prisma.users.findFirst({
+      where: { email: { equals: userEmail, mode: 'insensitive' } },
+    });
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+
+    const { id: sourceId } = await params;
+    const source = await loadAuthorizedProject(sourceId, user.id);
+    if (!source) return NextResponse.json({ error: 'Source project not found' }, { status: 404 });
+
+    const body = await request.json();
+
+    if (typeof body.depends_on_project_id !== 'string' || body.depends_on_project_id.trim().length === 0) {
+      return NextResponse.json(
+        { error: 'Validation', field: 'depends_on_project_id', message: 'required' },
+        { status: 400 }
+      );
+    }
+    const targetId = body.depends_on_project_id.trim();
+
+    // Defense-in-depth: app-level rejection (DB CHECK rejects too).
+    if (targetId === sourceId) {
+      return NextResponse.json(
+        { error: 'Validation', field: 'depends_on_project_id', message: 'a project cannot depend on itself' },
+        { status: 400 }
+      );
+    }
+
+    if (!VALID_TYPES.includes(body.dependency_type)) {
+      return NextResponse.json(
+        { error: 'Validation', field: 'dependency_type', message: 'must be blocks, informs, or derived_from' },
+        { status: 400 }
+      );
+    }
+    const dependency_type = body.dependency_type as ProjectDependencyType;
+
+    const target = await loadAuthorizedProject(targetId, user.id);
+    if (!target) return NextResponse.json({ error: 'Target project not found' }, { status: 404 });
+
+    // Pre-emptive uniqueness check on (project_id, depends_on_project_id, dependency_type).
+    const existing = await prisma.operations_project_dependencies.findFirst({
+      where: {
+        project_id: sourceId,
+        depends_on_project_id: targetId,
+        dependency_type,
+      },
+    });
+    if (existing) {
+      return NextResponse.json(
+        { error: 'Duplicate', message: `this ${dependency_type} edge already exists` },
+        { status: 409 }
+      );
+    }
+
+    // β: cycle detection over `blocks` edges only. Mutual informs/derived_from
+    // are legitimate semantics; cycles allowed.
+    if (dependency_type === 'blocks') {
+      // Filter to user's own projects via relation predicate (cheap belt-and-
+      // suspenders; cascade FKs already guarantee no orphan-ownership rows).
+      const blocksEdges = await prisma.operations_project_dependencies.findMany({
+        where: {
+          dependency_type: 'blocks',
+          project: { user_id: user.id },
+        },
+        select: { project_id: true, depends_on_project_id: true },
+      });
+      const adj = buildAdjacency(blocksEdges);
+      if (dfsHasCycle(adj, sourceId, targetId)) {
+        return NextResponse.json(
+          {
+            error: 'Cycle',
+            field: 'depends_on_project_id',
+            message: `adding this blocks edge would create a cycle: "${target.title}" already depends (transitively) on "${source.title}"`,
+          },
+          { status: 400 }
+        );
+      }
+    }
+
+    const dependency = await prisma.operations_project_dependencies.create({
+      data: {
+        project_id: sourceId,
+        depends_on_project_id: targetId,
+        dependency_type,
+        rationale: typeof body.rationale === 'string' && body.rationale.trim().length > 0
+          ? body.rationale.trim()
+          : null,
+        created_by: userEmail,
+      },
+    });
+
+    await writeAuditLog({
+      actor: {
+        user_id: user.id,
+        email: userEmail,
+        type: 'human_user',
+      },
+      action: {
+        type: 'operations_project_dependency_added',
+        description: `${source.title} ${dependency_type} ${target.title}`,
+      },
+      target: {
+        table: 'operations_project_dependencies',
+        id: dependency.id,
+      },
+      payload: {
+        after: dependency,
+        metadata: {
+          source_project_id: sourceId,
+          source_project_title: source.title,
+          target_project_id: targetId,
+          target_project_title: target.title,
+          dependency_type,
+        },
+      },
+    });
+
+    return NextResponse.json({ dependency, isCreate: true }, { status: 201 });
+  } catch (error) {
+    console.error('[Dependencies POST]', error);
+    return NextResponse.json(
+      { error: 'Failed to create dependency', message: error instanceof Error ? error.message : 'unknown' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/components/workbench/operations/SectionD_ProjectBacklog.tsx
+++ b/src/components/workbench/operations/SectionD_ProjectBacklog.tsx
@@ -40,6 +40,11 @@ export default function SectionD_ProjectBacklog() {
   const [createSaving, setCreateSaving] = useState(false);
   const [createError, setCreateError] = useState<string | null>(null);
 
+  // Lifted target state for cross-row navigation. When a dependency in
+  // ProjectRow A is clicked, this is set to the target project's id;
+  // ProjectRow B's useEffect on isJumpTarget triggers scroll + expand.
+  const [targetProjectId, setTargetProjectId] = useState<string | null>(null);
+
   const fetchProjects = async () => {
     setLoading(true);
     setError(null);
@@ -285,8 +290,12 @@ export default function SectionD_ProjectBacklog() {
               key={p.id}
               project={p}
               entities={entities}
+              allProjects={projects}
               onUpdate={fetchProjects}
               onDelete={fetchProjects}
+              isJumpTarget={targetProjectId === p.id}
+              onClearTarget={() => setTargetProjectId(null)}
+              onJumpTo={setTargetProjectId}
             />
           ))}
         </div>

--- a/src/components/workbench/operations/projects/DependencyList.tsx
+++ b/src/components/workbench/operations/projects/DependencyList.tsx
@@ -1,0 +1,351 @@
+/**
+ * DependencyList — renders incoming + outgoing dependency edges for a project.
+ *
+ * Self-fetches via GET /api/operations/projects/[projectId]/dependencies on
+ * mount. ProjectRow renders <DependencyList projectId={...} onJumpTo={...} />
+ * and never needs to know about dependency state.
+ *
+ * Primary view: `blocks` edges only (institutional Bridgewater framing —
+ * blocks is the ordering constraint; informs/derived_from are advisory).
+ * Future "show advisory edges" toggle can reveal informs/derived_from in a
+ * faded sub-list.
+ *
+ * "+ add dependency" form: pick target project, pick type, optional rationale.
+ * If the type is `blocks`, server runs DFS cycle detection and may 400.
+ *
+ * Click on a dependency target → onJumpTo(targetProjectId) bubbles to
+ * SectionD_ProjectBacklog which scrolls + auto-expands the target row.
+ */
+
+'use client';
+
+import { useEffect, useState } from 'react';
+import type {
+  Dependency,
+  DependencyForm,
+  DependencyType,
+  HydratedDependency,
+  InverseDependency,
+  Project,
+} from './types';
+import { DEFAULT_DEPENDENCY_FORM, DEPENDENCY_TYPE_LABELS, DEPENDENCY_TYPE_DESCRIPTIONS } from './types';
+
+interface Props {
+  projectId: string;
+  /** All user projects (for the target dropdown). Excludes the current project. */
+  allProjects: Project[];
+  /** Callback to scroll + auto-expand the target row in SectionD. */
+  onJumpTo: (projectId: string) => void;
+}
+
+const DEPENDENCY_TYPES: DependencyType[] = ['blocks', 'informs', 'derived_from'];
+
+export default function DependencyList({ projectId, allProjects, onJumpTo }: Props) {
+  const [outgoing, setOutgoing] = useState<HydratedDependency[]>([]);
+  const [incoming, setIncoming] = useState<InverseDependency[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [showAdvisory, setShowAdvisory] = useState(false);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+
+  const [showCreate, setShowCreate] = useState(false);
+  const [createForm, setCreateForm] = useState<DependencyForm>(DEFAULT_DEPENDENCY_FORM);
+  const [createSaving, setCreateSaving] = useState(false);
+  const [createError, setCreateError] = useState<string | null>(null);
+
+  const fetchDependencies = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/operations/projects/${projectId}/dependencies`);
+      const body = await res.json();
+      if (!res.ok) {
+        setError(body?.message ?? body?.error ?? 'failed to load dependencies');
+        setOutgoing([]);
+        setIncoming([]);
+        return;
+      }
+      setOutgoing(body.outgoing ?? []);
+      setIncoming(body.incoming ?? []);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'failed to load dependencies');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchDependencies();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [projectId]);
+
+  const startCreate = () => {
+    setCreateForm(DEFAULT_DEPENDENCY_FORM);
+    setCreateError(null);
+    setShowCreate(true);
+  };
+
+  const cancelCreate = () => {
+    setShowCreate(false);
+    setCreateForm(DEFAULT_DEPENDENCY_FORM);
+    setCreateError(null);
+  };
+
+  const handleCreate = async () => {
+    setCreateSaving(true);
+    setCreateError(null);
+    try {
+      const res = await fetch(`/api/operations/projects/${projectId}/dependencies`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(createForm),
+      });
+      const body = await res.json();
+      if (!res.ok) {
+        setCreateError(body?.message ?? body?.error ?? 'failed to create');
+        return;
+      }
+      cancelCreate();
+      fetchDependencies();
+    } catch (e) {
+      setCreateError(e instanceof Error ? e.message : 'failed to create');
+    } finally {
+      setCreateSaving(false);
+    }
+  };
+
+  const handleDelete = async (depId: string) => {
+    if (!confirm('Remove this dependency edge?')) return;
+    setDeletingId(depId);
+    setError(null);
+    try {
+      const res = await fetch(
+        `/api/operations/projects/${projectId}/dependencies/${depId}`,
+        { method: 'DELETE' }
+      );
+      const body = await res.json();
+      if (!res.ok) {
+        setError(body?.message ?? body?.error ?? 'failed to delete');
+        return;
+      }
+      fetchDependencies();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'failed to delete');
+    } finally {
+      setDeletingId(null);
+    }
+  };
+
+  const inputClass =
+    'w-full px-2 py-1 border border-border rounded text-xs font-mono text-text-primary focus:outline-none focus:border-brand-purple';
+  const labelClass = 'text-text-faint uppercase tracking-wide mb-1 text-xs font-mono';
+
+  // Filter to blocks-only by default; show advisory edges only when toggled.
+  const outgoingBlocks = outgoing.filter((d) => d.dependency_type === 'blocks');
+  const outgoingAdvisory = outgoing.filter((d) => d.dependency_type !== 'blocks');
+  const incomingBlocks = incoming.filter((d) => d.dependency_type === 'blocks');
+  const incomingAdvisory = incoming.filter((d) => d.dependency_type !== 'blocks');
+
+  // Exclude self from target dropdown.
+  const targetCandidates = allProjects.filter((p) => p.id !== projectId);
+
+  const renderEdgeRow = (
+    dep: HydratedDependency | InverseDependency,
+    direction: 'outgoing' | 'incoming'
+  ) => {
+    const isOutgoing = direction === 'outgoing';
+    const linkedTitle = isOutgoing
+      ? (dep as HydratedDependency).depends_on_project_title
+      : (dep as InverseDependency).project_title;
+    const linkedStatus = isOutgoing
+      ? (dep as HydratedDependency).depends_on_project_status
+      : (dep as InverseDependency).project_status;
+    const linkedId = isOutgoing
+      ? dep.depends_on_project_id
+      : dep.project_id;
+
+    return (
+      <div
+        key={dep.id}
+        className="flex items-center justify-between gap-2 py-1 px-2 hover:bg-bg-row rounded"
+      >
+        <div className="flex items-center gap-2 min-w-0 flex-1">
+          <span className="text-text-faint">▸</span>
+          <button
+            type="button"
+            onClick={(e) => { e.stopPropagation(); onJumpTo(linkedId); }}
+            className="text-brand-purple hover:underline truncate text-left"
+            title={`Jump to ${linkedTitle}`}
+          >
+            {linkedTitle}
+          </button>
+          <span className="text-text-muted text-xs">({linkedStatus.replace(/_/g, ' ')})</span>
+          {dep.dependency_type !== 'blocks' && (
+            <span className="text-text-faint italic text-xs">
+              {DEPENDENCY_TYPE_LABELS[dep.dependency_type]}
+            </span>
+          )}
+          {dep.rationale && (
+            <span className="text-text-muted truncate" title={dep.rationale}>
+              — {dep.rationale}
+            </span>
+          )}
+        </div>
+        {isOutgoing && (
+          <button
+            type="button"
+            onClick={(e) => { e.stopPropagation(); handleDelete(dep.id); }}
+            disabled={deletingId === dep.id}
+            className="px-1.5 py-0.5 border border-red-300 text-red-700 rounded hover:bg-red-50 disabled:opacity-50 text-xs"
+            title="Remove this dependency"
+          >
+            {deletingId === dep.id ? '…' : '×'}
+          </button>
+        )}
+      </div>
+    );
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <div className="text-xs font-mono text-text-muted">
+          {outgoingBlocks.length + incomingBlocks.length} blocks edges
+          {(outgoingAdvisory.length + incomingAdvisory.length > 0) && (
+            <>, {outgoingAdvisory.length + incomingAdvisory.length} advisory</>
+          )}
+        </div>
+        <div className="flex items-center gap-2">
+          {(outgoingAdvisory.length > 0 || incomingAdvisory.length > 0) && (
+            <button
+              type="button"
+              onClick={(e) => { e.stopPropagation(); setShowAdvisory((x) => !x); }}
+              className="px-2 py-1 border border-border rounded text-xs font-mono hover:bg-bg-row"
+            >
+              {showAdvisory ? 'hide advisory' : 'show advisory'}
+            </button>
+          )}
+          {!showCreate && (
+            <button
+              type="button"
+              onClick={(e) => { e.stopPropagation(); startCreate(); }}
+              disabled={targetCandidates.length === 0}
+              className="px-2 py-1 border border-brand-purple bg-brand-purple text-white rounded text-xs font-mono hover:opacity-90 disabled:opacity-50"
+            >
+              + add dependency
+            </button>
+          )}
+        </div>
+      </div>
+
+      {error && (
+        <div className="text-xs font-mono px-3 py-2 rounded border bg-red-50 border-red-200 text-red-800">
+          {error}
+        </div>
+      )}
+
+      {showCreate && (
+        <div className="border border-brand-purple rounded p-3 bg-purple-50/30 text-xs font-mono space-y-3">
+          <div className="font-bold text-text-primary">new dependency</div>
+          {createError && (
+            <div className="px-3 py-2 rounded border bg-red-50 border-red-200 text-red-800">
+              {createError}
+            </div>
+          )}
+          <div>
+            <div className={labelClass}>target project</div>
+            <select
+              value={createForm.depends_on_project_id}
+              onChange={(e) => setCreateForm({ ...createForm, depends_on_project_id: e.target.value })}
+              className={inputClass}
+            >
+              <option value="">— select —</option>
+              {targetCandidates.map((p) => (
+                <option key={p.id} value={p.id}>
+                  {p.title}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <div className={labelClass}>type</div>
+            <select
+              value={createForm.dependency_type}
+              onChange={(e) =>
+                setCreateForm({ ...createForm, dependency_type: e.target.value as DependencyType })
+              }
+              className={inputClass}
+            >
+              {DEPENDENCY_TYPES.map((t) => (
+                <option key={t} value={t}>
+                  {DEPENDENCY_TYPE_LABELS[t]}
+                </option>
+              ))}
+            </select>
+            <div className="text-text-muted text-xs italic mt-1">
+              {DEPENDENCY_TYPE_DESCRIPTIONS[createForm.dependency_type]}
+            </div>
+          </div>
+          <div>
+            <div className={labelClass}>rationale (optional)</div>
+            <textarea
+              value={createForm.rationale}
+              onChange={(e) => setCreateForm({ ...createForm, rationale: e.target.value })}
+              rows={2}
+              className={inputClass}
+              placeholder="why does this dependency exist?"
+            />
+          </div>
+          <div className="flex items-center gap-2 pt-2 border-t border-border-light">
+            <button
+              type="button"
+              onClick={handleCreate}
+              disabled={createSaving}
+              className="px-3 py-1 border border-brand-purple bg-brand-purple text-white rounded hover:opacity-90 disabled:opacity-50"
+            >
+              {createSaving ? 'creating…' : 'add dependency'}
+            </button>
+            <button
+              type="button"
+              onClick={cancelCreate}
+              disabled={createSaving}
+              className="px-3 py-1 border border-border rounded hover:bg-bg-row disabled:opacity-50"
+            >
+              cancel
+            </button>
+          </div>
+        </div>
+      )}
+
+      {loading ? (
+        <div className="text-xs font-mono text-text-muted">loading dependencies…</div>
+      ) : outgoingBlocks.length === 0 && incomingBlocks.length === 0 && (!showAdvisory || (outgoingAdvisory.length === 0 && incomingAdvisory.length === 0)) ? (
+        <div className="text-xs font-mono text-text-muted italic">
+          no dependencies yet — click "+ add dependency" to link this project to others.
+        </div>
+      ) : (
+        <>
+          {(outgoingBlocks.length > 0 || (showAdvisory && outgoingAdvisory.length > 0)) && (
+            <div>
+              <div className={labelClass}>blocked by (this project depends on)</div>
+              <div className="space-y-0.5">
+                {outgoingBlocks.map((d) => renderEdgeRow(d, 'outgoing'))}
+                {showAdvisory && outgoingAdvisory.map((d) => renderEdgeRow(d, 'outgoing'))}
+              </div>
+            </div>
+          )}
+
+          {(incomingBlocks.length > 0 || (showAdvisory && incomingAdvisory.length > 0)) && (
+            <div>
+              <div className={labelClass}>blocks (other projects depend on this)</div>
+              <div className="space-y-0.5">
+                {incomingBlocks.map((d) => renderEdgeRow(d, 'incoming'))}
+                {showAdvisory && incomingAdvisory.map((d) => renderEdgeRow(d, 'incoming'))}
+              </div>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/workbench/operations/projects/ProjectRow.tsx
+++ b/src/components/workbench/operations/projects/ProjectRow.tsx
@@ -16,10 +16,11 @@
 
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type { Project, ProjectForm, ProjectStatus } from './types';
 import { STATUS_LABELS, STATUS_PILL_CLASSES } from './types';
 import TaskList from './TaskList';
+import DependencyList from './DependencyList';
 
 interface Entity {
   id: string;
@@ -29,8 +30,15 @@ interface Entity {
 interface Props {
   project: Project;
   entities: Entity[];
+  allProjects: Project[];
   onUpdate: () => void;
   onDelete: () => void;
+  /** When true, the row scrolls into view and auto-expands. */
+  isJumpTarget: boolean;
+  /** Called by SectionD to clear targetProjectId after the jump animates. */
+  onClearTarget: () => void;
+  /** Called when the user clicks a dependency link inside this row. */
+  onJumpTo: (projectId: string) => void;
 }
 
 const STATUS_OPTIONS: ProjectStatus[] = [
@@ -69,13 +77,34 @@ function entityName(entities: Entity[], entityId: string): string {
   return entities.find((e) => e.id === entityId)?.name ?? entityId;
 }
 
-export default function ProjectRow({ project, entities, onUpdate, onDelete }: Props) {
+export default function ProjectRow({ project, entities, allProjects, onUpdate, onDelete, isJumpTarget, onClearTarget, onJumpTo }: Props) {
   const [expanded, setExpanded] = useState(false);
   const [editing, setEditing] = useState(false);
   const [form, setForm] = useState<ProjectForm>(() => projectToForm(project));
   const [saving, setSaving] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [flash, setFlash] = useState(false);
+  const rowRef = useRef<HTMLDivElement>(null);
+
+  // When SectionD sets isJumpTarget=true on this row, scroll into view,
+  // auto-expand, flash highlight for ~1.5s, then clear the target so the
+  // same dependency click can re-trigger.
+  useEffect(() => {
+    if (!isJumpTarget) return;
+    rowRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    setExpanded(true);
+    setFlash(true);
+    const t1 = setTimeout(() => setFlash(false), 1500);
+    const t2 = setTimeout(() => onClearTarget(), 1600);
+    return () => {
+      clearTimeout(t1);
+      clearTimeout(t2);
+    };
+    // onClearTarget is intentionally omitted — it's a stable ref from SectionD;
+    // including it would re-trigger the effect on every parent render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isJumpTarget]);
 
   const enterEdit = () => {
     setForm(projectToForm(project));
@@ -137,7 +166,13 @@ export default function ProjectRow({ project, entities, onUpdate, onDelete }: Pr
   const pillClass = `inline-block px-2 py-0.5 border rounded text-xs font-mono ${STATUS_PILL_CLASSES[project.status]}`;
 
   return (
-    <div className="border border-border rounded bg-white">
+    <div
+      ref={rowRef}
+      className={
+        'border rounded bg-white transition-colors ' +
+        (flash ? 'border-brand-purple shadow-md' : 'border-border')
+      }
+    >
       <div
         className="flex items-center justify-between px-4 py-2 cursor-pointer hover:bg-bg-row text-xs font-mono"
         onClick={() => !editing && setExpanded((x) => !x)}
@@ -174,6 +209,14 @@ export default function ProjectRow({ project, entities, onUpdate, onDelete }: Pr
           <div className="pt-2 border-t border-border-light">
             <div className={labelClass}>5 · execute (tasks)</div>
             <TaskList projectId={project.id} />
+          </div>
+          <div className="pt-2 border-t border-border-light">
+            <div className={labelClass}>6 · dependencies</div>
+            <DependencyList
+              projectId={project.id}
+              allProjects={allProjects}
+              onJumpTo={onJumpTo}
+            />
           </div>
           <div className="grid grid-cols-2 gap-4 pt-2 border-t border-border-light">
             <div>

--- a/src/components/workbench/operations/projects/types.ts
+++ b/src/components/workbench/operations/projects/types.ts
@@ -175,3 +175,72 @@ export const TASK_STATUS_PILL_CLASSES: Record<TaskStatus, string> = {
   completed: 'bg-green-50 text-green-800 border-green-300',
   cancelled: 'bg-gray-50 text-gray-500 border-gray-200',
 };
+
+/**
+ * ============================================================================
+ * Dependencies (PR-Ops-3c) — Project-to-project edges. Three types:
+ *   - blocks: source can't complete until target completes (acyclic constraint;
+ *     cycle detection enforced server-side via DFS over blocks-only graph)
+ *   - informs: source should reference target (advisory; mutual cycles allowed)
+ *   - derived_from: source's design originated from target (advisory; cycles
+ *     describe mislabeling, not a logic bug)
+ * ============================================================================
+ */
+
+export type DependencyType = 'blocks' | 'informs' | 'derived_from';
+
+export interface Dependency {
+  id: string;
+  project_id: string;
+  depends_on_project_id: string;
+  dependency_type: DependencyType;
+  rationale: string | null;
+  created_at: string;
+  created_by: string | null;
+}
+
+/**
+ * Hydrated dependency for UI rendering — joins the target project's
+ * title for display ("blocked by: Trading Pipeline and MVP").
+ * Returned by GET endpoint, never written by client.
+ */
+export interface HydratedDependency extends Dependency {
+  depends_on_project_title: string;
+  depends_on_project_status: string;
+}
+
+/**
+ * Inverse direction: when a project is the TARGET of someone else's
+ * dependency edge, the UI shows it as "this project blocks: X".
+ */
+export interface InverseDependency extends Dependency {
+  project_title: string;
+  project_status: string;
+}
+
+/**
+ * Form-side shape for creating a dependency.
+ */
+export interface DependencyForm {
+  depends_on_project_id: string;
+  dependency_type: DependencyType;
+  rationale: string;
+}
+
+export const DEFAULT_DEPENDENCY_FORM: DependencyForm = {
+  depends_on_project_id: '',
+  dependency_type: 'blocks',
+  rationale: '',
+};
+
+export const DEPENDENCY_TYPE_LABELS: Record<DependencyType, string> = {
+  blocks: 'blocks',
+  informs: 'informs',
+  derived_from: 'derived from',
+};
+
+export const DEPENDENCY_TYPE_DESCRIPTIONS: Record<DependencyType, string> = {
+  blocks: 'this project cannot complete until the target completes (hard ordering)',
+  informs: 'this project should reference the target (advisory, mutual cycles allowed)',
+  derived_from: "this project's design originated from the target (lineage)",
+};

--- a/src/lib/operations/cycleDetection.ts
+++ b/src/lib/operations/cycleDetection.ts
@@ -1,0 +1,88 @@
+/**
+ * Cycle detection for the operations_project_dependencies graph.
+ *
+ * Pure function — no DB access, no side effects. Takes a precomputed
+ * adjacency map and returns whether adding a proposed edge would create
+ * a cycle.
+ *
+ * Used only for `blocks`-typed edges (PR-Ops-3c, β). Advisory edges
+ * (informs, derived_from) skip cycle detection because mutual cross-
+ * reference is a legitimate semantic for them. Only `blocks` is a strict
+ * acyclic ordering constraint.
+ *
+ * Algorithm: iterative DFS from the proposed target. If the search
+ * reaches the proposed source, the new edge would close a cycle.
+ * Visited Set prevents infinite loops in pre-existing (legitimate by
+ * being non-blocks, but theoretically possible if data was inserted
+ * raw) cycle data.
+ *
+ * Complexity: O(V + E) where V = projects, E = blocks edges. At
+ * single-user scale (≤200 projects per recon), trivially fast.
+ *
+ * Extracted from API route handler so it can be:
+ *   1. Tested in isolation
+ *   2. Reused by the priority engine (PR-Ops-4) for topological sort
+ *   3. Reasoned about without auth/Prisma context noise
+ */
+
+export interface DependencyEdge {
+  project_id: string;
+  depends_on_project_id: string;
+}
+
+/**
+ * Build adjacency map from a flat edge list.
+ * adj[X] = list of project IDs that X "blocks" (i.e., X depends on them
+ * in the sense "X cannot complete until those are done").
+ *
+ * In the schema: `project_id blocks depends_on_project_id` means project_id
+ * is the source and depends_on_project_id is the prerequisite. So the
+ * adjacency from a project's perspective is "this project's prerequisites".
+ */
+export function buildAdjacency(edges: DependencyEdge[]): Map<string, string[]> {
+  const adj = new Map<string, string[]>();
+  for (const e of edges) {
+    if (!adj.has(e.project_id)) adj.set(e.project_id, []);
+    adj.get(e.project_id)!.push(e.depends_on_project_id);
+  }
+  return adj;
+}
+
+/**
+ * Returns true if adding edge (sourceId → targetId) to the existing graph
+ * would create a cycle.
+ *
+ * Logic: a cycle exists iff `targetId` can already reach `sourceId` via
+ * existing edges. If so, adding sourceId → targetId closes the loop.
+ *
+ * @param adj   Pre-built adjacency map (from buildAdjacency).
+ * @param sourceId   Proposed edge source (the project that will "block on" target).
+ * @param targetId   Proposed edge target (the prerequisite project).
+ * @returns true if the edge would create a cycle, false otherwise.
+ */
+export function dfsHasCycle(
+  adj: Map<string, string[]>,
+  sourceId: string,
+  targetId: string
+): boolean {
+  // Edge case: self-loop. DB CHECK rejects it, but defense-in-depth.
+  if (sourceId === targetId) return true;
+
+  const visited = new Set<string>();
+  const stack: string[] = [targetId];
+
+  while (stack.length > 0) {
+    const node = stack.pop()!;
+    if (node === sourceId) return true;
+    if (visited.has(node)) continue;
+    visited.add(node);
+    const neighbors = adj.get(node);
+    if (neighbors) {
+      for (const next of neighbors) {
+        if (!visited.has(next)) stack.push(next);
+      }
+    }
+  }
+
+  return false;
+}


### PR DESCRIPTION
Ships the dependency graph layer of the projects/tasks/dependencies trio. Dependencies live inside their parent project's expanded view as "6 · dependencies" — alongside "5 · execute (tasks)" from PR-Ops-3b. This completes the project-scoping surface; PR-Ops-4 (priority engine) consumes the graph for ranking.

New module: src/lib/operations/cycleDetection.ts
  Pure DFS module — no DB, no side effects. Two functions:
    buildAdjacency(edges) — constructs Map<string, string[]> from a
      flat dependency edge list.
    dfsHasCycle(adj, sourceId, targetId) — iterative DFS from
      targetId; returns true if sourceId is reachable from targetId
      (i.e., adding sourceId → targetId would close a cycle).
  Visited Set guards against infinite loops on pre-existing legitimate
  cycle data. Self-loop edge case handled defensively even though DB
  CHECK rejects it.
  Extracted from API route handler so it is:
    1. Testable in isolation
    2. Reusable by the priority engine (PR-Ops-4) for topological sort
    3. Reasoned about without auth/Prisma context noise

New endpoints:

  GET  /api/operations/projects/[id]/dependencies
    Returns { outgoing: HydratedDependency[], incoming: InverseDependency[] }.
    Outgoing = edges where THIS project is the source ("blocked by"
    relationship from this project's perspective).
    Incoming = edges where THIS project is the target ("this project
    blocks" relationship from this project's perspective).
    Both directions hydrated with the other endpoint's title and
    status via Map-based join (two findMany calls; cheap at scale).

  POST /api/operations/projects/[id]/dependencies
    Body: { depends_on_project_id, dependency_type, rationale? }.
    Validation order:
      - body.depends_on_project_id present
      - target ≠ source (defense-in-depth alongside DB CHECK) - dependency_type ∈ { blocks, informs, derived_from } - source project owned by user (loaded by parent route param) - target project owned by user (loaded explicitly) - (source, target, type) tuple not already present (pre-emptive 409 even though @@unique would reject) - β: cycle detection IF type === 'blocks': Filter operations_project_dependencies to user's blocks edges only via relation predicate `where: { dependency_type: 'blocks', project: { user_id: user.id } }`. Build adjacency map. DFS from target_id. If source_id is reachable, reject with 400 ("adding this blocks edge would create a cycle: ${target.title} already depends transitively on ${source.title}"). - informs and derived_from skip cycle detection — these are advisory edge types where mutual cross-reference is a legitimate semantic. Cycles in informs describe coupled-domain projects (e.g., "Tax-loss harvesting" informs "Year-end rebalance" and vice versa); cycles in derived_from describe lineage mislabeling but no execution deadlock. Audits operations_project_dependency_added with both project titles in metadata for replay context.

  DELETE /api/operations/projects/[id]/dependencies/[depId]
    Defensive parentage check: depId must belong to projectId (prevents cross-project edge deletion via guessed depId). Hydrates target title BEFORE delete (otherwise the row is gone and audit description loses context). Hard delete with full payload_before captured. Audits operations_project_dependency_removed with full metadata.

    No GET or PATCH endpoints — dependency edges are write-once- delete in MVP scope. Editing a rationale would require remove+add pair; UI can compose if needed.

Types module (types.ts append):
  - DependencyType (3-value union: blocks/informs/derived_from)
  - Dependency (1:1 mirror of operations_project_dependencies)
  - HydratedDependency (extends Dependency with target title + status, returned by GET for outgoing edges)
  - InverseDependency (extends Dependency with source title + status, returned by GET for incoming edges)
  - DependencyForm (writable fields only)
  - DEFAULT_DEPENDENCY_FORM (defaults type to 'blocks' — institutional default; most semantically meaningful edge type)
  - DEPENDENCY_TYPE_LABELS, DEPENDENCY_TYPE_DESCRIPTIONS (UI metadata with plain-English semantics for the type dropdown)

New component: DependencyList.tsx
  Self-contained component that takes projectId + allProjects + onJumpTo
  callback. Self-fetches via GET /api/operations/projects/[id]/dependencies
  on mount. Renders blocks-only primary view ("blocked by:" + "blocks:"
  sub-lists) with optional "show advisory" toggle revealing informs/
  derived_from in the same lists when present. "+ add dependency" inline
  form with target dropdown (excludes self), type dropdown (with
  description helper text), and optional rationale.
  Click on a target title → onJumpTo(targetId) bubbles to SectionD,
  which lifts targetProjectId state and triggers the row's scroll +
  auto-expand pattern.
  Delete via × button on outgoing edges only (incoming edges are
  owned by the OTHER project and must be deleted from there).
  e.stopPropagation() on every action button to prevent the
  containing ProjectRow's click-to-collapse from firing.

ProjectRow.tsx modifications:
  - Combined `useEffect, useRef, useState` import (replaces solo useState).
  - New import: DependencyList.
  - Props interface extended with allProjects + isJumpTarget + onClearTarget + onJumpTo (4 new props).
  - rowRef + flash state added.
  - useEffect([isJumpTarget]) triggers: scrollIntoView(smooth, center) + setExpanded(true) + setFlash(true) for 1500ms + onClearTarget() at 1600ms. onClearTarget intentionally omitted from deps (stable parent ref; including it would re-trigger on every parent render).
  - Outer container gains ref={rowRef} + conditional flash class (border-brand-purple + shadow-md when flashing; border-border otherwise; transition-colors makes the flash smooth).
  - New "6 · dependencies" block inserted between "5 · execute (tasks)" and est minutes/cost grid, rendering <DependencyList projectId={...} allProjects={...} onJumpTo={...} />.
  - All other code byte-identical to PR-Ops-3b's ProjectRow.

SectionD_ProjectBacklog.tsx modifications:
  - New targetProjectId state lifted from ProjectRow.
  - <ProjectRow> render call passes 4 new props: allProjects={projects} isJumpTarget={targetProjectId === p.id} onClearTarget={() => setTargetProjectId(null)} onJumpTo={setTargetProjectId}
  - All other code byte-identical to prior PRs.

Architectural decisions (locked, institutional):
  - β cycle scope: only blocks edges count for cycle detection. informs/derived_from are advisory metadata where mutual cycles are legitimate. Bridgewater "constraint vs context" framing.
  - Dual-endpoint ownership: server verifies user owns BOTH source and target projects on POST. No user_id column on dependencies table — denormalization-avoidance via cascade FKs.
  - α UI scope: dependencies render INSIDE ProjectRow as section 6, not as a separate top-level graph viewer. Spatial truth: tasks and edges both belong to the project. Top-level graph viz is PR-Ops-4 priority dashboard, not duplicate work here.
  - δ cross-row navigation: imperative ref-based scrollIntoView + lifted targetProjectId state. No URL hash, no back-button noise. Flash highlight animation co-located with scroll for natural state flow.

Pattern conventions (institutional, mirroring PR-Ops-3a/3b):
  - All endpoints follow the auth precedent: inline getVerifiedEmail() + inline prisma.users.findFirst + sequential prisma + writeAuditLog awaits (NOT transactional — matches codebase convention).
  - loadAuthorizedProject helper deduplicates the (id, user_id) check.
  - Cycle detection extracted to pure function for testability + reuse in PR-Ops-4 priority engine topological sort.
  - Audit metadata captures both endpoint project titles for replay context — future audit replay can reconstruct relationships without re-joining to projects table.

Verification:
  - prisma generate: no schema changes (operations_project_dependencies landed in PR-Ops-1)
  - tsc --noEmit: exit 0, zero errors
  - Both dependency audit action types (added, removed) verified present in AuditActionType (PR-Ops-1) and in SUBSYSTEM_ACTION_TYPES.operations_ static map at /api/audit-log/route.ts (PR-Ops-2a-fix2).

Smoke test plan post-merge:
  1. Open Project A (e.g., "Sign up for Cal State LA"). Expand row → new "6 · dependencies" section visible below "5 · execute (tasks)" with "0 blocks edges" header and empty-state copy.
  2. Click "+ add dependency". Inline form appears with target dropdown showing 4 other projects (self excluded), type dropdown defaulting to "blocks" with description "this project cannot complete until the target completes (hard ordering)", optional rationale.
  3. Pick target = "Taxes - File Taxes (Personal)", type = blocks, rationale = "FAFSA needs clean tax returns". Click "add dependency".
  4. Edge appears in "blocked by:" sub-list with "Taxes - File Taxes (Personal) (not started)" target title and rationale visible.
  5. Open Project B = "Taxes - File Taxes (Personal)". Expand → "6 · dependencies" shows "blocks (other projects depend on this): Sign up for Cal State LA (not started)" in incoming list.
  6. Try to add the inverse edge: B blocks A. Click "+ add dependency" in B's row, target = "Sign up for Cal State LA", type = blocks. Click "add dependency". Server returns 400 with message: "adding this blocks edge would create a cycle: 'Sign up for Cal State LA' already depends (transitively) on 'Taxes - File Taxes (Personal)'".
  7. Now try the same inverse but with type = informs. Click again, type = informs, save. Succeeds — informs cycles allowed.
  8. From Project A, click "Taxes - File Taxes (Personal)" link in the "blocked by:" list. Page scrolls smoothly, Project B's row auto-expands, border flashes purple for 1.5s.
  9. Click × delete on Project A's outgoing blocks edge. Confirm prompt appears. Confirm → edge disappears from both A's outgoing and B's incoming lists.
 10. Audit Tail (Section K) shows new rows in chain order:
      - operations_project_dependency_added (A blocks B) - operations_project_dependency_added (B informs A) - operations_project_dependency_removed (A blocks B) Each with both project titles in metadata. content_hash chain intact.

Rollback: pure additive PR. Revert by reverting the merge commit. Removes the "6 · dependencies" block from ProjectRow's expanded view; the dependency endpoints become unreachable but cause no errors. No data loss; existing operations_project_dependencies rows persist (orphan from UI perspective, fully readable via psql).

Known scope deferrals (intentional, not bugs):
  - PATCH on dependency edges (rationale editing): defer; UI can compose remove+add if needed.
  - Bulk add/remove dependency operations: defer.
  - Top-level graph visualization: deliberately not built; PR-Ops-4 ships the priority dashboard which is the canonical "see the whole graph" surface.
  - Priority scoring (priority_score on tasks/projects): PR-Ops-4.