### PR TITLE
Claude/pr ops 4.3 daily plan page

### DIFF
--- a/src/app/api/operations/daily-plan/items/route.ts
+++ b/src/app/api/operations/daily-plan/items/route.ts
@@ -89,7 +89,10 @@ export async function GET(request: NextRequest) {
 
     const items = await prisma.operations_daily_plan_items.findMany({
       where: { user_id: user.id, plan_date: { gte: from, lte: to } },
-      include: { calendar_blocks: { orderBy: { scheduled_start: 'asc' } } },
+      include: {
+        calendar_blocks: { orderBy: { scheduled_start: 'asc' } },
+        task: { select: { id: true, title: true, status: true } },
+      },
       orderBy: [{ plan_date: 'asc' }, { display_order: 'asc' }],
     });
 

--- a/src/app/operations/page.tsx
+++ b/src/app/operations/page.tsx
@@ -2,21 +2,20 @@
  * src/app/operations/page.tsx
  *
  * Daily Plan — Operations home. Renders Section B (North Star) and
- * Section C (Today's Decision) as placeholders. Real wiring lands in
- * later PRs (PR-Ops-2b for North Star, PR-Ops-4 for Today's Decision).
+ * Section C (Daily Plan — operations_daily_plan_items, date-navigated).
  *
  * Chrome (identity bar + sub-nav) is provided by the parent
  * src/app/operations/layout.tsx.
  */
 
-import PlaceholderCard from '@/components/workbench/operations/PlaceholderCard';
 import SectionB_NorthStar from '@/components/workbench/operations/SectionB_NorthStar';
+import SectionC_DailyPlan from '@/components/workbench/operations/SectionC_DailyPlan';
 
 export default function OperationsDailyPlanPage() {
   return (
     <>
       <SectionB_NorthStar />
-      <PlaceholderCard letter="C" title="TODAY'S DECISION" unbuiltLabel="UNBUILT · PR-Ops-4" />
+      <SectionC_DailyPlan />
     </>
   );
 }

--- a/src/components/workbench/operations/SectionC_DailyPlan.tsx
+++ b/src/components/workbench/operations/SectionC_DailyPlan.tsx
@@ -1,0 +1,275 @@
+/**
+ * src/components/workbench/operations/SectionC_DailyPlan.tsx
+ *
+ * Section C · Daily Plan — date-navigated list of operations_daily_plan_items.
+ * Task-linked items show the linked task's title/status; ad-hoc items show
+ * their own title. calendar_blocks render read-only beneath each item.
+ *
+ * Cross-entity by design: the day-plan is "everything I'm doing today" — the
+ * GET items endpoint is user-scoped (no entity filter), so the operations
+ * entity selector is intentionally ignored here. Ad-hoc creation still needs
+ * an entity_id, so the create form carries its own entity selector.
+ */
+
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useOperationsEntity } from './EntitySelector';
+import DailyPlanItemRow from './dailyplan/DailyPlanItemRow';
+import type { DailyPlanItem } from './dailyplan/types';
+
+const inputClass =
+  'w-full px-2 py-1 border border-border rounded text-xs font-mono text-text-primary focus:outline-none focus:border-brand-purple';
+
+function todayIso(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+function prevDay(iso: string): string {
+  const d = new Date(`${iso}T00:00:00.000Z`);
+  d.setUTCDate(d.getUTCDate() - 1);
+  return d.toISOString().slice(0, 10);
+}
+function nextDay(iso: string): string {
+  const d = new Date(`${iso}T00:00:00.000Z`);
+  d.setUTCDate(d.getUTCDate() + 1);
+  return d.toISOString().slice(0, 10);
+}
+
+const EMPTY_CREATE_FORM = {
+  ad_hoc_title: '',
+  ad_hoc_description: '',
+  notes: '',
+  entity_id: '',
+};
+
+export default function SectionC_DailyPlan() {
+  const { entities } = useOperationsEntity();
+
+  const [currentDate, setCurrentDate] = useState<string>(todayIso());
+  const [items, setItems] = useState<DailyPlanItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [showCreate, setShowCreate] = useState(false);
+  const [createForm, setCreateForm] = useState(EMPTY_CREATE_FORM);
+  const [creating, setCreating] = useState(false);
+  const [createError, setCreateError] = useState<string | null>(null);
+
+  const fetchItems = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(
+        `/api/operations/daily-plan/items?from=${currentDate}&to=${currentDate}`
+      );
+      const body = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setError(body?.message ?? body?.error ?? 'failed to load daily plan');
+        setItems([]);
+        return;
+      }
+      setItems(body.items ?? []);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'failed to load daily plan');
+      setItems([]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchItems();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentDate]);
+
+  const resetCreateForm = () => setCreateForm(EMPTY_CREATE_FORM);
+
+  const handleCreate = async () => {
+    if (!createForm.entity_id) {
+      setCreateError('entity is required');
+      return;
+    }
+    if (createForm.ad_hoc_title.trim().length === 0) {
+      setCreateError('title is required');
+      return;
+    }
+    setCreating(true);
+    setCreateError(null);
+    try {
+      const res = await fetch('/api/operations/daily-plan/items', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          plan_date: currentDate,
+          ad_hoc_title: createForm.ad_hoc_title,
+          ad_hoc_description: createForm.ad_hoc_description,
+          notes: createForm.notes,
+          entity_id: createForm.entity_id,
+        }),
+      });
+      const body = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setCreateError(body?.message ?? body?.error ?? 'failed to create item');
+        return;
+      }
+      resetCreateForm();
+      setShowCreate(false);
+      fetchItems();
+    } catch (e) {
+      setCreateError(e instanceof Error ? e.message : 'failed to create item');
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const navBtnClass =
+    'px-2 py-0.5 border border-border rounded hover:bg-bg-row text-text-primary disabled:opacity-50';
+
+  return (
+    <section className="bg-white rounded border border-border shadow-sm p-5">
+      <div className="flex items-center justify-between mb-3">
+        <h2 className="font-mono text-sm font-bold tracking-wide text-text-primary">
+          C · DAILY PLAN
+        </h2>
+        <div className="flex items-center gap-3 text-xs font-mono">
+          <span className="text-text-muted">
+            {items.length} {items.length === 1 ? 'item' : 'items'}
+          </span>
+          {!showCreate && (
+            <button
+              type="button"
+              onClick={() => setShowCreate(true)}
+              className="px-2 py-1 border border-brand-purple bg-brand-purple text-white rounded hover:opacity-90"
+            >
+              + add item
+            </button>
+          )}
+        </div>
+      </div>
+
+      <div className="flex items-center gap-2 mb-4 text-xs font-mono">
+        <button type="button" onClick={() => setCurrentDate(prevDay(currentDate))} className={navBtnClass}>
+          ← prev
+        </button>
+        <button type="button" onClick={() => setCurrentDate(todayIso())} className={navBtnClass}>
+          today
+        </button>
+        <button type="button" onClick={() => setCurrentDate(nextDay(currentDate))} className={navBtnClass}>
+          next →
+        </button>
+        <input
+          type="date"
+          value={currentDate}
+          onChange={(e) => setCurrentDate(e.target.value || todayIso())}
+          className="px-2 py-0.5 border border-border rounded text-text-primary"
+        />
+        <span className="text-text-muted ml-2">(showing all entities)</span>
+      </div>
+
+      {showCreate && (
+        <div className="border border-brand-purple rounded p-3 bg-purple-50/30 space-y-2 mb-4">
+          <div className="font-mono text-xs font-bold text-text-primary">
+            new ad-hoc item · {currentDate}
+          </div>
+          <div>
+            <label className="text-xs font-mono text-text-muted">entity</label>
+            <select
+              className={inputClass}
+              value={createForm.entity_id}
+              onChange={(e) => setCreateForm({ ...createForm, entity_id: e.target.value })}
+            >
+              <option value="">— select entity —</option>
+              {entities.map((e) => (
+                <option key={e.id} value={e.id}>
+                  {e.name}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label className="text-xs font-mono text-text-muted">title</label>
+            <input
+              type="text"
+              className={inputClass}
+              value={createForm.ad_hoc_title}
+              onChange={(e) => setCreateForm({ ...createForm, ad_hoc_title: e.target.value })}
+              maxLength={500}
+              placeholder="what are you doing?"
+            />
+          </div>
+          <div>
+            <label className="text-xs font-mono text-text-muted">description (optional)</label>
+            <textarea
+              className={inputClass}
+              value={createForm.ad_hoc_description}
+              onChange={(e) => setCreateForm({ ...createForm, ad_hoc_description: e.target.value })}
+              rows={3}
+              maxLength={1500}
+            />
+          </div>
+          <div>
+            <label className="text-xs font-mono text-text-muted">notes (optional)</label>
+            <textarea
+              className={inputClass}
+              value={createForm.notes}
+              onChange={(e) => setCreateForm({ ...createForm, notes: e.target.value })}
+              rows={2}
+              maxLength={1500}
+            />
+          </div>
+          {createError && (
+            <div className="px-3 py-2 rounded border bg-red-50 border-red-200 text-red-800 text-xs font-mono">
+              {createError}
+            </div>
+          )}
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={handleCreate}
+              disabled={creating}
+              className="px-3 py-1 border border-brand-purple bg-brand-purple text-white rounded hover:opacity-90 disabled:opacity-50 text-xs font-mono"
+            >
+              {creating ? 'creating…' : 'create item'}
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setShowCreate(false);
+                resetCreateForm();
+                setCreateError(null);
+              }}
+              disabled={creating}
+              className="px-3 py-1 border border-border rounded hover:bg-bg-row disabled:opacity-50 text-xs font-mono"
+            >
+              cancel
+            </button>
+          </div>
+        </div>
+      )}
+
+      {loading ? (
+        <div className="text-text-muted font-mono text-sm">loading daily plan…</div>
+      ) : error ? (
+        <div className="px-3 py-2 rounded border bg-red-50 border-red-200 text-red-800 text-xs font-mono">
+          {error}
+        </div>
+      ) : items.length === 0 ? (
+        <div className="text-text-muted font-mono text-sm">
+          nothing scheduled for {currentDate} — use &apos;+ add item&apos; or schedule a task from
+          Projects.
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {items.map((item) => (
+            <DailyPlanItemRow
+              key={item.id}
+              item={item}
+              onUpdate={fetchItems}
+              onDelete={fetchItems}
+            />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/workbench/operations/dailyplan/DailyPlanItemRow.tsx
+++ b/src/components/workbench/operations/dailyplan/DailyPlanItemRow.tsx
@@ -1,0 +1,239 @@
+/**
+ * DailyPlanItemRow — one operations_daily_plan_items row on the Daily Plan page.
+ *
+ * Task-linked items render the linked task's title + status pill; ad-hoc items
+ * render ad_hoc_title/description. calendar_blocks are listed read-only beneath
+ * (block creation/editing is PR-Ops-4.5). Inline edit covers notes +
+ * display_order for all items, plus ad_hoc_title/description for ad-hoc items
+ * (task_id / entity_id / plan_date are immutable per the PR-Ops-4.1 endpoint).
+ */
+
+'use client';
+
+import { useState } from 'react';
+import type { DailyPlanItem } from './types';
+
+interface Props {
+  item: DailyPlanItem;
+  onUpdate: () => void;
+  onDelete: () => void;
+}
+
+const inputClass =
+  'w-full px-2 py-1 border border-border rounded text-xs font-mono text-text-primary focus:outline-none focus:border-brand-purple';
+
+function formatTime(iso: string): string {
+  return new Date(iso).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', hour12: false });
+}
+
+export default function DailyPlanItemRow({ item, onUpdate, onDelete }: Props) {
+  const isAdHoc = !item.task;
+
+  const [editing, setEditing] = useState(false);
+  const [form, setForm] = useState({
+    ad_hoc_title: item.ad_hoc_title ?? '',
+    ad_hoc_description: item.ad_hoc_description ?? '',
+    notes: item.notes ?? '',
+    display_order: String(item.display_order),
+  });
+  const [saving, setSaving] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const enterEdit = () => {
+    setForm({
+      ad_hoc_title: item.ad_hoc_title ?? '',
+      ad_hoc_description: item.ad_hoc_description ?? '',
+      notes: item.notes ?? '',
+      display_order: String(item.display_order),
+    });
+    setError(null);
+    setEditing(true);
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    setError(null);
+    try {
+      const body: Record<string, unknown> = {
+        notes: form.notes,
+        display_order: Number(form.display_order),
+      };
+      if (isAdHoc) {
+        body.ad_hoc_title = form.ad_hoc_title;
+        body.ad_hoc_description = form.ad_hoc_description;
+      }
+      const res = await fetch(`/api/operations/daily-plan/items/${item.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      const resBody = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setError(resBody?.message ?? resBody?.error ?? 'failed to save');
+        return;
+      }
+      setEditing(false);
+      onUpdate();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'failed to save');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!window.confirm('Delete this item from the daily plan?')) return;
+    setDeleting(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/operations/daily-plan/items/${item.id}`, {
+        method: 'DELETE',
+      });
+      if (!res.ok) {
+        const resBody = await res.json().catch(() => ({}));
+        setError(resBody?.message ?? resBody?.error ?? 'failed to delete');
+        return;
+      }
+      onDelete();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'failed to delete');
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  return (
+    <div className="bg-white border border-border rounded p-3 space-y-2">
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex-1 min-w-0">
+          {item.task ? (
+            <div className="flex items-center gap-2 flex-wrap">
+              <span className="text-xs font-mono text-text-muted">[task]</span>
+              <span className="font-mono text-sm text-text-primary">{item.task.title}</span>
+              <span className="px-1.5 py-0 border border-border rounded text-xs font-mono text-text-muted">
+                {item.task.status}
+              </span>
+            </div>
+          ) : (
+            <div className="font-mono text-sm text-text-primary">{item.ad_hoc_title}</div>
+          )}
+
+          {isAdHoc && item.ad_hoc_description && (
+            <div className="text-xs font-mono text-text-muted mt-1 whitespace-pre-wrap">
+              {item.ad_hoc_description}
+            </div>
+          )}
+
+          {item.notes && (
+            <div className="text-xs font-mono text-text-muted mt-1 italic whitespace-pre-wrap">
+              {item.notes}
+            </div>
+          )}
+        </div>
+
+        <div className="flex items-center gap-2 shrink-0">
+          {!editing && (
+            <button
+              type="button"
+              onClick={enterEdit}
+              className="px-2 py-0.5 border border-border text-text-muted rounded hover:bg-bg-row text-xs font-mono"
+            >
+              edit
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={handleDelete}
+            disabled={deleting}
+            className="px-2 py-0.5 border border-red-300 text-red-700 rounded hover:bg-red-50 disabled:opacity-50 text-xs font-mono"
+          >
+            {deleting ? 'deleting…' : 'delete'}
+          </button>
+        </div>
+      </div>
+
+      {item.calendar_blocks.length > 0 && (
+        <div className="flex flex-wrap gap-2 pl-2 border-l-2 border-border-light">
+          {item.calendar_blocks.map((b) => (
+            <div key={b.id} className="text-xs font-mono text-text-muted">
+              {formatTime(b.scheduled_start)}–{formatTime(b.scheduled_end)} · {b.status}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {editing && (
+        <div className="border border-brand-purple rounded p-3 bg-purple-50/30 space-y-2">
+          {isAdHoc && (
+            <div>
+              <label className="text-xs font-mono text-text-muted">title</label>
+              <input
+                type="text"
+                className={inputClass}
+                value={form.ad_hoc_title}
+                onChange={(e) => setForm({ ...form, ad_hoc_title: e.target.value })}
+                maxLength={500}
+              />
+            </div>
+          )}
+          {isAdHoc && (
+            <div>
+              <label className="text-xs font-mono text-text-muted">description</label>
+              <textarea
+                className={inputClass}
+                value={form.ad_hoc_description}
+                onChange={(e) => setForm({ ...form, ad_hoc_description: e.target.value })}
+                rows={3}
+                maxLength={1500}
+              />
+            </div>
+          )}
+          <div>
+            <label className="text-xs font-mono text-text-muted">notes</label>
+            <textarea
+              className={inputClass}
+              value={form.notes}
+              onChange={(e) => setForm({ ...form, notes: e.target.value })}
+              rows={3}
+              maxLength={1500}
+            />
+          </div>
+          <div>
+            <label className="text-xs font-mono text-text-muted">display order</label>
+            <input
+              type="number"
+              className={inputClass}
+              value={form.display_order}
+              onChange={(e) => setForm({ ...form, display_order: e.target.value })}
+            />
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={handleSave}
+              disabled={saving}
+              className="px-3 py-1 border border-brand-purple bg-brand-purple text-white rounded hover:opacity-90 disabled:opacity-50 text-xs font-mono"
+            >
+              {saving ? 'saving…' : 'save'}
+            </button>
+            <button
+              type="button"
+              onClick={() => setEditing(false)}
+              disabled={saving}
+              className="px-3 py-1 border border-border rounded hover:bg-bg-row disabled:opacity-50 text-xs font-mono"
+            >
+              cancel
+            </button>
+          </div>
+        </div>
+      )}
+
+      {error && (
+        <div className="px-3 py-2 rounded border bg-red-50 border-red-200 text-red-800 text-xs font-mono">
+          {error}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/workbench/operations/dailyplan/types.ts
+++ b/src/components/workbench/operations/dailyplan/types.ts
@@ -1,0 +1,34 @@
+import type { OperationsTaskStatus, CalendarBlockStatus } from '@prisma/client';
+
+export type CalendarBlockSummary = {
+  id: string;
+  scheduled_start: string;
+  scheduled_end: string;
+  actual_start: string | null;
+  actual_end: string | null;
+  status: CalendarBlockStatus;
+  notes: string | null;
+};
+
+export type LinkedTaskSummary = {
+  id: string;
+  title: string;
+  status: OperationsTaskStatus;
+};
+
+export type DailyPlanItem = {
+  id: string;
+  user_id: string;
+  entity_id: string;
+  plan_date: string; // ISO datetime
+  task_id: string | null;
+  ad_hoc_title: string | null;
+  ad_hoc_description: string | null;
+  display_order: number;
+  notes: string | null;
+  created_at: string;
+  updated_at: string;
+  created_by: string | null;
+  task: LinkedTaskSummary | null;
+  calendar_blocks: CalendarBlockSummary[];
+};

--- a/src/lib/operations/loadAuthorizedDailyPlanItem.ts
+++ b/src/lib/operations/loadAuthorizedDailyPlanItem.ts
@@ -3,6 +3,9 @@ import { prisma } from '@/lib/prisma';
 export async function loadAuthorizedDailyPlanItem(itemId: string, userId: string) {
   return prisma.operations_daily_plan_items.findFirst({
     where: { id: itemId, user_id: userId },
-    include: { calendar_blocks: { orderBy: { scheduled_start: 'asc' } } },
+    include: {
+      calendar_blocks: { orderBy: { scheduled_start: 'asc' } },
+      task: { select: { id: true, title: true, status: true } },
+    },
   });
 }


### PR DESCRIPTION
## What ships

A real Daily Plan page replaces the "C · TODAY'S DECISION" placeholder on /operations. Lists today's `operations_daily_plan_items` with task titles, calendar blocks displayed inline as read-only text, inline edit per row, ad-hoc item creation, and date navigation (prev / today / next / date picker).

First operator-facing view of the daily plan layer. Closes the loop: schedule a task from Projects (PR-Ops-4.4) → see it appear on this page.

## Architecture (locked)

**Backend touched minimally.** PR-Ops-4.3a is a surgical one-line `include` enrichment on the GET items endpoint: `task: { id, title, status }`. The existing `loadAuthorizedDailyPlanItem` helper picks up the same enrichment automatically, so GET items, GET itemId, and DELETE itemId (via the helper) all return identical shape.

**Cross-entity view.** The page deliberately ignores `selectedEntityId` and shows all entities' items for the date. The day-plan is naturally cross-entity ("everything I'm doing today across Personal/Business/Trading"). A small "(showing all entities)" note next to the date nav makes this explicit. The entity selector is used ONLY inside the ad-hoc create form (POST requires `entity_id`).

**No timezone drift.** `currentDate` is a YYYY-MM-DD string. `plan_date` is a Postgres `@db.Date` serialized as ISO datetime by Prisma. The UI never compares timestamps — it drives both the GET query and the displayed date from the same YYYY-MM-DD string. UTC helpers (`todayIso`, `prevDay`, `nextDay`) all use `setUTCDate` to avoid drift.

**Server-derived provenance preserved.** Ad-hoc create form sends `{ plan_date, ad_hoc_title, ad_hoc_description, notes, entity_id }`. The endpoint validates `entity_id` is supplied for ad-hoc items. For task-linked items, the existing PR-Ops-4.4 schedule affordance handles creation (this page only creates ad-hoc items inline).

**Read-only calendar blocks.** Blocks are listed under each item as `HH:MM–HH:MM · <status>` text. No drag-to-time, no block creation UI here — that's PR-Ops-4.5.

**Single funnel through 4.1 endpoints.** GET items, POST items, PATCH itemId, DELETE itemId. No new API. No new business logic in the frontend.

## Backend change (commit 4.3a — 0fc0dc0)

Added `task: { select: { id: true, title: true, status: true } }` to the Prisma `include` clause in two locations:
- `src/lib/operations/loadAuthorizedDailyPlanItem.ts` (helper, backs GET itemId + DELETE itemId)
- `src/app/api/operations/daily-plan/items/route.ts` (GET items findMany)

8 insertions, 2 deletions, 2 files. POST/PATCH untouched.

## Frontend (commit 4.3b — fd2dd55)

**Three new files:**
- `src/components/workbench/operations/dailyplan/types.ts` — `DailyPlanItem`, `LinkedTaskSummary`, `CalendarBlockSummary` types
- `src/components/workbench/operations/dailyplan/DailyPlanItemRow.tsx` — row component
- `src/components/workbench/operations/SectionC_DailyPlan.tsx` — section component

**One modified file:**
- `src/app/operations/page.tsx` — `<PlaceholderCard letter="C" ... />` → `<SectionC_DailyPlan />`

## UX details

**Date navigation:** `← prev` / `today` / `next →` buttons + native `<input type="date">`. Empty-input fallback to today (prevents accidental empty-string queries).

**Empty state:** "nothing scheduled for <date> — use '+ add item' or schedule a task from Projects." Helpful pointer to both creation paths.

**Item row visual:**
- Task-linked: `[task]` label + task title + status pill
- Ad-hoc: title rendered directly, optional description below
- Notes shown below in italic
- Calendar blocks listed in a left-bordered strip below

**Inline edit:**
- For task-linked items: only `notes` and `display_order` editable
- For ad-hoc items: also `ad_hoc_title` and `ad_hoc_description`
- Edit button hidden while editing (no redundant no-op)
- Purple-bg form pattern mirrors SectionD_ProjectBacklog

**Delete:** `window.confirm` before DELETE. Cascades to calendar_blocks server-side (PR-Ops-4.0 CASCADE constraint).

## What's NOT in this PR

- Block creation/editing UI (PR-Ops-4.5)
- Re-ordering by drag-and-drop (display_order is editable as a number; drag is a separate UX investment)
- "Already scheduled" indicator on task rows in Projects (PR-Ops-4.4.1)
- Cross-day operations (move item from one date to another) — currently requires delete + recreate
- AI-suggested scheduling (PR-Ops-4.9)
- Status changes on blocks (the block UI doesn't exist yet)

## Verification

- All tsc clean
- Audit-before-action on both commits
- Cosmetic deviations from spec all surfaced and justified (apostrophe HTML entities prevent React lint failure; empty-input fallback prevents bad GET; edit-button hide while editing prevents no-op)
- No regression risk: backend change is purely additive (`include` expansion), frontend is new files + one placeholder swap

## Commits (2)

- 0fc0dc0 — GET items task enrichment
- fd2dd55 — Daily Plan page UI

## Branch

`claude/pr-ops-4.3-daily-plan-page`