### PR TITLE
PR-Ops-3.5: AI foundation + first consumer feature (generate-design b…

### DIFF
--- a/prisma/migrations/20260509000000_pr_ops_3_5_ai_foundation/migration.sql
+++ b/prisma/migrations/20260509000000_pr_ops_3_5_ai_foundation/migration.sql
@@ -1,0 +1,42 @@
+-- PR-Ops-3.5: AI Foundation
+-- Adds operations_ai_inference audit enum value and operations_ai_usage table
+-- for cost tracking across all AI features in the operations workbench.
+--
+-- Postgres note: ALTER TYPE ADD VALUE is non-transactional in pre-12 and
+-- cannot run inside a BEGIN/COMMIT block. Azure runs Postgres 14+, but
+-- Prisma's migration runner handles this correctly when ALTER TYPE is the
+-- only enum-modifying statement in its own statement group.
+
+ALTER TYPE "AuditActionType" ADD VALUE 'operations_ai_inference';
+
+CREATE TABLE "operations_ai_usage" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "user_id" TEXT NOT NULL,
+    "model" VARCHAR(100) NOT NULL,
+    "purpose" VARCHAR(100) NOT NULL,
+    "target_table" VARCHAR(100),
+    "target_id" UUID,
+    "input_tokens" INTEGER NOT NULL,
+    "output_tokens" INTEGER NOT NULL,
+    "cost_usd" DECIMAL(10,6) NOT NULL,
+    "inputs_summary" TEXT,
+    "output_summary" TEXT,
+    "created_at" TIMESTAMPTZ(6) NOT NULL DEFAULT NOW(),
+    "created_by" TEXT,
+
+    CONSTRAINT "operations_ai_usage_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "operations_ai_usage_user_created_idx"
+    ON "operations_ai_usage" ("user_id", "created_at" DESC);
+
+CREATE INDEX "operations_ai_usage_target_idx"
+    ON "operations_ai_usage" ("target_table", "target_id");
+
+CREATE INDEX "operations_ai_usage_purpose_created_idx"
+    ON "operations_ai_usage" ("purpose", "created_at" DESC);
+
+ALTER TABLE "operations_ai_usage"
+    ADD CONSTRAINT "operations_ai_usage_user_id_fkey"
+    FOREIGN KEY ("user_id") REFERENCES "users"("id")
+    ON DELETE NO ACTION ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -476,6 +476,7 @@ model users {
   accountable_tasks       compliance_tasks[]       @relation("task_accountable")
   user_profile            user_profiles?
   operations_north_star   operations_north_star?
+  operations_ai_usage     operations_ai_usage[]
   discovery_runs          discovery_runs[]
 }
 
@@ -2030,6 +2031,7 @@ enum AuditActionType {
   regulatory_chunks_embedded
   embedding_run_completed
   embedding_run_cost_capped
+  operations_ai_inference
   operations_project_created
   operations_project_updated
   operations_project_status_changed
@@ -2473,18 +2475,18 @@ model discovery_proposals {
 }
 
 model embedding_runs {
-  id              String   @id @default(uuid()) @db.Uuid
-  started_at      DateTime @db.Timestamptz(6)
+  id              String    @id @default(uuid()) @db.Uuid
+  started_at      DateTime  @db.Timestamptz(6)
   completed_at    DateTime? @db.Timestamptz(6)
   model_name      String
-  chunks_embedded Int      @default(0)
-  tokens_total    Int      @default(0)
-  cost_usd        Decimal  @default(0) @db.Decimal(10, 4)
-  cost_cap_usd    Decimal  @db.Decimal(10, 4)
+  chunks_embedded Int       @default(0)
+  tokens_total    Int       @default(0)
+  cost_usd        Decimal   @default(0) @db.Decimal(10, 4)
+  cost_cap_usd    Decimal   @db.Decimal(10, 4)
   outcome         String
   error_message   String?
-  metadata        Json     @default("{}")
-  created_at      DateTime @default(now()) @db.Timestamptz(6)
+  metadata        Json      @default("{}")
+  created_at      DateTime  @default(now()) @db.Timestamptz(6)
 
   @@index([started_at(sort: Desc)])
   @@index([outcome])
@@ -2531,30 +2533,30 @@ enum IssueStatus {
 }
 
 model operations_projects {
-  id                       String                            @id @default(uuid()) @db.Uuid
+  id                       String        @id @default(uuid()) @db.Uuid
   user_id                  String
   entity_id                String
-  title                    String                            @db.VarChar(500)
-  goal                     String                            @db.Text
-  problem                  String                            @db.Text
-  diagnosis                String                            @db.Text
-  design                   String                            @db.Text
-  status                   ProjectStatus                     @default(not_started)
-  target_completion_date   DateTime?                         @db.Timestamptz(6)
+  title                    String        @db.VarChar(500)
+  goal                     String        @db.Text
+  problem                  String        @db.Text
+  diagnosis                String        @db.Text
+  design                   String        @db.Text
+  status                   ProjectStatus @default(not_started)
+  target_completion_date   DateTime?     @db.Timestamptz(6)
   estimated_total_minutes  Int?
-  estimated_total_cost_usd Decimal?                          @db.Decimal(15, 2)
-  priority_score           Decimal?                          @db.Decimal(10, 4)
-  priority_inputs_hash     String?                           @db.VarChar(64)
-  priority_computed_at     DateTime?                         @db.Timestamptz(6)
-  priority_rationale       String?                           @db.Text
-  created_at               DateTime                          @default(now()) @db.Timestamptz(6)
-  updated_at               DateTime                          @updatedAt @db.Timestamptz(6)
+  estimated_total_cost_usd Decimal?      @db.Decimal(15, 2)
+  priority_score           Decimal?      @db.Decimal(10, 4)
+  priority_inputs_hash     String?       @db.VarChar(64)
+  priority_computed_at     DateTime?     @db.Timestamptz(6)
+  priority_rationale       String?       @db.Text
+  created_at               DateTime      @default(now()) @db.Timestamptz(6)
+  updated_at               DateTime      @updatedAt @db.Timestamptz(6)
   created_by               String?
 
-  tasks                    operations_project_tasks[]
-  outgoing_dependencies    operations_project_dependencies[] @relation("project_dependency_source")
-  incoming_dependencies    operations_project_dependencies[] @relation("project_dependency_target")
-  linked_issues            operations_issue_log_entries[]
+  tasks                 operations_project_tasks[]
+  outgoing_dependencies operations_project_dependencies[] @relation("project_dependency_source")
+  incoming_dependencies operations_project_dependencies[] @relation("project_dependency_target")
+  linked_issues         operations_issue_log_entries[]
 
   @@unique([user_id, title])
   @@index([user_id, entity_id, status])
@@ -2565,28 +2567,28 @@ model operations_projects {
 }
 
 model operations_project_tasks {
-  id                     String                @id @default(uuid()) @db.Uuid
-  project_id             String                @db.Uuid
-  user_id                String
-  entity_id              String
-  title                  String                @db.VarChar(500)
-  description            String?               @db.Text
-  status                 OperationsTaskStatus  @default(open)
-  estimated_minutes      Int?
-  estimated_cost_usd     Decimal?              @db.Decimal(15, 2)
-  deadline               DateTime?             @db.Timestamptz(6)
-  priority_score         Decimal?              @db.Decimal(10, 4)
-  priority_inputs_hash   String?               @db.VarChar(64)
-  priority_computed_at   DateTime?             @db.Timestamptz(6)
-  priority_rationale     String?               @db.Text
-  unblocks_label         String?               @db.Text
-  display_order          Int                   @default(0)
-  completed_at           DateTime?             @db.Timestamptz(6)
-  created_at             DateTime              @default(now()) @db.Timestamptz(6)
-  updated_at             DateTime              @updatedAt @db.Timestamptz(6)
-  created_by             String?
+  id                   String               @id @default(uuid()) @db.Uuid
+  project_id           String               @db.Uuid
+  user_id              String
+  entity_id            String
+  title                String               @db.VarChar(500)
+  description          String?              @db.Text
+  status               OperationsTaskStatus @default(open)
+  estimated_minutes    Int?
+  estimated_cost_usd   Decimal?             @db.Decimal(15, 2)
+  deadline             DateTime?            @db.Timestamptz(6)
+  priority_score       Decimal?             @db.Decimal(10, 4)
+  priority_inputs_hash String?              @db.VarChar(64)
+  priority_computed_at DateTime?            @db.Timestamptz(6)
+  priority_rationale   String?              @db.Text
+  unblocks_label       String?              @db.Text
+  display_order        Int                  @default(0)
+  completed_at         DateTime?            @db.Timestamptz(6)
+  created_at           DateTime             @default(now()) @db.Timestamptz(6)
+  updated_at           DateTime             @updatedAt @db.Timestamptz(6)
+  created_by           String?
 
-  project                operations_projects   @relation(fields: [project_id], references: [id], onDelete: Cascade)
+  project operations_projects @relation(fields: [project_id], references: [id], onDelete: Cascade)
 
   @@index([project_id, status, display_order])
   @@index([user_id, status, priority_score])
@@ -2596,16 +2598,16 @@ model operations_project_tasks {
 }
 
 model operations_project_dependencies {
-  id                       String                  @id @default(uuid()) @db.Uuid
-  project_id               String                  @db.Uuid
-  depends_on_project_id    String                  @db.Uuid
-  dependency_type          ProjectDependencyType
-  rationale                String?                 @db.Text
-  created_at               DateTime                @default(now()) @db.Timestamptz(6)
-  created_by               String?
+  id                    String                @id @default(uuid()) @db.Uuid
+  project_id            String                @db.Uuid
+  depends_on_project_id String                @db.Uuid
+  dependency_type       ProjectDependencyType
+  rationale             String?               @db.Text
+  created_at            DateTime              @default(now()) @db.Timestamptz(6)
+  created_by            String?
 
-  project                  operations_projects     @relation("project_dependency_source", fields: [project_id], references: [id], onDelete: Cascade)
-  depends_on_project       operations_projects     @relation("project_dependency_target", fields: [depends_on_project_id], references: [id], onDelete: Cascade)
+  project            operations_projects @relation("project_dependency_source", fields: [project_id], references: [id], onDelete: Cascade)
+  depends_on_project operations_projects @relation("project_dependency_target", fields: [depends_on_project_id], references: [id], onDelete: Cascade)
 
   @@unique([project_id, depends_on_project_id, dependency_type])
   @@index([project_id])
@@ -2615,26 +2617,26 @@ model operations_project_dependencies {
 }
 
 model operations_routines {
-  id                              String                            @id @default(uuid()) @db.Uuid
-  user_id                         String
-  entity_id                       String
-  name                            String                            @db.VarChar(200)
-  description                     String?                           @db.Text
-  schedule_rrule                  String                            @db.Text
-  timezone                        String                            @default("America/Los_Angeles") @db.VarChar(64)
-  next_due_at                     DateTime?                         @db.Timestamptz(6)
-  last_evaluated_at               DateTime?                         @db.Timestamptz(6)
-  last_completed_at               DateTime?                         @db.Timestamptz(6)
-  consecutive_completion_streak   Int                               @default(0)
-  consecutive_miss_streak         Int                               @default(0)
-  ideal_time_label                String?                           @db.VarChar(50)
-  fail_threshold_minutes          Int                               @default(0)
-  is_active                       Boolean                           @default(true)
-  created_at                      DateTime                          @default(now()) @db.Timestamptz(6)
-  updated_at                      DateTime                          @updatedAt @db.Timestamptz(6)
-  created_by                      String?
+  id                            String    @id @default(uuid()) @db.Uuid
+  user_id                       String
+  entity_id                     String
+  name                          String    @db.VarChar(200)
+  description                   String?   @db.Text
+  schedule_rrule                String    @db.Text
+  timezone                      String    @default("America/Los_Angeles") @db.VarChar(64)
+  next_due_at                   DateTime? @db.Timestamptz(6)
+  last_evaluated_at             DateTime? @db.Timestamptz(6)
+  last_completed_at             DateTime? @db.Timestamptz(6)
+  consecutive_completion_streak Int       @default(0)
+  consecutive_miss_streak       Int       @default(0)
+  ideal_time_label              String?   @db.VarChar(50)
+  fail_threshold_minutes        Int       @default(0)
+  is_active                     Boolean   @default(true)
+  created_at                    DateTime  @default(now()) @db.Timestamptz(6)
+  updated_at                    DateTime  @updatedAt @db.Timestamptz(6)
+  created_by                    String?
 
-  completions                     operations_routine_completions[]
+  completions operations_routine_completions[]
 
   @@unique([user_id, name])
   @@index([user_id, is_active, next_due_at])
@@ -2644,16 +2646,16 @@ model operations_routines {
 }
 
 model operations_routine_completions {
-  id              String              @id @default(uuid()) @db.Uuid
-  routine_id      String              @db.Uuid
-  user_id         String
-  expected_at     DateTime            @db.Timestamptz(6)
-  completed_at    DateTime            @default(now()) @db.Timestamptz(6)
-  delta_minutes   Int
-  notes           String?             @db.Text
-  created_at      DateTime            @default(now()) @db.Timestamptz(6)
+  id            String   @id @default(uuid()) @db.Uuid
+  routine_id    String   @db.Uuid
+  user_id       String
+  expected_at   DateTime @db.Timestamptz(6)
+  completed_at  DateTime @default(now()) @db.Timestamptz(6)
+  delta_minutes Int
+  notes         String?  @db.Text
+  created_at    DateTime @default(now()) @db.Timestamptz(6)
 
-  routine         operations_routines @relation(fields: [routine_id], references: [id], onDelete: Cascade)
+  routine operations_routines @relation(fields: [routine_id], references: [id], onDelete: Cascade)
 
   @@unique([routine_id, expected_at])
   @@index([routine_id, expected_at])
@@ -2661,31 +2663,54 @@ model operations_routine_completions {
   @@map("operations_routine_completions")
 }
 
-model operations_issue_log_entries {
-  id                       String                            @id @default(uuid()) @db.Uuid
-  user_id                  String
-  entity_id                String
-  title                    String                            @db.VarChar(500)
-  description              String                            @db.Text
-  severity                 IssueSeverity
-  status                   IssueStatus                       @default(open)
-  root_cause_proximate     String?                           @db.Text
-  root_cause_systemic      String?                           @db.Text
-  resolution               String?                           @db.Text
-  resolution_category      String?                           @db.VarChar(50)
-  recurrence_count         Int                               @default(0)
-  linked_issue_id          String?                           @db.Uuid
-  linked_project_id        String?                           @db.Uuid
-  occurred_at              DateTime                          @db.Timestamptz(6)
-  discovered_at            DateTime                          @default(now()) @db.Timestamptz(6)
-  resolved_at              DateTime?                         @db.Timestamptz(6)
-  created_at               DateTime                          @default(now()) @db.Timestamptz(6)
-  updated_at               DateTime                          @updatedAt @db.Timestamptz(6)
-  created_by               String?
+model operations_ai_usage {
+  id             String   @id @default(uuid()) @db.Uuid
+  user_id        String
+  model          String   @db.VarChar(100)
+  purpose        String   @db.VarChar(100)
+  target_table   String?  @db.VarChar(100)
+  target_id      String?  @db.Uuid
+  input_tokens   Int
+  output_tokens  Int
+  cost_usd       Decimal  @db.Decimal(10, 6)
+  inputs_summary String?  @db.Text
+  output_summary String?  @db.Text
+  created_at     DateTime @default(now()) @db.Timestamptz(6)
+  created_by     String?
 
-  linked_issue             operations_issue_log_entries?     @relation("operations_issue_chain", fields: [linked_issue_id], references: [id], onDelete: SetNull)
-  recurrences              operations_issue_log_entries[]    @relation("operations_issue_chain")
-  linked_project           operations_projects?              @relation(fields: [linked_project_id], references: [id], onDelete: SetNull)
+  user users @relation(fields: [user_id], references: [id])
+
+  @@index([user_id, created_at(sort: Desc)])
+  @@index([target_table, target_id])
+  @@index([purpose, created_at(sort: Desc)])
+  @@map("operations_ai_usage")
+}
+
+model operations_issue_log_entries {
+  id                   String        @id @default(uuid()) @db.Uuid
+  user_id              String
+  entity_id            String
+  title                String        @db.VarChar(500)
+  description          String        @db.Text
+  severity             IssueSeverity
+  status               IssueStatus   @default(open)
+  root_cause_proximate String?       @db.Text
+  root_cause_systemic  String?       @db.Text
+  resolution           String?       @db.Text
+  resolution_category  String?       @db.VarChar(50)
+  recurrence_count     Int           @default(0)
+  linked_issue_id      String?       @db.Uuid
+  linked_project_id    String?       @db.Uuid
+  occurred_at          DateTime      @db.Timestamptz(6)
+  discovered_at        DateTime      @default(now()) @db.Timestamptz(6)
+  resolved_at          DateTime?     @db.Timestamptz(6)
+  created_at           DateTime      @default(now()) @db.Timestamptz(6)
+  updated_at           DateTime      @updatedAt @db.Timestamptz(6)
+  created_by           String?
+
+  linked_issue   operations_issue_log_entries?  @relation("operations_issue_chain", fields: [linked_issue_id], references: [id], onDelete: SetNull)
+  recurrences    operations_issue_log_entries[] @relation("operations_issue_chain")
+  linked_project operations_projects?           @relation(fields: [linked_project_id], references: [id], onDelete: SetNull)
 
   @@index([user_id, status])
   @@index([user_id, severity, status])
@@ -2697,25 +2722,25 @@ model operations_issue_log_entries {
 }
 
 model operations_vendor_directory {
-  id                       String      @id @default(uuid()) @db.Uuid
-  user_id                  String
-  entity_id                String
-  chart_account_id         String?     @db.Uuid
-  vendor_name              String      @db.VarChar(200)
-  category                 String?     @db.VarChar(100)
-  amount_usd               Decimal?    @db.Decimal(15, 2)
-  billing_rrule            String?     @db.Text
-  next_due_date            DateTime?   @db.Date
-  last_paid_date           DateTime?   @db.Date
-  last_paid_amount_usd     Decimal?    @db.Decimal(15, 2)
-  contact_email            String?     @db.VarChar(255)
-  contact_url              String?     @db.VarChar(500)
-  account_number_last4     String?     @db.VarChar(4)
-  notes                    String?     @db.Text
-  is_active                Boolean     @default(true)
-  created_at               DateTime    @default(now()) @db.Timestamptz(6)
-  updated_at               DateTime    @updatedAt @db.Timestamptz(6)
-  created_by               String?
+  id                   String    @id @default(uuid()) @db.Uuid
+  user_id              String
+  entity_id            String
+  chart_account_id     String?   @db.Uuid
+  vendor_name          String    @db.VarChar(200)
+  category             String?   @db.VarChar(100)
+  amount_usd           Decimal?  @db.Decimal(15, 2)
+  billing_rrule        String?   @db.Text
+  next_due_date        DateTime? @db.Date
+  last_paid_date       DateTime? @db.Date
+  last_paid_amount_usd Decimal?  @db.Decimal(15, 2)
+  contact_email        String?   @db.VarChar(255)
+  contact_url          String?   @db.VarChar(500)
+  account_number_last4 String?   @db.VarChar(4)
+  notes                String?   @db.Text
+  is_active            Boolean   @default(true)
+  created_at           DateTime  @default(now()) @db.Timestamptz(6)
+  updated_at           DateTime  @updatedAt @db.Timestamptz(6)
+  created_by           String?
 
   @@unique([user_id, entity_id, vendor_name])
   @@index([user_id, is_active])
@@ -2735,24 +2760,24 @@ model operations_vendor_directory {
 // =============================================================================
 
 model operations_north_star {
-  id                       String     @id @default(uuid()) @db.Uuid
-  user_id                  String     @unique
-  mission_statement        String?    @db.Text
-  life_stage               String?    @db.VarChar(50)
-  core_values              String[]   @default([])
-  guiding_principles       String?    @db.Text
-  one_year_target          String?    @db.Text
-  three_year_target        String?    @db.Text
-  current_location_label   String?    @db.VarChar(200)
-  current_timezone         String     @default("America/Los_Angeles") @db.VarChar(64)
-  review_cadence_days      Int        @default(90)
-  last_reviewed_at         DateTime?  @db.Timestamptz(6)
-  next_review_at           DateTime?  @db.Timestamptz(6)
-  created_at               DateTime   @default(now()) @db.Timestamptz(6)
-  updated_at               DateTime   @updatedAt @db.Timestamptz(6)
-  created_by               String?
+  id                     String    @id @default(uuid()) @db.Uuid
+  user_id                String    @unique
+  mission_statement      String?   @db.Text
+  life_stage             String?   @db.VarChar(50)
+  core_values            String[]  @default([])
+  guiding_principles     String?   @db.Text
+  one_year_target        String?   @db.Text
+  three_year_target      String?   @db.Text
+  current_location_label String?   @db.VarChar(200)
+  current_timezone       String    @default("America/Los_Angeles") @db.VarChar(64)
+  review_cadence_days    Int       @default(90)
+  last_reviewed_at       DateTime? @db.Timestamptz(6)
+  next_review_at         DateTime? @db.Timestamptz(6)
+  created_at             DateTime  @default(now()) @db.Timestamptz(6)
+  updated_at             DateTime  @updatedAt @db.Timestamptz(6)
+  created_by             String?
 
-  user                     users      @relation(fields: [user_id], references: [id], onDelete: Cascade)
+  user users @relation(fields: [user_id], references: [id], onDelete: Cascade)
 
   @@index([next_review_at])
   @@map("operations_north_star")

--- a/src/app/api/audit-log/route.ts
+++ b/src/app/api/audit-log/route.ts
@@ -14,6 +14,8 @@ import { getVerifiedEmail } from '@/lib/cookie-auth';
  */
 const SUBSYSTEM_ACTION_TYPES: Record<string, AuditActionType[]> = {
   operations_: [
+    // PR-Ops-3.5
+    'operations_ai_inference',
     // PR-Ops-1
     'operations_project_created',
     'operations_project_updated',

--- a/src/app/api/operations/projects/[id]/generate-design/route.ts
+++ b/src/app/api/operations/projects/[id]/generate-design/route.ts
@@ -1,0 +1,74 @@
+/**
+ * /api/operations/projects/[id]/generate-design
+ *
+ * POST — generate an institutional-rigor design field for the project,
+ *        using its current goal/problem/diagnosis as input.
+ *
+ *        Does NOT save to the project. Returns the generated text in
+ *        the response; user must explicitly accept and PATCH the project
+ *        with the new design field separately.
+ *
+ *        Validates that the project has non-empty goal/problem/diagnosis
+ *        before calling the AI — those are the inputs the generator
+ *        depends on.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { generateProjectDesign } from '@/lib/ai/generateProjectDesign';
+
+export async function POST(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const user = await prisma.users.findFirst({
+      where: { email: { equals: userEmail, mode: 'insensitive' } },
+    });
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+
+    const { id: projectId } = await params;
+    const project = await prisma.operations_projects.findFirst({
+      where: { id: projectId, user_id: user.id },
+    });
+    if (!project) return NextResponse.json({ error: 'Project not found' }, { status: 404 });
+
+    if (!project.goal.trim() || !project.problem.trim() || !project.diagnosis.trim()) {
+      return NextResponse.json(
+        {
+          error: 'Validation',
+          message: 'project must have goal, problem, and diagnosis fields filled before generating design',
+        },
+        { status: 400 }
+      );
+    }
+
+    const result = await generateProjectDesign({
+      userId: user.id,
+      userEmail,
+      projectId,
+      projectTitle: project.title,
+      goal: project.goal,
+      problem: project.problem,
+      diagnosis: project.diagnosis,
+    });
+
+    return NextResponse.json({
+      generated_design: result.generatedDesign,
+      usage_id: result.usageId,
+      input_tokens: result.inputTokens,
+      output_tokens: result.outputTokens,
+      cost_usd: result.costUsd,
+    });
+  } catch (error) {
+    console.error('[Generate Design POST]', error);
+    return NextResponse.json(
+      { error: 'Failed to generate design', message: error instanceof Error ? error.message : 'unknown' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/components/workbench/operations/projects/ProjectRow.tsx
+++ b/src/components/workbench/operations/projects/ProjectRow.tsx
@@ -84,6 +84,12 @@ export default function ProjectRow({ project, entities, allProjects, onUpdate, o
   const [saving, setSaving] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [generatingDesign, setGeneratingDesign] = useState(false);
+  const [generatedDesignPreview, setGeneratedDesignPreview] = useState<string | null>(null);
+  const [generationError, setGenerationError] = useState<string | null>(null);
+  const [generationCost, setGenerationCost] = useState<
+    { cost_usd: string; input_tokens: number; output_tokens: number } | null
+  >(null);
   const [flash, setFlash] = useState(false);
   const rowRef = useRef<HTMLDivElement>(null);
 
@@ -138,6 +144,33 @@ export default function ProjectRow({ project, entities, allProjects, onUpdate, o
       setError(e instanceof Error ? e.message : 'failed to save');
     } finally {
       setSaving(false);
+    }
+  };
+
+  const handleGenerateDesign = async () => {
+    setGeneratingDesign(true);
+    setGenerationError(null);
+    setGeneratedDesignPreview(null);
+    setGenerationCost(null);
+    try {
+      const res = await fetch(`/api/operations/projects/${project.id}/generate-design`, {
+        method: 'POST',
+      });
+      const body = await res.json();
+      if (!res.ok) {
+        setGenerationError(body?.message ?? body?.error ?? 'failed to generate design');
+        return;
+      }
+      setGeneratedDesignPreview(body.generated_design);
+      setGenerationCost({
+        cost_usd: body.cost_usd,
+        input_tokens: body.input_tokens,
+        output_tokens: body.output_tokens,
+      });
+    } catch (e) {
+      setGenerationError(e instanceof Error ? e.message : 'failed to generate design');
+    } finally {
+      setGeneratingDesign(false);
     }
   };
 
@@ -325,13 +358,67 @@ export default function ProjectRow({ project, entities, allProjects, onUpdate, o
             />
           </div>
           <div>
-            <div className={labelClass}>4 · design — the plan</div>
+            <div className="flex items-center justify-between mb-1">
+              <div className={labelClass}>4 · design — the plan</div>
+              <button
+                type="button"
+                onClick={handleGenerateDesign}
+                disabled={generatingDesign}
+                className="px-2 py-0.5 border border-brand-purple text-brand-purple rounded text-xs font-mono hover:bg-purple-50 disabled:opacity-50"
+                title="Generate institutional-rigor design field from your goal/problem/diagnosis"
+              >
+                {generatingDesign ? 'generating…' : '↑ generate plan'}
+              </button>
+            </div>
             <textarea
               value={form.design}
               onChange={(e) => setForm({ ...form, design: e.target.value })}
               rows={3}
               className={inputClass}
             />
+            {generationError && (
+              <div className="mt-2 px-3 py-2 rounded border bg-red-50 border-red-200 text-red-800 text-xs font-mono">
+                {generationError}
+              </div>
+            )}
+            {generatedDesignPreview && (
+              <div className="mt-2 border border-brand-purple rounded p-3 bg-purple-50/30 text-xs font-mono space-y-2">
+                <div className="font-bold text-text-primary flex items-center justify-between">
+                  <span>AI-generated design (review before saving)</span>
+                  {generationCost && (
+                    <span className="text-text-muted text-xs font-normal">
+                      ${generationCost.cost_usd} · {generationCost.input_tokens} in · {generationCost.output_tokens} out
+                    </span>
+                  )}
+                </div>
+                <div className="text-text-primary whitespace-pre-wrap p-2 bg-white border border-border-light rounded">
+                  {generatedDesignPreview}
+                </div>
+                <div className="flex items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setForm({ ...form, design: generatedDesignPreview });
+                      setGeneratedDesignPreview(null);
+                      setGenerationCost(null);
+                    }}
+                    className="px-3 py-1 border border-brand-purple bg-brand-purple text-white rounded hover:opacity-90"
+                  >
+                    use this
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setGeneratedDesignPreview(null);
+                      setGenerationCost(null);
+                    }}
+                    className="px-3 py-1 border border-border rounded hover:bg-bg-row"
+                  >
+                    discard
+                  </button>
+                </div>
+              </div>
+            )}
           </div>
 
           <div className="grid grid-cols-3 gap-3">

--- a/src/lib/ai/client.ts
+++ b/src/lib/ai/client.ts
@@ -1,0 +1,69 @@
+/**
+ * Singleton Anthropic client for the operations workbench AI features.
+ *
+ * Centralizes the SDK instantiation that was previously scattered across
+ * 5 API routes. All new AI features (PR-Ops-3.5 onward) use this client;
+ * existing routes can incrementally migrate without behavior change.
+ *
+ * Model alias convention: callers pass the dated model ID directly (e.g.,
+ * 'claude-sonnet-4-20250514') matching existing codebase usage. Future PR
+ * may centralize model selection but v0 keeps the choice with the caller.
+ */
+
+import Anthropic from '@anthropic-ai/sdk';
+
+let _client: Anthropic | null = null;
+
+export function getAnthropicClient(): Anthropic {
+  if (_client) return _client;
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) {
+    throw new Error('ANTHROPIC_API_KEY is not set in environment');
+  }
+  _client = new Anthropic({ apiKey });
+  return _client;
+}
+
+/**
+ * Sonnet 4 (dated 2025-05-14) — current production model in this codebase.
+ * Matches the convention used by /api/ai/* and /api/ops/* routes.
+ */
+export const MODEL_SONNET_4 = 'claude-sonnet-4-20250514';
+
+/**
+ * Cost per million tokens for cost tracking. Source: Anthropic pricing page.
+ * Update when pricing changes; future PR may move this to a per-model
+ * config that auto-syncs.
+ */
+export const COST_PER_MILLION_INPUT_USD: Record<string, number> = {
+  'claude-sonnet-4-20250514': 3.0,
+};
+
+export const COST_PER_MILLION_OUTPUT_USD: Record<string, number> = {
+  'claude-sonnet-4-20250514': 15.0,
+};
+
+/**
+ * Compute USD cost for a completed call. Returns Decimal-precision
+ * dollar amount as a string (suitable for Prisma.Decimal).
+ *
+ * Throws if model isn't in the cost table — defensive against silently
+ * recording $0 for an unknown model.
+ */
+export function computeCostUsd(
+  model: string,
+  inputTokens: number,
+  outputTokens: number
+): string {
+  const inputRate = COST_PER_MILLION_INPUT_USD[model];
+  const outputRate = COST_PER_MILLION_OUTPUT_USD[model];
+  if (inputRate === undefined || outputRate === undefined) {
+    throw new Error(
+      `[ai-client] no cost rate registered for model "${model}". ` +
+      `Add to COST_PER_MILLION_*_USD in src/lib/ai/client.ts`
+    );
+  }
+  const cost = (inputTokens * inputRate + outputTokens * outputRate) / 1_000_000;
+  // Format with 6 decimal places to match Decimal(10,6) schema column.
+  return cost.toFixed(6);
+}

--- a/src/lib/ai/exemplars/projectDesign.ts
+++ b/src/lib/ai/exemplars/projectDesign.ts
@@ -1,0 +1,64 @@
+/**
+ * Project Design Exemplar — Student Loan for Bachelors.
+ *
+ * This is the institutional gold-standard project scoping that the AI
+ * design generator uses as its few-shot example. The user's Student
+ * Loan project (UUID: ea189313-296c-4c9e-8279-7e3450debe7e) was scoped
+ * manually with Bridgewater 5-step rigor; its content is embedded here
+ * verbatim as the exemplar all future generations should match in
+ * depth and structure.
+ *
+ * Updating this constant is a deliberate code change — the exemplar is
+ * NOT runtime-fetched from DB. Reasoning:
+ *   1. Engineered standard, not variable user data
+ *   2. Deterministic cost per call (input tokens fixed)
+ *   3. Code review gates exemplar evolution
+ *
+ * If the canonical exemplar needs to evolve, edit this file with a
+ * commit explaining why.
+ */
+
+export const PROJECT_DESIGN_EXEMPLAR = {
+  title: 'Student Loan for Bachelors - Sallie Mae | FASFA | Grants | Scholarships',
+  goal: `Federal student aid (subsidized + unsubsidized Direct Loans) and a private loan alternative both fully approved and ready to disburse to Cal State LA, covering the full cost of attendance for the academic year (tuition + mandatory fees + books + reasonable cost-of-living allowance per CSU guidelines), with all loan terms — interest rates, repayment schedules, deferment options, total cost over loan life — documented in writing and reviewed against each other to choose the lowest-cost path.
+
+Success means:
+
+(a) FAFSA submitted and Student Aid Index determined;
+(b) Cal State LA financial aid award letter received;
+(c) federal loan offers accepted at the chosen amount;
+(d) at least one private loan offer obtained for comparison (even if not accepted) so the federal vs. private decision is informed;
+(e) all required Master Promissory Notes signed;
+(f) entrance counseling completed;
+(g) disbursement scheduled to align with Cal State LA's enrollment confirmation.`,
+  problem: `Current state: California-based, no concrete prerequisite work started. No FSA ID created, FAFSA not yet filed, Cal State LA admission application not submitted, transcripts from prior institutions not requested, 2025 personal tax return not yet completed, no private lender pre-qualifications run.
+Gap to goal — required actions not yet taken:
+
+FSA ID creation (federalstudentaid.gov account) — required to file FAFSA.
+FAFSA 2026-2027 submission — Cal State LA's specific deadline needs verification.
+Cal State LA admission application — separate from financial aid; needed before financial aid award letter can be issued.
+Transcripts from any prior institutions — required for admission application.
+Tax return data for FAFSA — FAFSA pulls IRS data via Data Retrieval Tool; clean personal return must be filed first.
+Private lender shortlist — Sallie Mae, College Ave, Earnest are major options; comparison requires soft-pull pre-qualification at minimum 2-3 lenders.
+
+Specific known unknowns:
+
+Cal State LA accounting bachelor's program total cost of attendance for 2026-2027 academic year.
+Whether trading P&L is reportable income on FAFSA and how it's classified.
+Whether Temple Stuart LLC pass-through income affects Student Aid Index calculation.
+Whether prior coursework transfers to Cal State LA accounting bachelor's program.
+The actual May 9 date significance — internal goal, deadline, or arbitrary.`,
+  diagnosis: `First: this project is the FINAL step of a four-stage chain (clean tax return → FAFSA + admission → award letter + offers → loan acceptance + signing + disbursement). Treating it as standalone creates the illusion that loan-specific work needs doing now, when the real upstream blockers are tax filing and admission paperwork. The "Student Loan" project is downstream of the "Taxes Personal" and "Sign up for Cal State LA" projects.
+Second: the FAFSA filing for a solo founder with trading entity P&L plus Temple Stuart LLC pass-through plus Schedule C plus capital gains is materially more complex than a standard W-2 filer. This is CPA-level disclosure work that benefits from completing both personal AND business tax returns first so the FAFSA's IRS Data Retrieval Tool pulls clean numbers.
+Third: the May 9 target date was set without verification of any external deadline. FAFSA 2026-2027 priority deadlines have already passed (March 2 at most California schools). Cal State LA's actual fall 2026 enrollment plus disbursement timeline runs through August/September, not May. Target was aspirational, not calendar-anchored.`,
+  design: `Phase 1 (immediate, ~2 weeks): unblock the upstream chain. Complete personal tax return so FAFSA has clean IRS data. Complete business tax return if it affects pass-through to personal. Request transcripts from all prior institutions. Create FSA ID. Look up Cal State LA published cost of attendance and confirm fall 2026 enrollment is the actual target. Outcome: ready to file FAFSA and Cal State LA admission application with all source documents in hand.
+Phase 2 (~4 weeks after phase 1): file FAFSA 2026-2027. Submit Cal State LA admission application with transcripts. Contact Cal State LA financial aid office for any program-specific questions about transferring credits and accounting program structure. Outcome: applications submitted, awaiting determination.
+Phase 3 (~8 weeks after phase 2): receive Cal State LA admission decision. Receive financial aid award letter and Student Aid Index from FAFSA. Run private loan comparison shopping in parallel — soft-pull pre-qualifications with Sallie Mae, College Ave, Earnest. Compare federal subsidized + unsubsidized offers against private offers across interest rate, total cost over loan life, repayment terms, deferment flexibility. Outcome: full financing menu in hand for decision.
+Phase 4 (immediately before enrollment, ~August 2026): accept federal loan amounts at the chosen level. Sign all required Master Promissory Notes. Complete entrance counseling. Optionally accept private loan if comparison favors it. Confirm disbursement schedule aligns with Cal State LA's fall 2026 enrollment confirmation. Outcome: financing locked, classes can begin.
+Decision points:
+
+Phase 1 reveals tax filing is more complex than scoped → push entire project timeline; do not skip clean tax data.
+Cal State LA admission rejected → reset entire project; goal becomes irrelevant.
+FAFSA Student Aid Index produces unexpected aid amount → re-evaluate private loan need.
+Cost of attendance exceeds federal aid maximum → private loan becomes mandatory rather than comparative.`,
+} as const;

--- a/src/lib/ai/generateProjectDesign.ts
+++ b/src/lib/ai/generateProjectDesign.ts
@@ -1,0 +1,120 @@
+/**
+ * generateProjectDesign — produces an institutional-rigor design field
+ * for a project, given its goal/problem/diagnosis fields as input.
+ *
+ * Uses Claude Sonnet 4 with the Student Loan project as few-shot exemplar.
+ * Returns the generated text + cost metadata; does NOT auto-save to the
+ * project (caller must explicitly write back via PATCH after user accepts).
+ *
+ * Truth-first principle: the user must consciously accept the AI's output
+ * before it overwrites their field. The endpoint that calls this returns
+ * the generated text in a preview pane; user reviews and decides.
+ */
+
+import { recordUsage } from './recordUsage';
+import { MODEL_SONNET_4 } from './client';
+import { PROJECT_DESIGN_EXEMPLAR } from './exemplars/projectDesign';
+
+interface GenerateInput {
+  userId: string;
+  userEmail: string;
+  projectId: string;
+  projectTitle: string;
+  goal: string;
+  problem: string;
+  diagnosis: string;
+}
+
+interface GenerateOutput {
+  generatedDesign: string;
+  usageId: string;
+  inputTokens: number;
+  outputTokens: number;
+  costUsd: string;
+}
+
+const SYSTEM_PROMPT = `You are a project scoping consultant trained on the institutional rigor of Bridgewater Associates' Principles, Citadel's risk discipline, and Renaissance Technologies' empirical method.
+
+Your job: generate the DESIGN field of a project — a phased plan with decision points — given the user's GOAL, PROBLEM, and DIAGNOSIS fields.
+
+The user's natural-voice grammar maps to Bridgewater's 5-step scoping:
+  - GOAL field: "I WANT" lines (desires / target end states)
+  - PROBLEM field: "I DID NOT" lines (current gaps)
+  - DIAGNOSIS field: "I NEED" lines (root requirements)
+  - DESIGN field: "I WILL" lines, but synthesized into PHASES with timelines and decision points
+
+The DESIGN you produce must:
+1. Match the depth and structure of the EXEMPLAR below
+2. Have explicit phases (Phase 1, Phase 2, etc.) with rough timelines
+3. Each phase has a clear OUTCOME stated
+4. Include a "Decision points" section at the end listing scenarios that would re-trigger scoping (e.g., "if X happens, push timeline" / "if Y, reset entire project")
+5. Reference specific blockers/upstream-dependencies surfaced in the user's PROBLEM and DIAGNOSIS fields
+6. Be written in declarative voice (the system, not "I will" — the design is the project's plan, not the operator's first-person commitment)
+7. Match the prose length of the exemplar's DESIGN field (~2000 chars)
+
+Return ONLY the design field text. No preamble. No "Here is your design field:". No surrounding markdown code blocks. Just the raw text that would go in the form's design textarea.
+
+═══════════════════════════════════════════════════════════════════════════════
+EXEMPLAR — institutional gold standard for project scoping rigor
+═══════════════════════════════════════════════════════════════════════════════
+
+Project title: "${PROJECT_DESIGN_EXEMPLAR.title}"
+
+GOAL field:
+${PROJECT_DESIGN_EXEMPLAR.goal}
+
+PROBLEM field:
+${PROJECT_DESIGN_EXEMPLAR.problem}
+
+DIAGNOSIS field:
+${PROJECT_DESIGN_EXEMPLAR.diagnosis}
+
+DESIGN field (← THIS is what you produce):
+${PROJECT_DESIGN_EXEMPLAR.design}
+
+═══════════════════════════════════════════════════════════════════════════════
+
+Now produce a DESIGN field at this exact rigor for the user's project below.`;
+
+export async function generateProjectDesign(input: GenerateInput): Promise<GenerateOutput> {
+  const userMessage = `Project title: "${input.projectTitle}"
+
+GOAL field:
+${input.goal}
+
+PROBLEM field:
+${input.problem}
+
+DIAGNOSIS field:
+${input.diagnosis}
+
+DESIGN field: [you produce this — match the exemplar's depth and structure]`;
+
+  const inputsSummary =
+    `project_id=${input.projectId}; ` +
+    `goal_len=${input.goal.length}; problem_len=${input.problem.length}; ` +
+    `diagnosis_len=${input.diagnosis.length}`;
+
+  const result = await recordUsage({
+    userId: input.userId,
+    userEmail: input.userEmail,
+    model: MODEL_SONNET_4,
+    systemPrompt: SYSTEM_PROMPT,
+    userMessage,
+    maxTokens: 2000,
+    temperature: 0.3,
+    purpose: 'project_design_generation',
+    targetTable: 'operations_projects',
+    targetId: input.projectId,
+    inputsSummary,
+    auditDescription: `Generated design field for project "${input.projectTitle}"`,
+  });
+
+  return {
+    generatedDesign: result.text,
+    usageId: result.usageId,
+    inputTokens: result.inputTokens,
+    outputTokens: result.outputTokens,
+    costUsd: result.costUsd,
+  };
+}

--- a/src/lib/ai/recordUsage.ts
+++ b/src/lib/ai/recordUsage.ts
@@ -1,0 +1,129 @@
+/**
+ * recordUsage — wraps an Anthropic message call with cost tracking and
+ * audit logging. Every AI feature in the operations workbench should
+ * use this wrapper so cost data and evidentiary audit rows are written
+ * uniformly.
+ *
+ * Returns the AI's text output PLUS the usage row id (so callers can
+ * include it in their own audit metadata if desired).
+ *
+ * Order of operations (sequential awaits, matches codebase convention):
+ *   1. Call Anthropic.messages.create
+ *   2. Compute cost from usage tokens
+ *   3. Insert operations_ai_usage row
+ *   4. Write audit_log row with action_type='operations_ai_inference',
+ *      payload.metadata.usage_id pointing to the usage row
+ *   5. Return text + usage_id to caller
+ *
+ * The audit log target is the AFFECTED entity (e.g., the project being
+ * scoped), NOT the usage row itself. This means filtering audit_log by
+ * target_table='operations_projects' AND target_id=X surfaces every
+ * event affecting the project including AI generations.
+ */
+
+import type Anthropic from '@anthropic-ai/sdk';
+import { prisma } from '@/lib/prisma';
+import { writeAuditLog } from '@/lib/audit/writeAuditLog';
+import { computeCostUsd, getAnthropicClient } from './client';
+
+interface RecordUsageInput {
+  /** Caller identification — used by audit row + usage row. */
+  userId: string;
+  userEmail: string;
+
+  /** Model + call parameters. */
+  model: string;
+  systemPrompt: string;
+  userMessage: string;
+  maxTokens: number;
+  temperature: number;
+
+  /** Cost tracking metadata. */
+  purpose: string;            // e.g., 'project_design_generation'
+  targetTable: string | null; // e.g., 'operations_projects'
+  targetId: string | null;    // e.g., the project's UUID
+  inputsSummary: string | null;  // human-readable digest
+  auditDescription: string;   // e.g., 'Generated design for "Project X"'
+}
+
+interface RecordUsageOutput {
+  text: string;
+  usageId: string;
+  inputTokens: number;
+  outputTokens: number;
+  costUsd: string;
+}
+
+export async function recordUsage(input: RecordUsageInput): Promise<RecordUsageOutput> {
+  const client = getAnthropicClient();
+
+  const response = await client.messages.create({
+    model: input.model,
+    max_tokens: input.maxTokens,
+    temperature: input.temperature,
+    system: input.systemPrompt,
+    messages: [{ role: 'user', content: input.userMessage }],
+  });
+
+  const text = response.content
+    .filter((b): b is Anthropic.TextBlock => b.type === 'text')
+    .map((b) => b.text)
+    .join('');
+
+  const inputTokens = response.usage.input_tokens;
+  const outputTokens = response.usage.output_tokens;
+  const costUsd = computeCostUsd(input.model, inputTokens, outputTokens);
+
+  const outputSummary =
+    text.length > 200 ? `${text.length} chars; preview: ${text.slice(0, 180)}…` : text;
+
+  const usageRow = await prisma.operations_ai_usage.create({
+    data: {
+      user_id: input.userId,
+      model: input.model,
+      purpose: input.purpose,
+      target_table: input.targetTable,
+      target_id: input.targetId,
+      input_tokens: inputTokens,
+      output_tokens: outputTokens,
+      cost_usd: costUsd,
+      inputs_summary: input.inputsSummary,
+      output_summary: outputSummary,
+      created_by: input.userEmail,
+    },
+  });
+
+  await writeAuditLog({
+    actor: {
+      user_id: input.userId,
+      email: input.userEmail,
+      type: 'human_user',
+    },
+    action: {
+      type: 'operations_ai_inference',
+      description: input.auditDescription,
+    },
+    target: {
+      table: input.targetTable ?? 'operations_ai_usage',
+      id: input.targetId ?? usageRow.id,
+    },
+    payload: {
+      metadata: {
+        usage_id: usageRow.id,
+        purpose: input.purpose,
+        model: input.model,
+        input_tokens: inputTokens,
+        output_tokens: outputTokens,
+        cost_usd: costUsd,
+      },
+    },
+  });
+
+  return {
+    text,
+    usageId: usageRow.id,
+    inputTokens,
+    outputTokens,
+    costUsd,
+  };
+}


### PR DESCRIPTION
…utton)

Establishes the AI infrastructure primitive (cost tracking + audit integration + recordUsage wrapper + hardcoded exemplar) AND ships the first consumer feature on top of it (one-click design generation for projects). Both in one PR because the foundation needs a consumer to validate it works end-to-end.

The user-facing payoff: open a project's edit form with goal + problem + diagnosis filled in (in natural voice — "I WANT", "I DID NOT", "I NEED" patterns), click "↑ generate plan" next to the design field, and Claude Sonnet 4 produces an institutional-rigor design (4 phases + decision points) in ~3 seconds. User reviews in a preview pane, clicks "use this" to populate the form, then saves.

Cost per generation: ~$0.03. Tracked per-call in operations_ai_usage with full audit chain. The AI never auto-saves — user must consciously accept output before it overwrites their field. Truth- first principle.

New schema:
  operations_ai_usage table — per-AI-call cost tracking. Columns:
    id, user_id, model, purpose, target_table, target_id,
    input_tokens, output_tokens, cost_usd (Decimal 10,6),
    inputs_summary, output_summary, created_at, created_by.
    Indexes: (user_id, created_at desc), (target_table, target_id),
    (purpose, created_at desc). FK to users.
  AuditActionType enum gains: operations_ai_inference. This is the
    single audit type for ALL AI calls in the operations workbench
    (the metadata.purpose field discriminates between project design
    generation, future priority engine semantic match, future issue
    clustering, etc.).

Architectural decisions (locked, institutional):
  - Hardcoded exemplar via PROJECT_DESIGN_EXEMPLAR constant in src/lib/ai/exemplars/projectDesign.ts. NOT runtime DB-fetched. Reasons: engineered standard not user-data-driven, deterministic cost per call, code-review-gated evolution.
  - Audit→usage one-way pointer via metadata.usage_id. Avoids backfill ordering problem of bidirectional FKs. Operations_ai_usage has NO audit_log_id column.
  - Audit target is the affected entity (operations_projects), not the usage row. Means filtering audit_log by target_table= 'operations_projects' AND target_id=X surfaces every event affecting the project including AI generations.
  - Endpoint validates non-empty goal/problem/diagnosis BEFORE calling AI — prevents wasted spend on invalid input.
  - User must consciously accept AI output via use/discard buttons in preview pane. No auto-save. Truth-first non-negotiable.

Establishes src/lib/ai/ directory as architectural primitive. Future AI features (PR-Ops-4 priority engine, PR-Ops-6 issue clustering, PR-Ops-8 content drafting) compose against:
  - src/lib/ai/client.ts — singleton Anthropic client + MODEL_SONNET_4 constant + COST_PER_MILLION_*_USD tables + computeCostUsd helper (defensive against unknown models)
  - src/lib/ai/recordUsage.ts — wrapper that does AI call + cost compute + usage row insert + audit row write. Sequential awaits matching codebase convention. Returns text + usage_id + cost metadata.
  - src/lib/ai/exemplars/ — hardcoded few-shot exemplars per artifact type. Each artifact's wizard gets its own *.ts file embedding the institutional gold standard.

First consumer module: src/lib/ai/generateProjectDesign.ts
  System prompt embeds the Student Loan project verbatim as
  few-shot example showing what an institutional design field
  looks like. AI is instructed to produce declarative voice (the
  project's plan, NOT first-person operator commitments). Returns
  generated text + cost metadata; does NOT auto-save.

Endpoint: POST /api/operations/projects/[id]/generate-design
  Auth: getVerifiedEmail + prisma.users.findFirst + project
  ownership check via (id, user_id). Validates non-empty
  goal/problem/diagnosis. Calls generateProjectDesign. Returns
  { generated_design, usage_id, input_tokens, output_tokens,
  cost_usd } without auto-save.

UI: ProjectRow.tsx in edit mode only (NOT view mode) gains:
  - "↑ generate plan" button next to "4 · design — the plan" label. Disabled while generating; shows "generating…" during call.
  - Preview pane below textarea when generation completes:
    - AI output rendered in whitespace-pre-wrap monospace
    - Cost line: "$0.0XXX · N in · M out" (small, muted)
    - Two buttons: "use this" (replaces form.design + clears preview) and "discard" (clears preview only)
  - Error inline if generation fails (red-bordered).

Existing AI routes (5 sites in /api/ai/* and /api/ops/*) are NOT migrated to the new infrastructure in this PR. Future PR can do incremental migration sweep when/if cost tracking on those routes becomes a priority. New AI features ship on the new infrastructure from day one.

Postgres migration note: ALTER TYPE ADD VALUE is non-transactional pre-Postgres 12. Azure runs Postgres 14+ but the migration file places ALTER TYPE in its own statement group ahead of the CREATE TABLE block to keep the migration runner's behavior deterministic.

Pattern conventions (institutional, mirroring PR-Ops-3a/3b/3c/5):
  - Endpoint follows auth precedent: inline getVerifiedEmail + inline prisma.users.findFirst + sequential awaits (NOT transactional — codebase convention).
  - operations_ai_usage uses snake_case user_id column matching all operations_* tables (NOT camelCase userId — that's the entities table convention which differs).
  - prisma format ran across schema and produced cosmetic whitespace realignments on adjacent models (embedding_runs, operations_projects, operations_project_tasks, operations_project_dependencies, operations_routines, operations_routine_completions, operations_issue_log_entries, operations_vendor_directory, operations_north_star). Semantic content unchanged — only column padding shifted because the schema's longest type name changed. Acceptable per SOC 2 audit-replay reasoning (alternative is fighting prisma format on every future PR).

Verification:
  - rrule@^2.8.1 unaffected (PR-Ops-5 dependency, not touched here)
  - @anthropic-ai/sdk@^0.74.0 unchanged (already installed; PR centralizes the client wrapper, doesn't add the SDK)
  - prisma generate succeeded; new operations_ai_usage and operations_ai_inference both available to TypeScript
  - tsc --noEmit: exit 0, zero errors
  - psql verification confirmed Student Loan project content-rich (goal=979 chars, problem=1411, diagnosis=1129, design=2021) and embedded exemplar matches DB content byte-for-byte

Smoke test plan post-merge:
  1. Open Student Loan project in edit mode at /operations/projects.
  2. Click "↑ generate plan" next to the design field. Button shows "generating…" for ~3 sec.
  3. Preview pane appears below textarea. AI-generated design renders in monospace block. Cost shows "$0.03XX · ~3000 in · ~1500 out".
  4. Read the AI output. Should match Bridgewater rigor — 4 phases with timelines + outcomes + decision points section. Should reference the project's specific problem/diagnosis content (e.g., FAFSA upstream chain, tax filing, Cal State LA admission). Voice should be declarative (NOT first-person "I will").
  5. Click "use this" → form.design populates with AI text → preview pane clears.
  6. Click save → project updated → audit log shows TWO new rows in chain order: - operations_ai_inference (target_table= 'operations_projects', target_id=ea189313, metadata includes usage_id, model, tokens, cost_usd) - operations_project_updated (the user's acceptance of the new design)
  7. psql operations_ai_usage table now has 1 row with model= 'claude-sonnet-4-20250514', purpose='project_design_generation', target_id=ea189313, cost_usd≈0.0316, created_by=alex's email.
  8. Try a different project with empty goal/problem/diagnosis — click button. Expect 400 with message "project must have goal, problem, and diagnosis fields filled before generating design". No AI call made; no usage row written.
  9. Use "↑ generate plan" on Cal State LA, Taxes Personal, Taxes Business, Trading Pipeline projects. Each takes ~3 seconds and produces an institutional-rigor design field. Total backlog scoped at Bridgewater bar in ~25 minutes (was estimated at 2+ hours of manual chat-based scoping).

Rollback: pure additive PR. Revert by reverting the merge commit. The "↑ generate plan" button disappears from ProjectRow's edit mode. Migration is non-destructive (new table + new enum value); reverting via the Prisma migration system requires manual intervention because ALTER TYPE ADD VALUE cannot be removed via ALTER TYPE DROP VALUE in standard Postgres — would require creating a new enum without the value, swapping. In practice reverting the migration is unnecessary for code rollback; leftover enum value and table are unused and inert.

Known scope deferrals (intentional, not bugs):
  - Generate plan for natural-voice goal/problem/diagnosis fields (currently AI generates DESIGN only; user still writes goal/problem/diagnosis in their own words). This is correct v0 behavior — the user is the source of truth for what they want, what's missing, and what's required. AI's job is the synthesis step (design), not the intent capture step.
  - "Generate goal" / "generate problem" / "generate diagnosis" buttons: defer. The user's original natural-voice content is institutionally critical for capturing real intent. Future PR could add an "upgrade voice to institutional" pass on those fields if user feedback demands it.
  - Migration of existing 5 AI routes to recordUsage wrapper: defer. Behavior unchanged in v0; cost tracking only flows through the new infrastructure. Future PR can do coordinated sweep.
  - AI usage dashboard surfacing the cost data: defer. The data is there in operations_ai_usage; querying it via psql works fine for v0. Future Section in operations workbench could render running monthly AI spend.
  - operations_ai_overrides table for tracking accept/edit/reject per AI suggestion: defer. v0 captures the original AI output in audit_log + the user's acceptance via subsequent operations_project_updated audit row, so the override pattern is reconstructible from existing data. Dedicated table can come when override-driven weight learning becomes a priority (PR-Ops-4 priority engine v2+).