### PR TITLE
Claude/pr ops 4.1 daily plan api

### DIFF
--- a/prisma/migrations/20260518000000_pr_ops_4_1_audit_enums/migration.sql
+++ b/prisma/migrations/20260518000000_pr_ops_4_1_audit_enums/migration.sql
@@ -1,0 +1,9 @@
+-- PR-Ops-4.1: add daily plan + calendar block audit action types
+-- Note: PostgreSQL ALTER TYPE ADD VALUE cannot run inside a transaction block.
+
+ALTER TYPE "AuditActionType" ADD VALUE IF NOT EXISTS 'operations_daily_plan_item_created';
+ALTER TYPE "AuditActionType" ADD VALUE IF NOT EXISTS 'operations_daily_plan_item_updated';
+ALTER TYPE "AuditActionType" ADD VALUE IF NOT EXISTS 'operations_daily_plan_item_deleted';
+ALTER TYPE "AuditActionType" ADD VALUE IF NOT EXISTS 'operations_calendar_block_created';
+ALTER TYPE "AuditActionType" ADD VALUE IF NOT EXISTS 'operations_calendar_block_updated';
+ALTER TYPE "AuditActionType" ADD VALUE IF NOT EXISTS 'operations_calendar_block_deleted';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2048,6 +2048,12 @@ enum AuditActionType {
   operations_routine_updated
   operations_routine_deactivated
   operations_routine_deleted
+  operations_daily_plan_item_created
+  operations_daily_plan_item_updated
+  operations_daily_plan_item_deleted
+  operations_calendar_block_created
+  operations_calendar_block_updated
+  operations_calendar_block_deleted
   operations_routine_completed
   operations_routine_missed
   operations_issue_logged

--- a/src/app/api/operations/daily-plan/blocks/[blockId]/route.ts
+++ b/src/app/api/operations/daily-plan/blocks/[blockId]/route.ts
@@ -1,0 +1,229 @@
+/**
+ * /api/operations/daily-plan/blocks/[blockId]
+ *
+ * PATCH  — update a calendar block. Mutable: scheduled_start/end, status,
+ *          notes, actual_start/end. Immutable: id, user_id, entity_id,
+ *          daily_plan_item_id, created_by, created_at. When a scheduled
+ *          time changes, overlap is re-checked (excluding this block);
+ *          a conflict returns 409 unless body.allow_conflicts is true.
+ * DELETE — hard delete.
+ *
+ * Both handlers scope by user_id with defensive 404 non-disclosure.
+ * Audits operations_calendar_block_updated / _deleted.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { Prisma, CalendarBlockStatus } from '@prisma/client';
+import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { writeAuditLog } from '@/lib/audit/writeAuditLog';
+import { loadAuthorizedCalendarBlock } from '@/lib/operations/loadAuthorizedCalendarBlock';
+import { detectBlockConflicts } from '@/lib/operations/detectBlockConflicts';
+
+const VALID_STATUSES: CalendarBlockStatus[] = [
+  'scheduled',
+  'in_progress',
+  'completed',
+  'missed',
+  'cancelled',
+];
+
+function parseDate(v: unknown): Date | null {
+  if (typeof v !== 'string' || v.length === 0) return null;
+  const d = new Date(v);
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ blockId: string }> }
+) {
+  try {
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const user = await prisma.users.findFirst({
+      where: { email: { equals: userEmail, mode: 'insensitive' } },
+    });
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+
+    const { blockId } = await params;
+    const existing = await loadAuthorizedCalendarBlock(blockId, user.id);
+    if (!existing) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+
+    const body = await request.json();
+    const data: Prisma.operations_calendar_blocksUpdateInput = {};
+
+    // Scheduled times: compute effective values, validate ordering,
+    // re-check overlap (excluding this block) when either side changes.
+    let effectiveStart = existing.scheduled_start;
+    let effectiveEnd = existing.scheduled_end;
+    let timeChanged = false;
+
+    if (body.scheduled_start !== undefined) {
+      const s = parseDate(body.scheduled_start);
+      if (!s) {
+        return NextResponse.json(
+          { error: 'Validation', field: 'scheduled_start', message: 'scheduled_start must be a valid ISO datetime' },
+          { status: 400 }
+        );
+      }
+      effectiveStart = s;
+      timeChanged = true;
+    }
+
+    if (body.scheduled_end !== undefined) {
+      const e = parseDate(body.scheduled_end);
+      if (!e) {
+        return NextResponse.json(
+          { error: 'Validation', field: 'scheduled_end', message: 'scheduled_end must be a valid ISO datetime' },
+          { status: 400 }
+        );
+      }
+      effectiveEnd = e;
+      timeChanged = true;
+    }
+
+    let conflicts: string[] = [];
+    if (timeChanged) {
+      if (effectiveEnd.getTime() <= effectiveStart.getTime()) {
+        return NextResponse.json(
+          { error: 'Validation', field: 'scheduled_end', message: 'scheduled_end must be after scheduled_start' },
+          { status: 400 }
+        );
+      }
+      const allowConflicts = body.allow_conflicts === true;
+      conflicts = await detectBlockConflicts(user.id, effectiveStart, effectiveEnd, blockId);
+      if (conflicts.length > 0 && !allowConflicts) {
+        return NextResponse.json(
+          { error: 'Conflict', conflicting_block_ids: conflicts },
+          { status: 409 }
+        );
+      }
+      data.scheduled_start = effectiveStart;
+      data.scheduled_end = effectiveEnd;
+    }
+
+    if (body.actual_start !== undefined) {
+      if (body.actual_start === null || body.actual_start === '') {
+        data.actual_start = null;
+      } else {
+        const a = parseDate(body.actual_start);
+        if (!a) {
+          return NextResponse.json(
+            { error: 'Validation', field: 'actual_start', message: 'actual_start must be a valid ISO datetime' },
+            { status: 400 }
+          );
+        }
+        data.actual_start = a;
+      }
+    }
+
+    if (body.actual_end !== undefined) {
+      if (body.actual_end === null || body.actual_end === '') {
+        data.actual_end = null;
+      } else {
+        const a = parseDate(body.actual_end);
+        if (!a) {
+          return NextResponse.json(
+            { error: 'Validation', field: 'actual_end', message: 'actual_end must be a valid ISO datetime' },
+            { status: 400 }
+          );
+        }
+        data.actual_end = a;
+      }
+    }
+
+    if (body.status !== undefined) {
+      if (!VALID_STATUSES.includes(body.status)) {
+        return NextResponse.json(
+          { error: 'Validation', field: 'status', message: 'invalid status value' },
+          { status: 400 }
+        );
+      }
+      data.status = body.status as CalendarBlockStatus;
+    }
+
+    if (body.notes !== undefined) {
+      data.notes =
+        typeof body.notes === 'string' && body.notes.trim().length > 0
+          ? body.notes.trim()
+          : null;
+    }
+
+    const block = await prisma.operations_calendar_blocks.update({
+      where: { id: blockId },
+      data,
+    });
+
+    await writeAuditLog({
+      actor: { user_id: user.id, email: userEmail, type: 'human_user' },
+      action: {
+        type: 'operations_calendar_block_updated',
+        description: `Updated calendar block ${blockId}`,
+      },
+      target: { table: 'operations_calendar_blocks', id: block.id },
+      payload: {
+        before: existing,
+        after: block,
+        metadata: {
+          daily_plan_item_id: existing.daily_plan_item_id,
+          time_changed: timeChanged,
+          conflicts_overridden: conflicts.length > 0 ? conflicts : undefined,
+        },
+      },
+    });
+
+    return NextResponse.json({ block, conflicts });
+  } catch (error) {
+    console.error('[Calendar Block PATCH]', error);
+    return NextResponse.json(
+      { error: 'Failed to update calendar block', message: error instanceof Error ? error.message : 'unknown' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ blockId: string }> }
+) {
+  try {
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const user = await prisma.users.findFirst({
+      where: { email: { equals: userEmail, mode: 'insensitive' } },
+    });
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+
+    const { blockId } = await params;
+    const existing = await loadAuthorizedCalendarBlock(blockId, user.id);
+    if (!existing) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+
+    await prisma.operations_calendar_blocks.delete({ where: { id: blockId } });
+
+    await writeAuditLog({
+      actor: { user_id: user.id, email: userEmail, type: 'human_user' },
+      action: {
+        type: 'operations_calendar_block_deleted',
+        description: `Deleted calendar block ${blockId}`,
+      },
+      target: { table: 'operations_calendar_blocks', id: blockId },
+      payload: {
+        before: existing,
+        metadata: {
+          daily_plan_item_id: existing.daily_plan_item_id,
+        },
+      },
+    });
+
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    console.error('[Calendar Block DELETE]', error);
+    return NextResponse.json(
+      { error: 'Failed to delete calendar block', message: error instanceof Error ? error.message : 'unknown' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/operations/daily-plan/items/[itemId]/blocks/route.ts
+++ b/src/app/api/operations/daily-plan/items/[itemId]/blocks/route.ts
@@ -1,0 +1,139 @@
+/**
+ * POST /api/operations/daily-plan/items/[itemId]/blocks
+ *
+ * Creates a calendar block under a daily plan item. user_id and entity_id
+ * are derived from the parent item (never trusted from the client). Overlap
+ * with existing non-cancelled/non-missed blocks is rejected with 409 unless
+ * the body sets allow_conflicts: true. Conflicts are always reported in the
+ * response so the frontend can render a visual indicator either way.
+ *
+ * Audits operations_calendar_block_created.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { CalendarBlockStatus } from '@prisma/client';
+import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { writeAuditLog } from '@/lib/audit/writeAuditLog';
+import { loadAuthorizedDailyPlanItem } from '@/lib/operations/loadAuthorizedDailyPlanItem';
+import { detectBlockConflicts } from '@/lib/operations/detectBlockConflicts';
+
+const VALID_STATUSES: CalendarBlockStatus[] = [
+  'scheduled',
+  'in_progress',
+  'completed',
+  'missed',
+  'cancelled',
+];
+
+function parseDate(v: unknown): Date | null {
+  if (typeof v !== 'string' || v.length === 0) return null;
+  const d = new Date(v);
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ itemId: string }> }
+) {
+  try {
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const user = await prisma.users.findFirst({
+      where: { email: { equals: userEmail, mode: 'insensitive' } },
+    });
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+
+    const { itemId } = await params;
+    const item = await loadAuthorizedDailyPlanItem(itemId, user.id);
+    if (!item) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+
+    const body = await request.json();
+
+    const start = parseDate(body.scheduled_start);
+    if (!start) {
+      return NextResponse.json(
+        { error: 'Validation', field: 'scheduled_start', message: 'scheduled_start is required (ISO datetime)' },
+        { status: 400 }
+      );
+    }
+    const end = parseDate(body.scheduled_end);
+    if (!end) {
+      return NextResponse.json(
+        { error: 'Validation', field: 'scheduled_end', message: 'scheduled_end is required (ISO datetime)' },
+        { status: 400 }
+      );
+    }
+    if (end.getTime() <= start.getTime()) {
+      return NextResponse.json(
+        { error: 'Validation', field: 'scheduled_end', message: 'scheduled_end must be after scheduled_start' },
+        { status: 400 }
+      );
+    }
+
+    let status: CalendarBlockStatus = 'scheduled';
+    if (body.status !== undefined) {
+      if (!VALID_STATUSES.includes(body.status)) {
+        return NextResponse.json(
+          { error: 'Validation', field: 'status', message: 'invalid status value' },
+          { status: 400 }
+        );
+      }
+      status = body.status as CalendarBlockStatus;
+    }
+
+    const notes =
+      typeof body.notes === 'string' && body.notes.trim().length > 0
+        ? body.notes.trim()
+        : null;
+
+    const allowConflicts = body.allow_conflicts === true;
+
+    const conflicts = await detectBlockConflicts(user.id, start, end);
+    if (conflicts.length > 0 && !allowConflicts) {
+      return NextResponse.json(
+        { error: 'Conflict', conflicting_block_ids: conflicts },
+        { status: 409 }
+      );
+    }
+
+    const block = await prisma.operations_calendar_blocks.create({
+      data: {
+        user_id: item.user_id,
+        entity_id: item.entity_id,
+        daily_plan_item_id: item.id,
+        scheduled_start: start,
+        scheduled_end: end,
+        status,
+        notes,
+        created_by: userEmail,
+      },
+    });
+
+    await writeAuditLog({
+      actor: { user_id: user.id, email: userEmail, type: 'human_user' },
+      action: {
+        type: 'operations_calendar_block_created',
+        description: `Created calendar block under daily plan item ${itemId}`,
+      },
+      target: { table: 'operations_calendar_blocks', id: block.id },
+      payload: {
+        after: block,
+        metadata: {
+          daily_plan_item_id: itemId,
+          allow_conflicts_used: allowConflicts,
+          conflicts_overridden: conflicts.length > 0 ? conflicts : undefined,
+        },
+      },
+    });
+
+    return NextResponse.json({ block, conflicts }, { status: 201 });
+  } catch (error) {
+    console.error('[Calendar Block POST]', error);
+    return NextResponse.json(
+      { error: 'Failed to create calendar block', message: error instanceof Error ? error.message : 'unknown' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/operations/daily-plan/items/[itemId]/route.ts
+++ b/src/app/api/operations/daily-plan/items/[itemId]/route.ts
@@ -1,0 +1,213 @@
+/**
+ * /api/operations/daily-plan/items/[itemId]
+ *
+ * GET    — read one daily plan item with its calendar_blocks joined.
+ * PATCH  — update mutable fields (notes, display_order, ad_hoc_title,
+ *          ad_hoc_description). task_id / entity_id / plan_date are
+ *          immutable — delete + recreate to change them. Clearing
+ *          ad_hoc_title is rejected unless the item is task-linked
+ *          (preserves the task_id-or-ad_hoc_title CHECK invariant).
+ * DELETE — hard delete. calendar_blocks cascade-delete via the FK
+ *          ON DELETE CASCADE; the pre-delete blocks are captured in
+ *          the audit payload_before.
+ *
+ * All handlers scope by user_id with defensive 404 non-disclosure.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { Prisma } from '@prisma/client';
+import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { writeAuditLog } from '@/lib/audit/writeAuditLog';
+import { loadAuthorizedDailyPlanItem } from '@/lib/operations/loadAuthorizedDailyPlanItem';
+
+function trimNullable(v: unknown): string | null {
+  if (typeof v !== 'string') return null;
+  const t = v.trim();
+  return t.length > 0 ? t : null;
+}
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ itemId: string }> }
+) {
+  try {
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const user = await prisma.users.findFirst({
+      where: { email: { equals: userEmail, mode: 'insensitive' } },
+    });
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+
+    const { itemId } = await params;
+    const item = await loadAuthorizedDailyPlanItem(itemId, user.id);
+    if (!item) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+
+    return NextResponse.json({ item });
+  } catch (error) {
+    console.error('[Daily Plan Item GET]', error);
+    return NextResponse.json(
+      { error: 'Failed to load daily plan item', message: error instanceof Error ? error.message : 'unknown' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ itemId: string }> }
+) {
+  try {
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const user = await prisma.users.findFirst({
+      where: { email: { equals: userEmail, mode: 'insensitive' } },
+    });
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+
+    const { itemId } = await params;
+    const existing = await prisma.operations_daily_plan_items.findFirst({
+      where: { id: itemId, user_id: user.id },
+    });
+    if (!existing) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+
+    const body = await request.json();
+    const data: Prisma.operations_daily_plan_itemsUpdateInput = {};
+
+    if (body.notes !== undefined) {
+      const n = trimNullable(body.notes);
+      if (n !== null && n.length > 1500) {
+        return NextResponse.json(
+          { error: 'Validation', field: 'notes', message: 'notes exceeds 1500 characters' },
+          { status: 400 }
+        );
+      }
+      data.notes = n;
+    }
+
+    if (body.display_order !== undefined) {
+      const n = Number(body.display_order);
+      if (!Number.isFinite(n)) {
+        return NextResponse.json(
+          { error: 'Validation', field: 'display_order', message: 'display_order must be a number' },
+          { status: 400 }
+        );
+      }
+      data.display_order = Math.trunc(n);
+    }
+
+    if (body.ad_hoc_title !== undefined) {
+      const t = trimNullable(body.ad_hoc_title);
+      if (t === null && existing.task_id === null) {
+        return NextResponse.json(
+          {
+            error: 'Validation',
+            field: 'ad_hoc_title',
+            message: 'ad_hoc_title cannot be cleared on an ad-hoc item — a task-linked or titled item is required',
+          },
+          { status: 400 }
+        );
+      }
+      if (t !== null && t.length > 500) {
+        return NextResponse.json(
+          { error: 'Validation', field: 'ad_hoc_title', message: 'ad_hoc_title exceeds 500 characters' },
+          { status: 400 }
+        );
+      }
+      data.ad_hoc_title = t;
+    }
+
+    if (body.ad_hoc_description !== undefined) {
+      const d = trimNullable(body.ad_hoc_description);
+      if (d !== null && d.length > 1500) {
+        return NextResponse.json(
+          { error: 'Validation', field: 'ad_hoc_description', message: 'ad_hoc_description exceeds 1500 characters' },
+          { status: 400 }
+        );
+      }
+      data.ad_hoc_description = d;
+    }
+
+    const item = await prisma.operations_daily_plan_items.update({
+      where: { id: itemId },
+      data,
+    });
+
+    await writeAuditLog({
+      actor: { user_id: user.id, email: userEmail, type: 'human_user' },
+      action: {
+        type: 'operations_daily_plan_item_updated',
+        description: `Updated daily plan item ${itemId}`,
+      },
+      target: { table: 'operations_daily_plan_items', id: item.id },
+      payload: {
+        before: existing,
+        after: item,
+        metadata: {
+          plan_date: existing.plan_date,
+          entity_id: existing.entity_id,
+        },
+      },
+    });
+
+    return NextResponse.json({ item });
+  } catch (error) {
+    console.error('[Daily Plan Item PATCH]', error);
+    return NextResponse.json(
+      { error: 'Failed to update daily plan item', message: error instanceof Error ? error.message : 'unknown' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ itemId: string }> }
+) {
+  try {
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const user = await prisma.users.findFirst({
+      where: { email: { equals: userEmail, mode: 'insensitive' } },
+    });
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+
+    const { itemId } = await params;
+    const existing = await loadAuthorizedDailyPlanItem(itemId, user.id);
+    if (!existing) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+
+    // calendar_blocks cascade-delete via FK ON DELETE CASCADE — capture
+    // them before the delete so the audit payload retains the full state.
+    const { calendar_blocks, ...item } = existing;
+
+    await prisma.operations_daily_plan_items.delete({ where: { id: itemId } });
+
+    await writeAuditLog({
+      actor: { user_id: user.id, email: userEmail, type: 'human_user' },
+      action: {
+        type: 'operations_daily_plan_item_deleted',
+        description: `Deleted daily plan item ${itemId} (${calendar_blocks.length} calendar block(s) cascade-deleted)`,
+      },
+      target: { table: 'operations_daily_plan_items', id: itemId },
+      payload: {
+        before: { item, calendar_blocks },
+        metadata: {
+          plan_date: item.plan_date,
+          entity_id: item.entity_id,
+          cascaded_block_count: calendar_blocks.length,
+        },
+      },
+    });
+
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    console.error('[Daily Plan Item DELETE]', error);
+    return NextResponse.json(
+      { error: 'Failed to delete daily plan item', message: error instanceof Error ? error.message : 'unknown' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/operations/daily-plan/items/route.ts
+++ b/src/app/api/operations/daily-plan/items/route.ts
@@ -1,0 +1,234 @@
+/**
+ * /api/operations/daily-plan/items
+ *
+ * GET  — list daily plan items in a plan_date range (default: today).
+ *        Each item includes its calendar_blocks, ordered by start.
+ *        No audit (read-only).
+ * POST — create a daily plan item. Exactly one of task_id (task-linked)
+ *        or ad_hoc_title (ad-hoc) must be supplied. Task-linked items
+ *        derive entity_id from the task (β-1: never trust client value);
+ *        ad-hoc items require entity_id in the body. display_order is
+ *        server-computed as max+1 within the (user_id, plan_date) scope.
+ *        Audits operations_daily_plan_item_created.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { writeAuditLog } from '@/lib/audit/writeAuditLog';
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+/** Parse a YYYY-MM-DD string to a UTC-midnight Date, or null if malformed. */
+function parsePlanDate(s: string): Date | null {
+  if (!DATE_RE.test(s)) return null;
+  const d = new Date(`${s}T00:00:00.000Z`);
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
+function todayUtc(): Date {
+  const now = new Date();
+  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+}
+
+function trimNullable(v: unknown): string | null {
+  if (typeof v !== 'string') return null;
+  const t = v.trim();
+  return t.length > 0 ? t : null;
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const user = await prisma.users.findFirst({
+      where: { email: { equals: userEmail, mode: 'insensitive' } },
+    });
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+
+    const { searchParams } = new URL(request.url);
+    const fromParam = searchParams.get('from');
+    const toParam = searchParams.get('to');
+
+    let from: Date;
+    if (fromParam) {
+      const parsed = parsePlanDate(fromParam);
+      if (!parsed) {
+        return NextResponse.json(
+          { error: 'Validation', field: 'from', message: 'from must be a valid YYYY-MM-DD date' },
+          { status: 400 }
+        );
+      }
+      from = parsed;
+    } else {
+      from = todayUtc();
+    }
+
+    let to: Date;
+    if (toParam) {
+      const parsed = parsePlanDate(toParam);
+      if (!parsed) {
+        return NextResponse.json(
+          { error: 'Validation', field: 'to', message: 'to must be a valid YYYY-MM-DD date' },
+          { status: 400 }
+        );
+      }
+      to = parsed;
+    } else {
+      to = from;
+    }
+
+    if (from.getTime() > to.getTime()) {
+      return NextResponse.json(
+        { error: 'Validation', field: 'to', message: 'to must be on or after from' },
+        { status: 400 }
+      );
+    }
+
+    const items = await prisma.operations_daily_plan_items.findMany({
+      where: { user_id: user.id, plan_date: { gte: from, lte: to } },
+      include: { calendar_blocks: { orderBy: { scheduled_start: 'asc' } } },
+      orderBy: [{ plan_date: 'asc' }, { display_order: 'asc' }],
+    });
+
+    return NextResponse.json({ items });
+  } catch (error) {
+    console.error('[Daily Plan Items GET]', error);
+    return NextResponse.json(
+      { error: 'Failed to load daily plan items', message: error instanceof Error ? error.message : 'unknown' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const user = await prisma.users.findFirst({
+      where: { email: { equals: userEmail, mode: 'insensitive' } },
+    });
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+
+    const body = await request.json();
+
+    if (typeof body.plan_date !== 'string' || body.plan_date.length === 0) {
+      return NextResponse.json(
+        { error: 'Validation', field: 'plan_date', message: 'plan_date is required (YYYY-MM-DD)' },
+        { status: 400 }
+      );
+    }
+    const planDate = parsePlanDate(body.plan_date);
+    if (!planDate) {
+      return NextResponse.json(
+        { error: 'Validation', field: 'plan_date', message: 'plan_date must be a valid YYYY-MM-DD date' },
+        { status: 400 }
+      );
+    }
+
+    const taskIdRaw = trimNullable(body.task_id);
+    const adHocTitle = trimNullable(body.ad_hoc_title);
+    const adHocDescription = trimNullable(body.ad_hoc_description);
+    const notes = trimNullable(body.notes);
+
+    // CHECK constraint mirror: exactly one of task_id / ad_hoc_title.
+    if (taskIdRaw && adHocTitle) {
+      return NextResponse.json(
+        { error: 'Validation', field: 'task_id', message: 'provide either task_id or ad_hoc_title, not both' },
+        { status: 400 }
+      );
+    }
+    if (!taskIdRaw && !adHocTitle) {
+      return NextResponse.json(
+        { error: 'Validation', field: 'ad_hoc_title', message: 'one of task_id or ad_hoc_title is required' },
+        { status: 400 }
+      );
+    }
+
+    let entityId: string;
+    let taskId: string | null = null;
+    let finalAdHocDescription: string | null = null;
+
+    if (taskIdRaw) {
+      // Task-linked: defensive 404 on cross-user, entity_id derived from task.
+      const task = await prisma.operations_project_tasks.findFirst({
+        where: { id: taskIdRaw, user_id: user.id },
+      });
+      if (!task) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+      taskId = task.id;
+      entityId = task.entity_id;
+    } else {
+      // Ad-hoc: entity_id required in body, length-bounded text fields.
+      if (adHocTitle && adHocTitle.length > 500) {
+        return NextResponse.json(
+          { error: 'Validation', field: 'ad_hoc_title', message: 'ad_hoc_title exceeds 500 characters' },
+          { status: 400 }
+        );
+      }
+      if (adHocDescription && adHocDescription.length > 1500) {
+        return NextResponse.json(
+          { error: 'Validation', field: 'ad_hoc_description', message: 'ad_hoc_description exceeds 1500 characters' },
+          { status: 400 }
+        );
+      }
+      const entityIdRaw = trimNullable(body.entity_id);
+      if (!entityIdRaw) {
+        return NextResponse.json(
+          { error: 'Validation', field: 'entity_id', message: 'entity_id is required for ad-hoc items' },
+          { status: 400 }
+        );
+      }
+      entityId = entityIdRaw;
+      finalAdHocDescription = adHocDescription;
+    }
+
+    // display_order = max+1 within (user_id, plan_date).
+    const last = await prisma.operations_daily_plan_items.findFirst({
+      where: { user_id: user.id, plan_date: planDate },
+      orderBy: { display_order: 'desc' },
+      select: { display_order: true },
+    });
+    const displayOrder = last ? last.display_order + 1 : 0;
+
+    const item = await prisma.operations_daily_plan_items.create({
+      data: {
+        user_id: user.id,
+        entity_id: entityId,
+        plan_date: planDate,
+        task_id: taskId,
+        ad_hoc_title: adHocTitle,
+        ad_hoc_description: finalAdHocDescription,
+        notes,
+        display_order: displayOrder,
+        created_by: userEmail,
+      },
+    });
+
+    await writeAuditLog({
+      actor: { user_id: user.id, email: userEmail, type: 'human_user' },
+      action: {
+        type: 'operations_daily_plan_item_created',
+        description: `Created daily plan item for ${body.plan_date}`,
+      },
+      target: { table: 'operations_daily_plan_items', id: item.id },
+      payload: {
+        after: item,
+        metadata: {
+          plan_date: body.plan_date,
+          entity_id: entityId,
+          task_id: taskId,
+        },
+      },
+    });
+
+    return NextResponse.json({ item, isCreate: true }, { status: 201 });
+  } catch (error) {
+    console.error('[Daily Plan Items POST]', error);
+    return NextResponse.json(
+      { error: 'Failed to create daily plan item', message: error instanceof Error ? error.message : 'unknown' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/lib/operations/detectBlockConflicts.ts
+++ b/src/lib/operations/detectBlockConflicts.ts
@@ -1,0 +1,41 @@
+import { Prisma } from '@prisma/client';
+import { prisma } from '@/lib/prisma';
+
+/**
+ * Detects calendar-block overlaps for a given user + time range.
+ *
+ * Uses the Postgres OVERLAPS operator. Half-open interval semantics:
+ * a block ending at exactly T does NOT conflict with a block starting at T.
+ *
+ * Filters out cancelled and missed blocks (those slots are free).
+ *
+ * @param userId          The user whose calendar is being checked.
+ * @param scheduledStart  Proposed start.
+ * @param scheduledEnd    Proposed end (must be > scheduledStart, validated by caller).
+ * @param excludeBlockId  Optional block id to exclude (used by PATCH so a block doesn't conflict with itself).
+ * @returns Array of conflicting block ids (empty if no conflicts).
+ *
+ * Race note: detection is not transactional with the subsequent write.
+ * Consistent with the project's α-1 single-user race-acceptance posture.
+ */
+export async function detectBlockConflicts(
+  userId: string,
+  scheduledStart: Date,
+  scheduledEnd: Date,
+  excludeBlockId?: string
+): Promise<string[]> {
+  const conditions: Prisma.Sql[] = [
+    Prisma.sql`user_id = ${userId}`,
+    Prisma.sql`status NOT IN ('cancelled', 'missed')`,
+    Prisma.sql`(scheduled_start, scheduled_end) OVERLAPS (${scheduledStart}::timestamptz, ${scheduledEnd}::timestamptz)`,
+  ];
+  if (excludeBlockId) {
+    conditions.push(Prisma.sql`id != ${excludeBlockId}::uuid`);
+  }
+
+  const whereClause = Prisma.join(conditions, ' AND ');
+  const rows = await prisma.$queryRaw<{ id: string }[]>(
+    Prisma.sql`SELECT id FROM operations_calendar_blocks WHERE ${whereClause}`
+  );
+  return rows.map((r) => r.id);
+}

--- a/src/lib/operations/loadAuthorizedCalendarBlock.ts
+++ b/src/lib/operations/loadAuthorizedCalendarBlock.ts
@@ -1,0 +1,7 @@
+import { prisma } from '@/lib/prisma';
+
+export async function loadAuthorizedCalendarBlock(blockId: string, userId: string) {
+  return prisma.operations_calendar_blocks.findFirst({
+    where: { id: blockId, user_id: userId },
+  });
+}

--- a/src/lib/operations/loadAuthorizedDailyPlanItem.ts
+++ b/src/lib/operations/loadAuthorizedDailyPlanItem.ts
@@ -1,0 +1,8 @@
+import { prisma } from '@/lib/prisma';
+
+export async function loadAuthorizedDailyPlanItem(itemId: string, userId: string) {
+  return prisma.operations_daily_plan_items.findFirst({
+    where: { id: itemId, user_id: userId },
+    include: { calendar_blocks: { orderBy: { scheduled_start: 'asc' } } },
+  });
+}


### PR DESCRIPTION
## What ships

CRUD API layer for `operations_daily_plan_items` and `operations_calendar_blocks` (PR-Ops-4.0 tables). Eight endpoints. Pure backend — no UI changes. Foundation for PR-Ops-4.3 (Daily Plan page) and PR-Ops-4.5 (calendar block UI).

## Architecture (locked)

**Defensive non-disclosure throughout.** All endpoints return 404 (not 403) for cross-user access. No information leak about resource existence.

**Server-derived provenance.** `entity_id` for task-linked items derives from `task.entity_id` (client value ignored). For calendar blocks, `entity_id` and `user_id` always derive from parent `operations_daily_plan_items`. Client cannot inject scope.

**App-side CHECK constraint mirroring.** PR-Ops-4.0's DB CHECKs (item XOR invariant, block time-ordering) validated at the route layer first. Violations return clean 400 `{ error: 'Validation', field, message }` instead of raw DB errors.

**Conflict detection with operator override.** New helper `detectBlockConflicts` uses Postgres `OVERLAPS` with half-open `[start, end)` semantics (back-to-back blocks do NOT conflict). Filters cancelled/missed. POST/PATCH return 409 with `conflicting_block_ids` array unless `allow_conflicts: true` in body. Conflicts always reported in response even when overridden (for frontend visual indicators).

**Single funnel for audit.** Every mutation writes to `audit_log` via `writeAuditLog` AFTER any database operation commits (can't nest in `$transaction` — runs its own Serializable tx). Six new `AuditActionType` enum values via single migration.

**Race acceptance.** Conflict detection and write are not atomic (TOCTOU window). Consistent with α-1 single-user posture documented across the codebase. Not guarded — single-user system, vanishingly rare.

## Endpoints (8)
GET    /api/operations/daily-plan/items                       List items by date range
POST   /api/operations/daily-plan/items                       Create item (task-linked or ad-hoc)
GET    /api/operations/daily-plan/items/[itemId]              Read one item with calendar_blocks joined
PATCH  /api/operations/daily-plan/items/[itemId]              Update mutable fields
DELETE /api/operations/daily-plan/items/[itemId]              Delete item (cascades to blocks)
POST   /api/operations/daily-plan/items/[itemId]/blocks       Create calendar block
PATCH  /api/operations/daily-plan/blocks/[blockId]            Update block (start/end/status/actuals/notes)
DELETE /api/operations/daily-plan/blocks/[blockId]            Delete block

## Migration

`20260518000000_pr_ops_4_1_audit_enums` — adds six values to `AuditActionType`:
- `operations_daily_plan_item_created` / `_updated` / `_deleted`
- `operations_calendar_block_created` / `_updated` / `_deleted`

Single `ALTER TYPE ADD VALUE IF NOT EXISTS` per value, no `BEGIN/COMMIT` (Postgres requires enum additions outside transactions). Additive, non-breaking.

## Helpers added

- `src/lib/operations/loadAuthorizedDailyPlanItem.ts` — defensive 404 ownership check, returns item with `calendar_blocks` joined
- `src/lib/operations/loadAuthorizedCalendarBlock.ts` — defensive 404 ownership check for blocks
- `src/lib/operations/detectBlockConflicts.ts` — Postgres `OVERLAPS` query via composed `Prisma.sql`, `::timestamptz` parameter casts for type safety, supports `excludeBlockId` for PATCH self-exclusion

## Validation rules

**Items POST:**
- `task_id` XOR `ad_hoc_title` (one required, both rejected)
- Task-linked: validates task exists AND `task.user_id === user.id` (defensive 404), `entity_id` derived from task
- Ad-hoc: `entity_id` required from body, title ≤500 chars, description ≤1500 chars
- `plan_date` required, YYYY-MM-DD format
- `display_order` server-computed as `max+1` within `(user_id, plan_date)` scope

**Items PATCH:**
- Mutable: `notes`, `display_order`, `ad_hoc_title`, `ad_hoc_description`
- Immutable: `task_id`, `entity_id`, `plan_date`, `user_id`, `created_by` (delete + recreate to change link or date)
- Clearing `ad_hoc_title` requires existing `task_id !== null` (preserve XOR invariant)

**Blocks POST/PATCH:**
- `scheduled_end > scheduled_start` (mirrors DB CHECK)
- Status validated against `CalendarBlockStatus` enum
- `actual_start`/`actual_end` have no ordering constraint (corrections allowed)
- Conflict detection runs on every time-field change

## Verification

- Both commits tsc-clean
- All Prisma queries scoped by authenticated user
- All audit writes carry `metadata` for replay context (plan_date, entity_id, allow_conflicts_used, conflicts_overridden)
- `Prisma.sql` composition keeps all user values as bound parameters — no injection surface
- Cascading deletes captured in `payload.before` (item delete loads blocks first for audit completeness)

## Known gaps (logged, not in this PR)

- Ad-hoc item `entity_id` is client-trusted with no validation against user-owned entities. Pattern exists elsewhere in the codebase; warrants a follow-up PR (PR-Ops-4.1.1 candidate) to add entity ownership checks across all routes accepting `entity_id` from body.
- No UI (PR-Ops-4.3 + 4.5)
- `coa_code`, `actual_cost_usd`, `actual_minutes` on tasks not yet wired (PR-Ops-4.6)
- Conflict detection has TOCTOU race (documented, accepted per α-1 posture)

## Commits (2)

- 1d78a36 — items CRUD endpoints + audit enum migration + ownership helper
- 8858ee3 — calendar block endpoints + conflict detection helper

## Branch

`claude/pr-ops-4.1-daily-plan-api`