### PR TITLE
PR-Ops-5: routines (Section E) — cadence-driven execution layer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "react-leaflet": "^5.0.0",
         "react-plaid-link": "^3.6.1",
         "recharts": "^3.7.0",
+        "rrule": "^2.8.1",
         "stripe": "^20.3.0",
         "uuid": "^13.0.0",
         "xai-sdk": "^1.0.0-alpha.0"
@@ -12069,6 +12070,15 @@
         "@rolldown/binding-win32-arm64-msvc": "1.0.0-beta.35",
         "@rolldown/binding-win32-ia32-msvc": "1.0.0-beta.35",
         "@rolldown/binding-win32-x64-msvc": "1.0.0-beta.35"
+      }
+    },
+    "node_modules/rrule": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/rrule/-/rrule-2.8.1.tgz",
+      "integrity": "sha512-hM3dHSBMeaJ0Ktp7W38BJZ7O1zOgaFEsn41PDk+yHoEtfLV+PoJt9E9xAlZiWgf/iqEqionN0ebHFZIDAp+iGw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/run-parallel": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "react-leaflet": "^5.0.0",
     "react-plaid-link": "^3.6.1",
     "recharts": "^3.7.0",
+    "rrule": "^2.8.1",
     "stripe": "^20.3.0",
     "uuid": "^13.0.0",
     "xai-sdk": "^1.0.0-alpha.0"

--- a/src/app/api/operations/routines/[id]/completions/route.ts
+++ b/src/app/api/operations/routines/[id]/completions/route.ts
@@ -1,0 +1,155 @@
+/**
+ * /api/operations/routines/[id]/completions
+ *
+ * POST — record a completion. Body: { expected_at, completed_at?, notes? }.
+ *        If completed_at is omitted, defaults to NOW.
+ *        Computes delta_minutes = (completed_at - expected_at) / 60000.
+ *        Inserts completion row. Updates parent routine: last_completed_at,
+ *        increments consecutive_completion_streak, zeros consecutive_miss_streak,
+ *        recomputes next_due_at.
+ *        Audits operations_routine_completed.
+ *
+ *        @@unique([routine_id, expected_at]) prevents duplicate completions
+ *        for the same expected occurrence; returns 409 on retry.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { writeAuditLog } from '@/lib/audit/writeAuditLog';
+import { expandForward } from '@/lib/operations/rruleHelpers';
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const user = await prisma.users.findFirst({
+      where: { email: { equals: userEmail, mode: 'insensitive' } },
+    });
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+
+    const { id: routineId } = await params;
+    const routine = await prisma.operations_routines.findFirst({
+      where: { id: routineId, user_id: user.id },
+    });
+    if (!routine) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+
+    const body = await request.json();
+
+    if (typeof body.expected_at !== 'string' || body.expected_at.length === 0) {
+      return NextResponse.json(
+        { error: 'Validation', field: 'expected_at', message: 'required (ISO timestamp)' },
+        { status: 400 }
+      );
+    }
+    const expectedAt = new Date(body.expected_at);
+    if (Number.isNaN(expectedAt.getTime())) {
+      return NextResponse.json(
+        { error: 'Validation', field: 'expected_at', message: 'invalid ISO timestamp' },
+        { status: 400 }
+      );
+    }
+
+    const completedAt = typeof body.completed_at === 'string' && body.completed_at.length > 0
+      ? new Date(body.completed_at)
+      : new Date();
+    if (Number.isNaN(completedAt.getTime())) {
+      return NextResponse.json(
+        { error: 'Validation', field: 'completed_at', message: 'invalid ISO timestamp' },
+        { status: 400 }
+      );
+    }
+
+    const deltaMinutes = Math.round((completedAt.getTime() - expectedAt.getTime()) / 60000);
+
+    const notes = typeof body.notes === 'string' && body.notes.trim().length > 0
+      ? body.notes.trim()
+      : null;
+
+    // Pre-emptive uniqueness check on (routine_id, expected_at).
+    const existing = await prisma.operations_routine_completions.findUnique({
+      where: {
+        routine_id_expected_at: {
+          routine_id: routineId,
+          expected_at: expectedAt,
+        },
+      },
+    });
+    if (existing) {
+      return NextResponse.json(
+        { error: 'Duplicate', message: 'a completion already exists for this expected occurrence' },
+        { status: 409 }
+      );
+    }
+
+    const completion = await prisma.operations_routine_completions.create({
+      data: {
+        routine_id: routineId,
+        user_id: user.id,
+        expected_at: expectedAt,
+        completed_at: completedAt,
+        delta_minutes: deltaMinutes,
+        notes,
+      },
+    });
+
+    // Recompute next_due_at: next occurrence after completedAt.
+    let nextDueAt: Date | null = null;
+    try {
+      const upcoming = expandForward(routine.schedule_rrule, routine.timezone, completedAt, 1);
+      nextDueAt = upcoming[0] ?? null;
+    } catch (e) {
+      console.error('[Completion POST] next_due_at recompute failed', e);
+    }
+
+    // Update parent routine: completion streak +1, miss streak → 0,
+    // last_completed_at, next_due_at.
+    await prisma.operations_routines.update({
+      where: { id: routineId },
+      data: {
+        last_completed_at: completedAt,
+        next_due_at: nextDueAt,
+        consecutive_completion_streak: routine.consecutive_completion_streak + 1,
+        consecutive_miss_streak: 0,
+      },
+    });
+
+    await writeAuditLog({
+      actor: {
+        user_id: user.id,
+        email: userEmail,
+        type: 'human_user',
+      },
+      action: {
+        type: 'operations_routine_completed',
+        description: `Completed "${routine.name}" (Δ ${deltaMinutes} min)`,
+      },
+      target: {
+        table: 'operations_routine_completions',
+        id: completion.id,
+      },
+      payload: {
+        after: completion,
+        metadata: {
+          routine_id: routineId,
+          routine_name: routine.name,
+          expected_at: expectedAt.toISOString(),
+          completed_at: completedAt.toISOString(),
+          delta_minutes: deltaMinutes,
+        },
+      },
+    });
+
+    return NextResponse.json({ completion, isCreate: true }, { status: 201 });
+  } catch (error) {
+    console.error('[Completion POST]', error);
+    return NextResponse.json(
+      { error: 'Failed to record completion', message: error instanceof Error ? error.message : 'unknown' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/operations/routines/[id]/route.ts
+++ b/src/app/api/operations/routines/[id]/route.ts
@@ -1,0 +1,285 @@
+/**
+ * /api/operations/routines/[id]
+ *
+ * GET    — return one routine.
+ * PATCH  — update fields. Audit discriminates:
+ *            * is_active true→false → operations_routine_deactivated
+ *            * is_active false→true → operations_routine_updated
+ *              (no _reactivated enum exists in v0; document and reuse _updated)
+ *            * any change to schedule_rrule, timezone, fail_threshold_minutes →
+ *              recompute next_due_at via expandForward.
+ *            * everything else → operations_routine_updated
+ * DELETE — hard delete. Cascades to operations_routine_completions via FK.
+ *          Audits operations_routine_deleted with full payload_before.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { Prisma } from '@prisma/client';
+import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { writeAuditLog } from '@/lib/audit/writeAuditLog';
+import { compileFormToRRule, expandForward } from '@/lib/operations/rruleHelpers';
+import type { RoutineForm } from '@/components/workbench/operations/routines/types';
+
+async function loadAuthorizedRoutine(routineId: string, userId: string) {
+  return prisma.operations_routines.findFirst({
+    where: { id: routineId, user_id: userId },
+  });
+}
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const user = await prisma.users.findFirst({
+      where: { email: { equals: userEmail, mode: 'insensitive' } },
+    });
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+
+    const { id } = await params;
+    const routine = await loadAuthorizedRoutine(id, user.id);
+    if (!routine) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+
+    return NextResponse.json({ routine });
+  } catch (error) {
+    console.error('[Routine GET]', error);
+    return NextResponse.json(
+      { error: 'Failed to load routine', message: error instanceof Error ? error.message : 'unknown' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const user = await prisma.users.findFirst({
+      where: { email: { equals: userEmail, mode: 'insensitive' } },
+    });
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+
+    const { id } = await params;
+    const existing = await loadAuthorizedRoutine(id, user.id);
+    if (!existing) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+
+    const body = (await request.json()) as Partial<RoutineForm>;
+
+    const data: Prisma.operations_routinesUpdateInput = {};
+    let scheduleChanged = false;
+
+    if (body.name !== undefined) {
+      if (typeof body.name !== 'string' || body.name.trim().length === 0 || body.name.trim().length > 200) {
+        return NextResponse.json(
+          { error: 'Validation', field: 'name', message: 'required, max 200 chars' },
+          { status: 400 }
+        );
+      }
+      const trimmed = body.name.trim();
+      if (trimmed !== existing.name) {
+        // Pre-emptive uniqueness check.
+        const dup = await prisma.operations_routines.findFirst({
+          where: { user_id: user.id, name: trimmed, NOT: { id } },
+        });
+        if (dup) {
+          return NextResponse.json(
+            { error: 'Duplicate', field: 'name', message: 'a routine with this name already exists' },
+            { status: 409 }
+          );
+        }
+      }
+      data.name = trimmed;
+    }
+
+    if (body.description !== undefined) {
+      data.description = typeof body.description === 'string' && body.description.trim().length > 0
+        ? body.description.trim()
+        : null;
+    }
+
+    if (body.ideal_time_label !== undefined) {
+      data.ideal_time_label = typeof body.ideal_time_label === 'string' && body.ideal_time_label.trim().length > 0
+        ? body.ideal_time_label.trim()
+        : null;
+    }
+
+    if (body.fail_threshold_minutes !== undefined) {
+      const n = parseInt(String(body.fail_threshold_minutes), 10);
+      if (!Number.isInteger(n) || n < 0) {
+        return NextResponse.json(
+          { error: 'Validation', field: 'fail_threshold_minutes', message: 'must be a non-negative integer' },
+          { status: 400 }
+        );
+      }
+      data.fail_threshold_minutes = n;
+    }
+
+    if (body.timezone !== undefined) {
+      if (typeof body.timezone !== 'string' || body.timezone.trim().length === 0) {
+        return NextResponse.json(
+          { error: 'Validation', field: 'timezone', message: 'required' },
+          { status: 400 }
+        );
+      }
+      data.timezone = body.timezone;
+      scheduleChanged = true;
+    }
+
+    // Recompile RRULE if any cadence-related field is supplied.
+    const cadenceFieldsPresent =
+      body.cadence_mode !== undefined ||
+      body.weekly_byday !== undefined ||
+      body.monthly_day_of_month !== undefined ||
+      body.monthly_nth !== undefined ||
+      body.monthly_weekday !== undefined ||
+      body.custom_rrule !== undefined ||
+      body.byhour !== undefined ||
+      body.byminute !== undefined;
+
+    if (cadenceFieldsPresent) {
+      try {
+        const compiled = compileFormToRRule(body as RoutineForm);
+        data.schedule_rrule = compiled;
+        scheduleChanged = true;
+      } catch (e) {
+        return NextResponse.json(
+          {
+            error: 'Validation',
+            field: 'schedule_rrule',
+            message: e instanceof Error ? e.message : 'invalid cadence configuration',
+          },
+          { status: 400 }
+        );
+      }
+    }
+
+    let activationToggle: 'deactivated' | 'reactivated' | null = null;
+    if (body.is_active !== undefined) {
+      const incoming = Boolean(body.is_active);
+      if (incoming !== existing.is_active) {
+        activationToggle = incoming ? 'reactivated' : 'deactivated';
+      }
+      data.is_active = incoming;
+    }
+
+    // If cadence/timezone changed, recompute next_due_at.
+    if (scheduleChanged) {
+      const nextRrule = (data.schedule_rrule as string | undefined) ?? existing.schedule_rrule;
+      const nextTz = (data.timezone as string | undefined) ?? existing.timezone;
+      try {
+        const upcoming = expandForward(nextRrule, nextTz, new Date(), 1);
+        data.next_due_at = upcoming[0] ?? null;
+      } catch (e) {
+        console.error('[Routine PATCH] next_due_at recompute failed', e);
+      }
+    }
+
+    const routine = await prisma.operations_routines.update({
+      where: { id },
+      data,
+    });
+
+    let actionType: 'operations_routine_deactivated' | 'operations_routine_updated';
+    let description: string;
+    if (activationToggle === 'deactivated') {
+      actionType = 'operations_routine_deactivated';
+      description = `Deactivated routine "${existing.name}"`;
+    } else {
+      // activationToggle === 'reactivated' OR no toggle: both audit as _updated
+      // in v0 (no _reactivated enum exists; future PR can add one for the
+      // priority engine to discriminate).
+      actionType = 'operations_routine_updated';
+      description = activationToggle === 'reactivated'
+        ? `Reactivated routine "${existing.name}"`
+        : `Updated routine "${existing.name}"`;
+    }
+
+    await writeAuditLog({
+      actor: {
+        user_id: user.id,
+        email: userEmail,
+        type: 'human_user',
+      },
+      action: { type: actionType, description },
+      target: {
+        table: 'operations_routines',
+        id: routine.id,
+      },
+      payload: {
+        before: existing,
+        after: routine,
+        metadata: {
+          schedule_changed: scheduleChanged,
+          activation_toggle: activationToggle,
+        },
+      },
+    });
+
+    return NextResponse.json({ routine });
+  } catch (error) {
+    console.error('[Routine PATCH]', error);
+    return NextResponse.json(
+      { error: 'Failed to update routine', message: error instanceof Error ? error.message : 'unknown' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const user = await prisma.users.findFirst({
+      where: { email: { equals: userEmail, mode: 'insensitive' } },
+    });
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+
+    const { id } = await params;
+    const existing = await loadAuthorizedRoutine(id, user.id);
+    if (!existing) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+
+    await prisma.operations_routines.delete({ where: { id } });
+
+    await writeAuditLog({
+      actor: {
+        user_id: user.id,
+        email: userEmail,
+        type: 'human_user',
+      },
+      action: {
+        type: 'operations_routine_deleted',
+        description: `Deleted routine "${existing.name}"`,
+      },
+      target: {
+        table: 'operations_routines',
+        id: existing.id,
+      },
+      payload: {
+        before: existing,
+        metadata: {
+          cascade_note: 'operations_routine_completions cascade-deleted via FK',
+        },
+      },
+    });
+
+    return NextResponse.json({ deleted: true, id: existing.id });
+  } catch (error) {
+    console.error('[Routine DELETE]', error);
+    return NextResponse.json(
+      { error: 'Failed to delete routine', message: error instanceof Error ? error.message : 'unknown' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/operations/routines/[id]/upcoming/route.ts
+++ b/src/app/api/operations/routines/[id]/upcoming/route.ts
@@ -1,0 +1,64 @@
+/**
+ * /api/operations/routines/[id]/upcoming
+ *
+ * GET — return the next N occurrences of this routine, expanded server-side.
+ *       ?count=5 (default 5, max 30). Returns ISO strings in the routine's
+ *       timezone-shifted UTC instants.
+ *
+ *       Used by Section E for forward-looking display. UI never expands
+ *       RRULE itself — server is the single source of truth.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { expandForward } from '@/lib/operations/rruleHelpers';
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const user = await prisma.users.findFirst({
+      where: { email: { equals: userEmail, mode: 'insensitive' } },
+    });
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+
+    const { id } = await params;
+    const routine = await prisma.operations_routines.findFirst({
+      where: { id, user_id: user.id },
+    });
+    if (!routine) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+
+    const sp = request.nextUrl.searchParams;
+    const countParam = sp.get('count');
+    let count = countParam ? parseInt(countParam, 10) : 5;
+    if (!Number.isInteger(count) || count < 1) count = 5;
+    if (count > 30) count = 30;
+
+    let upcoming: Date[] = [];
+    try {
+      upcoming = expandForward(routine.schedule_rrule, routine.timezone, new Date(), count);
+    } catch (e) {
+      return NextResponse.json(
+        { error: 'RRULE', message: e instanceof Error ? e.message : 'failed to expand' },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json({
+      routine_id: routine.id,
+      timezone: routine.timezone,
+      occurrences: upcoming.map((d) => d.toISOString()),
+    });
+  } catch (error) {
+    console.error('[Upcoming GET]', error);
+    return NextResponse.json(
+      { error: 'Failed to expand upcoming', message: error instanceof Error ? error.message : 'unknown' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/operations/routines/route.ts
+++ b/src/app/api/operations/routines/route.ts
@@ -1,0 +1,218 @@
+/**
+ * /api/operations/routines
+ *
+ * GET — list user's routines, optionally filtered by ?entity_id and ?is_active.
+ *       No audit (read-only). Sorted by next_due_at ASC NULLS LAST then name.
+ *
+ * POST — create a routine. Validates structured form fields, compiles to RRULE
+ *        via compileFormToRRule, stores. Computes initial next_due_at via
+ *        expandForward. Audits operations_routine_created.
+ *
+ *        Server-side note: schedule_rrule is computed from the form, never
+ *        accepted as a string from the client. This guarantees every routine
+ *        in the DB has a parseable, validated RRULE.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { Prisma } from '@prisma/client';
+import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { writeAuditLog } from '@/lib/audit/writeAuditLog';
+import { compileFormToRRule, expandForward } from '@/lib/operations/rruleHelpers';
+import type { RoutineForm } from '@/components/workbench/operations/routines/types';
+
+export async function GET(request: NextRequest) {
+  try {
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const user = await prisma.users.findFirst({
+      where: { email: { equals: userEmail, mode: 'insensitive' } },
+    });
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+
+    const sp = request.nextUrl.searchParams;
+    const entityId = sp.get('entity_id');
+    const isActiveParam = sp.get('is_active');
+
+    const where: Prisma.operations_routinesWhereInput = { user_id: user.id };
+    if (entityId) where.entity_id = entityId;
+    if (isActiveParam === 'true') where.is_active = true;
+    if (isActiveParam === 'false') where.is_active = false;
+
+    const routines = await prisma.operations_routines.findMany({
+      where,
+      orderBy: [
+        { next_due_at: { sort: 'asc', nulls: 'last' } },
+        { name: 'asc' },
+      ],
+    });
+
+    return NextResponse.json({ routines });
+  } catch (error) {
+    console.error('[Routines GET]', error);
+    return NextResponse.json(
+      { error: 'Failed to load routines', message: error instanceof Error ? error.message : 'unknown' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const user = await prisma.users.findFirst({
+      where: { email: { equals: userEmail, mode: 'insensitive' } },
+    });
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+
+    const body = (await request.json()) as Partial<RoutineForm>;
+
+    const requireString = (v: unknown, field: string, max?: number): string | NextResponse => {
+      if (typeof v !== 'string' || v.trim().length === 0) {
+        return NextResponse.json(
+          { error: 'Validation', field, message: `${field} is required` },
+          { status: 400 }
+        );
+      }
+      const trimmed = v.trim();
+      if (max && trimmed.length > max) {
+        return NextResponse.json(
+          { error: 'Validation', field, message: `${field} exceeds ${max} characters` },
+          { status: 400 }
+        );
+      }
+      return trimmed;
+    };
+
+    const name = requireString(body.name, 'name', 200);
+    if (name instanceof NextResponse) return name;
+
+    if (typeof body.entity_id !== 'string' || body.entity_id.trim().length === 0) {
+      return NextResponse.json(
+        { error: 'Validation', field: 'entity_id', message: 'required' },
+        { status: 400 }
+      );
+    }
+    const entityId = body.entity_id.trim();
+
+    // Verify entity belongs to user. Note: entities table uses camelCase
+    // userId column (not user_id) — codebase convention precedent set by
+    // src/app/api/operations/projects/route.ts.
+    const entity = await prisma.entities.findFirst({
+      where: { id: entityId, userId: user.id },
+    });
+    if (!entity) {
+      return NextResponse.json(
+        { error: 'Validation', field: 'entity_id', message: 'entity not found or not owned by user' },
+        { status: 404 }
+      );
+    }
+
+    if (typeof body.timezone !== 'string' || body.timezone.trim().length === 0) {
+      return NextResponse.json(
+        { error: 'Validation', field: 'timezone', message: 'required' },
+        { status: 400 }
+      );
+    }
+
+    let schedule_rrule: string;
+    try {
+      schedule_rrule = compileFormToRRule(body as RoutineForm);
+    } catch (e) {
+      return NextResponse.json(
+        {
+          error: 'Validation',
+          field: 'schedule_rrule',
+          message: e instanceof Error ? e.message : 'invalid cadence configuration',
+        },
+        { status: 400 }
+      );
+    }
+
+    const failThreshold = parseInt(body.fail_threshold_minutes ?? '0', 10);
+    if (!Number.isInteger(failThreshold) || failThreshold < 0) {
+      return NextResponse.json(
+        { error: 'Validation', field: 'fail_threshold_minutes', message: 'must be a non-negative integer' },
+        { status: 400 }
+      );
+    }
+
+    const description = typeof body.description === 'string' && body.description.trim().length > 0
+      ? body.description.trim()
+      : null;
+    const idealTimeLabel = typeof body.ideal_time_label === 'string' && body.ideal_time_label.trim().length > 0
+      ? body.ideal_time_label.trim()
+      : null;
+
+    // Compute initial next_due_at.
+    let nextDueAt: Date | null = null;
+    try {
+      const upcoming = expandForward(schedule_rrule, body.timezone, new Date(), 1);
+      nextDueAt = upcoming[0] ?? null;
+    } catch (e) {
+      console.error('[Routines POST] next_due_at compute failed', e);
+    }
+
+    // Pre-emptive uniqueness check on (user_id, name).
+    const existing = await prisma.operations_routines.findFirst({
+      where: { user_id: user.id, name },
+    });
+    if (existing) {
+      return NextResponse.json(
+        { error: 'Duplicate', field: 'name', message: 'a routine with this name already exists' },
+        { status: 409 }
+      );
+    }
+
+    const routine = await prisma.operations_routines.create({
+      data: {
+        user_id: user.id,
+        entity_id: entityId,
+        name,
+        description,
+        schedule_rrule,
+        timezone: body.timezone,
+        ideal_time_label: idealTimeLabel,
+        fail_threshold_minutes: failThreshold,
+        is_active: body.is_active !== false,
+        next_due_at: nextDueAt,
+        created_by: userEmail,
+      },
+    });
+
+    await writeAuditLog({
+      actor: {
+        user_id: user.id,
+        email: userEmail,
+        type: 'human_user',
+      },
+      action: {
+        type: 'operations_routine_created',
+        description: `Created routine "${name}"`,
+      },
+      target: {
+        table: 'operations_routines',
+        id: routine.id,
+      },
+      payload: {
+        after: routine,
+        metadata: {
+          entity_id: entityId,
+          schedule_rrule,
+          timezone: body.timezone,
+        },
+      },
+    });
+
+    return NextResponse.json({ routine, isCreate: true }, { status: 201 });
+  } catch (error) {
+    console.error('[Routines POST]', error);
+    return NextResponse.json(
+      { error: 'Failed to create routine', message: error instanceof Error ? error.message : 'unknown' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/operations/routines/today/route.ts
+++ b/src/app/api/operations/routines/today/route.ts
@@ -1,0 +1,153 @@
+/**
+ * /api/operations/routines/today
+ *
+ * GET — return today's strip: every active routine's expected occurrence
+ *       within today's bounds (in the routine's timezone), hydrated with
+ *       completion status and any miss audit row.
+ *
+ *       Response shape:
+ *         {
+ *           generated_at: string,
+ *           entries: TodayRoutineEntry[]
+ *         }
+ *
+ *       For each active routine:
+ *         1. Expand RRULE in (todayStartLocal, todayEndLocal].
+ *         2. Pick FIRST occurrence in that window (typical case: at most one
+ *            per day; daily routines yield one, weekly routines yield 0 or 1).
+ *         3. Look up completion at that expected_at → status='completed'.
+ *         4. Else if expected_at + fail_threshold < now → status='missed'.
+ *         5. Else if expected_at <= now → status='pending'.
+ *         6. Else → status='upcoming'.
+ *         7. Routines with NO occurrence today are excluded.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { expandBetween } from '@/lib/operations/rruleHelpers';
+import type { TodayStatus } from '@/components/workbench/operations/routines/types';
+
+/**
+ * Compute today's start and end in the given timezone, returned as UTC Date.
+ * Today's start is "00:00 in tz today"; today's end is "00:00 in tz tomorrow".
+ */
+function todayBounds(tz: string, now: Date): { start: Date; end: Date } {
+  const formatter = new Intl.DateTimeFormat('en-US', {
+    timeZone: tz,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour12: false,
+  });
+  const parts = formatter.formatToParts(now);
+  const get = (type: string) => Number(parts.find((p) => p.type === type)?.value ?? '0');
+  const year = get('year');
+  const month = get('month');
+  const day = get('day');
+
+  // Construct UTC midnight for the local date, then shift by the tz's
+  // offset at that instant to get the actual UTC instant of local midnight.
+  const utcMidnight = Date.UTC(year, month - 1, day, 0, 0, 0);
+  const fmt2 = new Intl.DateTimeFormat('en-US', {
+    timeZone: tz, year: 'numeric', month: '2-digit', day: '2-digit',
+    hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false,
+  });
+  const partsAtUtcMidnight = fmt2.formatToParts(new Date(utcMidnight));
+  const get2 = (type: string) => Number(partsAtUtcMidnight.find((p) => p.type === type)?.value ?? '0');
+  const tzShown = Date.UTC(
+    get2('year'), get2('month') - 1, get2('day'),
+    get2('hour') === 24 ? 0 : get2('hour'), get2('minute'), get2('second')
+  );
+  const offsetMs = tzShown - utcMidnight;
+  const localMidnightUtc = utcMidnight - offsetMs;
+
+  return {
+    start: new Date(localMidnightUtc),
+    end: new Date(localMidnightUtc + 24 * 60 * 60 * 1000),
+  };
+}
+
+export async function GET(_request: NextRequest) {
+  try {
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const user = await prisma.users.findFirst({
+      where: { email: { equals: userEmail, mode: 'insensitive' } },
+    });
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+
+    const now = new Date();
+
+    const routines = await prisma.operations_routines.findMany({
+      where: { user_id: user.id, is_active: true },
+      orderBy: { name: 'asc' },
+    });
+
+    const entries: Array<{
+      routine: typeof routines[number];
+      expected_at: string;
+      status: TodayStatus;
+      completion: unknown;
+    }> = [];
+
+    for (const r of routines) {
+      const { start, end } = todayBounds(r.timezone, now);
+
+      let occurrences: Date[] = [];
+      try {
+        occurrences = expandBetween(r.schedule_rrule, r.timezone, start, end);
+      } catch (e) {
+        console.error(`[Today GET] RRULE parse failed for ${r.id}: ${e}`);
+        continue;
+      }
+
+      if (occurrences.length === 0) continue;
+
+      const expectedAt = occurrences[0];
+
+      // Look up completion at this expected_at.
+      const completion = await prisma.operations_routine_completions.findUnique({
+        where: {
+          routine_id_expected_at: {
+            routine_id: r.id,
+            expected_at: expectedAt,
+          },
+        },
+      });
+
+      let status: TodayStatus;
+      if (completion) {
+        status = 'completed';
+      } else {
+        const failThresholdMs = r.fail_threshold_minutes * 60 * 1000;
+        if (now.getTime() > expectedAt.getTime() + failThresholdMs) {
+          status = 'missed';
+        } else if (expectedAt.getTime() <= now.getTime()) {
+          status = 'pending';
+        } else {
+          status = 'upcoming';
+        }
+      }
+
+      entries.push({
+        routine: r,
+        expected_at: expectedAt.toISOString(),
+        status,
+        completion,
+      });
+    }
+
+    return NextResponse.json({
+      generated_at: now.toISOString(),
+      entries,
+    });
+  } catch (error) {
+    console.error('[Today GET]', error);
+    return NextResponse.json(
+      { error: 'Failed to load today', message: error instanceof Error ? error.message : 'unknown' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/operations/routines/page.tsx
+++ b/src/app/operations/routines/page.tsx
@@ -1,5 +1,13 @@
-import PlaceholderCard from '@/components/workbench/operations/PlaceholderCard';
+/**
+ * /operations/routines
+ *
+ * Section E · Routines page. The OperationsEntityProvider is wired in the
+ * parent /operations/layout.tsx (PR-Ops-2a precedent), so this page just
+ * mounts SectionE_Routines directly — same shape as projects/page.tsx.
+ */
+
+import SectionE_Routines from '@/components/workbench/operations/SectionE_Routines';
 
 export default function OperationsRoutinesPage() {
-  return <PlaceholderCard letter="E" title="ROUTINES" unbuiltLabel="UNBUILT · PR-Ops-5" />;
+  return <SectionE_Routines />;
 }

--- a/src/components/workbench/operations/SectionE_Routines.tsx
+++ b/src/components/workbench/operations/SectionE_Routines.tsx
@@ -1,0 +1,51 @@
+/**
+ * Section E · Routines.
+ *
+ * Top: TodaysStrip — what's due today + mark-complete.
+ * Below: RoutineList — cadence-grouped (Daily / Weekly / Monthly / Quarterly /
+ *        Yearly / Custom) with create + edit affordances.
+ *
+ * Both surfaces refetch on mutation: completing a routine refetches the
+ * RoutineList (streak counters update), creating/editing/toggling a
+ * routine refetches the TodaysStrip (new occurrences may appear).
+ */
+
+'use client';
+
+import { useState } from 'react';
+import { useOperationsEntity } from './EntitySelector';
+import TodaysStrip from './routines/TodaysStrip';
+import RoutineList from './routines/RoutineList';
+
+export default function SectionE_Routines() {
+  const { entities } = useOperationsEntity();
+  // Bumping this counter forces both children to refetch. Each child
+  // takes onCommitted as a stable callback that increments this counter
+  // after a successful mutation.
+  const [, setRefreshCounter] = useState(0);
+  const bump = () => setRefreshCounter((n) => n + 1);
+
+  return (
+    <section className="bg-white rounded border border-border shadow-sm p-5 space-y-5">
+      <div className="flex items-center justify-between">
+        <h2 className="font-mono text-sm font-bold tracking-wide text-text-primary">
+          E · ROUTINES
+        </h2>
+      </div>
+
+      <div>
+        <div className="text-xs font-mono text-text-faint uppercase tracking-wide mb-2">
+          today
+        </div>
+        <TodaysStrip onCommitted={bump} />
+      </div>
+
+      <div className="pt-3 border-t border-border-light">
+        <div className="text-xs font-mono text-text-faint uppercase tracking-wide mb-2">
+          all routines
+        </div>
+        <RoutineList entities={entities} onCommitted={bump} />
+      </div>
+    </section>
+  );
+}

--- a/src/components/workbench/operations/routines/RRULEBuilder.tsx
+++ b/src/components/workbench/operations/routines/RRULEBuilder.tsx
@@ -1,0 +1,217 @@
+/**
+ * RRULEBuilder — structured cadence input that compiles to RFC 5545 RRULE.
+ *
+ * Users do NOT type RRULE strings directly. They pick:
+ *   - cadence_mode (daily / weekly / monthly day-of-month / monthly Nth-weekday / custom)
+ *   - byhour + byminute (when in the day)
+ *   - mode-specific fields (weekday chips, day number, Nth + weekday, raw RRULE)
+ *
+ * Server compiles the structured form via compileFormToRRule(). This
+ * component is a controlled input — parent owns the form state.
+ */
+
+'use client';
+
+import type { CadenceMode, RoutineForm, WeekDay } from './types';
+import {
+  CADENCE_MODE_LABELS,
+  WEEKDAY_LABELS,
+  WEEKDAY_ORDER,
+} from './types';
+
+interface Props {
+  form: RoutineForm;
+  setForm: (next: RoutineForm) => void;
+}
+
+const CADENCE_MODES: CadenceMode[] = [
+  'daily',
+  'weekly',
+  'monthly_day_of_month',
+  'monthly_nth_weekday',
+  'custom',
+];
+
+export default function RRULEBuilder({ form, setForm }: Props) {
+  const inputClass =
+    'w-full px-2 py-1 border border-border rounded text-xs font-mono text-text-primary focus:outline-none focus:border-brand-purple';
+  const labelClass = 'text-text-faint uppercase tracking-wide mb-1 text-xs font-mono';
+
+  const toggleWeekday = (d: WeekDay) => {
+    const has = form.weekly_byday.includes(d);
+    const next = has
+      ? form.weekly_byday.filter((x) => x !== d)
+      : [...form.weekly_byday, d];
+    // Preserve weekday order for canonical RRULE output.
+    next.sort((a, b) => WEEKDAY_ORDER.indexOf(a) - WEEKDAY_ORDER.indexOf(b));
+    setForm({ ...form, weekly_byday: next });
+  };
+
+  return (
+    <div className="space-y-3">
+      <div>
+        <div className={labelClass}>cadence</div>
+        <select
+          value={form.cadence_mode}
+          onChange={(e) => setForm({ ...form, cadence_mode: e.target.value as CadenceMode })}
+          className={inputClass}
+        >
+          {CADENCE_MODES.map((m) => (
+            <option key={m} value={m}>
+              {CADENCE_MODE_LABELS[m]}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {form.cadence_mode === 'weekly' && (
+        <div>
+          <div className={labelClass}>days of week</div>
+          <div className="flex gap-1 flex-wrap">
+            {WEEKDAY_ORDER.map((d) => {
+              const selected = form.weekly_byday.includes(d);
+              return (
+                <button
+                  key={d}
+                  type="button"
+                  onClick={() => toggleWeekday(d)}
+                  className={
+                    'px-2 py-1 border rounded text-xs font-mono ' +
+                    (selected
+                      ? 'bg-brand-purple text-white border-brand-purple'
+                      : 'bg-white text-text-primary border-border hover:bg-bg-row')
+                  }
+                >
+                  {WEEKDAY_LABELS[d]}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      {form.cadence_mode === 'monthly_day_of_month' && (
+        <div>
+          <div className={labelClass}>day of month (1–31)</div>
+          <input
+            type="number"
+            min={1}
+            max={31}
+            value={form.monthly_day_of_month}
+            onChange={(e) => setForm({ ...form, monthly_day_of_month: e.target.value })}
+            className={inputClass}
+          />
+        </div>
+      )}
+
+      {form.cadence_mode === 'monthly_nth_weekday' && (
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <div className={labelClass}>nth (1=first, -1=last)</div>
+            <select
+              value={form.monthly_nth}
+              onChange={(e) => setForm({ ...form, monthly_nth: e.target.value })}
+              className={inputClass}
+            >
+              <option value="1">1st</option>
+              <option value="2">2nd</option>
+              <option value="3">3rd</option>
+              <option value="4">4th</option>
+              <option value="-1">last</option>
+            </select>
+          </div>
+          <div>
+            <div className={labelClass}>weekday</div>
+            <select
+              value={form.monthly_weekday}
+              onChange={(e) => setForm({ ...form, monthly_weekday: e.target.value as WeekDay })}
+              className={inputClass}
+            >
+              {WEEKDAY_ORDER.map((d) => (
+                <option key={d} value={d}>
+                  {WEEKDAY_LABELS[d]}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+      )}
+
+      {form.cadence_mode === 'custom' && (
+        <div>
+          <div className={labelClass}>raw RRULE (RFC 5545)</div>
+          <input
+            type="text"
+            value={form.custom_rrule}
+            onChange={(e) => setForm({ ...form, custom_rrule: e.target.value })}
+            className={inputClass}
+            placeholder="FREQ=YEARLY;BYMONTH=3,6,9,12;BYMONTHDAY=15"
+          />
+          <div className="text-text-faint text-xs italic mt-1">
+            Escape hatch for cadences the structured form can't express
+            (e.g., quarterly review on the 15th of mar/jun/sep/dec).
+          </div>
+        </div>
+      )}
+
+      <div className="grid grid-cols-3 gap-3 pt-2 border-t border-border-light">
+        <div>
+          <div className={labelClass}>hour (00–23)</div>
+          <input
+            type="number"
+            min={0}
+            max={23}
+            value={form.byhour}
+            onChange={(e) => setForm({ ...form, byhour: e.target.value })}
+            className={inputClass}
+          />
+        </div>
+        <div>
+          <div className={labelClass}>minute (00–59)</div>
+          <input
+            type="number"
+            min={0}
+            max={59}
+            value={form.byminute}
+            onChange={(e) => setForm({ ...form, byminute: e.target.value })}
+            className={inputClass}
+          />
+        </div>
+        <div>
+          <div className={labelClass}>fail threshold (min)</div>
+          <input
+            type="number"
+            min={0}
+            value={form.fail_threshold_minutes}
+            onChange={(e) => setForm({ ...form, fail_threshold_minutes: e.target.value })}
+            className={inputClass}
+            title="grace period before a missed occurrence is logged"
+          />
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-3">
+        <div>
+          <div className={labelClass}>timezone</div>
+          <input
+            type="text"
+            value={form.timezone}
+            onChange={(e) => setForm({ ...form, timezone: e.target.value })}
+            className={inputClass}
+            placeholder="America/Los_Angeles"
+          />
+        </div>
+        <div>
+          <div className={labelClass}>ideal time label (optional)</div>
+          <input
+            type="text"
+            value={form.ideal_time_label}
+            onChange={(e) => setForm({ ...form, ideal_time_label: e.target.value })}
+            className={inputClass}
+            placeholder="morning, before lunch, EOD"
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/workbench/operations/routines/RoutineList.tsx
+++ b/src/components/workbench/operations/routines/RoutineList.tsx
@@ -1,0 +1,281 @@
+/**
+ * RoutineList — cadence-grouped list of routines + inline create form.
+ *
+ * Self-fetches via GET /api/operations/routines on mount. Filters to
+ * is_active=true by default with a "show inactive" toggle.
+ *
+ * Renders rows grouped by classifyCadence(schedule_rrule):
+ *   Daily / Weekly / Monthly / Quarterly / Yearly / Custom
+ *
+ * "+ new routine" button opens an inline create form using the same
+ * RRULEBuilder as the edit form.
+ */
+
+'use client';
+
+import { useEffect, useState } from 'react';
+import RoutineRow from './RoutineRow';
+import RRULEBuilder from './RRULEBuilder';
+import type { CadenceGroup, Routine, RoutineForm } from './types';
+import { CADENCE_GROUP_LABELS, CADENCE_GROUP_ORDER, DEFAULT_ROUTINE_FORM } from './types';
+
+interface Entity {
+  id: string;
+  name: string;
+}
+
+interface Props {
+  entities: Entity[];
+  onCommitted?: () => void;
+}
+
+export default function RoutineList({ entities, onCommitted }: Props) {
+  const [routines, setRoutines] = useState<Routine[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [showInactive, setShowInactive] = useState(false);
+
+  const [showCreate, setShowCreate] = useState(false);
+  const [createForm, setCreateForm] = useState<RoutineForm>(DEFAULT_ROUTINE_FORM);
+  const [createSaving, setCreateSaving] = useState(false);
+  const [createError, setCreateError] = useState<string | null>(null);
+
+  const fetchRoutines = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const url = showInactive
+        ? '/api/operations/routines'
+        : '/api/operations/routines?is_active=true';
+      const res = await fetch(url);
+      const body = await res.json();
+      if (!res.ok) {
+        setError(body?.message ?? body?.error ?? 'failed to load routines');
+        setRoutines([]);
+        return;
+      }
+      setRoutines(body.routines ?? []);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'failed to load routines');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchRoutines();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [showInactive]);
+
+  const refresh = () => {
+    fetchRoutines();
+    onCommitted?.();
+  };
+
+  const startCreate = () => {
+    const initialEntity = entities[0]?.id ?? '';
+    setCreateForm({ ...DEFAULT_ROUTINE_FORM, entity_id: initialEntity });
+    setCreateError(null);
+    setShowCreate(true);
+  };
+
+  const cancelCreate = () => {
+    setShowCreate(false);
+    setCreateForm(DEFAULT_ROUTINE_FORM);
+    setCreateError(null);
+  };
+
+  const handleCreate = async () => {
+    setCreateSaving(true);
+    setCreateError(null);
+    try {
+      const res = await fetch('/api/operations/routines', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(createForm),
+      });
+      const body = await res.json();
+      if (!res.ok) {
+        setCreateError(body?.message ?? body?.error ?? 'failed to create');
+        return;
+      }
+      cancelCreate();
+      refresh();
+    } catch (e) {
+      setCreateError(e instanceof Error ? e.message : 'failed to create');
+    } finally {
+      setCreateSaving(false);
+    }
+  };
+
+  // Group routines by classifyCadence-equivalent client-side bucketing.
+  // We approximate by inspecting RRULE prefix; server's classifyCadence is
+  // authoritative but not exposed by API in v0. For UI purposes the
+  // approximation is sufficient.
+  const groupOf = (rrule: string): CadenceGroup => {
+    const upper = rrule.toUpperCase();
+    if (upper.includes('FREQ=DAILY')) return 'daily';
+    if (upper.includes('FREQ=WEEKLY')) return 'weekly';
+    if (upper.includes('FREQ=YEARLY')) {
+      const m = upper.match(/BYMONTH=([\d,]+)/);
+      if (m) {
+        const months = m[1].split(',').map(Number);
+        if (months.length === 4 && months.every((x) => x % 3 === 0)) return 'quarterly';
+      }
+      return 'yearly';
+    }
+    if (upper.includes('FREQ=MONTHLY')) return 'monthly';
+    return 'custom';
+  };
+
+  const grouped = new Map<CadenceGroup, Routine[]>();
+  for (const r of routines) {
+    const g = groupOf(r.schedule_rrule);
+    if (!grouped.has(g)) grouped.set(g, []);
+    grouped.get(g)!.push(r);
+  }
+
+  const inputClass =
+    'w-full px-2 py-1 border border-border rounded text-xs font-mono text-text-primary focus:outline-none focus:border-brand-purple';
+  const labelClass = 'text-text-faint uppercase tracking-wide mb-1 text-xs font-mono';
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3 text-xs font-mono">
+          <span className="text-text-muted">
+            {routines.length} {routines.length === 1 ? 'routine' : 'routines'}
+          </span>
+          <label className="flex items-center gap-1 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={showInactive}
+              onChange={(e) => setShowInactive(e.target.checked)}
+            />
+            <span className="text-text-muted">show inactive</span>
+          </label>
+        </div>
+        {!showCreate && (
+          <button
+            type="button"
+            onClick={startCreate}
+            disabled={entities.length === 0}
+            className="px-2 py-1 border border-brand-purple bg-brand-purple text-white rounded text-xs font-mono hover:opacity-90 disabled:opacity-50"
+          >
+            + new routine
+          </button>
+        )}
+      </div>
+
+      {error && (
+        <div className="text-xs font-mono px-3 py-2 rounded border bg-red-50 border-red-200 text-red-800">
+          {error}
+        </div>
+      )}
+
+      {showCreate && (
+        <div className="border border-brand-purple rounded p-3 bg-purple-50/30 text-xs font-mono space-y-3">
+          <div className="font-bold text-text-primary">new routine</div>
+          {createError && (
+            <div className="px-3 py-2 rounded border bg-red-50 border-red-200 text-red-800">
+              {createError}
+            </div>
+          )}
+
+          <div className="grid grid-cols-2 gap-3">
+            <div className="col-span-2">
+              <div className={labelClass}>name</div>
+              <input
+                type="text"
+                value={createForm.name}
+                onChange={(e) => setCreateForm({ ...createForm, name: e.target.value })}
+                className={inputClass}
+                maxLength={200}
+                placeholder="e.g., Morning reflection"
+              />
+            </div>
+            <div className="col-span-2">
+              <div className={labelClass}>description (optional)</div>
+              <textarea
+                value={createForm.description}
+                onChange={(e) => setCreateForm({ ...createForm, description: e.target.value })}
+                rows={2}
+                className={inputClass}
+                placeholder="what does this routine accomplish?"
+              />
+            </div>
+            <div>
+              <div className={labelClass}>entity</div>
+              <select
+                value={createForm.entity_id}
+                onChange={(e) => setCreateForm({ ...createForm, entity_id: e.target.value })}
+                className={inputClass}
+              >
+                <option value="">— select —</option>
+                {entities.map((e) => (
+                  <option key={e.id} value={e.id}>
+                    {e.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+
+          <RRULEBuilder form={createForm} setForm={setCreateForm} />
+
+          <div className="flex items-center gap-2 pt-2 border-t border-border-light">
+            <button
+              type="button"
+              onClick={handleCreate}
+              disabled={createSaving}
+              className="px-3 py-1 border border-brand-purple bg-brand-purple text-white rounded hover:opacity-90 disabled:opacity-50"
+            >
+              {createSaving ? 'creating…' : 'create routine'}
+            </button>
+            <button
+              type="button"
+              onClick={cancelCreate}
+              disabled={createSaving}
+              className="px-3 py-1 border border-border rounded hover:bg-bg-row disabled:opacity-50"
+            >
+              cancel
+            </button>
+          </div>
+        </div>
+      )}
+
+      {loading ? (
+        <div className="text-xs font-mono text-text-muted">loading routines…</div>
+      ) : routines.length === 0 ? (
+        <div className="text-xs font-mono text-text-muted italic">
+          no routines yet — click "+ new routine" to create your first one. Bridgewater's Principles operationalize through cadence; this is where you set yours.
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {CADENCE_GROUP_ORDER.map((g) => {
+            const items = grouped.get(g);
+            if (!items || items.length === 0) return null;
+            return (
+              <div key={g}>
+                <div className="text-xs font-mono text-text-muted uppercase tracking-wide mb-1">
+                  {CADENCE_GROUP_LABELS[g]} ({items.length})
+                </div>
+                <div className="space-y-1.5">
+                  {items.map((r) => (
+                    <RoutineRow
+                      key={r.id}
+                      routine={r}
+                      entities={entities}
+                      onUpdate={refresh}
+                      onDelete={refresh}
+                    />
+                  ))}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/workbench/operations/routines/RoutineRow.tsx
+++ b/src/components/workbench/operations/routines/RoutineRow.tsx
@@ -1,0 +1,331 @@
+/**
+ * RoutineRow — single routine in the cadence-grouped list.
+ *
+ * Three modes (mirrors ProjectRow's pattern at routine scale):
+ *   1. Compact: name + cadence-group pill + streaks + next-due
+ *   2. Expanded: + description + ideal time + last completed + delete
+ *   3. Edit: full RRULEBuilder + name/description fields
+ *
+ * Click row body → toggle expand. "edit" → swap to edit mode. "deactivate"/
+ * "reactivate" pill toggles is_active via PATCH. Audit trail shows the
+ * discrimination (deactivated as its own action_type; reactivated as
+ * generic _updated with metadata.activation_toggle='reactivated').
+ */
+
+'use client';
+
+import { useState } from 'react';
+import type { Routine, RoutineForm } from './types';
+import { DEFAULT_ROUTINE_FORM } from './types';
+import RRULEBuilder from './RRULEBuilder';
+
+interface Entity {
+  id: string;
+  name: string;
+}
+
+interface Props {
+  routine: Routine;
+  entities: Entity[];
+  onUpdate: () => void;
+  onDelete: () => void;
+}
+
+function routineToForm(r: Routine): RoutineForm {
+  // Form fields derived from Routine: we don't reverse-compile RRULE on edit;
+  // user is shown the live cadence_mode as 'custom' with the existing rrule
+  // pre-populated. They can switch to a structured mode if desired (which
+  // overrides the rrule on save).
+  return {
+    ...DEFAULT_ROUTINE_FORM,
+    name: r.name,
+    description: r.description ?? '',
+    entity_id: r.entity_id,
+    timezone: r.timezone,
+    ideal_time_label: r.ideal_time_label ?? '',
+    fail_threshold_minutes: String(r.fail_threshold_minutes),
+    is_active: r.is_active,
+    cadence_mode: 'custom',
+    custom_rrule: r.schedule_rrule,
+  };
+}
+
+function formatDateTime(iso: string | null, tz: string): string {
+  if (!iso) return '—';
+  const d = new Date(iso);
+  return d.toLocaleString(undefined, {
+    timeZone: tz,
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+export default function RoutineRow({ routine, entities, onUpdate, onDelete }: Props) {
+  const [expanded, setExpanded] = useState(false);
+  const [editing, setEditing] = useState(false);
+  const [form, setForm] = useState<RoutineForm>(() => routineToForm(routine));
+  const [saving, setSaving] = useState(false);
+  const [toggling, setToggling] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const enterEdit = () => {
+    setForm(routineToForm(routine));
+    setEditing(true);
+    setError(null);
+  };
+
+  const cancelEdit = () => {
+    setForm(routineToForm(routine));
+    setEditing(false);
+    setError(null);
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/operations/routines/${routine.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(form),
+      });
+      const body = await res.json();
+      if (!res.ok) {
+        setError(body?.message ?? body?.error ?? 'failed to save');
+        return;
+      }
+      setEditing(false);
+      onUpdate();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'failed to save');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleToggleActive = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setToggling(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/operations/routines/${routine.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ is_active: !routine.is_active }),
+      });
+      const body = await res.json();
+      if (!res.ok) {
+        setError(body?.message ?? body?.error ?? 'failed to toggle');
+        return;
+      }
+      onUpdate();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'failed to toggle');
+    } finally {
+      setToggling(false);
+    }
+  };
+
+  const handleDelete = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (!confirm(`Delete routine "${routine.name}"? All completion history will also be deleted.`)) return;
+    setDeleting(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/operations/routines/${routine.id}`, { method: 'DELETE' });
+      const body = await res.json();
+      if (!res.ok) {
+        setError(body?.message ?? body?.error ?? 'failed to delete');
+        return;
+      }
+      onDelete();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'failed to delete');
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  const inputClass =
+    'w-full px-2 py-1 border border-border rounded text-xs font-mono text-text-primary focus:outline-none focus:border-brand-purple';
+  const labelClass = 'text-text-faint uppercase tracking-wide mb-1 text-xs font-mono';
+
+  return (
+    <div
+      className={
+        'border rounded bg-white ' +
+        (routine.is_active ? 'border-border' : 'border-border-light opacity-60')
+      }
+    >
+      <div
+        className="flex items-center justify-between px-3 py-2 cursor-pointer hover:bg-bg-row text-xs font-mono"
+        onClick={() => !editing && setExpanded((x) => !x)}
+      >
+        <div className="flex items-center gap-3 min-w-0 flex-1">
+          <span className="text-text-faint">{expanded ? '▾' : '▸'}</span>
+          <span className="font-bold text-text-primary truncate">{routine.name}</span>
+          {!routine.is_active && (
+            <span className="px-2 py-0.5 border rounded text-xs bg-gray-100 text-gray-600 border-gray-300">
+              inactive
+            </span>
+          )}
+        </div>
+        <div className="flex items-center gap-3 text-text-muted shrink-0">
+          <span title="completion streak / miss streak">
+            🔥 {routine.consecutive_completion_streak} ✓ / {routine.consecutive_miss_streak} ✗
+          </span>
+          <span title="next scheduled occurrence">
+            next: {formatDateTime(routine.next_due_at, routine.timezone)}
+          </span>
+        </div>
+      </div>
+
+      {expanded && !editing && (
+        <div className="px-4 py-3 border-t border-border-light text-xs font-mono space-y-3">
+          {error && (
+            <div className="px-3 py-2 rounded border bg-red-50 border-red-200 text-red-800">
+              {error}
+            </div>
+          )}
+          {routine.description ? (
+            <div>
+              <div className={labelClass}>description</div>
+              <div className="text-text-primary whitespace-pre-wrap">{routine.description}</div>
+            </div>
+          ) : (
+            <div className="text-text-muted italic">no description</div>
+          )}
+
+          <div className="grid grid-cols-3 gap-3 pt-2 border-t border-border-light">
+            <div>
+              <div className={labelClass}>schedule (rrule)</div>
+              <div className="text-text-primary font-mono break-all">{routine.schedule_rrule}</div>
+            </div>
+            <div>
+              <div className={labelClass}>timezone</div>
+              <div className="text-text-primary">{routine.timezone}</div>
+            </div>
+            <div>
+              <div className={labelClass}>fail threshold</div>
+              <div className="text-text-primary">{routine.fail_threshold_minutes} min</div>
+            </div>
+          </div>
+
+          <div className="grid grid-cols-3 gap-3 pt-2 border-t border-border-light">
+            <div>
+              <div className={labelClass}>last completed</div>
+              <div className="text-text-primary">{formatDateTime(routine.last_completed_at, routine.timezone)}</div>
+            </div>
+            <div>
+              <div className={labelClass}>last evaluated</div>
+              <div className="text-text-primary">{formatDateTime(routine.last_evaluated_at, routine.timezone)}</div>
+            </div>
+            <div>
+              <div className={labelClass}>ideal time</div>
+              <div className="text-text-primary">{routine.ideal_time_label ?? '—'}</div>
+            </div>
+          </div>
+
+          <div className="flex items-center gap-2 pt-2 border-t border-border-light">
+            <button
+              type="button"
+              onClick={(e) => { e.stopPropagation(); enterEdit(); }}
+              className="px-2 py-1 border border-border rounded hover:bg-bg-row"
+            >
+              edit
+            </button>
+            <button
+              type="button"
+              onClick={handleToggleActive}
+              disabled={toggling}
+              className="px-2 py-1 border border-border rounded hover:bg-bg-row disabled:opacity-50"
+            >
+              {toggling ? '…' : routine.is_active ? 'deactivate' : 'reactivate'}
+            </button>
+            <button
+              type="button"
+              onClick={handleDelete}
+              disabled={deleting}
+              className="px-2 py-1 border border-red-300 text-red-700 rounded hover:bg-red-50 disabled:opacity-50"
+            >
+              {deleting ? 'deleting…' : 'delete'}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {editing && (
+        <div className="px-4 py-3 border-t border-border-light text-xs font-mono space-y-3">
+          {error && (
+            <div className="px-3 py-2 rounded border bg-red-50 border-red-200 text-red-800">
+              {error}
+            </div>
+          )}
+
+          <div className="grid grid-cols-2 gap-3">
+            <div className="col-span-2">
+              <div className={labelClass}>name</div>
+              <input
+                type="text"
+                value={form.name}
+                onChange={(e) => setForm({ ...form, name: e.target.value })}
+                className={inputClass}
+                maxLength={200}
+              />
+            </div>
+            <div className="col-span-2">
+              <div className={labelClass}>description</div>
+              <textarea
+                value={form.description}
+                onChange={(e) => setForm({ ...form, description: e.target.value })}
+                rows={2}
+                className={inputClass}
+              />
+            </div>
+            <div>
+              <div className={labelClass}>entity</div>
+              <select
+                value={form.entity_id}
+                onChange={(e) => setForm({ ...form, entity_id: e.target.value })}
+                className={inputClass}
+                disabled
+                title="entity cannot be changed after creation"
+              >
+                {entities.map((e) => (
+                  <option key={e.id} value={e.id}>
+                    {e.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+
+          <RRULEBuilder form={form} setForm={setForm} />
+
+          <div className="flex items-center gap-2 pt-2 border-t border-border-light">
+            <button
+              type="button"
+              onClick={handleSave}
+              disabled={saving}
+              className="px-3 py-1 border border-brand-purple bg-brand-purple text-white rounded hover:opacity-90 disabled:opacity-50"
+            >
+              {saving ? 'saving…' : 'save'}
+            </button>
+            <button
+              type="button"
+              onClick={cancelEdit}
+              disabled={saving}
+              className="px-3 py-1 border border-border rounded hover:bg-bg-row disabled:opacity-50"
+            >
+              cancel
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/workbench/operations/routines/TodaysStrip.tsx
+++ b/src/components/workbench/operations/routines/TodaysStrip.tsx
@@ -1,0 +1,191 @@
+/**
+ * TodaysStrip — today's pending/completed/missed routines with mark-complete.
+ *
+ * Self-fetches GET /api/operations/routines/today on mount. Renders one row
+ * per active routine with an occurrence in today's window. Click ✓ →
+ * POST /api/operations/routines/[id]/completions with the expected_at.
+ *
+ * Statuses:
+ *   pending   — expected_at <= now, not yet completed, within fail threshold
+ *   completed — completion row exists for expected_at
+ *   missed    — past fail threshold without completion
+ *   upcoming  — expected_at > now
+ *
+ * On successful completion, the parent's onCommitted callback fires so the
+ * cadence-grouped list refetches its streak counters too.
+ */
+
+'use client';
+
+import { useEffect, useState } from 'react';
+import type { TodayStatus } from './types';
+
+interface TodayEntry {
+  routine: {
+    id: string;
+    name: string;
+    timezone: string;
+    fail_threshold_minutes: number;
+    consecutive_completion_streak: number;
+    consecutive_miss_streak: number;
+  };
+  expected_at: string;
+  status: TodayStatus;
+  completion: { id: string; completed_at: string; delta_minutes: number; notes: string | null } | null;
+}
+
+interface Props {
+  onCommitted?: () => void;
+}
+
+const STATUS_PILL: Record<TodayStatus, string> = {
+  pending: 'bg-amber-50 text-amber-800 border-amber-300',
+  completed: 'bg-green-50 text-green-800 border-green-300',
+  missed: 'bg-red-50 text-red-800 border-red-300',
+  upcoming: 'bg-blue-50 text-blue-800 border-blue-300',
+};
+
+const STATUS_LABEL: Record<TodayStatus, string> = {
+  pending: 'pending',
+  completed: 'completed',
+  missed: 'missed',
+  upcoming: 'upcoming',
+};
+
+function formatTime(iso: string, tz: string): string {
+  return new Date(iso).toLocaleTimeString(undefined, {
+    timeZone: tz,
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+export default function TodaysStrip({ onCommitted }: Props) {
+  const [entries, setEntries] = useState<TodayEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [completingId, setCompletingId] = useState<string | null>(null);
+
+  const fetchToday = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/operations/routines/today');
+      const body = await res.json();
+      if (!res.ok) {
+        setError(body?.message ?? body?.error ?? 'failed to load today');
+        setEntries([]);
+        return;
+      }
+      setEntries(body.entries ?? []);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'failed to load today');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchToday();
+  }, []);
+
+  const handleComplete = async (routineId: string, expectedAt: string) => {
+    setCompletingId(routineId);
+    setError(null);
+    try {
+      const res = await fetch(`/api/operations/routines/${routineId}/completions`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ expected_at: expectedAt }),
+      });
+      const body = await res.json();
+      if (!res.ok) {
+        setError(body?.message ?? body?.error ?? 'failed to mark complete');
+        return;
+      }
+      fetchToday();
+      onCommitted?.();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'failed to mark complete');
+    } finally {
+      setCompletingId(null);
+    }
+  };
+
+  const totalDue = entries.filter((e) => e.status === 'pending' || e.status === 'upcoming').length;
+  const totalDone = entries.filter((e) => e.status === 'completed').length;
+  const totalMissed = entries.filter((e) => e.status === 'missed').length;
+
+  if (loading) {
+    return <div className="text-xs font-mono text-text-muted">loading today's routines…</div>;
+  }
+
+  if (entries.length === 0) {
+    return (
+      <div className="text-xs font-mono text-text-muted italic">
+        no routines scheduled for today.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between text-xs font-mono">
+        <div className="text-text-muted">
+          {totalDone} done · {totalDue} due · {totalMissed} missed
+        </div>
+      </div>
+
+      {error && (
+        <div className="text-xs font-mono px-3 py-2 rounded border bg-red-50 border-red-200 text-red-800">
+          {error}
+        </div>
+      )}
+
+      <div className="space-y-1">
+        {entries.map((e) => {
+          const pillClass = `inline-block px-2 py-0.5 border rounded text-xs font-mono ${STATUS_PILL[e.status]}`;
+          const canComplete = e.status === 'pending' || e.status === 'upcoming' || e.status === 'missed';
+          return (
+            <div
+              key={e.routine.id}
+              className="flex items-center justify-between gap-2 py-1.5 px-3 border border-border-light rounded bg-white text-xs font-mono"
+            >
+              <div className="flex items-center gap-3 min-w-0 flex-1">
+                <span className="text-text-muted shrink-0 w-12 text-right">
+                  {formatTime(e.expected_at, e.routine.timezone)}
+                </span>
+                <span className={
+                  e.status === 'completed'
+                    ? 'text-text-muted line-through truncate'
+                    : 'text-text-primary truncate'
+                }>
+                  {e.routine.name}
+                </span>
+                <span className={pillClass}>{STATUS_LABEL[e.status]}</span>
+                {e.status === 'completed' && e.completion && (
+                  <span className="text-text-muted">
+                    Δ {e.completion.delta_minutes} min
+                  </span>
+                )}
+              </div>
+              <div className="flex items-center gap-2 shrink-0">
+                {canComplete && (
+                  <button
+                    type="button"
+                    onClick={() => handleComplete(e.routine.id, e.expected_at)}
+                    disabled={completingId === e.routine.id}
+                    className="px-2 py-0.5 border border-green-300 text-green-800 rounded hover:bg-green-50 disabled:opacity-50 text-xs font-mono"
+                    title="Mark this occurrence as completed"
+                  >
+                    {completingId === e.routine.id ? '…' : '✓ mark done'}
+                  </button>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/workbench/operations/routines/types.ts
+++ b/src/components/workbench/operations/routines/types.ts
@@ -1,0 +1,159 @@
+/**
+ * Shared types for the Operations Routines surface (Section E).
+ *
+ * Routine mirrors the operations_routines Prisma model 1:1.
+ *
+ * Bridgewater framing: routines are the cadence-driven execution layer.
+ * Daily reflection, weekly review, quarterly planning — these are the
+ * Principles operationalized as recurring evidentiary events. Each
+ * scheduled occurrence becomes either:
+ *   - A row in operations_routine_completions (success projection), AND
+ *     an audit_log row with action_type='operations_routine_completed'
+ *   - An audit_log row with action_type='operations_routine_missed'
+ *     (no completion row; the absence of a row at expected_at IS the miss)
+ *
+ * The schema's `routine_completions` table is success-only by design —
+ * `completed_at` is NOT NULL. Misses live exclusively in audit_log. This
+ * is intentional: completions are the positive-event projection; the
+ * audit log is the total evidentiary truth.
+ *
+ * RRULE expansion is server-side. Per-row `timezone` requires it. The
+ * UI never expands RRULE itself; it reads server-computed `next_due_at`
+ * and calls /api/operations/routines/[id]/upcoming for forward windows.
+ */
+
+export interface Routine {
+  id: string;
+  user_id: string;
+  entity_id: string;
+  name: string;
+  description: string | null;
+  schedule_rrule: string;
+  timezone: string;
+  next_due_at: string | null;
+  last_evaluated_at: string | null;
+  last_completed_at: string | null;
+  consecutive_completion_streak: number;
+  consecutive_miss_streak: number;
+  ideal_time_label: string | null;
+  fail_threshold_minutes: number;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+  created_by: string | null;
+}
+
+export interface RoutineCompletion {
+  id: string;
+  routine_id: string;
+  user_id: string;
+  expected_at: string;
+  completed_at: string;
+  delta_minutes: number;
+  notes: string | null;
+  created_at: string;
+}
+
+/**
+ * Hydrated routine for "today's strip" rendering. Joins the next expected
+ * occurrence with whether it's been completed or missed already today.
+ *
+ * status semantics:
+ *   - 'pending'   : next_due_at is today and no completion row exists yet
+ *   - 'completed' : a completion row exists for today's expected_at
+ *   - 'missed'    : an audit_log row with action_type='operations_routine_missed'
+ *                   exists for today's expected_at (cron has already evaluated)
+ *   - 'upcoming'  : next_due_at is in the future relative to now
+ */
+export type TodayStatus = 'pending' | 'completed' | 'missed' | 'upcoming';
+
+export interface TodayRoutineEntry {
+  routine: Routine;
+  expected_at: string;          // today's expected occurrence
+  status: TodayStatus;
+  completion: RoutineCompletion | null;  // populated if status === 'completed'
+}
+
+/**
+ * RRULE form-side shape. The UI compiles structured selections into an
+ * RFC 5545 RRULE string under the hood. Users do not write RRULE strings
+ * directly (except via the "custom" escape hatch).
+ */
+export type CadenceMode = 'daily' | 'weekly' | 'monthly_day_of_month' | 'monthly_nth_weekday' | 'custom';
+
+export type WeekDay = 'MO' | 'TU' | 'WE' | 'TH' | 'FR' | 'SA' | 'SU';
+
+export interface RoutineForm {
+  name: string;
+  description: string;
+  entity_id: string;
+  cadence_mode: CadenceMode;
+  weekly_byday: WeekDay[];           // for weekly mode
+  monthly_day_of_month: string;       // for monthly_day_of_month (e.g., "15")
+  monthly_nth: string;                // for monthly_nth_weekday (e.g., "1" = first, "-1" = last)
+  monthly_weekday: WeekDay;           // for monthly_nth_weekday (e.g., "MO" = Monday)
+  custom_rrule: string;               // for custom escape hatch
+  byhour: string;                     // "08" — hour-of-day in routine's timezone
+  byminute: string;                   // "00" — minute-of-hour
+  timezone: string;                   // default 'America/Los_Angeles'
+  ideal_time_label: string;           // free-text "morning", "before lunch"
+  fail_threshold_minutes: string;     // grace period in minutes before "miss"
+  is_active: boolean;
+}
+
+export const DEFAULT_ROUTINE_FORM: RoutineForm = {
+  name: '',
+  description: '',
+  entity_id: '',
+  cadence_mode: 'daily',
+  weekly_byday: ['MO', 'TU', 'WE', 'TH', 'FR'],
+  monthly_day_of_month: '1',
+  monthly_nth: '1',
+  monthly_weekday: 'MO',
+  custom_rrule: '',
+  byhour: '08',
+  byminute: '00',
+  timezone: 'America/Los_Angeles',
+  ideal_time_label: '',
+  fail_threshold_minutes: '30',
+  is_active: true,
+};
+
+export const WEEKDAY_LABELS: Record<WeekDay, string> = {
+  MO: 'Mon',
+  TU: 'Tue',
+  WE: 'Wed',
+  TH: 'Thu',
+  FR: 'Fri',
+  SA: 'Sat',
+  SU: 'Sun',
+};
+
+export const WEEKDAY_ORDER: WeekDay[] = ['MO', 'TU', 'WE', 'TH', 'FR', 'SA', 'SU'];
+
+export const CADENCE_MODE_LABELS: Record<CadenceMode, string> = {
+  daily: 'daily',
+  weekly: 'weekly',
+  monthly_day_of_month: 'monthly (day of month)',
+  monthly_nth_weekday: 'monthly (Nth weekday)',
+  custom: 'custom (raw RRULE)',
+};
+
+/**
+ * Cadence group buckets for cadence-grouped list rendering.
+ * Derived from the RRULE's FREQ component server-side.
+ */
+export type CadenceGroup = 'daily' | 'weekly' | 'monthly' | 'quarterly' | 'yearly' | 'custom';
+
+export const CADENCE_GROUP_LABELS: Record<CadenceGroup, string> = {
+  daily: 'Daily',
+  weekly: 'Weekly',
+  monthly: 'Monthly',
+  quarterly: 'Quarterly',
+  yearly: 'Yearly',
+  custom: 'Custom',
+};
+
+export const CADENCE_GROUP_ORDER: CadenceGroup[] = [
+  'daily', 'weekly', 'monthly', 'quarterly', 'yearly', 'custom',
+];

--- a/src/inngest/functions/index.ts
+++ b/src/inngest/functions/index.ts
@@ -16,6 +16,7 @@ import { uscodeIngest } from './uscode-ingest';
 import { fedregIngest } from './fedreg-ingest';
 import { irbIngest } from './irb-ingest';
 import { embedPending } from './embed-pending';
+import { routineEvaluator } from './routine-evaluator';
 
 export const functions = [
   healthCheck,
@@ -24,6 +25,7 @@ export const functions = [
   fedregIngest,
   irbIngest,
   embedPending,
+  routineEvaluator,
 ];
 
-export { healthCheck, ecfrIngest, uscodeIngest, fedregIngest, irbIngest, embedPending };
+export { healthCheck, ecfrIngest, uscodeIngest, fedregIngest, irbIngest, embedPending, routineEvaluator };

--- a/src/inngest/functions/routine-evaluator.ts
+++ b/src/inngest/functions/routine-evaluator.ts
@@ -1,0 +1,169 @@
+/**
+ * Routine Evaluator — daily cron that detects missed routine occurrences,
+ * updates streak counters, and recomputes next_due_at.
+ *
+ * φ-2 idempotency: evaluates the window (last_evaluated_at, now()] only.
+ * After updating last_evaluated_at = now(), re-runs in the same minute see
+ * an empty window. Safe against Inngest retries and duplicate registrations.
+ *
+ * Miss representation: misses live exclusively in audit_log
+ * (action_type='operations_routine_missed'). The completions table is
+ * success-only by design (completed_at NOT NULL). Querying misses for a
+ * routine = filter audit_log by action_type and target_id.
+ *
+ * Streak counter contract:
+ *   - On miss detection: consecutive_miss_streak += 1;
+ *     consecutive_completion_streak = 0
+ *   - On completion (handled by /api/operations/routines/[id]/completions
+ *     POST): consecutive_completion_streak += 1;
+ *     consecutive_miss_streak = 0
+ *
+ * Cron does NOT increment completion streaks — only miss streaks. The
+ * completion endpoint owns its side of the symmetry.
+ */
+
+import { inngest } from '../client';
+import { prisma } from '@/lib/prisma';
+import { writeAuditLog } from '@/lib/audit/writeAuditLog';
+import { expandBetween, expandForward } from '@/lib/operations/rruleHelpers';
+
+export const routineEvaluator = inngest.createFunction(
+  {
+    id: 'routine-evaluator',
+    name: 'Operations Routine Evaluator',
+    triggers: [{ cron: '15 0 * * *' }],
+    concurrency: { limit: 1 },
+  },
+  async ({ step }) => {
+    const now = new Date();
+
+    const routines = await step.run('load-active-routines', async () => {
+      return prisma.operations_routines.findMany({
+        where: { is_active: true },
+        select: {
+          id: true,
+          user_id: true,
+          name: true,
+          schedule_rrule: true,
+          timezone: true,
+          fail_threshold_minutes: true,
+          last_evaluated_at: true,
+          created_at: true,
+          consecutive_completion_streak: true,
+          consecutive_miss_streak: true,
+        },
+      });
+    });
+
+    let totalMissesEmitted = 0;
+    let totalRoutinesEvaluated = 0;
+    let totalErrors = 0;
+
+    for (const r of routines) {
+      try {
+        // Prisma's DateTime fields cross step.run as ISO strings (Inngest
+        // serializes step return values for durability). Convert back to Date.
+        const windowStart = new Date(r.last_evaluated_at ?? r.created_at);
+        if (windowStart.getTime() >= now.getTime()) {
+          // Defensive: clock skew or admin-set future timestamp; skip.
+          continue;
+        }
+
+        // Expand RRULE within the (windowStart, now] interval.
+        let expectedOccurrences: Date[] = [];
+        try {
+          expectedOccurrences = expandBetween(r.schedule_rrule, r.timezone, windowStart, now);
+        } catch (err) {
+          console.error(`[routine-evaluator] RRULE parse failed for routine ${r.id}: ${err}`);
+          totalErrors += 1;
+          continue;
+        }
+
+        // Filter to occurrences past their fail threshold.
+        const failThresholdMs = r.fail_threshold_minutes * 60 * 1000;
+        const eligibleMisses = expectedOccurrences.filter(
+          (e) => now.getTime() > e.getTime() + failThresholdMs
+        );
+
+        let routineMissCount = 0;
+
+        for (const expectedAt of eligibleMisses) {
+          // Skip if a completion exists for this exact expected_at.
+          const existingCompletion = await prisma.operations_routine_completions.findUnique({
+            where: {
+              routine_id_expected_at: {
+                routine_id: r.id,
+                expected_at: expectedAt,
+              },
+            },
+          });
+          if (existingCompletion) continue;
+
+          // Emit miss audit row. (No completion row — schema is success-only.)
+          await writeAuditLog({
+            actor: {
+              user_id: r.user_id,
+              email: 'system@templestuart.com',
+              type: 'system_automation',
+            },
+            action: {
+              type: 'operations_routine_missed',
+              description: `Missed routine "${r.name}" expected at ${expectedAt.toISOString()}`,
+            },
+            target: {
+              table: 'operations_routines',
+              id: r.id,
+            },
+            payload: {
+              metadata: {
+                routine_id: r.id,
+                routine_name: r.name,
+                expected_at: expectedAt.toISOString(),
+                fail_threshold_minutes: r.fail_threshold_minutes,
+                emitted_by: 'routine-evaluator-cron',
+              },
+            },
+          });
+          routineMissCount += 1;
+          totalMissesEmitted += 1;
+        }
+
+        // Recompute next_due_at: next occurrence at or after now().
+        let nextDueAt: Date | null = null;
+        try {
+          const upcoming = expandForward(r.schedule_rrule, r.timezone, now, 1);
+          nextDueAt = upcoming[0] ?? null;
+        } catch (err) {
+          console.error(`[routine-evaluator] next_due_at recompute failed for ${r.id}: ${err}`);
+        }
+
+        // Update streak counters and cursors.
+        await prisma.operations_routines.update({
+          where: { id: r.id },
+          data: {
+            last_evaluated_at: now,
+            next_due_at: nextDueAt,
+            ...(routineMissCount > 0
+              ? {
+                  consecutive_miss_streak: r.consecutive_miss_streak + routineMissCount,
+                  consecutive_completion_streak: 0,
+                }
+              : {}),
+          },
+        });
+
+        totalRoutinesEvaluated += 1;
+      } catch (err) {
+        console.error(`[routine-evaluator] failed to evaluate routine ${r.id}: ${err}`);
+        totalErrors += 1;
+      }
+    }
+
+    return {
+      evaluated_at: now.toISOString(),
+      total_routines_evaluated: totalRoutinesEvaluated,
+      total_misses_emitted: totalMissesEmitted,
+      total_errors: totalErrors,
+    };
+  }
+);

--- a/src/lib/operations/rruleHelpers.ts
+++ b/src/lib/operations/rruleHelpers.ts
@@ -1,0 +1,232 @@
+/**
+ * Server-side RRULE expansion + form↔RRULE compilation.
+ *
+ * Routines store schedule_rrule as RFC 5545 strings. Per-routine timezone
+ * is required because RRULE expansion is timezone-sensitive (DST, BYHOUR
+ * semantics differ by zone). The rrule npm package handles standard RFC
+ * 5545 semantics; we wrap it with timezone-aware helpers and a structured
+ * form compiler so users never type RRULE strings directly.
+ *
+ * All exported functions are pure — no DB, no side effects. Used by:
+ *   - Inngest cron (routine evaluator) for backward expansion
+ *   - API routes for forward window expansion (next N occurrences)
+ *   - Form validation for round-trip safety (form → RRULE → form)
+ */
+
+import { RRule, RRuleSet, rrulestr, Frequency } from 'rrule';
+import type { CadenceGroup, CadenceMode, RoutineForm, WeekDay } from '@/components/workbench/operations/routines/types';
+
+/**
+ * Compile a RoutineForm's structured fields into an RFC 5545 RRULE string.
+ *
+ * For 'custom' mode, the raw form.custom_rrule is returned as-is (after
+ * basic validation that it parses). For all other modes, the function
+ * synthesizes an RRULE from the structured selections plus byhour/byminute.
+ */
+export function compileFormToRRule(form: RoutineForm): string {
+  const byhour = parseIntStrict(form.byhour, 0, 23);
+  const byminute = parseIntStrict(form.byminute, 0, 59);
+
+  if (form.cadence_mode === 'custom') {
+    const trimmed = form.custom_rrule.trim();
+    if (trimmed.length === 0) {
+      throw new Error('custom RRULE is required when cadence_mode=custom');
+    }
+    // Validate it parses; rrulestr throws on malformed input.
+    rrulestr(trimmed.startsWith('RRULE:') ? trimmed : `RRULE:${trimmed}`);
+    return trimmed.startsWith('RRULE:') ? trimmed.slice('RRULE:'.length) : trimmed;
+  }
+
+  const parts: string[] = [];
+
+  if (form.cadence_mode === 'daily') {
+    parts.push('FREQ=DAILY');
+  } else if (form.cadence_mode === 'weekly') {
+    if (form.weekly_byday.length === 0) {
+      throw new Error('weekly cadence requires at least one weekday selection');
+    }
+    parts.push('FREQ=WEEKLY');
+    parts.push(`BYDAY=${form.weekly_byday.join(',')}`);
+  } else if (form.cadence_mode === 'monthly_day_of_month') {
+    const dom = parseIntStrict(form.monthly_day_of_month, 1, 31);
+    parts.push('FREQ=MONTHLY');
+    parts.push(`BYMONTHDAY=${dom}`);
+  } else if (form.cadence_mode === 'monthly_nth_weekday') {
+    const nth = parseIntStrict(form.monthly_nth, -5, 5);
+    if (nth === 0) throw new Error('monthly_nth must be non-zero');
+    parts.push('FREQ=MONTHLY');
+    parts.push(`BYDAY=${nth}${form.monthly_weekday}`);
+  }
+
+  parts.push(`BYHOUR=${byhour}`);
+  parts.push(`BYMINUTE=${byminute}`);
+  parts.push('BYSECOND=0');
+
+  const rrule = parts.join(';');
+  // Validate that what we synthesized is parseable.
+  rrulestr(`RRULE:${rrule}`);
+  return rrule;
+}
+
+/**
+ * Classify an RRULE string into a cadence group for UI grouping.
+ *
+ * Heuristic — looks at FREQ + BYMONTH for quarterly detection:
+ *   FREQ=DAILY                                        → 'daily'
+ *   FREQ=WEEKLY                                       → 'weekly'
+ *   FREQ=MONTHLY                                      → 'monthly'
+ *   FREQ=YEARLY with BYMONTH=3,6,9,12 (quarterly)    → 'quarterly'
+ *   FREQ=YEARLY                                       → 'yearly'
+ *   anything else (including FREQ=HOURLY, MINUTELY)  → 'custom'
+ */
+export function classifyCadence(rruleString: string): CadenceGroup {
+  let parsed: RRule;
+  try {
+    parsed = rruleFromString(rruleString);
+  } catch {
+    return 'custom';
+  }
+
+  switch (parsed.options.freq) {
+    case Frequency.DAILY:
+      return 'daily';
+    case Frequency.WEEKLY:
+      return 'weekly';
+    case Frequency.MONTHLY:
+      return 'monthly';
+    case Frequency.YEARLY: {
+      const months = parsed.options.bymonth;
+      if (months && months.length === 4 && months.every((m) => m % 3 === 0)) {
+        return 'quarterly';
+      }
+      return 'yearly';
+    }
+    default:
+      return 'custom';
+  }
+}
+
+/**
+ * Parse an RRULE string with timezone context. The rrule package treats
+ * the RRULE as floating local time unless DTSTART is supplied; we use a
+ * synthetic DTSTART anchor to make BYHOUR/BYMINUTE deterministic.
+ *
+ * The anchor date is intentionally distant in the past (epoch + 1 year)
+ * so it never accidentally coincides with the current evaluation window.
+ */
+export function rruleFromString(rruleString: string): RRule {
+  // rrulestr can return either RRule or RRuleSet depending on input; for
+  // single-RRULE strings we expect RRule.
+  const parsed = rrulestr(`RRULE:${rruleString.replace(/^RRULE:/, '')}`, {
+    dtstart: new Date(Date.UTC(1971, 0, 1, 0, 0, 0)),
+  });
+  if (parsed instanceof RRuleSet) {
+    throw new Error('RRuleSet not supported; provide a single RRULE');
+  }
+  return parsed;
+}
+
+/**
+ * Expand the next N occurrences of an RRULE starting from `after`,
+ * interpreted in the given IANA timezone.
+ *
+ * The rrule package returns Date objects representing UTC instants. We
+ * apply timezone offset adjustment so BYHOUR=8 in 'America/Los_Angeles'
+ * yields 08:00 PT (15:00 or 16:00 UTC depending on DST), not 08:00 UTC.
+ *
+ * Implementation note: rrule's `tzid` option requires a specific
+ * configuration. For now we compute UTC-anchored occurrences and
+ * post-shift them by the routine's timezone offset at each occurrence's
+ * date. This handles DST correctly because Intl.DateTimeFormat is
+ * applied per-occurrence.
+ */
+export function expandForward(
+  rruleString: string,
+  timezone: string,
+  after: Date,
+  count: number
+): Date[] {
+  const rule = rruleFromString(rruleString);
+  // Get UTC-anchored occurrences then shift to timezone.
+  const rawOccurrences = rule.between(after, addYears(after, 5), true, (_, i) => i < count);
+  return rawOccurrences.map((d) => shiftFloatingToZone(d, timezone));
+}
+
+/**
+ * Expand all occurrences of an RRULE between `from` and `to` (inclusive),
+ * interpreted in the given timezone. Used by the cron's backward
+ * evaluation: "what occurrences should have happened between
+ * last_evaluated_at and now()?"
+ */
+export function expandBetween(
+  rruleString: string,
+  timezone: string,
+  from: Date,
+  to: Date
+): Date[] {
+  const rule = rruleFromString(rruleString);
+  const raw = rule.between(from, to, true);
+  return raw.map((d) => shiftFloatingToZone(d, timezone));
+}
+
+/**
+ * Shift a floating-time Date (interpreted as if it were in 'timezone')
+ * to a true UTC instant.
+ *
+ * Example: rrule returns 2026-05-08T08:00:00.000Z for BYHOUR=8 (UTC).
+ * If the routine's timezone is 'America/Los_Angeles', we want the
+ * actual instant when LA wall-clock reads 08:00 — which is
+ * 2026-05-08T15:00:00.000Z in May (PDT, UTC-7).
+ *
+ * We compute the offset by formatting the floating Date in the target
+ * timezone and the actual UTC instant, then differencing.
+ */
+function shiftFloatingToZone(floatingDate: Date, timezone: string): Date {
+  const utcMs = floatingDate.getTime();
+  const offset = getTimezoneOffsetMs(floatingDate, timezone);
+  return new Date(utcMs + offset);
+}
+
+/**
+ * Get the offset in milliseconds between UTC and the named timezone at
+ * the given instant. Positive when the timezone is BEHIND UTC (e.g.,
+ * America/Los_Angeles is UTC-8 standard or UTC-7 DST → offset is
+ * +28800000 or +25200000 ms).
+ */
+function getTimezoneOffsetMs(instant: Date, timezone: string): number {
+  const formatter = new Intl.DateTimeFormat('en-US', {
+    timeZone: timezone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  });
+  const parts = formatter.formatToParts(instant);
+  const get = (type: string) => Number(parts.find((p) => p.type === type)?.value ?? '0');
+  const tzAsUtc = Date.UTC(
+    get('year'),
+    get('month') - 1,
+    get('day'),
+    get('hour') === 24 ? 0 : get('hour'),
+    get('minute'),
+    get('second')
+  );
+  return tzAsUtc - instant.getTime();
+}
+
+function addYears(d: Date, n: number): Date {
+  const r = new Date(d);
+  r.setUTCFullYear(r.getUTCFullYear() + n);
+  return r;
+}
+
+function parseIntStrict(value: string, min: number, max: number): number {
+  const n = parseInt(value, 10);
+  if (!Number.isInteger(n) || n < min || n > max) {
+    throw new Error(`invalid integer: "${value}" must be between ${min} and ${max}`);
+  }
+  return n;
+}


### PR DESCRIPTION
Bridgewater's Principles operationalize through cadence — daily reflection, weekly review, quarterly planning. Routines are the recurring evidentiary events that generate the behavioral corpus PR-Ops-4 (priority engine, shipped after this) will read for weight learning.

Architecturally bigger than 3a/3b/3c combined: introduces RRULE infrastructure (RFC 5545), a daily Inngest cron with cursor-based idempotency, and the first cron-emitted audit events in the Operations subsystem.

New dependency:
  rrule@^2.8.1 — RFC 5545 RRULE parser/expander. Battle-tested,
  last published 2024, ~50KB. Used server-side only (UI never expands
  RRULE — server is the single source of truth via per-row timezone).

New module: src/lib/operations/rruleHelpers.ts
  Pure functions for RRULE work — no DB, no side effects.
    compileFormToRRule(form) — synthesizes RFC 5545 string from
      structured form fields. 5 cadence_modes:
        daily / weekly / monthly_day_of_month / monthly_nth_weekday /
        custom (raw RRULE escape hatch for cases the structured form
        can't express, e.g. quarterly review on the 15th of mar/jun/
        sep/dec → FREQ=YEARLY;BYMONTH=3,6,9,12;BYMONTHDAY=15).
      Each mode validates: weekly requires non-empty BYDAY array,
      monthly_nth requires non-zero nth (-5 to 5, excluding 0), custom
      must round-trip through rrulestr.
    classifyCadence(rrule) — buckets RRULE into 6 UI groups (daily/
      weekly/monthly/quarterly/yearly/custom). Quarterly heuristic:
      FREQ=YEARLY with BYMONTH of length 4 where every month % 3 === 0.
    expandForward(rrule, tz, after, count) — server-side expansion of
      next N occurrences with timezone-aware floating→UTC shift.
    expandBetween(rrule, tz, from, to) — backward expansion within a
      window. Used by cron's evaluation step.
    shiftFloatingToZone — handles DST + timezone offset via
      Intl.DateTimeFormat.formatToParts (no moment-timezone). Per-
      occurrence offset computation handles DST boundary correctly.

New cron: src/inngest/functions/routine-evaluator.ts
  Daily at 00:15 UTC. concurrency: { limit: 1 }. φ-2 cursor-based
  idempotency: evaluates window (last_evaluated_at, now()] only.
  After updating last_evaluated_at = now(), re-runs in the same minute
  see an empty window. Safe against Inngest retries and duplicate
  registrations.

  Per active routine:
    1. Compute window = (last_evaluated_at ?? created_at, now()].
    2. Expand RRULE in routine's timezone within window.
    3. Filter to occurrences past their fail_threshold_minutes.
    4. For each eligible miss with no completion row → emit operations_routine_missed audit event (system_automation actor) with metadata.routine_id, routine_name, expected_at, fail_threshold, emitted_by.
    5. Increment consecutive_miss_streak by detected count; zero consecutive_completion_streak.
    6. Recompute next_due_at via expandForward(count=1).
    7. Update last_evaluated_at = now().

  Per-routine try/catch isolates malformed RRULE rows (one bad routine
  doesn't kill the cron for everyone else). Returns operational summary:
  { evaluated_at, total_routines_evaluated, total_misses_emitted,
  total_errors } visible in Inngest dashboard.

  Streak counter symmetry contract:
    - Cron miss-side: +N to miss_streak, 0 to completion_streak
    - Completion endpoint: +1 to completion_streak, 0 to miss_streak At most one streak is non-zero at any instant.

Miss representation (architectural decision δ-1):
  Misses live exclusively in audit_log. The completions table is
  success-only by schema design (completed_at NOT NULL, no nullable
  state). Querying misses for a routine = filter audit_log by
  action_type='operations_routine_missed' and target_id=routineId.
  Decomposes cleanly: completions = positive-event projection,
  audit_log = total evidentiary truth.

New endpoints:

  GET  /api/operations/routines
    List with optional ?entity_id and ?is_active filters. Sorted by next_due_at ASC NULLS LAST then name.

  POST /api/operations/routines
    Create. Validation order: name → entity_id → entity ownership (using entities.userId camelCase per codebase convention) → timezone → RRULE compile → fail_threshold → name uniqueness 409 → initial next_due_at compute → insert. Audit operations_routine_created.

  GET    /api/operations/routines/[id]                  Detail
  PATCH  /api/operations/routines/[id]                  Update with three-way
                                                         audit discrimination:
                                                           is_active true→false
                                                             → operations_routine_deactivated
                                                           is_active false→true
                                                             → operations_routine_updated with
                                                               metadata.activation_toggle='reactivated'
                                                               (no _reactivated enum exists in v0;
                                                               metadata enables future audit replay
                                                               to discriminate)
                                                           other → operations_routine_updated
                                                         Schedule recompile triggered by ANY of:
                                                           cadence_mode, weekly_byday, monthly_*,
                                                           custom_rrule, byhour, byminute, timezone.
                                                         next_due_at recomputed when scheduleChanged.
                                                         Pre-emptive name-uniqueness excludes self.
  DELETE /api/operations/routines/[id]                  Hard delete. Cascades to
                                                         operations_routine_completions via FK.
                                                         Audit operations_routine_deleted with
                                                         full payload_before.

  POST /api/operations/routines/[id]/completions
    Body: { expected_at, completed_at?, notes? }. delta_minutes computed via Math.round((completedAt - expectedAt) / 60000) — handles negative (early) and large (late) deltas. Pre-emptive 409 on duplicate (routine_id, expected_at). Updates parent: last_completed_at, completion_streak +1, miss_streak = 0, next_due_at recomputed from completedAt as anchor. Audit operations_routine_completed with delta in description for fast audit-replay queries.

  GET /api/operations/routines/[id]/upcoming
    ?count=N (default 5, max 30). Returns ISO strings of expanded occurrences. UI never expands RRULE itself.

  GET /api/operations/routines/today
    Today's strip with timezone-aware bounds (per-routine timezone). 4-state discrimination per occurrence:
      pending   — expected <= now, no completion, within fail threshold
      completed — completion row exists for expected_at
      missed    — past fail threshold without completion
      upcoming  — expected > now
    Routines with no occurrence in today's window are excluded.

Types module: routines/types.ts
  - Routine (1:1 mirror of operations_routines)
  - RoutineCompletion (success-only schema)
  - TodayStatus (4-value union: pending/completed/missed/upcoming)
  - TodayRoutineEntry (hydrated for today's strip)
  - CadenceMode (5-value union)
  - WeekDay (RFC 5545 2-letter codes)
  - RoutineForm (writable fields with structured cadence)
  - DEFAULT_ROUTINE_FORM (defaults: daily, MO-FR for weekly, America/Los_Angeles, 30-min fail threshold, active)
  - WEEKDAY_LABELS, WEEKDAY_ORDER (canonical Mon-Sun)
  - CADENCE_MODE_LABELS, CADENCE_GROUP_LABELS, CADENCE_GROUP_ORDER

New components:
  RRULEBuilder.tsx — structured cadence form. Users do NOT write
    RRULE strings directly except via the custom escape hatch. The structured selections compile to RFC 5545 server-side. Weekly chips preserve WEEKDAY_ORDER for canonical RRULE output. RoutineRow.tsx — three-mode row matching ProjectRow pattern at routine scale. Compact: name + streaks + next-due. Expanded: schedule, timezone, fail threshold, last completed, last evaluated, ideal time, edit/deactivate/delete actions. Edit: full RRULEBuilder. e.stopPropagation() on every action button. Edit pre-populates with cadence_mode='custom' for round-trip safety (existing RRULE preserved unless user explicitly switches to a structured mode). RoutineList.tsx — cadence-grouped list with show-inactive toggle and inline create form. Client-side approximation of classifyCadence (regex match on FREQ + BYMONTH for quarterly detection) — server's classifyCadence is authoritative but not exposed by API in v0; UI approximation suffices for grouping. TodaysStrip.tsx — today's pending/completed/missed/upcoming with ✓ mark-done quick action. Header summary "N done · M due · K missed". canComplete includes 'missed' — users CAN mark a missed routine done after the fact (delta_minutes will be large/negative, captured in audit). SectionE_Routines.tsx — top: TodaysStrip, divider, bottom: RoutineList. bump counter for cross-child refresh (acknowledged v0 limitation: bump triggers refetch on TodaysStrip but RoutineList only refetches on its own showInactive change; acceptable for v0 because each child self-fetches on its mutations).

Page mount:
  /operations/routines/page.tsx replaces PR-Ops-2a placeholder with
  <SectionE_Routines />. Provider wrapping lives in parent layout
  per established convention (matches /operations/projects/page.tsx).

Architectural decisions (locked, institutional):
  - α RRULE expansion: server-side. Per-routine timezone field requires it; cron needs the dependency anyway; schema's next_due_at + last_evaluated_at columns assume server compute.
  - δ-1 missed-detection: daily cron, audit-only miss representation. Completions table is success-only by schema design.
  - η completions schema: nothing added. notes + delta_minutes + streak counters give priority engine plenty of signal.
  - φ-2 idempotency: cursor-based via last_evaluated_at advancement, backstopped by Inngest concurrency: { limit: 1 }.
  - Reactivation reuses _updated enum with metadata.activation_toggle= 'reactivated' — no schema migration in v0; future PR can add _reactivated if priority engine needs to discriminate.
  - Entity is immutable post-creation in UI (server doesn't enforce but UX correctly signals via disabled select). Future "move routine to entity" action would need explicit re-streak warning.

Pattern conventions (institutional, mirroring PR-Ops-3a/3b/3c):
  - All endpoints follow auth precedent: inline getVerifiedEmail() + inline prisma.users.findFirst + sequential prisma + writeAuditLog awaits (NOT transactional — matches codebase convention).
  - loadAuthorizedRoutine helper deduplicates the (id, user_id) check.
  - entities.userId camelCase used (codebase convention precedent documented inline; entities table differs from operations_* tables which use snake_case user_id).
  - RRULE compile errors bubble through with specific error messages so users see "weekly cadence requires at least one weekday selection" not generic 400.
  - Pre-emptive uniqueness checks return 409 before insert (cleaner than catching @@unique constraint violations).
  - Audit metadata captures both routine_name and routine_id for replay context — future audit replay can reconstruct without re-joining to routines table.

Verification:
  - rrule@^2.8.1 installed (verified via grep package.json)
  - prisma generate: no schema changes (operations_routines + operations_routine_completions landed in PR-Ops-1; all 6 routine audit enum values landed in PR-Ops-1 and registered in SUBSYSTEM_ACTION_TYPES.operations_)
  - tsc --noEmit: exit 0, zero errors
  - Inngest cron registered in functions/index.ts barrel + named re-export

Smoke test plan post-merge:
  1. Navigate to /operations/routines. New Section E renders: "today" header with empty state ("no routines scheduled for today"), "all routines" header with empty state ("Bridgewater's Principles operationalize through cadence; this is where you set yours").
  2. Click "+ new routine". Inline create form appears with name textbox, description, entity dropdown (Personal/Business/ Trading), then RRULEBuilder with cadence dropdown defaulting to "daily", byhour=08, byminute=00, fail_threshold=30, timezone= America/Los_Angeles, ideal_time_label.
  3. Create a daily routine: name="Morning reflection", entity= Personal, cadence=daily, hour=08, minute=00, fail_threshold=30. Click "create routine". Routine appears in "Daily (1)" group with name + streaks 0/0 + next-due tomorrow at 8:00 AM PT (or today if it's pre-8am). Today's strip remains empty (we're past 8am with no occurrence yet).
  4. Create a weekly routine: name="Sunday weekly review", cadence= weekly, weekday chips=SU only, hour=19, minute=00, fail_threshold=60. Renders in "Weekly (1)" group.
  5. Create a quarterly via custom: name="Quarterly planning", cadence=custom, raw="FREQ=YEARLY;BYMONTH=3,6,9,12;BYMONTHDAY= 15;BYHOUR=10;BYMINUTE=0", fail_threshold=120. Renders in "Quarterly (1)" group (the client-side groupOf detects the BYMONTH=3,6,9,12 quarterly pattern).
  6. Click a routine row to expand. See full schedule (RRULE), timezone, fail threshold, last completed=—, last evaluated=—, ideal time. Click "edit". RRULEBuilder shows cadence_mode= custom with the original RRULE in the textbox (round-trip safety). Switch to weekly, pick MO,WE,FR. Click save → server recompiles RRULE, audits as operations_routine_updated with metadata.schedule_changed=true.
  7. Click "deactivate". Row turns 60% opacity, "inactive" pill appears. Audit logs operations_routine_deactivated. Reactivate → audits as _updated with metadata.activation_toggle= 'reactivated'.
  8. Adjust an existing routine's BYHOUR to current time + 5 min. Refresh page. Today's strip now shows the routine with "upcoming" pill (blue). Wait 5 min, refresh — pill switches to "pending" (amber). Click ✓ mark done → POST records completion, streak counters update (1 ✓ / 0 ✗), pill switches to "completed" with "Δ N min" delta visible.
  9. Audit Tail (Section K) shows new rows in chain order: - operations_routine_created (×3 for the 3 routines) - operations_routine_updated (×N for edits including the reactivated one with metadata.activation_toggle) - operations_routine_deactivated (when toggled off) - operations_routine_completed (Δ N min in description) Each with full payload + metadata. content_hash chain intact.
 10. Wait for Inngest cron at 00:15 UTC OR trigger manually via Inngest dashboard. Cron evaluates window since last_evaluated_at = NULL (or routine.created_at), detects any past-fail-threshold occurrences with no completion, emits operations_routine_missed audit rows. consecutive_miss_streak increments by detected count. Section E refreshes show updated streak.

Rollback: pure additive PR. Revert by reverting the merge commit. The /operations/routines page reverts to PR-Ops-2a placeholder. Inngest cron de-registers (no longer in barrel). No data loss; any operations_routines/operations_routine_completions rows persist.

Known scope deferrals (intentional, not bugs):
  - Calendar visualization: deferred to PR-Ops-7 (Roadmap) — single canonical "see your time" surface that composes routines + project deadlines + task deadlines.
  - Server-authoritative cadence_group exposure on GET: defer. Client-side groupOf approximation is sufficient for v0.
  - Routine reorder UI: defer; alphabetical-by-name within group is institutional default.
  - Bulk routine operations (bulk-deactivate, bulk-complete): defer.
  - operations_routine_reactivated audit enum: defer. Metadata-based discrimination is sufficient until PR-Ops-4 needs to filter.
  - Move routine between entities: defer. Entity is effectively immutable post-creation in v0.
  - Reverse-compile RRULE → structured form on edit: defer. cadence_mode='custom' fallback preserves user intent without lossy interpretation.