### PR TITLE
PR-Ops-4.4: schedule this task affordance — today/tomorrow/pick date …

### DIFF
--- a/src/components/workbench/operations/projects/TaskRow.tsx
+++ b/src/components/workbench/operations/projects/TaskRow.tsx
@@ -75,6 +75,12 @@ export default function TaskRow({ task, projectId, index, onUpdate, onDelete }: 
   const [history, setHistory] = useState<TaskStatusHistoryRow[] | null>(null);
   const [historyLoading, setHistoryLoading] = useState(false);
   const [historyError, setHistoryError] = useState<string | null>(null);
+  const [scheduling, setScheduling] = useState(false);
+  const [scheduleMenuOpen, setScheduleMenuOpen] = useState(false);
+  const [scheduleDate, setScheduleDate] = useState<string>(() =>
+    new Date().toISOString().slice(0, 10)
+  );
+  const [scheduleSuccess, setScheduleSuccess] = useState<string | null>(null);
 
   const enterEdit = () => {
     setForm(taskToForm(task));
@@ -186,6 +192,40 @@ export default function TaskRow({ task, projectId, index, onUpdate, onDelete }: 
     }
   };
 
+  const todayIso = () => new Date().toISOString().slice(0, 10);
+  const tomorrowIso = () => {
+    const d = new Date();
+    d.setUTCDate(d.getUTCDate() + 1);
+    return d.toISOString().slice(0, 10);
+  };
+
+  const handleSchedule = async (targetDate: string) => {
+    setScheduling(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/operations/daily-plan/items', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          plan_date: targetDate,
+          task_id: task.id,
+        }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.message ?? body.error ?? `HTTP ${res.status}`);
+      }
+      setScheduleSuccess(`scheduled for ${targetDate}`);
+      setScheduleMenuOpen(false);
+      // Auto-clear success message after 4 seconds.
+      setTimeout(() => setScheduleSuccess(null), 4000);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to schedule task');
+    } finally {
+      setScheduling(false);
+    }
+  };
+
   const handleDelete = async (e: React.MouseEvent) => {
     e.stopPropagation();
     if (!confirm(`Delete task "${task.title}"?`)) return;
@@ -279,8 +319,72 @@ export default function TaskRow({ task, projectId, index, onUpdate, onDelete }: 
           >
             history
           </button>
+          {task.status !== 'completed' && task.status !== 'cancelled' && (
+            <button
+              type="button"
+              onClick={(e) => { e.stopPropagation(); setScheduleMenuOpen((x) => !x); }}
+              disabled={scheduling}
+              className="px-2 py-0.5 border border-border text-text-muted rounded hover:bg-bg-row disabled:opacity-50 text-xs font-mono"
+              title="Schedule this task on a daily plan"
+            >
+              {scheduling ? '↗ scheduling…' : '↗ schedule'}
+            </button>
+          )}
+          {scheduleSuccess && (
+            <span className="text-xs font-mono text-green-700">{scheduleSuccess}</span>
+          )}
         </div>
       </div>
+
+      {scheduleMenuOpen && (
+        <div
+          className="mx-6 mt-2 mb-2 p-2 border border-border-light rounded bg-bg-row text-xs font-mono"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <div className="flex items-center gap-2 flex-wrap">
+            <span className="text-text-muted">schedule for:</span>
+            <button
+              type="button"
+              onClick={(e) => { e.stopPropagation(); handleSchedule(todayIso()); }}
+              disabled={scheduling}
+              className="px-2 py-0.5 border border-border text-text-primary rounded hover:bg-white disabled:opacity-50"
+            >
+              today
+            </button>
+            <button
+              type="button"
+              onClick={(e) => { e.stopPropagation(); handleSchedule(tomorrowIso()); }}
+              disabled={scheduling}
+              className="px-2 py-0.5 border border-border text-text-primary rounded hover:bg-white disabled:opacity-50"
+            >
+              tomorrow
+            </button>
+            <span className="text-text-muted">or</span>
+            <input
+              type="date"
+              value={scheduleDate}
+              onChange={(e) => setScheduleDate(e.target.value)}
+              onClick={(e) => e.stopPropagation()}
+              className="px-2 py-0.5 border border-border rounded text-text-primary"
+            />
+            <button
+              type="button"
+              onClick={(e) => { e.stopPropagation(); handleSchedule(scheduleDate); }}
+              disabled={scheduling || !scheduleDate}
+              className="px-2 py-0.5 border border-border text-text-primary rounded hover:bg-white disabled:opacity-50"
+            >
+              schedule
+            </button>
+            <button
+              type="button"
+              onClick={(e) => { e.stopPropagation(); setScheduleMenuOpen(false); }}
+              className="px-2 py-0.5 text-text-muted hover:bg-bg-row rounded"
+            >
+              cancel
+            </button>
+          </div>
+        </div>
+      )}
 
       {showHistory && (
         <div className="mx-6 mt-2 mb-2 p-2 border border-border-light rounded bg-bg-row text-xs font-mono">


### PR DESCRIPTION
## What ships

A "↗ schedule" button on every TaskRow that creates an `operations_daily_plan_items` row for the task on a chosen date. Three options: today / tomorrow / pick date. Pure frontend change — backend is the verified PR-Ops-4.1 POST items endpoint, untouched.

First user-facing connection between the Operations project backlog and the Daily Plan layer. Every task becomes one click away from today's plan.

## Architecture (locked)

**Backend project-agnostic.** Calls `/api/operations/daily-plan/items` directly with `{ plan_date, task_id: task.id }`. The endpoint is top-level and derives `entity_id` from `task.entity_id` server-side. No project nesting needed.

**Semantic distinction: scheduling ≠ task mutation.** `onUpdate()` deliberately NOT called on success. Scheduling creates a separate `operations_daily_plan_items` row; the task itself is unchanged. Triggering a parent refetch would collapse the expanded row state and waste a round-trip. Confirmation is purely local via ephemeral success indicator.

**Hidden for completed/cancelled tasks.** Scheduling a done task is semantically incoherent. Mirrors the conditional render of the `✓ complete` button — same pattern, consistent UX.

**Inline reveal menu, no dropdown framework.** Click button → toggles inline panel with three options + native date input. All click handlers call `e.stopPropagation()` to prevent row expand toggle. Lightweight, matches the existing history panel pattern.

**Ephemeral success indicator.** Small green text "↗ scheduled for YYYY-MM-DD" appears next to the button on success, auto-clears after 4 seconds via setTimeout. Visible confirmation of the specific date — surfaces accidental double-adds until PR-Ops-4.4.1 ships the "already scheduled" indicator.

**Errors reuse existing error state.** No new error UI surface; failures route into the file's existing red banner. Bridgewater principle: don't multiply mechanisms.

## What's NOT in this PR

- "Already scheduled" indicator on tasks (deferred to PR-Ops-4.4.1) — duplicate scheduling is currently possible but visible via the success toast
- Bulk schedule (schedule multiple tasks at once)
- Schedule-with-block (schedule the task AND immediately create a calendar_block) — separate PR when calendar UI ships
- Drag-and-drop to a Daily Plan UI (waits for PR-Ops-4.3)
- Re-scheduling a previously scheduled task (currently creates a second row; cleanup post-4.4.1)

## State added to TaskRow

- `scheduling: boolean` — loading flag during POST
- `scheduleMenuOpen: boolean` — inline panel toggle
- `scheduleDate: string` — YYYY-MM-DD value for the date input, default = today
- `scheduleSuccess: string | null` — ephemeral confirmation message, auto-clears via setTimeout

## Handler

`handleSchedule(targetDate: string)` — POSTs to the daily-plan items endpoint, sets success on 201, routes failures into the existing `error` state. No `onUpdate()` call.

Helpers `todayIso()` and `tomorrowIso()` inline (matches existing codebase pattern — no shared date utility exists).

## Visibility rules

Button rendered ONLY when:
- `task.status !== 'completed'`
- `task.status !== 'cancelled'`

Matches the conditional logic for the existing `✓ complete` button.

## Verification

- tsc clean
- One file changed (TaskRow.tsx), 104 insertions
- Audit-before-action: re-viewed file structure, confirmed button placement and menu placement match existing patterns (history panel)
- onUpdate() invariant preserved (audited and confirmed in commit report)
- All click handlers stopPropagation to prevent row expand toggle

## Commits (1)

- 679739f — schedule affordance + menu + handler

## Branch

`claude/pr-ops-4.4-schedule-task`