### PR TITLE
PR-Ops-4.0: daily plan schema foundation — operations_daily_plan_item…

### DIFF
--- a/prisma/migrations/20260516000000_pr_ops_4_0_daily_plan_schema/migration.sql
+++ b/prisma/migrations/20260516000000_pr_ops_4_0_daily_plan_schema/migration.sql
@@ -1,0 +1,81 @@
+-- PR-Ops-4.0 Daily Plan Schema Foundation
+-- New tables: operations_daily_plan_items, operations_calendar_blocks, operations_task_status_history
+-- New enum: CalendarBlockStatus
+-- Modifications to operations_project_tasks: coa_code, actual_cost_usd, actual_minutes
+
+BEGIN;
+
+-- 1. New enum for calendar block status
+CREATE TYPE "CalendarBlockStatus" AS ENUM ('scheduled', 'in_progress', 'completed', 'missed', 'cancelled');
+
+-- 2. operations_daily_plan_items
+CREATE TABLE "operations_daily_plan_items" (
+  "id"                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  "user_id"             TEXT NOT NULL,
+  "entity_id"           TEXT NOT NULL,
+  "plan_date"           DATE NOT NULL,
+  "task_id"             UUID,
+  "ad_hoc_title"        VARCHAR(500),
+  "ad_hoc_description"  TEXT,
+  "display_order"       INT NOT NULL DEFAULT 0,
+  "notes"               TEXT,
+  "created_at"          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  "updated_at"          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  "created_by"          TEXT,
+  CONSTRAINT "operations_daily_plan_items_task_or_adhoc_check"
+    CHECK ("task_id" IS NOT NULL OR "ad_hoc_title" IS NOT NULL),
+  CONSTRAINT "operations_daily_plan_items_task_id_fkey"
+    FOREIGN KEY ("task_id") REFERENCES "operations_project_tasks"("id") ON DELETE SET NULL
+);
+CREATE INDEX "operations_daily_plan_items_user_date_idx" ON "operations_daily_plan_items"("user_id", "plan_date");
+CREATE INDEX "operations_daily_plan_items_task_idx" ON "operations_daily_plan_items"("task_id");
+CREATE INDEX "operations_daily_plan_items_entity_idx" ON "operations_daily_plan_items"("entity_id");
+
+-- 3. operations_calendar_blocks
+CREATE TABLE "operations_calendar_blocks" (
+  "id"                   UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  "user_id"              TEXT NOT NULL,
+  "entity_id"            TEXT NOT NULL,
+  "daily_plan_item_id"   UUID NOT NULL,
+  "scheduled_start"      TIMESTAMPTZ NOT NULL,
+  "scheduled_end"        TIMESTAMPTZ NOT NULL,
+  "actual_start"         TIMESTAMPTZ,
+  "actual_end"           TIMESTAMPTZ,
+  "status"               "CalendarBlockStatus" NOT NULL DEFAULT 'scheduled',
+  "notes"                TEXT,
+  "created_at"           TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  "updated_at"           TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  "created_by"           TEXT,
+  CONSTRAINT "operations_calendar_blocks_plan_item_fkey"
+    FOREIGN KEY ("daily_plan_item_id") REFERENCES "operations_daily_plan_items"("id") ON DELETE CASCADE,
+  CONSTRAINT "operations_calendar_blocks_time_check"
+    CHECK ("scheduled_end" > "scheduled_start")
+);
+CREATE INDEX "operations_calendar_blocks_user_time_idx" ON "operations_calendar_blocks"("user_id", "scheduled_start", "scheduled_end");
+CREATE INDEX "operations_calendar_blocks_plan_item_idx" ON "operations_calendar_blocks"("daily_plan_item_id");
+
+-- 4. operations_task_status_history
+CREATE TABLE "operations_task_status_history" (
+  "id"               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  "task_id"          UUID NOT NULL,
+  "user_id"          TEXT NOT NULL,
+  "previous_status"  "OperationsTaskStatus",
+  "new_status"       "OperationsTaskStatus" NOT NULL,
+  "changed_at"       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  "changed_by"       TEXT,
+  "reason"           TEXT,
+  CONSTRAINT "operations_task_status_history_task_fkey"
+    FOREIGN KEY ("task_id") REFERENCES "operations_project_tasks"("id") ON DELETE CASCADE
+);
+CREATE INDEX "operations_task_status_history_task_idx" ON "operations_task_status_history"("task_id", "changed_at" DESC);
+CREATE INDEX "operations_task_status_history_user_idx" ON "operations_task_status_history"("user_id", "changed_at" DESC);
+
+-- 5. operations_project_tasks additions
+ALTER TABLE "operations_project_tasks"
+  ADD COLUMN "coa_code"         VARCHAR(50),
+  ADD COLUMN "actual_cost_usd"  DECIMAL(15, 2),
+  ADD COLUMN "actual_minutes"   INT;
+
+CREATE INDEX "operations_project_tasks_coa_code_idx" ON "operations_project_tasks"("coa_code");
+
+COMMIT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2510,6 +2510,14 @@ enum OperationsTaskStatus {
   cancelled
 }
 
+enum CalendarBlockStatus {
+  scheduled
+  in_progress
+  completed
+  missed
+  cancelled
+}
+
 enum ProjectDependencyType {
   blocks
   informs
@@ -2587,19 +2595,87 @@ model operations_project_tasks {
   unblocks_label       String?              @db.Text
   link_url             String?              @db.Text
   notes                String?              @db.Text
+  coa_code             String?              @db.VarChar(50)
+  actual_cost_usd      Decimal?             @db.Decimal(15, 2)
+  actual_minutes       Int?
   display_order        Int                  @default(0)
   completed_at         DateTime?            @db.Timestamptz(6)
   created_at           DateTime             @default(now()) @db.Timestamptz(6)
   updated_at           DateTime             @updatedAt @db.Timestamptz(6)
   created_by           String?
 
-  project operations_projects @relation(fields: [project_id], references: [id], onDelete: Cascade)
+  project          operations_projects              @relation(fields: [project_id], references: [id], onDelete: Cascade)
+  daily_plan_items operations_daily_plan_items[]
+  status_history   operations_task_status_history[]
 
   @@index([project_id, status, display_order])
   @@index([user_id, status, priority_score])
   @@index([deadline])
   @@index([entity_id])
+  @@index([coa_code])
   @@map("operations_project_tasks")
+}
+
+model operations_daily_plan_items {
+  id                 String   @id @default(uuid()) @db.Uuid
+  user_id            String
+  entity_id          String
+  plan_date          DateTime @db.Date
+  task_id            String?  @db.Uuid
+  ad_hoc_title       String?  @db.VarChar(500)
+  ad_hoc_description String?  @db.Text
+  display_order      Int      @default(0)
+  notes              String?  @db.Text
+  created_at         DateTime @default(now()) @db.Timestamptz(6)
+  updated_at         DateTime @updatedAt @db.Timestamptz(6)
+  created_by         String?
+
+  task            operations_project_tasks?   @relation(fields: [task_id], references: [id], onDelete: SetNull)
+  calendar_blocks operations_calendar_blocks[]
+
+  @@index([user_id, plan_date])
+  @@index([task_id])
+  @@index([entity_id])
+  @@map("operations_daily_plan_items")
+}
+
+model operations_calendar_blocks {
+  id                 String              @id @default(uuid()) @db.Uuid
+  user_id            String
+  entity_id          String
+  daily_plan_item_id String              @db.Uuid
+  scheduled_start    DateTime            @db.Timestamptz(6)
+  scheduled_end      DateTime            @db.Timestamptz(6)
+  actual_start       DateTime?           @db.Timestamptz(6)
+  actual_end         DateTime?           @db.Timestamptz(6)
+  status             CalendarBlockStatus @default(scheduled)
+  notes              String?             @db.Text
+  created_at         DateTime            @default(now()) @db.Timestamptz(6)
+  updated_at         DateTime            @updatedAt @db.Timestamptz(6)
+  created_by         String?
+
+  daily_plan_item operations_daily_plan_items @relation(fields: [daily_plan_item_id], references: [id], onDelete: Cascade)
+
+  @@index([user_id, scheduled_start, scheduled_end])
+  @@index([daily_plan_item_id])
+  @@map("operations_calendar_blocks")
+}
+
+model operations_task_status_history {
+  id              String                @id @default(uuid()) @db.Uuid
+  task_id         String                @db.Uuid
+  user_id         String
+  previous_status OperationsTaskStatus?
+  new_status      OperationsTaskStatus
+  changed_at      DateTime              @default(now()) @db.Timestamptz(6)
+  changed_by      String?
+  reason          String?               @db.Text
+
+  task operations_project_tasks @relation(fields: [task_id], references: [id], onDelete: Cascade)
+
+  @@index([task_id, changed_at(sort: Desc)])
+  @@index([user_id, changed_at(sort: Desc)])
+  @@map("operations_task_status_history")
 }
 
 model operations_project_dependencies {


### PR DESCRIPTION
## What ships

Foundation schema for Daily Plan integration with operations tasks. Pure schema migration — no UI, no API, no AI changes. Everything that follows (PR-Ops-4.1 through 4.11) builds on these tables.

## Architecture (locked)

- **Three-table chain:** `operations_project_tasks` ← `operations_daily_plan_items` ← `operations_calendar_blocks`. Each layer independently queryable, three distinct states (unscheduled / planned / blocked).
- **Status history is append-only:** `operations_task_status_history` enables undo/uncomplete with full audit trail.
- **coa_code as loose VARCHAR(50):** matches `calendar_events.coa_code` and `home_expenses.coa_code` precedent. App-level resolution via `(userId, entity_id, code)` composite. No FK constraint (chart_of_accounts.code isn't globally unique by design).
- **Coexists with legacy daily_plans:** that table is the 75-day-sprint personal tracker (wellness/habits/reflection). New tables are namespaced `operations_*` for task execution. Different domains, different lifecycles, no migration.
- **Ad-hoc daily plan items supported:** `task_id` is nullable with `ON DELETE SET NULL`. CHECK constraint enforces either `task_id` OR `ad_hoc_title` is set.

## Schema changes

**New tables (3):**
- `operations_daily_plan_items` — daily scheduling, FK to project tasks (nullable for ad-hoc)
- `operations_calendar_blocks` — zero-or-more time blocks per plan item, CHECK enforces `scheduled_end > scheduled_start`
- `operations_task_status_history` — append-only status change log

**New enum:**
- `CalendarBlockStatus` (scheduled, in_progress, completed, missed, cancelled)

**Modifications to `operations_project_tasks`:**
- `coa_code VARCHAR(50)?` for budget rollups
- `actual_cost_usd Decimal(15,2)?` for variance vs `estimated_cost_usd`
- `actual_minutes Int?` for variance vs `estimated_minutes`
- New relations: `daily_plan_items[]`, `status_history[]`
- New index: `(coa_code)`

## Indexes added

- `operations_daily_plan_items(user_id, plan_date)` — "what's on today"
- `operations_daily_plan_items(task_id)` — task → plan items lookup
- `operations_daily_plan_items(entity_id)` — entity-scoped queries
- `operations_calendar_blocks(user_id, scheduled_start, scheduled_end)` — conflict detection
- `operations_calendar_blocks(daily_plan_item_id)` — plan item → blocks
- `operations_task_status_history(task_id, changed_at DESC)` — replay history
- `operations_task_status_history(user_id, changed_at DESC)` — user audit trail
- `operations_project_tasks(coa_code)` — budget rollups

## Verification

- `prisma generate` clean
- `tsc --noEmit` zero new errors
- Migration SQL wrapped in BEGIN/COMMIT for atomicity
- CHECK constraint on `operations_daily_plan_items` enforces task_id-or-ad_hoc-title invariant
- CHECK constraint on `operations_calendar_blocks` enforces scheduled_end > scheduled_start
- All FK ON DELETE behaviors explicit: task_id SET NULL, plan_item_id CASCADE, history task_id CASCADE
- Migration is additive only — no existing column drops, no breaking changes to existing rows

## What's NOT in this PR

- No UI changes (PR-Ops-4.1)
- No API endpoints for daily plan / calendar blocks (PR-Ops-4.2)
- No status history wiring on existing task completion routes (PR-Ops-4.3)
- No budget rollup queries against coa_code (PR-Ops-4.4)
- No actual_cost_usd / actual_minutes population logic (PR-Ops-4.5)

Each follow-up will be its own scoped PR.

## Commits (1)

- 06ca994 — daily plan schema foundation

## Branch

`claude/pr-ops-4.0-daily-plan-schema`