### PR TITLE
PR-Ops-4.1.1: UUID format validation across operations routes — malfo…

### DIFF
--- a/src/app/api/operations/daily-plan/blocks/[blockId]/route.ts
+++ b/src/app/api/operations/daily-plan/blocks/[blockId]/route.ts
@@ -19,6 +19,7 @@ import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { writeAuditLog } from '@/lib/audit/writeAuditLog';
 import { loadAuthorizedCalendarBlock } from '@/lib/operations/loadAuthorizedCalendarBlock';
 import { detectBlockConflicts } from '@/lib/operations/detectBlockConflicts';
+import { isValidUuid } from '@/lib/operations/parseUuid';
 
 const VALID_STATUSES: CalendarBlockStatus[] = [
   'scheduled',
@@ -48,6 +49,9 @@ export async function PATCH(
     if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
 
     const { blockId } = await params;
+    if (!isValidUuid(blockId)) {
+      return NextResponse.json({ error: 'Validation', field: 'blockId', message: 'Invalid UUID format' }, { status: 400 });
+    }
     const existing = await loadAuthorizedCalendarBlock(blockId, user.id);
     if (!existing) return NextResponse.json({ error: 'Not found' }, { status: 404 });
 
@@ -198,6 +202,9 @@ export async function DELETE(
     if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
 
     const { blockId } = await params;
+    if (!isValidUuid(blockId)) {
+      return NextResponse.json({ error: 'Validation', field: 'blockId', message: 'Invalid UUID format' }, { status: 400 });
+    }
     const existing = await loadAuthorizedCalendarBlock(blockId, user.id);
     if (!existing) return NextResponse.json({ error: 'Not found' }, { status: 404 });
 

--- a/src/app/api/operations/daily-plan/items/[itemId]/blocks/route.ts
+++ b/src/app/api/operations/daily-plan/items/[itemId]/blocks/route.ts
@@ -17,6 +17,7 @@ import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { writeAuditLog } from '@/lib/audit/writeAuditLog';
 import { loadAuthorizedDailyPlanItem } from '@/lib/operations/loadAuthorizedDailyPlanItem';
 import { detectBlockConflicts } from '@/lib/operations/detectBlockConflicts';
+import { isValidUuid } from '@/lib/operations/parseUuid';
 
 const VALID_STATUSES: CalendarBlockStatus[] = [
   'scheduled',
@@ -46,6 +47,9 @@ export async function POST(
     if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
 
     const { itemId } = await params;
+    if (!isValidUuid(itemId)) {
+      return NextResponse.json({ error: 'Validation', field: 'itemId', message: 'Invalid UUID format' }, { status: 400 });
+    }
     const item = await loadAuthorizedDailyPlanItem(itemId, user.id);
     if (!item) return NextResponse.json({ error: 'Not found' }, { status: 404 });
 

--- a/src/app/api/operations/daily-plan/items/[itemId]/route.ts
+++ b/src/app/api/operations/daily-plan/items/[itemId]/route.ts
@@ -20,6 +20,7 @@ import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { writeAuditLog } from '@/lib/audit/writeAuditLog';
 import { loadAuthorizedDailyPlanItem } from '@/lib/operations/loadAuthorizedDailyPlanItem';
+import { isValidUuid } from '@/lib/operations/parseUuid';
 
 function trimNullable(v: unknown): string | null {
   if (typeof v !== 'string') return null;
@@ -41,6 +42,9 @@ export async function GET(
     if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
 
     const { itemId } = await params;
+    if (!isValidUuid(itemId)) {
+      return NextResponse.json({ error: 'Validation', field: 'itemId', message: 'Invalid UUID format' }, { status: 400 });
+    }
     const item = await loadAuthorizedDailyPlanItem(itemId, user.id);
     if (!item) return NextResponse.json({ error: 'Not found' }, { status: 404 });
 
@@ -68,6 +72,9 @@ export async function PATCH(
     if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
 
     const { itemId } = await params;
+    if (!isValidUuid(itemId)) {
+      return NextResponse.json({ error: 'Validation', field: 'itemId', message: 'Invalid UUID format' }, { status: 400 });
+    }
     const existing = await prisma.operations_daily_plan_items.findFirst({
       where: { id: itemId, user_id: user.id },
     });
@@ -176,6 +183,9 @@ export async function DELETE(
     if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
 
     const { itemId } = await params;
+    if (!isValidUuid(itemId)) {
+      return NextResponse.json({ error: 'Validation', field: 'itemId', message: 'Invalid UUID format' }, { status: 400 });
+    }
     const existing = await loadAuthorizedDailyPlanItem(itemId, user.id);
     if (!existing) return NextResponse.json({ error: 'Not found' }, { status: 404 });
 

--- a/src/app/api/operations/daily-plan/items/route.ts
+++ b/src/app/api/operations/daily-plan/items/route.ts
@@ -16,6 +16,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { writeAuditLog } from '@/lib/audit/writeAuditLog';
+import { isValidUuid } from '@/lib/operations/parseUuid';
 
 const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 
@@ -152,6 +153,12 @@ export async function POST(request: NextRequest) {
     let finalAdHocDescription: string | null = null;
 
     if (taskIdRaw) {
+      if (!isValidUuid(taskIdRaw)) {
+        return NextResponse.json(
+          { error: 'Validation', field: 'task_id', message: 'Invalid UUID format' },
+          { status: 400 }
+        );
+      }
       // Task-linked: defensive 404 on cross-user, entity_id derived from task.
       const task = await prisma.operations_project_tasks.findFirst({
         where: { id: taskIdRaw, user_id: user.id },

--- a/src/app/api/operations/projects/[id]/tasks/[taskId]/history/route.ts
+++ b/src/app/api/operations/projects/[id]/tasks/[taskId]/history/route.ts
@@ -9,6 +9,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { isValidUuid } from '@/lib/operations/parseUuid';
 
 export async function GET(
   _request: NextRequest,
@@ -24,6 +25,12 @@ export async function GET(
     if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
 
     const { id: projectId, taskId } = await params;
+    if (!isValidUuid(projectId)) {
+      return NextResponse.json({ error: 'Validation', field: 'id', message: 'Invalid UUID format' }, { status: 400 });
+    }
+    if (!isValidUuid(taskId)) {
+      return NextResponse.json({ error: 'Validation', field: 'taskId', message: 'Invalid UUID format' }, { status: 400 });
+    }
 
     const task = await prisma.operations_project_tasks.findFirst({
       where: { id: taskId, project_id: projectId },

--- a/src/app/api/operations/projects/[id]/tasks/[taskId]/route.ts
+++ b/src/app/api/operations/projects/[id]/tasks/[taskId]/route.ts
@@ -21,6 +21,7 @@ import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { writeAuditLog } from '@/lib/audit/writeAuditLog';
 import { recordTaskStatusChange } from '@/lib/operations/recordTaskStatusChange';
+import { isValidUuid } from '@/lib/operations/parseUuid';
 
 const VALID_STATUSES: OperationsTaskStatus[] = [
   'open',
@@ -56,6 +57,12 @@ export async function GET(
     if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
 
     const { id: projectId, taskId } = await params;
+    if (!isValidUuid(projectId)) {
+      return NextResponse.json({ error: 'Validation', field: 'id', message: 'Invalid UUID format' }, { status: 400 });
+    }
+    if (!isValidUuid(taskId)) {
+      return NextResponse.json({ error: 'Validation', field: 'taskId', message: 'Invalid UUID format' }, { status: 400 });
+    }
     const task = await loadAuthorizedTask(taskId, projectId, user.id);
     if (!task) return NextResponse.json({ error: 'Not found' }, { status: 404 });
 
@@ -83,6 +90,12 @@ export async function PATCH(
     if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
 
     const { id: projectId, taskId } = await params;
+    if (!isValidUuid(projectId)) {
+      return NextResponse.json({ error: 'Validation', field: 'id', message: 'Invalid UUID format' }, { status: 400 });
+    }
+    if (!isValidUuid(taskId)) {
+      return NextResponse.json({ error: 'Validation', field: 'taskId', message: 'Invalid UUID format' }, { status: 400 });
+    }
     const existing = await loadAuthorizedTask(taskId, projectId, user.id);
     if (!existing) return NextResponse.json({ error: 'Not found' }, { status: 404 });
 
@@ -318,6 +331,12 @@ export async function DELETE(
     if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
 
     const { id: projectId, taskId } = await params;
+    if (!isValidUuid(projectId)) {
+      return NextResponse.json({ error: 'Validation', field: 'id', message: 'Invalid UUID format' }, { status: 400 });
+    }
+    if (!isValidUuid(taskId)) {
+      return NextResponse.json({ error: 'Validation', field: 'taskId', message: 'Invalid UUID format' }, { status: 400 });
+    }
     const existing = await loadAuthorizedTask(taskId, projectId, user.id);
     if (!existing) return NextResponse.json({ error: 'Not found' }, { status: 404 });
 

--- a/src/app/api/operations/projects/[id]/tasks/[taskId]/uncomplete/route.ts
+++ b/src/app/api/operations/projects/[id]/tasks/[taskId]/uncomplete/route.ts
@@ -18,6 +18,7 @@ import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { writeAuditLog } from '@/lib/audit/writeAuditLog';
 import { recordTaskStatusChange } from '@/lib/operations/recordTaskStatusChange';
+import { isValidUuid } from '@/lib/operations/parseUuid';
 
 async function loadAuthorizedTask(taskId: string, projectId: string, userId: string) {
   return prisma.operations_project_tasks.findFirst({
@@ -45,6 +46,12 @@ export async function POST(
     if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
 
     const { id: projectId, taskId } = await params;
+    if (!isValidUuid(projectId)) {
+      return NextResponse.json({ error: 'Validation', field: 'id', message: 'Invalid UUID format' }, { status: 400 });
+    }
+    if (!isValidUuid(taskId)) {
+      return NextResponse.json({ error: 'Validation', field: 'taskId', message: 'Invalid UUID format' }, { status: 400 });
+    }
     const existing = await loadAuthorizedTask(taskId, projectId, user.id);
     if (!existing) return NextResponse.json({ error: 'Not found' }, { status: 404 });
 

--- a/src/lib/operations/parseUuid.ts
+++ b/src/lib/operations/parseUuid.ts
@@ -1,0 +1,22 @@
+/**
+ * UUID format validation predicate.
+ *
+ * Accepts any UUID version/variant matching the canonical 8-4-4-4-12 hex format.
+ * Case-insensitive (the DB column accepts mixed case; we normalize on insert).
+ *
+ * Use at route entry points after auth, before passing client-provided UUIDs
+ * into Prisma queries. Closes the Citadel-posture gap where malformed UUIDs
+ * would otherwise surface as Prisma P2023 errors → 500 Internal Server Error.
+ *
+ * Caller pattern:
+ *   if (!isValidUuid(taskId)) {
+ *     return NextResponse.json(
+ *       { error: 'Validation', field: 'taskId', message: 'Invalid UUID format' },
+ *       { status: 400 }
+ *     );
+ *   }
+ */
+export function isValidUuid(s: unknown): s is string {
+  return typeof s === 'string'
+    && /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(s);
+}


### PR DESCRIPTION
## What ships

UUID format validation at every operations route entry point that accepts client-supplied UUIDs. Malformed UUIDs now return clean 400 Validation instead of 500 Internal Server Error.

## The bug

Discovered during PR-Ops-4.1 end-to-end verification. When a client passes a non-UUID string (e.g. `"ITEM_ID_FROM_TEST_2"`) as a URL param or body field, the value flows untrimmed into a Prisma query. Postgres rejects the malformed UUID with `P2023` ("Inconsistent column data: invalid character"). The route's catch-all swallows it and returns a generic 500 leaking the raw Prisma error message.

Citadel posture violation: 500 means "server confused," not "client sent garbage." Malformed inputs should ALWAYS return 400.

## The fix

New helper `src/lib/operations/parseUuid.ts` — single boolean predicate:

```typescript
export function isValidUuid(s: unknown): s is string {
  return typeof s === 'string'
    && /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(s);
}
```

Type-narrowing predicate, case-insensitive, accepts any UUID version/variant (matches DB column tolerance).

Applied at 11 handlers across 7 route files. Validation runs **after** auth + user lookup, **before** any Prisma ownership query. Order matters: unauthenticated callers still receive 401 (don't leak input-shape feedback). Authenticated callers receive 400 with the exact field name that failed.

## Routes covered
items/route.ts                                   POST (validates body.task_id when present)
items/[itemId]/route.ts                          GET, PATCH, DELETE (validates itemId)
items/[itemId]/blocks/route.ts                   POST (validates itemId)
blocks/[blockId]/route.ts                        PATCH, DELETE (validates blockId)
tasks/[taskId]/route.ts                          GET, PATCH, DELETE (validates id + taskId)
tasks/[taskId]/uncomplete/route.ts               POST (validates id + taskId)
tasks/[taskId]/history/route.ts                  GET (validates id + taskId)

Total: 11 method handlers across 4.1 + 4.2 operations namespace.

## Architecture decisions (locked from CC's audit)

**Order: after auth, before ownership.** Don't leak input-shape feedback to unauthenticated requests. 401 wins over 400 when both could fire.

**URL params validated unconditionally.** Route wouldn't match without them. Body UUIDs validated only when present (after `trimNullable` returns non-null).

**No P2023 catch-block mapping.** Defense-in-depth would scatter error-code translation across every catch. Validation at the entry point closes the gap completely. 500 remains reserved for genuine "server confused" cases — the correct semantics.

**Helper scope: operations namespace only.** UUID validation is generic but nothing outside operations currently needs it. Co-located with sibling helpers (`loadAuthorizedDailyPlanItem`, `loadAuthorizedCalendarBlock`, `detectBlockConflicts`, `recordTaskStatusChange`, `parseUuid`).

**Defense-in-depth bonus:** validating `blockId` at the route entry closes the raw-SQL path in `detectBlockConflicts` too (which interpolates `${excludeBlockId}::uuid` — a malformed value there would throw `22P02` not `P2023`). One fix, two attack surfaces closed.

## Response shape

All routes return identical 400 shape on UUID validation failure:

```json
{ "error": "Validation", "field": "<paramName>", "message": "Invalid UUID format" }
```

Field name matches the destructured param name (`id`, `taskId`, `itemId`, `blockId`, `task_id`) so frontend can highlight the offending input.

## Verification

- tsc clean
- All 11 handlers verified by inspection
- One audit-before-action sweep across each route (line numbers re-checked before edit)
- No regression risk: validation is additive — well-formed UUIDs flow through unchanged
- No DB changes, no schema changes, no migration

## What's NOT in this PR

- Other UUID-accepting routes outside operations namespace (trading/finance) — separate scope, separate PR if needed
- POST `items/route.ts` body validates `task_id` but does NOT validate `entity_id` UUID shape (entity_id is a CUID/cuid2 in this codebase, not a strict UUID — separate validator needed if we ever tighten that)

## Commits (1)

- f021722 — helper + 7 route edits, 11 handlers, 83 insertions

## Branch

`claude/pr-ops-4.1.1-uuid-validation`