### PR TITLE
PR-Ops-3.7: structured lists refactor — natural-voice item arrays + S…

### DIFF
--- a/prisma/migrations/20260509180000_pr_ops_3_7_structured_lists/migration.sql
+++ b/prisma/migrations/20260509180000_pr_ops_3_7_structured_lists/migration.sql
@@ -1,0 +1,50 @@
+-- PR-Ops-3.7: Structured Lists Refactor
+--
+-- Replaces paragraph-style goal/problem/diagnosis with JSONB array
+-- columns (goal_items / problem_items / diagnosis_items). Each item is
+-- one natural-voice line ("I WANT to ...", "I DID NOT ...", "I HAVE NOT
+-- ...", "I NEED TO ..."). Verb prefix is stored verbatim per architectural
+-- decision (B): WYSIWYG, no hidden UI prefix layer.
+--
+-- Legacy columns (goal, problem, diagnosis, design) become nullable but
+-- remain in the schema. Reasoning: audit_log payload_before history
+-- references the old paragraph values; dropping would break audit replay.
+-- Future PR drops them once audit replay is no longer a concern.
+--
+-- The user has confirmed clean-slate state (5 prior projects deleted via
+-- UI before this PR shipped). No data migration needed; new projects
+-- start with empty array defaults.
+--
+-- Design column stays as before — AI populates it via the existing
+-- generate-design endpoint. Future variant could decompose design into
+-- structured "steps" array for richer rendering, but v0 keeps it as text.
+
+ALTER TABLE "operations_projects"
+    ADD COLUMN "goal_items" JSONB NOT NULL DEFAULT '[]'::jsonb,
+    ADD COLUMN "problem_items" JSONB NOT NULL DEFAULT '[]'::jsonb,
+    ADD COLUMN "diagnosis_items" JSONB NOT NULL DEFAULT '[]'::jsonb;
+
+ALTER TABLE "operations_projects"
+    ALTER COLUMN "goal" DROP NOT NULL,
+    ALTER COLUMN "problem" DROP NOT NULL,
+    ALTER COLUMN "diagnosis" DROP NOT NULL,
+    ALTER COLUMN "design" DROP NOT NULL;
+
+-- Drop the existing CHECK constraints that enforce non-empty trim.
+-- (PR-Ops-1 created these as content_non_empty checks. They reference
+--  the now-nullable columns. Re-create simpler nullable-OR-non-empty
+--  versions if needed; for v0 we drop them entirely since the new
+--  array columns enforce content via server-side validation.)
+--
+-- Use IF EXISTS so this is idempotent if constraints were named
+-- differently in the original migration.
+
+DO $$
+BEGIN
+    EXECUTE 'ALTER TABLE "operations_projects" DROP CONSTRAINT IF EXISTS "operations_projects_goal_check"';
+    EXECUTE 'ALTER TABLE "operations_projects" DROP CONSTRAINT IF EXISTS "operations_projects_problem_check"';
+    EXECUTE 'ALTER TABLE "operations_projects" DROP CONSTRAINT IF EXISTS "operations_projects_diagnosis_check"';
+    EXECUTE 'ALTER TABLE "operations_projects" DROP CONSTRAINT IF EXISTS "operations_projects_design_check"';
+EXCEPTION WHEN OTHERS THEN
+    RAISE NOTICE 'CHECK constraint cleanup encountered % — proceeding', SQLERRM;
+END $$;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2537,10 +2537,13 @@ model operations_projects {
   user_id                  String
   entity_id                String
   title                    String        @db.VarChar(500)
-  goal                     String        @db.Text
-  problem                  String        @db.Text
-  diagnosis                String        @db.Text
-  design                   String        @db.Text
+  goal                     String?       @db.Text
+  problem                  String?       @db.Text
+  diagnosis                String?       @db.Text
+  design                   String?       @db.Text
+  goal_items               Json          @default("[]") @db.JsonB
+  problem_items            Json          @default("[]") @db.JsonB
+  diagnosis_items          Json          @default("[]") @db.JsonB
   status                   ProjectStatus @default(not_started)
   target_completion_date   DateTime?     @db.Timestamptz(6)
   estimated_total_minutes  Int?

--- a/src/app/api/operations/ai/generate-design/route.ts
+++ b/src/app/api/operations/ai/generate-design/route.ts
@@ -1,21 +1,22 @@
 /**
  * POST /api/operations/ai/generate-design
  *
- * Stateless variant of the per-project endpoint. Accepts the user's
- * goal/problem/diagnosis directly in the request body — used by the
- * project CREATE form before a project_id exists.
+ * Stateless variant of the per-project endpoint (PR-Ops-3.6 introduced).
+ * PR-Ops-3.7 updates: accepts structured array inputs (goalItems,
+ * problemItems, diagnosisItems) instead of paragraph strings. The AI
+ * system prompt was rewritten to STEP-based output with research
+ * instruction; user message format is bulleted lists.
  *
- * The audit row's target falls back to the operations_ai_usage row
- * itself (target_table='operations_ai_usage', target_id=usage.id) via
- * the existing recordUsage fallback engineered in PR-Ops-3.5.
- * metadata.purpose discriminates from edit-mode calls.
- *
- * Same response shape as the per-project endpoint including the
- * inspection block. UI renders the same preview pane + drawer.
+ * Validation:
+ *   - title: non-empty trimmed string
+ *   - goalItems: non-empty array, each item ≤ 500 chars trimmed,
+ *                array ≤ 20 items
+ *   - problemItems: same
+ *   - diagnosisItems: same
  *
  * Truth-first: does NOT auto-save anything. Returns the generated text
  * for user review. User must explicitly click "use this" to populate
- * the create form's design textarea, then "create project" to save.
+ * the create form's design field, then "create project" to save.
  */
 
 import { NextRequest, NextResponse } from 'next/server';
@@ -25,9 +26,40 @@ import { generateProjectDesign } from '@/lib/ai/generateProjectDesign';
 
 interface RequestBody {
   title?: string;
-  goal?: string;
-  problem?: string;
-  diagnosis?: string;
+  goalItems?: unknown;
+  problemItems?: unknown;
+  diagnosisItems?: unknown;
+}
+
+const MAX_ITEMS_PER_ARRAY = 20;
+const MAX_CHARS_PER_ITEM = 500;
+
+function validateItems(value: unknown, fieldName: string): { ok: true; items: string[] } | { ok: false; message: string } {
+  if (!Array.isArray(value)) {
+    return { ok: false, message: `${fieldName} must be an array` };
+  }
+  if (value.length === 0) {
+    return { ok: false, message: `${fieldName} must contain at least one item` };
+  }
+  if (value.length > MAX_ITEMS_PER_ARRAY) {
+    return { ok: false, message: `${fieldName} cannot have more than ${MAX_ITEMS_PER_ARRAY} items` };
+  }
+  const items: string[] = [];
+  for (let i = 0; i < value.length; i++) {
+    const raw = value[i];
+    if (typeof raw !== 'string') {
+      return { ok: false, message: `${fieldName}[${i}] must be a string` };
+    }
+    const trimmed = raw.trim();
+    if (trimmed.length === 0) {
+      return { ok: false, message: `${fieldName}[${i}] cannot be empty` };
+    }
+    if (trimmed.length > MAX_CHARS_PER_ITEM) {
+      return { ok: false, message: `${fieldName}[${i}] exceeds ${MAX_CHARS_PER_ITEM} characters` };
+    }
+    items.push(trimmed);
+  }
+  return { ok: true, items };
 }
 
 export async function POST(request: NextRequest) {
@@ -41,32 +73,31 @@ export async function POST(request: NextRequest) {
     if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
 
     const body = (await request.json()) as RequestBody;
-    const title = (body.title ?? '').trim();
-    const goal = (body.goal ?? '').trim();
-    const problem = (body.problem ?? '').trim();
-    const diagnosis = (body.diagnosis ?? '').trim();
-
-    if (!title || !goal || !problem || !diagnosis) {
+    const title = (typeof body.title === 'string' ? body.title : '').trim();
+    if (!title) {
       return NextResponse.json(
-        {
-          error: 'Validation',
-          message: 'title, goal, problem, and diagnosis are all required to generate a design',
-        },
+        { error: 'Validation', message: 'title is required' },
         { status: 400 }
       );
     }
 
-    // generateProjectDesign accepts an empty projectId as the sentinel
-    // for stateless mode; it routes the audit row to the usage row via
-    // the recordUsage fallback and discriminates the purpose label.
+    const goalResult = validateItems(body.goalItems, 'goalItems');
+    if (!goalResult.ok) return NextResponse.json({ error: 'Validation', message: goalResult.message }, { status: 400 });
+
+    const problemResult = validateItems(body.problemItems, 'problemItems');
+    if (!problemResult.ok) return NextResponse.json({ error: 'Validation', message: problemResult.message }, { status: 400 });
+
+    const diagnosisResult = validateItems(body.diagnosisItems, 'diagnosisItems');
+    if (!diagnosisResult.ok) return NextResponse.json({ error: 'Validation', message: diagnosisResult.message }, { status: 400 });
+
     const result = await generateProjectDesign({
       userId: user.id,
       userEmail,
       projectId: '',
       projectTitle: title,
-      goal,
-      problem,
-      diagnosis,
+      goalItems: goalResult.items,
+      problemItems: problemResult.items,
+      diagnosisItems: diagnosisResult.items,
     });
 
     return NextResponse.json({

--- a/src/app/api/operations/projects/[id]/generate-design/route.ts
+++ b/src/app/api/operations/projects/[id]/generate-design/route.ts
@@ -4,19 +4,37 @@
  * POST — generate an institutional-rigor design field for the project,
  *        using its current goal/problem/diagnosis as input.
  *
- *        Does NOT save to the project. Returns the generated text in
- *        the response; user must explicitly accept and PATCH the project
- *        with the new design field separately.
+ * PR-Ops-3.7 update: reads structured array fields (goal_items,
+ * problem_items, diagnosis_items) when populated; falls back to
+ * legacy paragraph fields wrapped as single-element arrays for
+ * backwards compatibility during the migration window. After all
+ * projects are converted to structured lists, the legacy fallback
+ * branch can be removed in a cleanup PR.
  *
- *        Validates that the project has non-empty goal/problem/diagnosis
- *        before calling the AI — those are the inputs the generator
- *        depends on.
+ * Truth-first: does NOT save to the project. Returns the generated
+ * text in the response; user must explicitly accept and PATCH the
+ * project with the new design field separately.
  */
 
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { generateProjectDesign } from '@/lib/ai/generateProjectDesign';
+
+/**
+ * Resolve a field's items: prefer the JSONB array, fall back to wrapping
+ * the legacy paragraph as a single-element array. Returns null if neither
+ * has content (caller rejects).
+ */
+function resolveItems(itemsJson: unknown, legacyText: string | null): string[] | null {
+  if (Array.isArray(itemsJson)) {
+    const arr = itemsJson.filter((x): x is string => typeof x === 'string' && x.trim().length > 0);
+    if (arr.length > 0) return arr;
+  }
+  const legacy = (legacyText ?? '').trim();
+  if (legacy.length > 0) return [legacy];
+  return null;
+}
 
 export async function POST(
   _request: NextRequest,
@@ -37,11 +55,15 @@ export async function POST(
     });
     if (!project) return NextResponse.json({ error: 'Project not found' }, { status: 404 });
 
-    if (!project.goal.trim() || !project.problem.trim() || !project.diagnosis.trim()) {
+    const goalItems = resolveItems(project.goal_items, project.goal);
+    const problemItems = resolveItems(project.problem_items, project.problem);
+    const diagnosisItems = resolveItems(project.diagnosis_items, project.diagnosis);
+
+    if (!goalItems || !problemItems || !diagnosisItems) {
       return NextResponse.json(
         {
           error: 'Validation',
-          message: 'project must have goal, problem, and diagnosis fields filled before generating design',
+          message: 'project must have goal, problem, and diagnosis content (as items or legacy text) before generating design',
         },
         { status: 400 }
       );
@@ -52,9 +74,9 @@ export async function POST(
       userEmail,
       projectId,
       projectTitle: project.title,
-      goal: project.goal,
-      problem: project.problem,
-      diagnosis: project.diagnosis,
+      goalItems,
+      problemItems,
+      diagnosisItems,
     });
 
     return NextResponse.json({

--- a/src/app/api/operations/projects/[id]/route.ts
+++ b/src/app/api/operations/projects/[id]/route.ts
@@ -110,16 +110,61 @@ export async function PATCH(
       data.title = t;
     }
 
+    // Legacy paragraph fields (goal/problem/diagnosis/design) are now nullable
+    // post-PR-Ops-3.7. Source of truth for goal/problem/diagnosis is the
+    // *_items JSONB arrays; legacy paragraphs persist for backwards-compat
+    // until a future cleanup PR drops them. Design field continues to be
+    // populated by the AI generate-design endpoint via "use this" acceptance.
     for (const field of ['goal', 'problem', 'diagnosis', 'design'] as const) {
       if (body[field] !== undefined) {
         const t = trimNonEmpty(body[field]);
-        if (t === null) {
+        data[field] = t;
+      }
+    }
+
+    // PR-Ops-3.7: structured-list fields. Each is an array of strings,
+    // each item ≤ 500 chars, ≤ 20 items per array.
+    const validateItems = (
+      value: unknown,
+      fieldName: string
+    ): { ok: true; items: string[] } | { ok: false; message: string } => {
+      if (!Array.isArray(value)) {
+        return { ok: false, message: `${fieldName} must be an array` };
+      }
+      if (value.length > 20) {
+        return { ok: false, message: `${fieldName} cannot have more than 20 items` };
+      }
+      const items: string[] = [];
+      for (let i = 0; i < value.length; i++) {
+        const raw = value[i];
+        if (typeof raw !== 'string') {
+          return { ok: false, message: `${fieldName}[${i}] must be a string` };
+        }
+        const trimmed = raw.trim();
+        if (trimmed.length === 0) continue; // silently drop empty items
+        if (trimmed.length > 500) {
+          return { ok: false, message: `${fieldName}[${i}] exceeds 500 characters` };
+        }
+        items.push(trimmed);
+      }
+      return { ok: true, items };
+    };
+
+    const itemFieldMap = [
+      { body: 'goalItems', column: 'goal_items' as const },
+      { body: 'problemItems', column: 'problem_items' as const },
+      { body: 'diagnosisItems', column: 'diagnosis_items' as const },
+    ];
+    for (const { body: bodyKey, column } of itemFieldMap) {
+      if (body[bodyKey] !== undefined) {
+        const result = validateItems(body[bodyKey], bodyKey);
+        if (!result.ok) {
           return NextResponse.json(
-            { error: 'Validation', field, message: `${field} cannot be empty` },
+            { error: 'Validation', field: bodyKey, message: result.message },
             { status: 400 }
           );
         }
-        data[field] = t;
+        data[column] = result.items;
       }
     }
 

--- a/src/app/api/operations/projects/route.ts
+++ b/src/app/api/operations/projects/route.ts
@@ -130,14 +130,99 @@ export async function POST(request: NextRequest) {
     if (entity_id_raw instanceof NextResponse) return entity_id_raw;
     const title = requireString(body.title, 'title', 500);
     if (title instanceof NextResponse) return title;
-    const goal = requireString(body.goal, 'goal');
-    if (goal instanceof NextResponse) return goal;
-    const problem = requireString(body.problem, 'problem');
-    if (problem instanceof NextResponse) return problem;
-    const diagnosis = requireString(body.diagnosis, 'diagnosis');
-    if (diagnosis instanceof NextResponse) return diagnosis;
-    const design = requireString(body.design, 'design');
-    if (design instanceof NextResponse) return design;
+
+    // PR-Ops-3.7: structured-list fields are the source of truth. Each
+    // is required, non-empty array of trimmed strings ≤ 500 chars,
+    // ≤ 20 items per array.
+    const validateItems = (
+      value: unknown,
+      fieldName: string
+    ): { ok: true; items: string[] } | { ok: false; response: NextResponse } => {
+      if (!Array.isArray(value)) {
+        return {
+          ok: false,
+          response: NextResponse.json(
+            { error: 'Validation', field: fieldName, message: `${fieldName} must be an array` },
+            { status: 400 }
+          ),
+        };
+      }
+      if (value.length === 0) {
+        return {
+          ok: false,
+          response: NextResponse.json(
+            { error: 'Validation', field: fieldName, message: `${fieldName} must contain at least one item` },
+            { status: 400 }
+          ),
+        };
+      }
+      if (value.length > 20) {
+        return {
+          ok: false,
+          response: NextResponse.json(
+            { error: 'Validation', field: fieldName, message: `${fieldName} cannot have more than 20 items` },
+            { status: 400 }
+          ),
+        };
+      }
+      const items: string[] = [];
+      for (let i = 0; i < value.length; i++) {
+        const raw = value[i];
+        if (typeof raw !== 'string') {
+          return {
+            ok: false,
+            response: NextResponse.json(
+              { error: 'Validation', field: fieldName, message: `${fieldName}[${i}] must be a string` },
+              { status: 400 }
+            ),
+          };
+        }
+        const trimmed = raw.trim();
+        if (trimmed.length === 0) {
+          return {
+            ok: false,
+            response: NextResponse.json(
+              { error: 'Validation', field: fieldName, message: `${fieldName}[${i}] cannot be empty` },
+              { status: 400 }
+            ),
+          };
+        }
+        if (trimmed.length > 500) {
+          return {
+            ok: false,
+            response: NextResponse.json(
+              { error: 'Validation', field: fieldName, message: `${fieldName}[${i}] exceeds 500 characters` },
+              { status: 400 }
+            ),
+          };
+        }
+        items.push(trimmed);
+      }
+      return { ok: true, items };
+    };
+
+    const goalItemsResult = validateItems(body.goalItems, 'goalItems');
+    if (!goalItemsResult.ok) return goalItemsResult.response;
+    const problemItemsResult = validateItems(body.problemItems, 'problemItems');
+    if (!problemItemsResult.ok) return problemItemsResult.response;
+    const diagnosisItemsResult = validateItems(body.diagnosisItems, 'diagnosisItems');
+    if (!diagnosisItemsResult.ok) return diagnosisItemsResult.response;
+
+    // Legacy paragraph fields are optional/nullable post-PR-Ops-3.7. The
+    // *_items arrays above are the source of truth; legacy text is stored
+    // verbatim if the client sends it (transition-period dual-write).
+    const trimNullable = (v: unknown): string | null => {
+      if (typeof v !== 'string') return null;
+      const t = v.trim();
+      return t.length > 0 ? t : null;
+    };
+    const goal = trimNullable(body.goal);
+    const problem = trimNullable(body.problem);
+    const diagnosis = trimNullable(body.diagnosis);
+
+    // Design is AI-populated post-PR-Ops-3.7 via "use this" acceptance.
+    // Optional at create time; client may send it pre-populated.
+    const design = trimNullable(body.design);
 
     // Verify entity ownership.
     const entity = await prisma.entities.findFirst({
@@ -201,6 +286,9 @@ export async function POST(request: NextRequest) {
         problem,
         diagnosis,
         design,
+        goal_items: goalItemsResult.items,
+        problem_items: problemItemsResult.items,
+        diagnosis_items: diagnosisItemsResult.items,
         target_completion_date,
         estimated_total_minutes,
         estimated_total_cost_usd,

--- a/src/components/workbench/operations/SectionD_ProjectBacklog.tsx
+++ b/src/components/workbench/operations/SectionD_ProjectBacklog.tsx
@@ -19,6 +19,7 @@
 import { useEffect, useState } from 'react';
 import { useOperationsEntity } from './EntitySelector';
 import ProjectRow from './projects/ProjectRow';
+import ListManager from './projects/ListManager';
 import type { Project, ProjectForm } from './projects/types';
 import { DEFAULT_PROJECT_FORM } from './projects/types';
 import InspectionDrawer from './ai/InspectionDrawer';
@@ -64,11 +65,13 @@ export default function SectionD_ProjectBacklog() {
 
   const handleGenerateCreateDesign = async () => {
     const title = createForm.title?.trim() ?? '';
-    const goal = createForm.goal?.trim() ?? '';
-    const problem = createForm.problem?.trim() ?? '';
-    const diagnosis = createForm.diagnosis?.trim() ?? '';
-    if (!title || !goal || !problem || !diagnosis) {
-      setCreateDesignError('Fill in title, goal, problem, and diagnosis before generating a plan.');
+    if (
+      title.length === 0 ||
+      createForm.goalItems.length === 0 ||
+      createForm.problemItems.length === 0 ||
+      createForm.diagnosisItems.length === 0
+    ) {
+      setCreateDesignError('Title, goal, problem, and diagnosis are all required (with at least one item each).');
       return;
     }
 
@@ -81,7 +84,12 @@ export default function SectionD_ProjectBacklog() {
       const res = await fetch('/api/operations/ai/generate-design', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ title, goal, problem, diagnosis }),
+        body: JSON.stringify({
+          title,
+          goalItems: createForm.goalItems,
+          problemItems: createForm.problemItems,
+          diagnosisItems: createForm.diagnosisItems,
+        }),
       });
       const body = await res.json();
       if (!res.ok) {
@@ -259,54 +267,57 @@ export default function SectionD_ProjectBacklog() {
 
           <div>
             <div className={labelClass}>1 · goal — what success looks like</div>
-            <textarea
-              value={createForm.goal}
-              onChange={(e) => setCreateForm({ ...createForm, goal: e.target.value })}
-              rows={2}
-              className={inputClass}
-              placeholder="I WANT to..."
+            <ListManager
+              items={createForm.goalItems}
+              onChange={(next) => setCreateForm({ ...createForm, goalItems: next })}
+              verbPrefix="I WANT to "
+              placeholder="get loans approved"
+              disabled={createSaving}
             />
           </div>
           <div>
             <div className={labelClass}>2 · problem — gap between current and goal</div>
-            <textarea
-              value={createForm.problem}
-              onChange={(e) => setCreateForm({ ...createForm, problem: e.target.value })}
-              rows={2}
-              className={inputClass}
-              placeholder="I DID NOT... / I HAVE NOT..."
+            <ListManager
+              items={createForm.problemItems}
+              onChange={(next) => setCreateForm({ ...createForm, problemItems: next })}
+              verbPrefix="I DID NOT "
+              altVerbPrefix="I HAVE NOT "
+              placeholder="create an FSA ID yet"
+              disabled={createSaving}
             />
           </div>
           <div>
             <div className={labelClass}>3 · diagnosis — root cause</div>
-            <textarea
-              value={createForm.diagnosis}
-              onChange={(e) => setCreateForm({ ...createForm, diagnosis: e.target.value })}
-              rows={3}
-              className={inputClass}
-              placeholder="I NEED to..."
+            <ListManager
+              items={createForm.diagnosisItems}
+              onChange={(next) => setCreateForm({ ...createForm, diagnosisItems: next })}
+              verbPrefix="I NEED TO "
+              placeholder="complete personal tax return first"
+              disabled={createSaving}
             />
           </div>
           <div>
             <div className="flex items-center justify-between mb-1">
-              <div className={labelClass}>4 · design — the plan</div>
+              <div className={labelClass}>4 · design — the plan (AI-generated)</div>
               <button
                 type="button"
                 onClick={handleGenerateCreateDesign}
                 disabled={generatingCreateDesign}
                 className="px-2 py-0.5 border border-brand-purple text-brand-purple rounded text-xs font-mono hover:bg-purple-50 disabled:opacity-50"
-                title="Generate institutional-rigor design field from goal/problem/diagnosis"
+                title="Generate institutional-rigor design field from your goal/problem/diagnosis items"
               >
                 {generatingCreateDesign ? 'generating…' : '↑ generate plan'}
               </button>
             </div>
-            <textarea
-              value={createForm.design}
-              onChange={(e) => setCreateForm({ ...createForm, design: e.target.value })}
-              rows={3}
-              className={inputClass}
-              placeholder="click ↑ generate plan to synthesize from goal/problem/diagnosis, or write the plan yourself"
-            />
+            {createForm.design.trim().length > 0 ? (
+              <div className="text-text-primary text-xs font-mono whitespace-pre-wrap p-3 bg-white border border-border-light rounded">
+                {createForm.design}
+              </div>
+            ) : (
+              <div className="text-text-muted text-xs font-mono italic p-3 bg-bg-row border border-border-light rounded">
+                (no design yet — fill in goal/problem/diagnosis items above, then click "↑ generate plan")
+              </div>
+            )}
             {createDesignError && (
               <div className="mt-2 px-3 py-2 rounded border bg-red-50 border-red-200 text-red-800 text-xs font-mono">
                 {createDesignError}

--- a/src/components/workbench/operations/projects/ListManager.tsx
+++ b/src/components/workbench/operations/projects/ListManager.tsx
@@ -1,0 +1,258 @@
+/**
+ * ListManager — structured list editor for natural-voice items.
+ *
+ * Used by project goal/problem/diagnosis fields. Each item is one
+ * verb-prefixed line (e.g., "I WANT to get loans approved").
+ *
+ * Storage: items stored verbatim with verb prefix included (per
+ * PR-Ops-3.7 architectural decision B). Add-item input pre-fills the
+ * verb prefix to enforce institutional grammar discipline while
+ * keeping storage WYSIWYG.
+ *
+ * Limits: 500 chars per item, 20 items per list (server-validated;
+ * UI shows soft warning before hard cap).
+ *
+ * Used in:
+ *   - ProjectRow edit mode (3 instances per project)
+ *   - SectionD create form (3 instances per new project, Prompt 3)
+ */
+
+'use client';
+
+import { useState } from 'react';
+
+interface Props {
+  /** Current items (each is a complete natural-voice line with verb prefix). */
+  items: string[];
+  /** Callback when items change — caller manages the source-of-truth state. */
+  onChange: (next: string[]) => void;
+  /**
+   * Verb prefix to pre-fill when user clicks add. Examples:
+   *   - "I WANT to "
+   *   - "I DID NOT "
+   *   - "I HAVE NOT "
+   *   - "I NEED TO "
+   * The prefix is included verbatim in the saved item.
+   */
+  verbPrefix: string;
+  /** Optional alternate prefix (e.g., problem field has "I DID NOT" + "I HAVE NOT"). */
+  altVerbPrefix?: string;
+  /** Optional placeholder shown after the verb prefix in the input. */
+  placeholder?: string;
+  /** Disabled state (during save, regeneration, etc). */
+  disabled?: boolean;
+}
+
+const MAX_ITEMS = 20;
+const MAX_CHARS = 500;
+
+export default function ListManager({
+  items,
+  onChange,
+  verbPrefix,
+  altVerbPrefix,
+  placeholder,
+  disabled = false,
+}: Props) {
+  const [draft, setDraft] = useState<string>('');
+  const [draftPrefix, setDraftPrefix] = useState<string>(verbPrefix);
+  const [editingIndex, setEditingIndex] = useState<number | null>(null);
+  const [editingText, setEditingText] = useState<string>('');
+
+  const atLimit = items.length >= MAX_ITEMS;
+
+  const startAdd = (prefix: string) => {
+    if (atLimit) return;
+    setDraftPrefix(prefix);
+    setDraft(prefix);
+  };
+
+  const commitAdd = () => {
+    const trimmed = draft.trim();
+    if (trimmed.length === 0) {
+      setDraft('');
+      return;
+    }
+    if (trimmed.length > MAX_CHARS) return;
+    onChange([...items, trimmed]);
+    setDraft('');
+    setDraftPrefix(verbPrefix);
+  };
+
+  const cancelAdd = () => {
+    setDraft('');
+    setDraftPrefix(verbPrefix);
+  };
+
+  const startEdit = (i: number) => {
+    setEditingIndex(i);
+    setEditingText(items[i]);
+  };
+
+  const commitEdit = () => {
+    if (editingIndex === null) return;
+    const trimmed = editingText.trim();
+    if (trimmed.length === 0) {
+      // Empty edit = remove the item.
+      removeItem(editingIndex);
+      setEditingIndex(null);
+      setEditingText('');
+      return;
+    }
+    if (trimmed.length > MAX_CHARS) return;
+    const next = [...items];
+    next[editingIndex] = trimmed;
+    onChange(next);
+    setEditingIndex(null);
+    setEditingText('');
+  };
+
+  const cancelEdit = () => {
+    setEditingIndex(null);
+    setEditingText('');
+  };
+
+  const removeItem = (i: number) => {
+    onChange(items.filter((_, idx) => idx !== i));
+  };
+
+  const inputClass =
+    'w-full px-2 py-1 border border-border rounded text-xs font-mono text-text-primary focus:outline-none focus:border-brand-purple';
+
+  return (
+    <div className="space-y-1">
+      {items.length === 0 && draft.length === 0 && (
+        <div className="text-xs font-mono text-text-muted italic px-1">
+          (no items yet — click below to add)
+        </div>
+      )}
+
+      {items.map((item, i) => (
+        <div key={i} className="flex items-start gap-2 group">
+          <span className="text-text-faint text-xs font-mono mt-1 select-none">·</span>
+          {editingIndex === i ? (
+            <>
+              <input
+                type="text"
+                value={editingText}
+                onChange={(e) => setEditingText(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') commitEdit();
+                  if (e.key === 'Escape') cancelEdit();
+                }}
+                className={inputClass + ' flex-1'}
+                maxLength={MAX_CHARS}
+                disabled={disabled}
+                autoFocus
+              />
+              <button
+                type="button"
+                onClick={commitEdit}
+                disabled={disabled}
+                className="px-2 py-0.5 border border-brand-purple bg-brand-purple text-white rounded text-xs font-mono hover:opacity-90 disabled:opacity-50"
+              >
+                save
+              </button>
+              <button
+                type="button"
+                onClick={cancelEdit}
+                disabled={disabled}
+                className="px-2 py-0.5 border border-border rounded text-xs font-mono hover:bg-bg-row disabled:opacity-50"
+              >
+                cancel
+              </button>
+            </>
+          ) : (
+            <>
+              <span
+                className="flex-1 text-xs font-mono text-text-primary cursor-pointer hover:bg-bg-row rounded px-1"
+                onClick={() => !disabled && startEdit(i)}
+                title="Click to edit"
+              >
+                {item}
+              </span>
+              <button
+                type="button"
+                onClick={() => removeItem(i)}
+                disabled={disabled}
+                className="opacity-0 group-hover:opacity-100 px-1 text-text-faint hover:text-red-700 text-xs font-mono disabled:opacity-50"
+                title="Remove item"
+              >
+                ✕
+              </button>
+            </>
+          )}
+        </div>
+      ))}
+
+      {draft.length > 0 ? (
+        <div className="flex items-start gap-2">
+          <span className="text-brand-purple text-xs font-mono mt-1 select-none">+</span>
+          <input
+            type="text"
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') commitAdd();
+              if (e.key === 'Escape') cancelAdd();
+            }}
+            placeholder={placeholder}
+            className={inputClass + ' flex-1'}
+            maxLength={MAX_CHARS}
+            disabled={disabled}
+            autoFocus
+          />
+          <button
+            type="button"
+            onClick={commitAdd}
+            disabled={disabled || draft.trim().length === 0}
+            className="px-2 py-0.5 border border-brand-purple bg-brand-purple text-white rounded text-xs font-mono hover:opacity-90 disabled:opacity-50"
+          >
+            add
+          </button>
+          <button
+            type="button"
+            onClick={cancelAdd}
+            disabled={disabled}
+            className="px-2 py-0.5 border border-border rounded text-xs font-mono hover:bg-bg-row disabled:opacity-50"
+          >
+            cancel
+          </button>
+        </div>
+      ) : (
+        <div className="flex items-center gap-2 pt-1">
+          <button
+            type="button"
+            onClick={() => startAdd(verbPrefix)}
+            disabled={disabled || atLimit}
+            className="px-2 py-0.5 border border-brand-purple text-brand-purple rounded text-xs font-mono hover:bg-purple-50 disabled:opacity-50"
+            title={atLimit ? `Maximum ${MAX_ITEMS} items reached` : `Add a "${verbPrefix.trim()}" item`}
+          >
+            + {verbPrefix.trim()}...
+          </button>
+          {altVerbPrefix && (
+            <button
+              type="button"
+              onClick={() => startAdd(altVerbPrefix)}
+              disabled={disabled || atLimit}
+              className="px-2 py-0.5 border border-brand-purple text-brand-purple rounded text-xs font-mono hover:bg-purple-50 disabled:opacity-50"
+              title={atLimit ? `Maximum ${MAX_ITEMS} items reached` : `Add a "${altVerbPrefix.trim()}" item`}
+            >
+              + {altVerbPrefix.trim()}...
+            </button>
+          )}
+          {atLimit && (
+            <span className="text-xs font-mono text-text-muted italic">
+              (max {MAX_ITEMS} items reached)
+            </span>
+          )}
+          {!atLimit && items.length >= MAX_ITEMS - 5 && (
+            <span className="text-xs font-mono text-text-muted">
+              ({MAX_ITEMS - items.length} slots left)
+            </span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/workbench/operations/projects/ProjectRow.tsx
+++ b/src/components/workbench/operations/projects/ProjectRow.tsx
@@ -21,6 +21,7 @@ import type { Project, ProjectForm, ProjectStatus } from './types';
 import { STATUS_LABELS, STATUS_PILL_CLASSES } from './types';
 import TaskList from './TaskList';
 import DependencyList from './DependencyList';
+import ListManager from './ListManager';
 import InspectionDrawer from '../ai/InspectionDrawer';
 
 interface Entity {
@@ -55,10 +56,10 @@ function projectToForm(p: Project): ProjectForm {
   return {
     entity_id: p.entity_id,
     title: p.title,
-    goal: p.goal,
-    problem: p.problem,
-    diagnosis: p.diagnosis,
-    design: p.design,
+    design: p.design ?? '',
+    goalItems: Array.isArray(p.goal_items) ? p.goal_items.filter((x): x is string => typeof x === 'string') : [],
+    problemItems: Array.isArray(p.problem_items) ? p.problem_items.filter((x): x is string => typeof x === 'string') : [],
+    diagnosisItems: Array.isArray(p.diagnosis_items) ? p.diagnosis_items.filter((x): x is string => typeof x === 'string') : [],
     status: p.status,
     target_completion_date: p.target_completion_date
       ? p.target_completion_date.slice(0, 10)
@@ -220,6 +221,50 @@ export default function ProjectRow({ project, entities, allProjects, onUpdate, o
   const labelClass = 'text-text-faint uppercase tracking-wide mb-1 text-xs font-mono';
   const pillClass = `inline-block px-2 py-0.5 border rounded text-xs font-mono ${STATUS_PILL_CLASSES[project.status]}`;
 
+  // Derive structured-list arrays from the project. JsonB columns may
+  // come back as JsonValue at runtime; filter to strings defensively.
+  const goalItems = Array.isArray(project.goal_items)
+    ? project.goal_items.filter((x): x is string => typeof x === 'string')
+    : [];
+  const problemItems = Array.isArray(project.problem_items)
+    ? project.problem_items.filter((x): x is string => typeof x === 'string')
+    : [];
+  const diagnosisItems = Array.isArray(project.diagnosis_items)
+    ? project.diagnosis_items.filter((x): x is string => typeof x === 'string')
+    : [];
+
+  /**
+   * Render a structured field that may be either:
+   *   - new structured array (project.goal_items / problem_items / diagnosis_items)
+   *   - legacy paragraph (project.goal / problem / diagnosis as string|null)
+   *
+   * Prefers structured items; falls back to legacy paragraph when items
+   * array is empty. Both states render readably in the row.
+   */
+  const renderStructuredField = (
+    items: string[],
+    legacyText: string | null
+  ) => {
+    if (items.length > 0) {
+      return (
+        <ul className="list-disc list-inside text-text-primary text-xs font-mono space-y-0.5 ml-2">
+          {items.map((it, i) => (
+            <li key={i} className="break-words">{it}</li>
+          ))}
+        </ul>
+      );
+    }
+    if (legacyText && legacyText.trim().length > 0) {
+      return (
+        <div className="text-text-primary text-xs font-mono whitespace-pre-wrap">
+          {legacyText}
+          <span className="text-text-faint italic ml-2">(legacy paragraph format)</span>
+        </div>
+      );
+    }
+    return <div className="text-text-muted text-xs font-mono italic">(no content)</div>;
+  };
+
   return (
     <div
       ref={rowRef}
@@ -247,19 +292,19 @@ export default function ProjectRow({ project, entities, allProjects, onUpdate, o
         <div className="px-4 py-3 border-t border-border-light text-xs font-mono space-y-3">
           <div>
             <div className={labelClass}>1 · goal</div>
-            <div className="text-text-primary whitespace-pre-wrap">{project.goal}</div>
+            {renderStructuredField(goalItems, project.goal)}
           </div>
           <div>
             <div className={labelClass}>2 · problem</div>
-            <div className="text-text-primary whitespace-pre-wrap">{project.problem}</div>
+            {renderStructuredField(problemItems, project.problem)}
           </div>
           <div>
             <div className={labelClass}>3 · diagnosis</div>
-            <div className="text-text-primary whitespace-pre-wrap">{project.diagnosis}</div>
+            {renderStructuredField(diagnosisItems, project.diagnosis)}
           </div>
           <div>
             <div className={labelClass}>4 · design</div>
-            <div className="text-text-primary whitespace-pre-wrap">{project.design}</div>
+            <div className="text-text-primary whitespace-pre-wrap">{project.design ?? ''}</div>
           </div>
           <div className="pt-2 border-t border-border-light">
             <div className={labelClass}>5 · execute (tasks)</div>
@@ -354,50 +399,57 @@ export default function ProjectRow({ project, entities, allProjects, onUpdate, o
 
           <div>
             <div className={labelClass}>1 · goal — what success looks like</div>
-            <textarea
-              value={form.goal}
-              onChange={(e) => setForm({ ...form, goal: e.target.value })}
-              rows={2}
-              className={inputClass}
+            <ListManager
+              items={form.goalItems}
+              onChange={(next) => setForm({ ...form, goalItems: next })}
+              verbPrefix="I WANT to "
+              placeholder="get loans approved"
+              disabled={saving}
             />
           </div>
           <div>
             <div className={labelClass}>2 · problem — gap between current and goal</div>
-            <textarea
-              value={form.problem}
-              onChange={(e) => setForm({ ...form, problem: e.target.value })}
-              rows={2}
-              className={inputClass}
+            <ListManager
+              items={form.problemItems}
+              onChange={(next) => setForm({ ...form, problemItems: next })}
+              verbPrefix="I DID NOT "
+              altVerbPrefix="I HAVE NOT "
+              placeholder="create an FSA ID yet"
+              disabled={saving}
             />
           </div>
           <div>
             <div className={labelClass}>3 · diagnosis — root cause of the gap</div>
-            <textarea
-              value={form.diagnosis}
-              onChange={(e) => setForm({ ...form, diagnosis: e.target.value })}
-              rows={3}
-              className={inputClass}
+            <ListManager
+              items={form.diagnosisItems}
+              onChange={(next) => setForm({ ...form, diagnosisItems: next })}
+              verbPrefix="I NEED TO "
+              placeholder="complete personal tax return first"
+              disabled={saving}
             />
           </div>
           <div>
             <div className="flex items-center justify-between mb-1">
-              <div className={labelClass}>4 · design — the plan</div>
+              <div className={labelClass}>4 · design — the plan (AI-generated)</div>
               <button
                 type="button"
                 onClick={handleGenerateDesign}
                 disabled={generatingDesign}
                 className="px-2 py-0.5 border border-brand-purple text-brand-purple rounded text-xs font-mono hover:bg-purple-50 disabled:opacity-50"
-                title="Generate institutional-rigor design field from your goal/problem/diagnosis"
+                title="Generate institutional-rigor design field from your goal/problem/diagnosis items"
               >
                 {generatingDesign ? 'generating…' : '↑ generate plan'}
               </button>
             </div>
-            <textarea
-              value={form.design}
-              onChange={(e) => setForm({ ...form, design: e.target.value })}
-              rows={3}
-              className={inputClass}
-            />
+            {form.design.trim().length > 0 ? (
+              <div className="text-text-primary text-xs font-mono whitespace-pre-wrap p-3 bg-white border border-border-light rounded">
+                {form.design}
+              </div>
+            ) : (
+              <div className="text-text-muted text-xs font-mono italic p-3 bg-bg-row border border-border-light rounded">
+                (no design yet — fill in goal/problem/diagnosis items above, then click "↑ generate plan")
+              </div>
+            )}
             {generationError && (
               <div className="mt-2 px-3 py-2 rounded border bg-red-50 border-red-200 text-red-800 text-xs font-mono">
                 {generationError}

--- a/src/components/workbench/operations/projects/types.ts
+++ b/src/components/workbench/operations/projects/types.ts
@@ -23,10 +23,13 @@ export interface Project {
   user_id: string;
   entity_id: string;
   title: string;
-  goal: string;
-  problem: string;
-  diagnosis: string;
-  design: string;
+  goal: string | null;
+  problem: string | null;
+  diagnosis: string | null;
+  design: string | null;
+  goal_items: string[];
+  problem_items: string[];
+  diagnosis_items: string[];
   status: ProjectStatus;
   target_completion_date: string | null;
   estimated_total_minutes: number | null;
@@ -51,10 +54,10 @@ export interface Project {
 export interface ProjectForm {
   entity_id: string;
   title: string;
-  goal: string;
-  problem: string;
-  diagnosis: string;
   design: string;
+  goalItems: string[];
+  problemItems: string[];
+  diagnosisItems: string[];
   status: ProjectStatus;
   target_completion_date: string;          // ISO date (yyyy-mm-dd) or empty
   estimated_total_minutes: string;         // string for input binding; coerced server-side
@@ -64,10 +67,10 @@ export interface ProjectForm {
 export const DEFAULT_PROJECT_FORM: ProjectForm = {
   entity_id: '',
   title: '',
-  goal: '',
-  problem: '',
-  diagnosis: '',
   design: '',
+  goalItems: [],
+  problemItems: [],
+  diagnosisItems: [],
   status: 'not_started',
   target_completion_date: '',
   estimated_total_minutes: '',

--- a/src/lib/ai/exemplars/projectDesign.ts
+++ b/src/lib/ai/exemplars/projectDesign.ts
@@ -1,63 +1,65 @@
 /**
  * Project Design Exemplar — Student Loan for Bachelors.
  *
- * This is the institutional gold-standard project scoping that the AI
- * design generator uses as its few-shot example. The user's Student
- * Loan project (UUID: ea189313-296c-4c9e-8279-7e3450debe7e) was scoped
- * manually with Bridgewater 5-step rigor; its content is embedded here
- * verbatim as the exemplar all future generations should match in
- * depth and structure.
+ * The institutional gold-standard project scoping that the AI design
+ * generator uses as its few-shot example. Reformatted in PR-Ops-3.7
+ * to the structured-lists shape:
+ *   - goal_items, problem_items, diagnosis_items as arrays of natural-
+ *     voice items with verb prefix included
+ *   - design as STEP-based prose (replacing PR-Ops-3.5/3.6 phase-based
+ *     prose; same content, new section labels)
  *
- * Updating this constant is a deliberate code change — the exemplar is
- * NOT runtime-fetched from DB. Reasoning:
- *   1. Engineered standard, not variable user data
- *   2. Deterministic cost per call (input tokens fixed)
- *   3. Code review gates exemplar evolution
+ * The original Student Loan project (UUID ea189313-...) was deleted
+ * from the user's DB on 2026-05-08 as part of clean-slate preparation
+ * for PR-Ops-3.7. Its content lives on here as the engineered standard
+ * for what good scoping looks like — a code-review-gated artifact, not
+ * runtime user data.
  *
- * If the canonical exemplar needs to evolve, edit this file with a
- * commit explaining why.
+ * Updating this constant requires a deliberate code change. If the
+ * exemplar evolves (e.g., a new domain becomes a better template),
+ * commit explicit reasoning.
  */
 
 export const PROJECT_DESIGN_EXEMPLAR = {
   title: 'Student Loan for Bachelors - Sallie Mae | FASFA | Grants | Scholarships',
-  goal: `Federal student aid (subsidized + unsubsidized Direct Loans) and a private loan alternative both fully approved and ready to disburse to Cal State LA, covering the full cost of attendance for the academic year (tuition + mandatory fees + books + reasonable cost-of-living allowance per CSU guidelines), with all loan terms — interest rates, repayment schedules, deferment options, total cost over loan life — documented in writing and reviewed against each other to choose the lowest-cost path.
-
-Success means:
-
-(a) FAFSA submitted and Student Aid Index determined;
-(b) Cal State LA financial aid award letter received;
-(c) federal loan offers accepted at the chosen amount;
-(d) at least one private loan offer obtained for comparison (even if not accepted) so the federal vs. private decision is informed;
-(e) all required Master Promissory Notes signed;
-(f) entrance counseling completed;
-(g) disbursement scheduled to align with Cal State LA's enrollment confirmation.`,
-  problem: `Current state: California-based, no concrete prerequisite work started. No FSA ID created, FAFSA not yet filed, Cal State LA admission application not submitted, transcripts from prior institutions not requested, 2025 personal tax return not yet completed, no private lender pre-qualifications run.
-Gap to goal — required actions not yet taken:
-
-FSA ID creation (federalstudentaid.gov account) — required to file FAFSA.
-FAFSA 2026-2027 submission — Cal State LA's specific deadline needs verification.
-Cal State LA admission application — separate from financial aid; needed before financial aid award letter can be issued.
-Transcripts from any prior institutions — required for admission application.
-Tax return data for FAFSA — FAFSA pulls IRS data via Data Retrieval Tool; clean personal return must be filed first.
-Private lender shortlist — Sallie Mae, College Ave, Earnest are major options; comparison requires soft-pull pre-qualification at minimum 2-3 lenders.
-
-Specific known unknowns:
-
-Cal State LA accounting bachelor's program total cost of attendance for 2026-2027 academic year.
-Whether trading P&L is reportable income on FAFSA and how it's classified.
-Whether Temple Stuart LLC pass-through income affects Student Aid Index calculation.
-Whether prior coursework transfers to Cal State LA accounting bachelor's program.
-The actual May 9 date significance — internal goal, deadline, or arbitrary.`,
-  diagnosis: `First: this project is the FINAL step of a four-stage chain (clean tax return → FAFSA + admission → award letter + offers → loan acceptance + signing + disbursement). Treating it as standalone creates the illusion that loan-specific work needs doing now, when the real upstream blockers are tax filing and admission paperwork. The "Student Loan" project is downstream of the "Taxes Personal" and "Sign up for Cal State LA" projects.
-Second: the FAFSA filing for a solo founder with trading entity P&L plus Temple Stuart LLC pass-through plus Schedule C plus capital gains is materially more complex than a standard W-2 filer. This is CPA-level disclosure work that benefits from completing both personal AND business tax returns first so the FAFSA's IRS Data Retrieval Tool pulls clean numbers.
-Third: the May 9 target date was set without verification of any external deadline. FAFSA 2026-2027 priority deadlines have already passed (March 2 at most California schools). Cal State LA's actual fall 2026 enrollment plus disbursement timeline runs through August/September, not May. Target was aspirational, not calendar-anchored.`,
-  design: `Phase 1 (immediate, ~2 weeks): unblock the upstream chain. Complete personal tax return so FAFSA has clean IRS data. Complete business tax return if it affects pass-through to personal. Request transcripts from all prior institutions. Create FSA ID. Look up Cal State LA published cost of attendance and confirm fall 2026 enrollment is the actual target. Outcome: ready to file FAFSA and Cal State LA admission application with all source documents in hand.
-Phase 2 (~4 weeks after phase 1): file FAFSA 2026-2027. Submit Cal State LA admission application with transcripts. Contact Cal State LA financial aid office for any program-specific questions about transferring credits and accounting program structure. Outcome: applications submitted, awaiting determination.
-Phase 3 (~8 weeks after phase 2): receive Cal State LA admission decision. Receive financial aid award letter and Student Aid Index from FAFSA. Run private loan comparison shopping in parallel — soft-pull pre-qualifications with Sallie Mae, College Ave, Earnest. Compare federal subsidized + unsubsidized offers against private offers across interest rate, total cost over loan life, repayment terms, deferment flexibility. Outcome: full financing menu in hand for decision.
-Phase 4 (immediately before enrollment, ~August 2026): accept federal loan amounts at the chosen level. Sign all required Master Promissory Notes. Complete entrance counseling. Optionally accept private loan if comparison favors it. Confirm disbursement schedule aligns with Cal State LA's fall 2026 enrollment confirmation. Outcome: financing locked, classes can begin.
+  goal_items: [
+    'I WANT federal student aid (subsidized + unsubsidized Direct Loans) fully approved and ready to disburse to Cal State LA',
+    'I WANT a private loan alternative obtained for comparison so the federal vs. private decision is informed',
+    'I WANT all loan terms (interest rates, repayment schedules, deferment options, total cost over loan life) documented in writing',
+    'I WANT FAFSA submitted and Student Aid Index determined',
+    'I WANT Cal State LA financial aid award letter received',
+    'I WANT federal loan offers accepted at the chosen amount',
+    'I WANT all required Master Promissory Notes signed',
+    'I WANT entrance counseling completed',
+    'I WANT disbursement scheduled to align with Cal State LA\'s enrollment confirmation',
+  ],
+  problem_items: [
+    'I DID NOT create an FSA ID yet (federalstudentaid.gov account required to file FAFSA)',
+    'I HAVE NOT filed FAFSA 2026-2027',
+    'I DID NOT submit the Cal State LA admission application',
+    'I HAVE NOT requested transcripts from prior institutions',
+    'I DID NOT file my 2025 personal tax return yet',
+    'I HAVE NOT run private lender pre-qualifications (Sallie Mae, College Ave, Earnest)',
+    'I DID NOT verify Cal State LA accounting bachelor\'s program total cost of attendance for 2026-2027',
+    'I HAVE NOT determined whether trading P&L is reportable income on FAFSA and how it\'s classified',
+    'I HAVE NOT determined whether Temple Stuart LLC pass-through income affects Student Aid Index calculation',
+    'I HAVE NOT confirmed whether prior coursework transfers to Cal State LA accounting bachelor\'s program',
+  ],
+  diagnosis_items: [
+    'I NEED TO complete personal tax return first so FAFSA pulls clean IRS data via Data Retrieval Tool',
+    'I NEED TO complete business tax return so Schedule C and pass-through income are accurate before FAFSA',
+    'I NEED TO recognize this project is downstream of "Taxes Personal" and "Sign up for Cal State LA" — not standalone work',
+    'I NEED TO acknowledge that FAFSA priority deadlines (March 2 at most CA schools) have already passed for 2026-2027',
+    'I NEED TO calendar-anchor the target date to Cal State LA\'s actual fall 2026 enrollment plus disbursement timeline (August/September), not the aspirational May 9',
+    'I NEED TO treat FAFSA filing as CPA-level disclosure work given trading entity P&L plus LLC pass-through plus Schedule C plus capital gains complexity',
+  ],
+  design: `STEP 1 (immediate, ~2 weeks): unblock the upstream chain. Complete personal tax return so FAFSA has clean IRS data. Complete business tax return if it affects pass-through to personal. Request transcripts from all prior institutions. Create FSA ID. Look up Cal State LA published cost of attendance and confirm fall 2026 enrollment is the actual target. Outcome: ready to file FAFSA and Cal State LA admission application with all source documents in hand.
+STEP 2 (~4 weeks after step 1): file FAFSA 2026-2027. Submit Cal State LA admission application with transcripts. Contact Cal State LA financial aid office for any program-specific questions about transferring credits and accounting program structure. Outcome: applications submitted, awaiting determination.
+STEP 3 (~8 weeks after step 2): receive Cal State LA admission decision. Receive financial aid award letter and Student Aid Index from FAFSA. Run private loan comparison shopping in parallel — soft-pull pre-qualifications with Sallie Mae, College Ave, Earnest. Compare federal subsidized + unsubsidized offers against private offers across interest rate, total cost over loan life, repayment terms, deferment flexibility. Outcome: full financing menu in hand for decision.
+STEP 4 (immediately before enrollment, ~August 2026): accept federal loan amounts at the chosen level. Sign all required Master Promissory Notes. Complete entrance counseling. Optionally accept private loan if comparison favors it. Confirm disbursement schedule aligns with Cal State LA's fall 2026 enrollment confirmation. Outcome: financing locked, classes can begin.
 Decision points:
 
-Phase 1 reveals tax filing is more complex than scoped → push entire project timeline; do not skip clean tax data.
+STEP 1 reveals tax filing is more complex than scoped → push entire project timeline; do not skip clean tax data.
 Cal State LA admission rejected → reset entire project; goal becomes irrelevant.
 FAFSA Student Aid Index produces unexpected aid amount → re-evaluate private loan need.
 Cost of attendance exceeds federal aid maximum → private loan becomes mandatory rather than comparative.`,

--- a/src/lib/ai/generateProjectDesign.ts
+++ b/src/lib/ai/generateProjectDesign.ts
@@ -1,14 +1,16 @@
 /**
- * generateProjectDesign — produces an institutional-rigor design field
- * for a project, given its goal/problem/diagnosis fields as input.
+ * generateProjectDesign — produces an institutional-rigor STEP-based plan
+ * for a project, given its structured GOAL / PROBLEM / DIAGNOSIS items.
  *
- * Uses Claude Sonnet 4 with the Student Loan project as few-shot exemplar.
- * Returns the generated text + cost metadata; does NOT auto-save to the
- * project (caller must explicitly write back via PATCH after user accepts).
+ * Uses Claude Sonnet 4 with the Student Loan project as few-shot exemplar
+ * (post-PR-Ops-3.7 reformat to structured arrays + STEP labels).
  *
- * Truth-first principle: the user must consciously accept the AI's output
- * before it overwrites their field. The endpoint that calls this returns
- * the generated text in a preview pane; user reviews and decides.
+ * Returns the generated text + cost metadata + inspection block; does NOT
+ * auto-save to the project. Caller must explicitly write back via PATCH
+ * after user accepts the AI's output.
+ *
+ * Truth-first: user owns INPUTS (goal/problem/diagnosis items), AI owns
+ * SYNTHESIS (design field). Explicit acceptance gate between them.
  */
 
 import { recordUsage } from './recordUsage';
@@ -20,9 +22,9 @@ interface GenerateInput {
   userEmail: string;
   projectId: string;
   projectTitle: string;
-  goal: string;
-  problem: string;
-  diagnosis: string;
+  goalItems: string[];
+  problemItems: string[];
+  diagnosisItems: string[];
 }
 
 interface GenerateOutput {
@@ -41,26 +43,34 @@ interface GenerateOutput {
   };
 }
 
-const SYSTEM_PROMPT = `You are a project scoping consultant trained on the institutional rigor of Bridgewater Associates' Principles, Citadel's risk discipline, and Renaissance Technologies' empirical method.
+function bulletList(items: string[]): string {
+  if (items.length === 0) return '(none provided)';
+  return items.map((item) => `- ${item}`).join('\n');
+}
 
-Your job: generate the DESIGN field of a project — a phased plan with decision points — given the user's GOAL, PROBLEM, and DIAGNOSIS fields.
+const SYSTEM_PROMPT = `You are a project scoping expert trained on the institutional rigor of Bridgewater Associates' Principles, Citadel's risk discipline, and Renaissance Technologies' empirical method.
+
+Your job: generate the DESIGN of a project — a numbered step-by-step plan with decision points — given the user's GOAL items, PROBLEM items, and DIAGNOSIS items.
 
 The user's natural-voice grammar maps to Bridgewater's 5-step scoping:
-  - GOAL field: "I WANT" lines (desires / target end states)
-  - PROBLEM field: "I DID NOT" lines (current gaps)
-  - DIAGNOSIS field: "I NEED" lines (root requirements)
-  - DESIGN field: "I WILL" lines, but synthesized into PHASES with timelines and decision points
+  - GOAL items: "I WANT" lines (desires / target end states)
+  - PROBLEM items: "I DID NOT" / "I HAVE NOT" lines (current gaps)
+  - DIAGNOSIS items: "I NEED TO" lines (root requirements)
+  - DESIGN field: numbered STEPS with timelines and decision points (you produce this)
 
 The DESIGN you produce must:
 1. Match the depth and structure of the EXEMPLAR below
-2. Have explicit phases (Phase 1, Phase 2, etc.) with rough timelines
-3. Each phase has a clear OUTCOME stated
+2. Have explicit numbered STEPS (STEP 1, STEP 2, STEP 3, ...) with rough timelines where applicable
+3. Each STEP states a clear OUTCOME at its end
 4. Include a "Decision points" section at the end listing scenarios that would re-trigger scoping (e.g., "if X happens, push timeline" / "if Y, reset entire project")
-5. Reference specific blockers/upstream-dependencies surfaced in the user's PROBLEM and DIAGNOSIS fields
-6. Be written in declarative voice (the system, not "I will" — the design is the project's plan, not the operator's first-person commitment)
-7. Match the prose length of the exemplar's DESIGN field (~2000 chars)
+5. Reference specific blockers/upstream-dependencies surfaced in the user's PROBLEM and DIAGNOSIS items
+6. Be written in declarative voice — the project's plan, NOT the operator's first-person commitment. Do NOT echo the "I WANT / I DID NOT / I NEED TO" grammar in your output. The steps speak as the system's plan.
+7. Match the prose length of the exemplar's design field (~2000 chars)
 
-Return ONLY the design field text. No preamble. No "Here is your design field:". No surrounding markdown code blocks. Just the raw text that would go in the form's design textarea.
+CRITICAL — do research with your domain knowledge:
+Before drafting steps, draw on your training-data knowledge of the topic. For projects involving regulated processes (FAFSA, tax filing, business formation, SEC compliance, immigration paperwork, accreditation, etc.), reference specific real-world deadlines, agencies, standard practices, and downstream dependencies. The user has supplied their personal context as item lists; your job is to combine that context with institutional knowledge to produce a plan that is correct in the world, not just internally consistent with what the user typed.
+
+Return ONLY the design field text. No preamble. No "Here is your design field:". No surrounding markdown code blocks. Just the raw text that would go in the form's design field.
 
 ═══════════════════════════════════════════════════════════════════════════════
 EXEMPLAR — institutional gold standard for project scoping rigor
@@ -68,40 +78,41 @@ EXEMPLAR — institutional gold standard for project scoping rigor
 
 Project title: "${PROJECT_DESIGN_EXEMPLAR.title}"
 
-GOAL field:
-${PROJECT_DESIGN_EXEMPLAR.goal}
+GOAL items:
+${bulletList(PROJECT_DESIGN_EXEMPLAR.goal_items as unknown as string[])}
 
-PROBLEM field:
-${PROJECT_DESIGN_EXEMPLAR.problem}
+PROBLEM items:
+${bulletList(PROJECT_DESIGN_EXEMPLAR.problem_items as unknown as string[])}
 
-DIAGNOSIS field:
-${PROJECT_DESIGN_EXEMPLAR.diagnosis}
+DIAGNOSIS items:
+${bulletList(PROJECT_DESIGN_EXEMPLAR.diagnosis_items as unknown as string[])}
 
 DESIGN field (← THIS is what you produce):
 ${PROJECT_DESIGN_EXEMPLAR.design}
 
 ═══════════════════════════════════════════════════════════════════════════════
 
-Now produce a DESIGN field at this exact rigor for the user's project below.`;
+Now produce a DESIGN field at this exact rigor for the user's project below. Remember: declarative voice, STEP-based output, decision points section, research the topic with your domain knowledge.`;
 
 export async function generateProjectDesign(input: GenerateInput): Promise<GenerateOutput> {
   const userMessage = `Project title: "${input.projectTitle}"
 
-GOAL field:
-${input.goal}
+GOAL items:
+${bulletList(input.goalItems)}
 
-PROBLEM field:
-${input.problem}
+PROBLEM items:
+${bulletList(input.problemItems)}
 
-DIAGNOSIS field:
-${input.diagnosis}
+DIAGNOSIS items:
+${bulletList(input.diagnosisItems)}
 
 DESIGN field: [you produce this — match the exemplar's depth and structure]`;
 
   const inputsSummary =
     `project_id=${input.projectId}; ` +
-    `goal_len=${input.goal.length}; problem_len=${input.problem.length}; ` +
-    `diagnosis_len=${input.diagnosis.length}`;
+    `goal_items_count=${input.goalItems.length}; ` +
+    `problem_items_count=${input.problemItems.length}; ` +
+    `diagnosis_items_count=${input.diagnosisItems.length}`;
 
   // Stateless mode: when projectId is empty, the call originates from the
   // create form before a project exists. Pass null targets so recordUsage


### PR DESCRIPTION
…TEP-based AI synthesis

The biggest architectural redesign of the AI input layer. Replaces paragraph-style goal/problem/diagnosis with structured JSONB arrays of natural-voice items. Each item has a verb prefix ("I WANT to ", "I DID NOT ", "I HAVE NOT ", "I NEED TO ") that maps to Bridgewater's 5-step scoping discipline. AI receives clean structured arrays instead of paragraph blobs and produces STEP-based plans with explicit research grounding.

"From god, for the people" — the form now teaches the institutional grammar through the verb prefix prefill, the AI does research on the topic using domain knowledge, and the design field is fully AI-owned (no manual textarea — user owns INPUTS, AI owns SYNTHESIS, explicit acceptance gate between them).

THE NEW UX:
  User clicks "+ I WANT to..." button → input opens with verb prefix
  pre-filled → user types completion → enter to commit. Same pattern
  for "I DID NOT" / "I HAVE NOT" (problem field has both buttons) /
  "I NEED TO". Each list cap: 20 items × 500 chars each.

  User clicks "↑ generate plan" → AI receives bulleted item arrays +
  does research with domain knowledge of the topic → produces STEP
  1, STEP 2, STEP 3... numbered plan with timelines, outcomes, and a
  decision-points section. Plan renders read-only in the form. User
  clicks "use this" to accept. Save.

SCHEMA CHANGES:
  New JSONB columns on operations_projects:
    - goal_items (array of strings, default [])
    - problem_items (array of strings, default [])
    - diagnosis_items (array of strings, default []) All 3 NOT NULL with default '[]'::jsonb.

  Legacy columns made nullable:
    - goal, problem, diagnosis, design (now String?)

  Reasoning: audit_log payload_before history references the legacy
  paragraph values; dropping them would break audit replay. Future
  cleanup PR drops them once audit replay no longer relevant.

  Existing CHECK constraints (PR-Ops-1's content_non_empty checks)
  dropped via idempotent DO block. The new array columns enforce
  content via server-side validation; legacy columns being nullable
  means the old CHECKs would fail.

CLEAN-SLATE CONTEXT:
  User deleted all 5 prior projects on 2026-05-08 before this PR
  shipped. No data migration needed; new projects start with empty
  array defaults. The Student Loan project's content lives on as
  PROJECT_DESIGN_EXEMPLAR (code constant in src/lib/ai/exemplars/),
  unchanged from PR-Ops-3.5/3.6 — just reformatted to the new
  array+STEP shape.

NEW UI PRIMITIVE — ListManager:
  src/components/workbench/operations/projects/ListManager.tsx
  258 lines. Reusable structured-list editor:
    - verb-prefix pre-fill on add (input opens with "I WANT to ")
    - alt-verb support (problem field has "+ I DID NOT" + "+ I HAVE NOT")
    - per-item edit-on-click with Enter/Escape keyboard
    - per-item remove (✕ on hover)
    - server-validated 20-item × 500-char caps with UI soft warning ("N slots left" at 15+, "max reached" at 20)
    - disabled state propagation (during save / regenerate) Used 3× in ProjectRow edit mode + 3× in SectionD create form. Same primitive will compose for future artifact types (issues, routines, content pieces, trips) — each with its own verb grammar.

AI PROMPT REWRITE:
  System prompt now:
    - Uses STEP not PHASE everywhere
    - Receives bulleted item arrays in user message, not paragraphs
    - Explicit research instruction: "draw on your training-data knowledge of the topic. For projects involving regulated processes (FAFSA, tax filing, business formation, SEC compliance, immigration paperwork, accreditation, etc.), reference specific real-world deadlines, agencies, standard practices, and downstream dependencies."
    - Declarative voice instruction: "Do NOT echo the I WANT / I DID NOT / I NEED TO grammar in your output. The steps speak as the system's plan."
    - Returns ONLY the design field text (no preamble, no markdown wrappers)

  Exemplar reformatted: PROJECT_DESIGN_EXEMPLAR.goal_items /
  problem_items / diagnosis_items are arrays of verb-prefixed
  items; .design has STEP 1-4 + Decision points (replacing
  PR-Ops-3.5/3.6 PHASE 1-4 labels). Same content, new structure.

ENDPOINTS:
  POST /api/operations/projects: validates new array fields with
    60-line inline validateItems helper (≥1 item, ≤20 items, each
    ≤500 chars trimmed non-empty). Legacy goal/problem/diagnosis
    optional/nullable via trimNullable. Prisma create writes BOTH
    legacy fields (when present) AND array fields.

  PATCH /api/operations/projects/[id]: same validateItems pattern
    for partial updates. Legacy fields can now be nulled (sending
    '' or null clears them — was rejected before this PR). Array
    fields validated per-update if present in body.

  POST /api/operations/ai/generate-design (stateless): accepts
    title + goalItems + problemItems + diagnosisItems. Calls
    generateProjectDesign with empty-string projectId sentinel.
    Used by SectionD create form before project_id exists.

  POST /api/operations/projects/[id]/generate-design (per-project):
    reads project.goal_items / problem_items / diagnosis_items
    from DB. Falls back via resolveItems() to wrapping legacy
    paragraph as single-element array if items empty (transition-
    window backwards-compat for any project that has only legacy
    content). Rejects 400 if neither array nor legacy populated.

DUAL-SHAPE MIGRATION DISCIPLINE:
  The TypeScript ProjectForm interface went through 4 incremental
  stages during this PR:
    (1) Add array fields (Prompt 1) — broke 3 consumer files
    (2) Restore legacy fields alongside array fields (Prompt 1.5) —
        dual-shape, all consumers compile clean
    (3) Migrate ProjectRow + SectionD to use array fields (Prompts
        2 + 3) — incremental, each commit compiles
    (4) Drop legacy fields from ProjectForm (Prompt 4) — only safe
        after all consumers migrated; tsc verifies no missed refs

  Each commit compiled. Each commit shipped a correct intermediate
  state. The git history shows clean incremental progress through
  4 dependency-graph layers driven by the type checker. This is the
  production refactor discipline a senior engineer at Bridgewater /
  Citadel / Renaissance enforces — no broken intermediate states.

READ MODE LEGACY FALLBACK:
  ProjectRow's renderStructuredField helper tries items array first,
  falls back to legacy paragraph with "(legacy paragraph format)"
  annotation if items empty + legacy text non-empty. Empty state
  renders "(no content)". Future cleanup PR drops the fallback once
  legacy paragraph columns are dropped.

TRUTH-FIRST INVARIANT PRESERVED:
  - User owns INPUTS (goal_items / problem_items / diagnosis_items)
  - AI owns SYNTHESIS (design field, generated via stateless or per-project endpoint)
  - Explicit acceptance gate (use-this/discard buttons in preview pane) between AI output and persisted state
  - No auto-save anywhere in the AI flow
  - Inspection drawer (PR-Ops-3.6) renders the full system prompt + user message + raw response so the operator can verify what the AI saw and what it produced

COST IMPACT:
  System prompt is now ~3500 tokens (up ~500 from PR-Ops-3.6 due to
  research instruction + structured-list grammar explanation).
  Output ~1500 tokens. Per-call cost ~$0.0345 at Sonnet 4 pricing
  ($3/M input, $15/M output). Marginal increase from PR-Ops-3.6's
  ~$0.03 per call. Tracked via operations_ai_usage with full prompt
  persistence (PR-Ops-3.6 transparency layer).

VERIFICATION:
  - tsc --noEmit: exit 0, zero errors across all 4 corrective + 3 feature prompts
  - prisma format / validate / generate: all clean
  - Migration uses idempotent constraint cleanup (DO block with IF EXISTS) so unknown constraint names don't fail the apply
  - All API endpoints accept both legacy and new shape during transition window (clean dual-shape API contract)

SMOKE TEST PLAN POST-MERGE:
  1. Navigate to /operations/projects. Empty state renders (5 prior projects deleted; clean slate).
  2. Click "+ new project". Create form opens with title/entity/ ListManager × 3 + read-only design + "↑ generate plan" button.
  3. Type title: "Trading Pipeline and MVP". Pick entity: Trading.
  4. Click "+ I WANT to..." in goal section. Input opens with "I WANT to " pre-filled. Type "ship clean scanner output trustworthy enough to charge $99/month for". Press Enter. Item appears in list with bullet + remove button on hover.
  5. Add more "I WANT" items. Add "I DID NOT" + "I HAVE NOT" items (problem section has both buttons). Add "I NEED TO" items (diagnosis section).
  6. Click "↑ generate plan". ~3 seconds. Read-only design panel populates with STEP 1-N + Decision points. Inspection drawer below shows full prompt + research-informed AI reasoning.
  7. Click "use this" → createForm.design populated → click "create project" → project saved.
  8. Audit log (Section K) shows operations_ai_inference (stateless, target_table='operations_ai_usage', target_id=usage_row_id) + operations_project_created. Click each row to expand. AI row shows full prompt with research instruction visible.
  9. Open the new project → click edit → ListManagers populated with the items entered earlier. Edit one item by clicking it → input opens with current text → modify → enter saves. Remove an item via ✕ → item disappears.
 10. Click "↑ generate plan" again from edit mode (now per-project, not stateless). Audit row shows target_table=operations_projects.
 11. Repeat for Cal State LA / Taxes Personal / Taxes Business — full backlog at institutional rigor in ~25 minutes.

ROLLBACK: pure additive PR (3 new columns + nullable legacy + new primitives). Revert by reverting the merge commit. Migration is non-destructive; even if reverted, the JSONB columns stay (Postgres ALTER TABLE DROP COLUMN would work but isn't necessary — they're just unused). Legacy columns regain NOT NULL constraints if Prisma schema is reverted, which would fail for any project created post-3.7 with NULL legacy content. Recommend: do not revert migration; revert only application code if needed.

KNOWN SCOPE DEFERRALS (intentional, not bugs):
  - Drop legacy goal/problem/diagnosis/design columns from operations_ projects schema. Defer until audit replay no longer references them (or until audit replay is updated to read from items arrays).
  - Decompose AI-generated design field into structured "steps" array for richer rendering. v0 keeps it as text. Future PR could add operations_project_design_steps column.
  - Refactor empty-string projectId sentinel in generateProjectDesign to nullable string for cleaner typing. v0 functional.
  - Migration of legacy projects (none exist post clean-slate). Future PR could add a UI "import from paragraphs" flow if backwards data ever needs migration.
  - Additional verb grammars for future artifact types (issues: "I HIT" / "I OBSERVED" / "I SUSPECT" / etc.). Each artifact type gets its own ListManager configuration when its PR ships.