### PR TITLE
PR-Ops-3.6: AI transparency layer + create-form generate-plan + verb …

### DIFF
--- a/prisma/migrations/20260509120000_pr_ops_3_6_ai_transparency/migration.sql
+++ b/prisma/migrations/20260509120000_pr_ops_3_6_ai_transparency/migration.sql
@@ -1,0 +1,13 @@
+-- PR-Ops-3.6: AI Transparency Layer
+-- Adds full prompt/response capture columns to operations_ai_usage so
+-- every AI inference is fully inspectable in real-time (preview pane)
+-- and retrospectively (audit tail row expansion).
+--
+-- All three columns are nullable. PR-Ops-3.5 row(s) keep working with
+-- NULL values; UI renders graceful "predates PR-Ops-3.6" message.
+-- New rows from PR-Ops-3.6 onward populate them on every call.
+
+ALTER TABLE "operations_ai_usage"
+    ADD COLUMN "full_system_prompt" TEXT,
+    ADD COLUMN "full_user_message" TEXT,
+    ADD COLUMN "full_response" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2664,19 +2664,22 @@ model operations_routine_completions {
 }
 
 model operations_ai_usage {
-  id             String   @id @default(uuid()) @db.Uuid
-  user_id        String
-  model          String   @db.VarChar(100)
-  purpose        String   @db.VarChar(100)
-  target_table   String?  @db.VarChar(100)
-  target_id      String?  @db.Uuid
-  input_tokens   Int
-  output_tokens  Int
-  cost_usd       Decimal  @db.Decimal(10, 6)
-  inputs_summary String?  @db.Text
-  output_summary String?  @db.Text
-  created_at     DateTime @default(now()) @db.Timestamptz(6)
-  created_by     String?
+  id                 String   @id @default(uuid()) @db.Uuid
+  user_id            String
+  model              String   @db.VarChar(100)
+  purpose            String   @db.VarChar(100)
+  target_table       String?  @db.VarChar(100)
+  target_id          String?  @db.Uuid
+  input_tokens       Int
+  output_tokens      Int
+  cost_usd           Decimal  @db.Decimal(10, 6)
+  inputs_summary     String?  @db.Text
+  output_summary     String?  @db.Text
+  full_system_prompt String?  @db.Text
+  full_user_message  String?  @db.Text
+  full_response      String?  @db.Text
+  created_at         DateTime @default(now()) @db.Timestamptz(6)
+  created_by         String?
 
   user users @relation(fields: [user_id], references: [id])
 

--- a/src/app/api/operations/ai-usage/[id]/route.ts
+++ b/src/app/api/operations/ai-usage/[id]/route.ts
@@ -1,0 +1,64 @@
+/**
+ * GET /api/operations/ai-usage/[id]
+ *
+ * Returns the full operations_ai_usage row by id. Used by the audit
+ * tail (Section K) row-expansion feature to fetch full prompt/response
+ * content for AI inference rows on demand (lazy fetch with session-
+ * scoped cache on the client side).
+ *
+ * Auth: user must own the row (filter by user_id). Returning another
+ * user's AI inference row would leak prompt content + cost data —
+ * non-negotiable user-scoping per the security mandate.
+ *
+ * Returns 404 (not 403) when row exists but doesn't belong to caller —
+ * standard pattern matches how operations_projects/[id] handles it.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const user = await prisma.users.findFirst({
+      where: { email: { equals: userEmail, mode: 'insensitive' } },
+    });
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+
+    const { id } = await params;
+    const row = await prisma.operations_ai_usage.findFirst({
+      where: { id, user_id: user.id },
+    });
+    if (!row) return NextResponse.json({ error: 'AI usage row not found' }, { status: 404 });
+
+    return NextResponse.json({
+      id: row.id,
+      model: row.model,
+      purpose: row.purpose,
+      target_table: row.target_table,
+      target_id: row.target_id,
+      input_tokens: row.input_tokens,
+      output_tokens: row.output_tokens,
+      cost_usd: row.cost_usd.toString(),
+      inputs_summary: row.inputs_summary,
+      output_summary: row.output_summary,
+      full_system_prompt: row.full_system_prompt,
+      full_user_message: row.full_user_message,
+      full_response: row.full_response,
+      created_at: row.created_at.toISOString(),
+      created_by: row.created_by,
+    });
+  } catch (error) {
+    console.error('[AI Usage GET]', error);
+    return NextResponse.json(
+      { error: 'Failed to load AI usage row', message: error instanceof Error ? error.message : 'unknown' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/operations/ai/generate-design/route.ts
+++ b/src/app/api/operations/ai/generate-design/route.ts
@@ -1,0 +1,87 @@
+/**
+ * POST /api/operations/ai/generate-design
+ *
+ * Stateless variant of the per-project endpoint. Accepts the user's
+ * goal/problem/diagnosis directly in the request body — used by the
+ * project CREATE form before a project_id exists.
+ *
+ * The audit row's target falls back to the operations_ai_usage row
+ * itself (target_table='operations_ai_usage', target_id=usage.id) via
+ * the existing recordUsage fallback engineered in PR-Ops-3.5.
+ * metadata.purpose discriminates from edit-mode calls.
+ *
+ * Same response shape as the per-project endpoint including the
+ * inspection block. UI renders the same preview pane + drawer.
+ *
+ * Truth-first: does NOT auto-save anything. Returns the generated text
+ * for user review. User must explicitly click "use this" to populate
+ * the create form's design textarea, then "create project" to save.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { generateProjectDesign } from '@/lib/ai/generateProjectDesign';
+
+interface RequestBody {
+  title?: string;
+  goal?: string;
+  problem?: string;
+  diagnosis?: string;
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const user = await prisma.users.findFirst({
+      where: { email: { equals: userEmail, mode: 'insensitive' } },
+    });
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+
+    const body = (await request.json()) as RequestBody;
+    const title = (body.title ?? '').trim();
+    const goal = (body.goal ?? '').trim();
+    const problem = (body.problem ?? '').trim();
+    const diagnosis = (body.diagnosis ?? '').trim();
+
+    if (!title || !goal || !problem || !diagnosis) {
+      return NextResponse.json(
+        {
+          error: 'Validation',
+          message: 'title, goal, problem, and diagnosis are all required to generate a design',
+        },
+        { status: 400 }
+      );
+    }
+
+    // generateProjectDesign accepts an empty projectId as the sentinel
+    // for stateless mode; it routes the audit row to the usage row via
+    // the recordUsage fallback and discriminates the purpose label.
+    const result = await generateProjectDesign({
+      userId: user.id,
+      userEmail,
+      projectId: '',
+      projectTitle: title,
+      goal,
+      problem,
+      diagnosis,
+    });
+
+    return NextResponse.json({
+      generated_design: result.generatedDesign,
+      usage_id: result.usageId,
+      input_tokens: result.inputTokens,
+      output_tokens: result.outputTokens,
+      cost_usd: result.costUsd,
+      inspection: result.inspection,
+    });
+  } catch (error) {
+    console.error('[Stateless Generate Design POST]', error);
+    return NextResponse.json(
+      { error: 'Failed to generate design', message: error instanceof Error ? error.message : 'unknown' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/operations/projects/[id]/generate-design/route.ts
+++ b/src/app/api/operations/projects/[id]/generate-design/route.ts
@@ -63,6 +63,7 @@ export async function POST(
       input_tokens: result.inputTokens,
       output_tokens: result.outputTokens,
       cost_usd: result.costUsd,
+      inspection: result.inspection,
     });
   } catch (error) {
     console.error('[Generate Design POST]', error);

--- a/src/components/workbench/operations/SectionD_ProjectBacklog.tsx
+++ b/src/components/workbench/operations/SectionD_ProjectBacklog.tsx
@@ -21,6 +21,7 @@ import { useOperationsEntity } from './EntitySelector';
 import ProjectRow from './projects/ProjectRow';
 import type { Project, ProjectForm } from './projects/types';
 import { DEFAULT_PROJECT_FORM } from './projects/types';
+import InspectionDrawer from './ai/InspectionDrawer';
 
 interface Entity {
   id: string;
@@ -44,6 +45,72 @@ export default function SectionD_ProjectBacklog() {
   // ProjectRow A is clicked, this is set to the target project's id;
   // ProjectRow B's useEffect on isJumpTarget triggers scroll + expand.
   const [targetProjectId, setTargetProjectId] = useState<string | null>(null);
+
+  const [generatingCreateDesign, setGeneratingCreateDesign] = useState(false);
+  const [createDesignPreview, setCreateDesignPreview] = useState<string | null>(null);
+  const [createDesignError, setCreateDesignError] = useState<string | null>(null);
+  const [createDesignCost, setCreateDesignCost] = useState<
+    { cost_usd: string; input_tokens: number; output_tokens: number } | null
+  >(null);
+  const [createDesignInspection, setCreateDesignInspection] = useState<{
+    model: string;
+    temperature: number;
+    maxTokens: number;
+    systemPrompt: string;
+    userMessage: string;
+    rawResponse: string;
+    usageId: string;
+  } | null>(null);
+
+  const handleGenerateCreateDesign = async () => {
+    const title = createForm.title?.trim() ?? '';
+    const goal = createForm.goal?.trim() ?? '';
+    const problem = createForm.problem?.trim() ?? '';
+    const diagnosis = createForm.diagnosis?.trim() ?? '';
+    if (!title || !goal || !problem || !diagnosis) {
+      setCreateDesignError('Fill in title, goal, problem, and diagnosis before generating a plan.');
+      return;
+    }
+
+    setGeneratingCreateDesign(true);
+    setCreateDesignError(null);
+    setCreateDesignPreview(null);
+    setCreateDesignCost(null);
+    setCreateDesignInspection(null);
+    try {
+      const res = await fetch('/api/operations/ai/generate-design', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title, goal, problem, diagnosis }),
+      });
+      const body = await res.json();
+      if (!res.ok) {
+        setCreateDesignError(body?.message ?? body?.error ?? 'failed to generate design');
+        return;
+      }
+      setCreateDesignPreview(body.generated_design);
+      setCreateDesignCost({
+        cost_usd: body.cost_usd,
+        input_tokens: body.input_tokens,
+        output_tokens: body.output_tokens,
+      });
+      if (body.inspection) {
+        setCreateDesignInspection({
+          model: body.inspection.model,
+          temperature: body.inspection.temperature,
+          maxTokens: body.inspection.maxTokens,
+          systemPrompt: body.inspection.systemPrompt,
+          userMessage: body.inspection.userMessage,
+          rawResponse: body.inspection.rawResponse,
+          usageId: body.usage_id,
+        });
+      }
+    } catch (e) {
+      setCreateDesignError(e instanceof Error ? e.message : 'failed to generate design');
+    } finally {
+      setGeneratingCreateDesign(false);
+    }
+  };
 
   const fetchProjects = async () => {
     setLoading(true);
@@ -197,7 +264,7 @@ export default function SectionD_ProjectBacklog() {
               onChange={(e) => setCreateForm({ ...createForm, goal: e.target.value })}
               rows={2}
               className={inputClass}
-              placeholder="the specific outcome that means this project is done"
+              placeholder="I WANT to..."
             />
           </div>
           <div>
@@ -207,7 +274,7 @@ export default function SectionD_ProjectBacklog() {
               onChange={(e) => setCreateForm({ ...createForm, problem: e.target.value })}
               rows={2}
               className={inputClass}
-              placeholder="what's missing or broken right now"
+              placeholder="I DID NOT... / I HAVE NOT..."
             />
           </div>
           <div>
@@ -217,18 +284,90 @@ export default function SectionD_ProjectBacklog() {
               onChange={(e) => setCreateForm({ ...createForm, diagnosis: e.target.value })}
               rows={3}
               className={inputClass}
-              placeholder="why the gap exists — go deeper than symptoms"
+              placeholder="I NEED to..."
             />
           </div>
           <div>
-            <div className={labelClass}>4 · design — the plan</div>
+            <div className="flex items-center justify-between mb-1">
+              <div className={labelClass}>4 · design — the plan</div>
+              <button
+                type="button"
+                onClick={handleGenerateCreateDesign}
+                disabled={generatingCreateDesign}
+                className="px-2 py-0.5 border border-brand-purple text-brand-purple rounded text-xs font-mono hover:bg-purple-50 disabled:opacity-50"
+                title="Generate institutional-rigor design field from goal/problem/diagnosis"
+              >
+                {generatingCreateDesign ? 'generating…' : '↑ generate plan'}
+              </button>
+            </div>
             <textarea
               value={createForm.design}
               onChange={(e) => setCreateForm({ ...createForm, design: e.target.value })}
               rows={3}
               className={inputClass}
-              placeholder="the approach. tasks (step 5) come after this is locked."
+              placeholder="click ↑ generate plan to synthesize from goal/problem/diagnosis, or write the plan yourself"
             />
+            {createDesignError && (
+              <div className="mt-2 px-3 py-2 rounded border bg-red-50 border-red-200 text-red-800 text-xs font-mono">
+                {createDesignError}
+              </div>
+            )}
+            {createDesignPreview && (
+              <div className="mt-2 border border-brand-purple rounded p-3 bg-purple-50/30 text-xs font-mono space-y-2">
+                <div className="font-bold text-text-primary flex items-center justify-between">
+                  <span>AI-generated design (review before saving)</span>
+                  {createDesignCost && (
+                    <span className="text-text-muted text-xs font-normal">
+                      ${createDesignCost.cost_usd} · {createDesignCost.input_tokens} in · {createDesignCost.output_tokens} out
+                    </span>
+                  )}
+                </div>
+                <div className="text-text-primary whitespace-pre-wrap p-2 bg-white border border-border-light rounded">
+                  {createDesignPreview}
+                </div>
+                {createDesignInspection && (
+                  <InspectionDrawer
+                    data={{
+                      model: createDesignInspection.model,
+                      temperature: createDesignInspection.temperature,
+                      maxTokens: createDesignInspection.maxTokens,
+                      systemPrompt: createDesignInspection.systemPrompt,
+                      userMessage: createDesignInspection.userMessage,
+                      rawResponse: createDesignInspection.rawResponse,
+                      inputTokens: createDesignCost?.input_tokens ?? 0,
+                      outputTokens: createDesignCost?.output_tokens ?? 0,
+                      costUsd: createDesignCost?.cost_usd ?? '0',
+                      usageId: createDesignInspection.usageId,
+                    }}
+                  />
+                )}
+                <div className="flex items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setCreateForm({ ...createForm, design: createDesignPreview });
+                      setCreateDesignPreview(null);
+                      setCreateDesignCost(null);
+                      setCreateDesignInspection(null);
+                    }}
+                    className="px-3 py-1 border border-brand-purple bg-brand-purple text-white rounded hover:opacity-90"
+                  >
+                    use this
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setCreateDesignPreview(null);
+                      setCreateDesignCost(null);
+                      setCreateDesignInspection(null);
+                    }}
+                    className="px-3 py-1 border border-border rounded hover:bg-bg-row"
+                  >
+                    discard
+                  </button>
+                </div>
+              </div>
+            )}
           </div>
 
           <div className="grid grid-cols-2 gap-3">

--- a/src/components/workbench/operations/SectionK_AuditTail.tsx
+++ b/src/components/workbench/operations/SectionK_AuditTail.tsx
@@ -5,11 +5,18 @@
  *  - fetches with ?prefix=operations_ to scope to the Operations subsystem
  *  - calls verify-chain via POST (matches the endpoint contract)
  *  - reads body.rows only (current API response shape)
+ *
+ * PR-Ops-3.6: rows are click-to-expand. Click on the action cell toggles
+ * an expanded view that shows pretty-printed payload JSON for any row
+ * type, plus — for action_type='operations_ai_inference' — a lazy fetch
+ * to /api/operations/ai-usage/[id] that surfaces full prompt/response
+ * via InspectionDrawer. Cache is session-scoped.
  */
 
 'use client';
 
-import { useEffect, useState } from 'react';
+import { Fragment, useEffect, useState } from 'react';
+import InspectionDrawer from './ai/InspectionDrawer';
 
 interface AuditRow {
   id: string;
@@ -21,12 +28,25 @@ interface AuditRow {
   target_id: string | null;
   prev_hash: string;
   content_hash: string;
+  payload?: unknown;
 }
 
 interface VerifyResult {
   ok: boolean;
   rows_checked: number;
   message?: string;
+}
+
+interface AiUsageRow {
+  id: string;
+  model: string;
+  purpose: string;
+  input_tokens: number;
+  output_tokens: number;
+  cost_usd: string;
+  full_system_prompt: string | null;
+  full_user_message: string | null;
+  full_response: string | null;
 }
 
 function shortHash(h: string | null): string {
@@ -42,11 +62,24 @@ function relTime(iso: string): string {
   return `${Math.floor(ms / 86_400_000)}d ago`;
 }
 
+function readUsageId(payload: unknown): string | null {
+  if (typeof payload !== 'object' || payload === null) return null;
+  const meta = (payload as { metadata?: unknown }).metadata;
+  if (typeof meta !== 'object' || meta === null) return null;
+  const id = (meta as { usage_id?: unknown }).usage_id;
+  return typeof id === 'string' ? id : null;
+}
+
 export default function SectionK_AuditTail() {
   const [rows, setRows] = useState<AuditRow[]>([]);
   const [loading, setLoading] = useState(true);
   const [verifying, setVerifying] = useState(false);
   const [verifyResult, setVerifyResult] = useState<VerifyResult | null>(null);
+
+  const [expandedRows, setExpandedRows] = useState<Set<string>>(new Set());
+  const [aiUsageCache, setAiUsageCache] = useState<Map<string, AiUsageRow>>(new Map());
+  const [aiUsageLoading, setAiUsageLoading] = useState<Set<string>>(new Set());
+  const [aiUsageError, setAiUsageError] = useState<Map<string, string>>(new Map());
 
   useEffect(() => {
     let cancelled = false;
@@ -82,6 +115,113 @@ export default function SectionK_AuditTail() {
     } finally {
       setVerifying(false);
     }
+  };
+
+  const toggleRow = async (rowId: string, actionType: string, payload: unknown) => {
+    const isCurrentlyExpanded = expandedRows.has(rowId);
+    const next = new Set(expandedRows);
+    if (isCurrentlyExpanded) {
+      next.delete(rowId);
+      setExpandedRows(next);
+      return;
+    }
+    next.add(rowId);
+    setExpandedRows(next);
+
+    if (actionType !== 'operations_ai_inference') return;
+    const usageId = readUsageId(payload);
+    if (!usageId) return;
+    if (aiUsageCache.has(usageId) || aiUsageLoading.has(usageId)) return;
+
+    setAiUsageLoading((s) => {
+      const n = new Set(s);
+      n.add(usageId);
+      return n;
+    });
+    try {
+      const res = await fetch(`/api/operations/ai-usage/${usageId}`);
+      const body = await res.json();
+      if (!res.ok) {
+        setAiUsageError((m) => {
+          const n = new Map(m);
+          n.set(usageId, body?.message ?? body?.error ?? 'failed to load AI usage row');
+          return n;
+        });
+      } else {
+        setAiUsageCache((c) => {
+          const n = new Map(c);
+          n.set(usageId, body as AiUsageRow);
+          return n;
+        });
+      }
+    } catch (e) {
+      setAiUsageError((m) => {
+        const n = new Map(m);
+        n.set(usageId, e instanceof Error ? e.message : 'fetch failed');
+        return n;
+      });
+    } finally {
+      setAiUsageLoading((s) => {
+        const n = new Set(s);
+        n.delete(usageId);
+        return n;
+      });
+    }
+  };
+
+  const renderAiInspection = (payload: unknown) => {
+    const usageId = readUsageId(payload);
+    if (!usageId) {
+      return (
+        <div className="text-amber-800 text-xs font-mono">
+          (AI inference row missing usage_id in metadata)
+        </div>
+      );
+    }
+    if (aiUsageLoading.has(usageId)) {
+      return <div className="text-text-muted text-xs font-mono">loading AI inference details…</div>;
+    }
+    const err = aiUsageError.get(usageId);
+    if (err) {
+      return (
+        <div className="text-red-800 text-xs font-mono px-3 py-2 rounded border bg-red-50 border-red-200">
+          {err}
+        </div>
+      );
+    }
+    const usage = aiUsageCache.get(usageId);
+    if (!usage) return null;
+
+    const hasFullPrompts =
+      usage.full_system_prompt !== null &&
+      usage.full_user_message !== null &&
+      usage.full_response !== null;
+
+    if (!hasFullPrompts) {
+      return (
+        <InspectionDrawer
+          data={null}
+          legacyReason="(prompts not captured for this row — predates PR-Ops-3.6)"
+        />
+      );
+    }
+
+    return (
+      <InspectionDrawer
+        data={{
+          model: usage.model,
+          temperature: 0,
+          maxTokens: 0,
+          systemPrompt: usage.full_system_prompt!,
+          userMessage: usage.full_user_message!,
+          rawResponse: usage.full_response!,
+          inputTokens: usage.input_tokens,
+          outputTokens: usage.output_tokens,
+          costUsd: usage.cost_usd,
+          usageId,
+        }}
+      />
+    );
   };
 
   return (
@@ -131,22 +271,49 @@ export default function SectionK_AuditTail() {
               </tr>
             </thead>
             <tbody>
-              {rows.map((r) => (
-                <tr key={r.id} className="border-t border-border-light">
-                  <td className="py-1 text-text-muted">{relTime(r.created_at)}</td>
-                  <td className="py-1 text-text-primary">
-                    <div className="font-bold">{r.action_type}</div>
-                    <div className="text-text-muted truncate max-w-md">
-                      {r.action_description}
-                    </div>
-                  </td>
-                  <td className="py-1 text-text-muted truncate">
-                    {r.target_table ?? '—'}
-                  </td>
-                  <td className="py-1 text-text-faint">{shortHash(r.prev_hash)}</td>
-                  <td className="py-1 text-text-faint">{shortHash(r.content_hash)}</td>
-                </tr>
-              ))}
+              {rows.map((r) => {
+                const isExpanded = expandedRows.has(r.id);
+                return (
+                  <Fragment key={r.id}>
+                    <tr className="border-t border-border-light">
+                      <td className="py-1 text-text-muted">{relTime(r.created_at)}</td>
+                      <td
+                        className="py-1 text-text-primary cursor-pointer hover:bg-bg-row"
+                        onClick={() => toggleRow(r.id, r.action_type, r.payload)}
+                        title="Click to inspect this audit row"
+                      >
+                        <div className="font-bold flex items-center gap-1">
+                          <span className="text-text-faint">{isExpanded ? '▾' : '▸'}</span>
+                          <span>{r.action_type}</span>
+                        </div>
+                        <div className="text-text-muted truncate max-w-md">
+                          {r.action_description}
+                        </div>
+                      </td>
+                      <td className="py-1 text-text-muted truncate">
+                        {r.target_table ?? '—'}
+                      </td>
+                      <td className="py-1 text-text-faint">{shortHash(r.prev_hash)}</td>
+                      <td className="py-1 text-text-faint">{shortHash(r.content_hash)}</td>
+                    </tr>
+                    {isExpanded && (
+                      <tr>
+                        <td colSpan={5} className="bg-bg-row px-4 py-3 border-t border-border-light">
+                          <div className="text-xs font-mono space-y-3">
+                            <div>
+                              <div className="text-text-faint uppercase tracking-wide mb-1">payload</div>
+                              <pre className="whitespace-pre-wrap p-2 bg-white border border-border-light rounded max-h-64 overflow-y-auto text-xs">
+                                {JSON.stringify(r.payload, null, 2)}
+                              </pre>
+                            </div>
+                            {r.action_type === 'operations_ai_inference' && renderAiInspection(r.payload)}
+                          </div>
+                        </td>
+                      </tr>
+                    )}
+                  </Fragment>
+                );
+              })}
             </tbody>
           </table>
         </div>

--- a/src/components/workbench/operations/ai/InspectionDrawer.tsx
+++ b/src/components/workbench/operations/ai/InspectionDrawer.tsx
@@ -1,0 +1,168 @@
+/**
+ * InspectionDrawer — reusable AI inference inspection panel.
+ *
+ * Used by three surfaces:
+ *   1. ProjectRow edit-mode preview pane (real-time after generate)
+ *   2. SectionD create-form preview pane (real-time after generate)
+ *   3. SectionK audit tail row expansion (retrospective lookup)
+ *
+ * Renders the full institutional context of an AI inference:
+ *   - Model + temperature + max_tokens (operational parameters)
+ *   - System prompt (collapsible, monospace, full text)
+ *   - User message (collapsible, monospace, full text)
+ *   - Raw response (collapsible, monospace, full text)
+ *   - Cost breakdown (input tokens × rate + output tokens × rate)
+ *   - Audit trail metadata (usage_id, audit_log_id if known)
+ *
+ * Truth-first: every field is rendered verbatim. No truncation, no
+ * summarization. The operator sees exactly what the AI saw and
+ * exactly what it returned.
+ *
+ * Default state: drawer is CLOSED. One-click expansion is a deliberate
+ * trust act — most of the time the operator just wants to read the
+ * generated output. When they want to verify the AI's reasoning,
+ * they expand.
+ */
+
+'use client';
+
+import { useState } from 'react';
+
+export interface InspectionData {
+  model: string;
+  temperature: number;
+  maxTokens: number;
+  systemPrompt: string;
+  userMessage: string;
+  rawResponse: string;
+  inputTokens: number;
+  outputTokens: number;
+  costUsd: string;
+  usageId?: string;
+}
+
+interface Props {
+  data: InspectionData | null;
+  /**
+   * When data is null, the drawer renders a "predates PR-Ops-3.6 —
+   * prompts not captured" message. This handles the legacy case for
+   * audit tail expansion of pre-PR-Ops-3.6 rows.
+   */
+  legacyReason?: string;
+}
+
+export default function InspectionDrawer({ data, legacyReason }: Props) {
+  const [expanded, setExpanded] = useState(false);
+  const [systemOpen, setSystemOpen] = useState(false);
+  const [userOpen, setUserOpen] = useState(false);
+  const [responseOpen, setResponseOpen] = useState(false);
+
+  if (!data && legacyReason) {
+    return (
+      <div className="mt-2 px-3 py-2 rounded border bg-amber-50 border-amber-200 text-amber-900 text-xs font-mono">
+        {legacyReason}
+      </div>
+    );
+  }
+
+  if (!data) return null;
+
+  const labelClass = 'text-text-faint uppercase tracking-wide text-xs font-mono';
+  const blockClass =
+    'whitespace-pre-wrap font-mono text-xs p-3 bg-white border border-border-light rounded max-h-96 overflow-y-auto';
+
+  return (
+    <div className="mt-2 border border-border rounded">
+      <button
+        type="button"
+        onClick={() => setExpanded((x) => !x)}
+        className="w-full px-3 py-2 flex items-center justify-between text-xs font-mono text-text-primary hover:bg-bg-row"
+      >
+        <span className="flex items-center gap-2">
+          <span className="text-text-faint">{expanded ? '▾' : '▸'}</span>
+          <span>🔍 inspect this inference</span>
+        </span>
+        <span className="text-text-muted">
+          {data.model} · ${data.costUsd} · {data.inputTokens} in · {data.outputTokens} out
+        </span>
+      </button>
+
+      {expanded && (
+        <div className="px-4 py-3 border-t border-border-light space-y-3 text-xs font-mono">
+          <div className="grid grid-cols-3 gap-3">
+            <div>
+              <div className={labelClass}>model</div>
+              <div className="text-text-primary">{data.model}</div>
+            </div>
+            <div>
+              <div className={labelClass}>temperature</div>
+              <div className="text-text-primary">{data.temperature}</div>
+            </div>
+            <div>
+              <div className={labelClass}>max tokens</div>
+              <div className="text-text-primary">{data.maxTokens}</div>
+            </div>
+          </div>
+
+          <div className="grid grid-cols-3 gap-3 pt-2 border-t border-border-light">
+            <div>
+              <div className={labelClass}>input tokens</div>
+              <div className="text-text-primary">{data.inputTokens}</div>
+            </div>
+            <div>
+              <div className={labelClass}>output tokens</div>
+              <div className="text-text-primary">{data.outputTokens}</div>
+            </div>
+            <div>
+              <div className={labelClass}>cost (usd)</div>
+              <div className="text-text-primary">${data.costUsd}</div>
+            </div>
+          </div>
+
+          {data.usageId && (
+            <div className="pt-2 border-t border-border-light">
+              <div className={labelClass}>operations_ai_usage row id</div>
+              <div className="text-text-primary break-all">{data.usageId}</div>
+            </div>
+          )}
+
+          <div className="pt-2 border-t border-border-light">
+            <button
+              type="button"
+              onClick={() => setSystemOpen((x) => !x)}
+              className="text-xs font-mono text-text-primary hover:bg-bg-row px-2 py-1 rounded flex items-center gap-2"
+            >
+              <span className="text-text-faint">{systemOpen ? '▾' : '▸'}</span>
+              <span className={labelClass}>system prompt ({data.systemPrompt.length.toLocaleString()} chars)</span>
+            </button>
+            {systemOpen && <div className={blockClass + ' mt-1 text-text-primary'}>{data.systemPrompt}</div>}
+          </div>
+
+          <div>
+            <button
+              type="button"
+              onClick={() => setUserOpen((x) => !x)}
+              className="text-xs font-mono text-text-primary hover:bg-bg-row px-2 py-1 rounded flex items-center gap-2"
+            >
+              <span className="text-text-faint">{userOpen ? '▾' : '▸'}</span>
+              <span className={labelClass}>user message ({data.userMessage.length.toLocaleString()} chars)</span>
+            </button>
+            {userOpen && <div className={blockClass + ' mt-1 text-text-primary'}>{data.userMessage}</div>}
+          </div>
+
+          <div>
+            <button
+              type="button"
+              onClick={() => setResponseOpen((x) => !x)}
+              className="text-xs font-mono text-text-primary hover:bg-bg-row px-2 py-1 rounded flex items-center gap-2"
+            >
+              <span className="text-text-faint">{responseOpen ? '▾' : '▸'}</span>
+              <span className={labelClass}>raw response ({data.rawResponse.length.toLocaleString()} chars)</span>
+            </button>
+            {responseOpen && <div className={blockClass + ' mt-1 text-text-primary'}>{data.rawResponse}</div>}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/workbench/operations/projects/ProjectRow.tsx
+++ b/src/components/workbench/operations/projects/ProjectRow.tsx
@@ -21,6 +21,7 @@ import type { Project, ProjectForm, ProjectStatus } from './types';
 import { STATUS_LABELS, STATUS_PILL_CLASSES } from './types';
 import TaskList from './TaskList';
 import DependencyList from './DependencyList';
+import InspectionDrawer from '../ai/InspectionDrawer';
 
 interface Entity {
   id: string;
@@ -90,6 +91,15 @@ export default function ProjectRow({ project, entities, allProjects, onUpdate, o
   const [generationCost, setGenerationCost] = useState<
     { cost_usd: string; input_tokens: number; output_tokens: number } | null
   >(null);
+  const [generationInspection, setGenerationInspection] = useState<{
+    model: string;
+    temperature: number;
+    maxTokens: number;
+    systemPrompt: string;
+    userMessage: string;
+    rawResponse: string;
+    usageId: string;
+  } | null>(null);
   const [flash, setFlash] = useState(false);
   const rowRef = useRef<HTMLDivElement>(null);
 
@@ -152,6 +162,7 @@ export default function ProjectRow({ project, entities, allProjects, onUpdate, o
     setGenerationError(null);
     setGeneratedDesignPreview(null);
     setGenerationCost(null);
+    setGenerationInspection(null);
     try {
       const res = await fetch(`/api/operations/projects/${project.id}/generate-design`, {
         method: 'POST',
@@ -167,6 +178,17 @@ export default function ProjectRow({ project, entities, allProjects, onUpdate, o
         input_tokens: body.input_tokens,
         output_tokens: body.output_tokens,
       });
+      if (body.inspection) {
+        setGenerationInspection({
+          model: body.inspection.model,
+          temperature: body.inspection.temperature,
+          maxTokens: body.inspection.maxTokens,
+          systemPrompt: body.inspection.systemPrompt,
+          userMessage: body.inspection.userMessage,
+          rawResponse: body.inspection.rawResponse,
+          usageId: body.usage_id,
+        });
+      }
     } catch (e) {
       setGenerationError(e instanceof Error ? e.message : 'failed to generate design');
     } finally {
@@ -394,6 +416,22 @@ export default function ProjectRow({ project, entities, allProjects, onUpdate, o
                 <div className="text-text-primary whitespace-pre-wrap p-2 bg-white border border-border-light rounded">
                   {generatedDesignPreview}
                 </div>
+                {generationInspection && (
+                  <InspectionDrawer
+                    data={{
+                      model: generationInspection.model,
+                      temperature: generationInspection.temperature,
+                      maxTokens: generationInspection.maxTokens,
+                      systemPrompt: generationInspection.systemPrompt,
+                      userMessage: generationInspection.userMessage,
+                      rawResponse: generationInspection.rawResponse,
+                      inputTokens: generationCost?.input_tokens ?? 0,
+                      outputTokens: generationCost?.output_tokens ?? 0,
+                      costUsd: generationCost?.cost_usd ?? '0',
+                      usageId: generationInspection.usageId,
+                    }}
+                  />
+                )}
                 <div className="flex items-center gap-2">
                   <button
                     type="button"
@@ -401,6 +439,7 @@ export default function ProjectRow({ project, entities, allProjects, onUpdate, o
                       setForm({ ...form, design: generatedDesignPreview });
                       setGeneratedDesignPreview(null);
                       setGenerationCost(null);
+                      setGenerationInspection(null);
                     }}
                     className="px-3 py-1 border border-brand-purple bg-brand-purple text-white rounded hover:opacity-90"
                   >
@@ -411,6 +450,7 @@ export default function ProjectRow({ project, entities, allProjects, onUpdate, o
                     onClick={() => {
                       setGeneratedDesignPreview(null);
                       setGenerationCost(null);
+                      setGenerationInspection(null);
                     }}
                     className="px-3 py-1 border border-border rounded hover:bg-bg-row"
                   >

--- a/src/lib/ai/generateProjectDesign.ts
+++ b/src/lib/ai/generateProjectDesign.ts
@@ -31,6 +31,14 @@ interface GenerateOutput {
   inputTokens: number;
   outputTokens: number;
   costUsd: string;
+  inspection: {
+    model: string;
+    temperature: number;
+    maxTokens: number;
+    systemPrompt: string;
+    userMessage: string;
+    rawResponse: string;
+  };
 }
 
 const SYSTEM_PROMPT = `You are a project scoping consultant trained on the institutional rigor of Bridgewater Associates' Principles, Citadel's risk discipline, and Renaissance Technologies' empirical method.
@@ -95,6 +103,13 @@ DESIGN field: [you produce this — match the exemplar's depth and structure]`;
     `goal_len=${input.goal.length}; problem_len=${input.problem.length}; ` +
     `diagnosis_len=${input.diagnosis.length}`;
 
+  // Stateless mode: when projectId is empty, the call originates from the
+  // create form before a project exists. Pass null targets so recordUsage
+  // routes the audit row to the operations_ai_usage row itself via the
+  // PR-Ops-3.5 fallback. Use a discriminating purpose so cost analytics
+  // can distinguish create-form generations from per-project ones.
+  const isStateless = !input.projectId;
+
   const result = await recordUsage({
     userId: input.userId,
     userEmail: input.userEmail,
@@ -103,11 +118,15 @@ DESIGN field: [you produce this — match the exemplar's depth and structure]`;
     userMessage,
     maxTokens: 2000,
     temperature: 0.3,
-    purpose: 'project_design_generation',
-    targetTable: 'operations_projects',
-    targetId: input.projectId,
+    purpose: isStateless
+      ? 'project_design_generation_create_form'
+      : 'project_design_generation',
+    targetTable: isStateless ? null : 'operations_projects',
+    targetId: isStateless ? null : input.projectId,
     inputsSummary,
-    auditDescription: `Generated design field for project "${input.projectTitle}"`,
+    auditDescription: isStateless
+      ? `Generated design field for new project "${input.projectTitle}" (create form, no project_id yet)`
+      : `Generated design field for project "${input.projectTitle}"`,
   });
 
   return {
@@ -116,5 +135,6 @@ DESIGN field: [you produce this — match the exemplar's depth and structure]`;
     inputTokens: result.inputTokens,
     outputTokens: result.outputTokens,
     costUsd: result.costUsd,
+    inspection: result.inspection,
   };
 }

--- a/src/lib/ai/recordUsage.ts
+++ b/src/lib/ai/recordUsage.ts
@@ -52,6 +52,24 @@ interface RecordUsageOutput {
   inputTokens: number;
   outputTokens: number;
   costUsd: string;
+  /**
+   * Inspection block — the full context of this AI call.
+   * Returned to callers so endpoints can include it in their response
+   * for real-time transparency (the user sees exactly what went in
+   * and what came out before deciding to accept the AI's output).
+   *
+   * Persisted to operations_ai_usage.full_* columns for audit-tail
+   * row expansion (Section K) and post-hoc inspection by regulators,
+   * CPAs, or future weight-tuning analysis.
+   */
+  inspection: {
+    model: string;
+    temperature: number;
+    maxTokens: number;
+    systemPrompt: string;
+    userMessage: string;
+    rawResponse: string;
+  };
 }
 
 export async function recordUsage(input: RecordUsageInput): Promise<RecordUsageOutput> {
@@ -89,6 +107,9 @@ export async function recordUsage(input: RecordUsageInput): Promise<RecordUsageO
       cost_usd: costUsd,
       inputs_summary: input.inputsSummary,
       output_summary: outputSummary,
+      full_system_prompt: input.systemPrompt,
+      full_user_message: input.userMessage,
+      full_response: text,
       created_by: input.userEmail,
     },
   });
@@ -125,5 +146,13 @@ export async function recordUsage(input: RecordUsageInput): Promise<RecordUsageO
     inputTokens,
     outputTokens,
     costUsd,
+    inspection: {
+      model: input.model,
+      temperature: input.temperature,
+      maxTokens: input.maxTokens,
+      systemPrompt: input.systemPrompt,
+      userMessage: input.userMessage,
+      rawResponse: text,
+    },
   };
 }


### PR DESCRIPTION
…placeholders

"From god, for the people." Every AI inference in the operations workbench is now fully inspectable in real-time AND retrospectively. Bridgewater + Citadel + Renaissance bar: no black boxes, no silent summaries, no approximations. The operator sees exactly what the AI saw and exactly what the AI said.

This PR establishes three institutional capabilities:

1. INSPECTION: every AI call's full system prompt, user message, and raw response are persisted to operations_ai_usage and surfaced via a reusable InspectionDrawer component. Available at moment of generation (preview pane) and forever after via audit tail row expansion.

2. CREATE-FORM PARITY: the [↑ generate plan] button now lives in BOTH the project edit row AND the project create form. First-time scoping was the highest-leverage moment for AI assistance — the original PR-Ops-3.5 button only caught existing projects.

3. VERB GRAMMAR PLACEHOLDERS: the create form's textareas teach the Bridgewater scoping discipline through placeholder hints:
     Goal:      "I WANT to..."
     Problem:   "I DID NOT... / I HAVE NOT..."
     Diagnosis: "I NEED to..."
     Design:    "click ↑ generate plan to synthesize..."
   The form becomes the teaching tool. After 5-10 projects, users
   have internalized the grammar without needing the placeholder.

New schema (3 nullable TEXT columns on operations_ai_usage):
  full_system_prompt — the complete system prompt sent to Claude
  full_user_message  — the complete user message sent to Claude
  full_response      — the complete raw response received from Claude

All nullable. PR-Ops-3.5 row(s) keep working with NULL values; UI renders graceful "predates PR-Ops-3.6" amber message in InspectionDrawer when those columns are NULL. Forward-only data capture; no backfill.

New module: src/lib/ai/exemplars/ NOT touched (still hardcoded constant) New module: src/components/workbench/operations/ai/InspectionDrawer.tsx
  Reusable component used by three surfaces. Renders:
    - Operational params (model, temperature, max_tokens)
    - Cost breakdown (input tokens, output tokens, cost_usd)
    - operations_ai_usage row id (for psql lookup)
    - 3 collapsible sections: system prompt, user message, raw response Each shows char count in section header before opening. Each renders verbatim text in monospace block with max-h-96 overflow-y-auto so 12KB prompts don't break layout. Default state: drawer is CLOSED. One-click expansion is a deliberate trust act — most of the time the operator just reads the generated output. When they want to verify the AI's reasoning, they expand. Graceful NULL handling: when data is null and legacyReason is set, renders amber notice instead of crashing.

New endpoints:
  POST /api/operations/ai/generate-design  (stateless variant for
    create form). Validates title+goal+problem+diagnosis non-empty.
    Calls generateProjectDesign with empty-string projectId sentinel,
    which routes the audit row to operations_ai_usage row itself via
    the recordUsage fallback engineered in PR-Ops-3.5 — first caller
    to actually exercise that path. Same response shape as per-project
    endpoint including inspection block. Discriminates from per-project
    calls via metadata.purpose='project_design_generation_create_form'.
  GET /api/operations/ai-usage/[id] (for audit-tail expansion).
    User-scoped (no leak risk). Returns full row including 3 new
    full_* columns. cost_usd as string (Decimal serialization). Used
    by SectionK_AuditTail row expansion lazy fetch.

Modified library:
  recordUsage.ts: RecordUsageOutput gains inspection block. Existing
    prisma.create() now populates full_system_prompt, full_user_message,
    full_response. Return statement includes inspection. Every existing
    AI feature using recordUsage AUTOMATICALLY captures full prompts
    forever — institutional payoff of upgrading the foundation primitive.
  generateProjectDesign.ts: GenerateOutput forwards inspection.
    isStateless detection (`!input.projectId`) drives three ternaries:
    purpose label, targetTable null vs 'operations_projects', targetId
    null vs projectId. Audit description is verbose for stateless case.

Modified endpoint:
  /api/operations/projects/[id]/generate-design: response now includes
    inspection block (single line addition).

UI surfaces (3):

  SURFACE A — ProjectRow EDIT mode preview pane:
    Existing AI preview pane gets InspectionDrawer between the
    generated text block and the use-this/discard buttons. State:
    generationInspection captured from API response, cleared on
    use-this/discard/regeneration. Default closed; one click to
    inspect operational params + collapsible prompt sections.

  SURFACE B — SectionD_ProjectBacklog CREATE form:
    Goal/problem/diagnosis textareas get verb-grammar placeholders.
    Design textarea gets [↑ generate plan] button next to label.
    Same preview pane shape as Surface A: AI-generated design + cost
    + InspectionDrawer + use-this/discard. "Use this" populates createForm.design (local state) only — does NOT auto-save. User's explicit "create project" click remains the save trigger. Truth-first preserved. New state: 5 vars (generatingCreateDesign, createDesignPreview, createDesignError, createDesignCost, createDesignInspection). New handler: handleGenerateCreateDesign validates inputs server-side AND client-side, calls stateless endpoint.

  SURFACE C — SectionK_AuditTail row expansion:
    Action cell becomes clickable with ▸/▾ caret. Click toggles
    per-row expanded state. Expanded view renders:
      - Generic: pretty-printed payload JSON for ANY row type (debugging affordance for entire audit subsystem)
      - AI-specific: when action_type='operations_ai_inference', ALSO lazy-fetches the operations_ai_usage row via /api/operations/ai-usage/[id] and renders full prompts via InspectionDrawer Lazy fetch pattern: aiUsageCache (Map) + aiUsageLoading (Set) + aiUsageError (Map) for per-row state. Cache is session-scoped; page reload re-fetches. Only AI inference rows trigger fetch; other row types just show the generic payload JSON. Click target = action cell only (not whole row). Hash columns remain non-interactive so users can copy hashes without expanding. Fragment wrapper used to render the expanded second-row tr correctly inside tbody.

Architectural decisions (locked, institutional):
  - Hardcoded exemplar (PR-Ops-3.5 decision) UNCHANGED. Exemplar is engineered standard, not user-data-driven, code-review-gated.
  - Empty-string projectId sentinel triggers stateless mode. Future cleanup PR can refactor to `projectId: string | null` for clearer typing; v0 is functional.
  - Audit target fallback (PR-Ops-3.5 lines 107-108) finally has its first caller. The stateless endpoint exercises the path.
  - Audit row's metadata.usage_id is the one-way pointer (audit→usage). PR-Ops-3.5 decision preserved.
  - Lazy fetch with session-scoped cache for audit-tail expansion. Avoids 1+N waterfall on table load. Cache is per-component-mount; acceptable for v0 because audit tail typically loads <100 rows.
  - Click target = action cell only, not whole row. Preserves hash column copy-friendliness.
  - Default-closed drawer state. Inspection is a trust act, not overhead. Operator sees output first, drilling into prompts is deliberate.
  - Graceful NULL handling for PR-Ops-3.5 row's full_* columns. Truth-first about what we don't have ("predates PR-Ops-3.6").

Pattern conventions (institutional, mirroring PR-Ops-3.5):
  - All endpoints follow auth precedent: inline getVerifiedEmail + inline prisma.users.findFirst + sequential awaits.
  - operations_ai_usage uses snake_case user_id matching all operations_* tables.
  - Migration is non-destructive (3 nullable column adds, no data migration). Vercel auto-applies on deploy.
  - prisma format ran across schema and produced minor whitespace realignments around operations_ai_usage. Cosmetic only.

Verification:
  - prisma generate: succeeded; new full_* columns visible in TypeScript
  - tsc --noEmit: exit 0, zero errors
  - psql verification confirmed PR-Ops-3.5 row exists, 13 columns (post-migration: 16 columns), enum value live in production

Smoke test plan post-merge:
  1. Navigate to /operations/projects.
  2. Click "+ new project" to open the create form. Goal textarea shows placeholder "I WANT to...". Problem shows "I DID NOT... / I HAVE NOT...". Diagnosis shows "I NEED to...". Design shows guidance toward generate-plan button.
  3. Fill title + goal + problem + diagnosis with real natural-voice content for one of the 4 unscoped projects (Cal State LA, Taxes Personal, Taxes Business, or Trading Pipeline).
  4. Click [↑ generate plan] next to design label. ~3 seconds.
  5. Preview pane appears: AI-generated design rendered, cost line ($0.0XXX · ~3000 in · ~1500 out), [🔍 inspect this inference] drawer (closed), [use this] [discard] buttons.
  6. Click the inspect drawer. Expands to show: - Model: claude-sonnet-4-20250514 - Temperature: 0.3 - Max tokens: 2000 - Input/output tokens, cost - operations_ai_usage row id - 3 collapsible sections each with char count Click "system prompt" section → see full ~3000-char prompt with embedded Student Loan exemplar. Click "user message" → see your project's goal/problem/diagnosis verbatim. Click "raw response" → see exactly what Claude returned (matches the rendered preview above).
  7. Click "use this" → createForm.design populates → preview clears → click "create project" → project saved. Audit log shows TWO new rows in chain order: - operations_ai_inference (target_table='operations_ai_usage' since stateless mode, target_id=usage_row_id, metadata includes purpose='project_design_generation_create_form') - operations_project_created (the user's project save)
  8. Navigate to /operations/audit-tail (Section K). Find the operations_ai_inference row. Click on its action cell. Row expands showing payload JSON pretty-printed. Below that, InspectionDrawer renders. Click drawer to open. Click sections. Full prompts/response loaded via lazy fetch and cached. Re-collapse and re-expand: no second fetch (cache hit).
  9. Repeat steps 1-7 for the other 3 unscoped projects. Total backlog at institutional rigor in ~25 minutes.
 10. psql operations_ai_usage now has 5+ rows (1 PR-Ops-3.5 test + 4 PR-Ops-3.6 generations). All new rows have full_* columns populated. PR-Ops-3.5 row keeps NULL on those columns. Audit chain content_hash intact across all new rows.

Rollback: pure additive PR (3 new nullable columns + 4 new files + non-destructive UI additions). Revert via reverting the merge commit restores PR-Ops-3.5 behavior. Migration rollback would require creating a new enum without the new value (Postgres limitation) — not strictly necessary; the columns are nullable and inert if nothing populates them.

Known scope deferrals (intentional, not bugs):
  - temperature + max_tokens columns on operations_ai_usage for full retrospective parameter fidelity. Currently shown as 0 in audit-tail-expanded inspection drawer. Defer to when parameter drift across PRs becomes operationally important.
  - Refactor empty-string projectId to nullable string. v0 sentinel pattern is functional; clean up when next touching this code.
  - Operations AI cost dashboard surfacing trend data. Foundation is in place (operations_ai_usage table, indexed by purpose + created_at). Dashboard component can be added in a future PR when monthly AI spend becomes a budget concern.
  - Migration of 5 existing AI routes (/api/ai/*, /api/ops/*) to recordUsage wrapper. Defer; new AI features ship on the new infrastructure from day one.
  - Extracting create form to dedicated ProjectCreateForm.tsx component. SectionD_ProjectBacklog still under 350 lines. Refactor when it grows further.