### PR TITLE
Claude/pr ops 4.8.6 routine steps

### DIFF
--- a/prisma/migrations/20260518300000_pr_ops_4_8_6_routine_steps/migration.sql
+++ b/prisma/migrations/20260518300000_pr_ops_4_8_6_routine_steps/migration.sql
@@ -1,0 +1,38 @@
+-- PR-Ops-4.8.6a: routine sub-steps foundation
+--
+-- Adds operations_routine_steps with denormalized user_id + entity_id
+-- (matches operations_project_tasks precedent for defensive-404 ownership).
+--
+-- time_of_day is @db.Time, NULLABLE — operator can leave blank.
+-- Frontend (4.8.6c) auto-fills empty steps from parent routine.start_time
+-- with a 15-minute interval per step_order.
+--
+-- ISO serialization gotcha: Prisma maps @db.Time to JS Date; JSON arrives as
+-- '1970-01-01THH:MM:SS.000Z'. Frontend must .slice(11, 16) to extract HH:MM.
+
+BEGIN;
+
+CREATE TABLE "operations_routine_steps" (
+  "id"                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  "routine_id"        UUID NOT NULL,
+  "user_id"           TEXT NOT NULL,
+  "entity_id"         TEXT NOT NULL,
+  "step_order"        INT NOT NULL DEFAULT 0,
+  "time_of_day"       TIME,
+  "activity"          VARCHAR(200) NOT NULL,
+  "sub_activity"      VARCHAR(200),
+  "location"          VARCHAR(200),
+  "duration_minutes"  INT,
+  "notes"             TEXT,
+  "created_at"        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  "updated_at"        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  "created_by"        TEXT,
+  CONSTRAINT "operations_routine_steps_routine_fkey"
+    FOREIGN KEY ("routine_id") REFERENCES "operations_routines"("id") ON DELETE CASCADE
+);
+
+CREATE INDEX "operations_routine_steps_routine_order_idx" ON "operations_routine_steps"("routine_id", "step_order");
+CREATE INDEX "operations_routine_steps_routine_idx" ON "operations_routine_steps"("routine_id");
+CREATE INDEX "operations_routine_steps_user_idx" ON "operations_routine_steps"("user_id");
+
+COMMIT;

--- a/prisma/migrations/20260518400000_pr_ops_4_8_6_routine_step_audit_enums/migration.sql
+++ b/prisma/migrations/20260518400000_pr_ops_4_8_6_routine_step_audit_enums/migration.sql
@@ -1,0 +1,6 @@
+-- PR-Ops-4.8.6b: add audit action types for routine step CRUD
+-- Note: ALTER TYPE ADD VALUE cannot run in BEGIN/COMMIT block.
+
+ALTER TYPE "AuditActionType" ADD VALUE IF NOT EXISTS 'operations_routine_step_created';
+ALTER TYPE "AuditActionType" ADD VALUE IF NOT EXISTS 'operations_routine_step_updated';
+ALTER TYPE "AuditActionType" ADD VALUE IF NOT EXISTS 'operations_routine_step_deleted';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2056,6 +2056,9 @@ enum AuditActionType {
   operations_calendar_block_deleted
   operations_routine_completed
   operations_routine_missed
+  operations_routine_step_created
+  operations_routine_step_updated
+  operations_routine_step_deleted
   operations_issue_logged
   operations_issue_updated
   operations_issue_status_changed

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2729,12 +2729,37 @@ model operations_routines {
   created_by                    String?
 
   completions operations_routine_completions[]
+  steps       operations_routine_steps[]
 
   @@unique([user_id, name])
   @@index([user_id, is_active, next_due_at])
   @@index([user_id, entity_id])
   @@index([next_due_at])
   @@map("operations_routines")
+}
+
+model operations_routine_steps {
+  id               String    @id @default(uuid()) @db.Uuid
+  routine_id       String    @db.Uuid
+  user_id          String
+  entity_id        String
+  step_order       Int       @default(0)
+  time_of_day      DateTime? @db.Time(6)
+  activity         String    @db.VarChar(200)
+  sub_activity     String?   @db.VarChar(200)
+  location         String?   @db.VarChar(200)
+  duration_minutes Int?
+  notes            String?   @db.Text
+  created_at       DateTime  @default(now()) @db.Timestamptz(6)
+  updated_at       DateTime  @updatedAt @db.Timestamptz(6)
+  created_by       String?
+
+  routine operations_routines @relation(fields: [routine_id], references: [id], onDelete: Cascade)
+
+  @@index([routine_id, step_order])
+  @@index([routine_id])
+  @@index([user_id])
+  @@map("operations_routine_steps")
 }
 
 model operations_routine_completions {

--- a/src/app/api/operations/routines/[id]/route.ts
+++ b/src/app/api/operations/routines/[id]/route.ts
@@ -110,6 +110,9 @@ function parseTimeOrNull(
 async function loadAuthorizedRoutine(routineId: string, userId: string) {
   return prisma.operations_routines.findFirst({
     where: { id: routineId, user_id: userId },
+    include: {
+      steps: { orderBy: { step_order: 'asc' } },
+    },
   });
 }
 

--- a/src/app/api/operations/routines/[id]/route.ts
+++ b/src/app/api/operations/routines/[id]/route.ts
@@ -20,6 +20,7 @@ import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { writeAuditLog } from '@/lib/audit/writeAuditLog';
 import { compileFormToRRule, expandForward } from '@/lib/operations/rruleHelpers';
 import type { RoutineForm } from '@/components/workbench/operations/routines/types';
+import { parseTimeOrNull } from '@/lib/operations/parseTime';
 
 /**
  * Parse an optional YYYY-MM-DD date-bound value. Empty/null/undefined → null
@@ -58,52 +59,6 @@ function parseDateOrNull(
       ),
     };
   }
-  return { value: d, error: null };
-}
-
-/**
- * Parse an HH:MM time string into a JS Date with a 1970-01-01 anchor
- * (Prisma @db.Time round-trip expects a Date; the date part is ignored).
- * Returns { value: null, error: null } for null/empty input.
- * Returns { value: null, error: 400-response } for invalid format.
- */
-function parseTimeOrNull(
-  v: unknown,
-  field: string
-): { value: Date | null; error: NextResponse | null } {
-  if (v === null || v === undefined || v === '') return { value: null, error: null };
-  if (typeof v !== 'string') {
-    return {
-      value: null,
-      error: NextResponse.json(
-        { error: 'Validation', field, message: 'must be string HH:MM or null' },
-        { status: 400 }
-      ),
-    };
-  }
-  const match = /^(\d{2}):(\d{2})$/.exec(v);
-  if (!match) {
-    return {
-      value: null,
-      error: NextResponse.json(
-        { error: 'Validation', field, message: 'must match HH:MM' },
-        { status: 400 }
-      ),
-    };
-  }
-  const hh = Number(match[1]);
-  const mm = Number(match[2]);
-  if (hh < 0 || hh > 23 || mm < 0 || mm > 59) {
-    return {
-      value: null,
-      error: NextResponse.json(
-        { error: 'Validation', field, message: 'hour 00-23, minute 00-59' },
-        { status: 400 }
-      ),
-    };
-  }
-  // Prisma @db.Time accepts a Date — 1970-01-01 anchor; Postgres discards the date part.
-  const d = new Date(Date.UTC(1970, 0, 1, hh, mm, 0, 0));
   return { value: d, error: null };
 }
 

--- a/src/app/api/operations/routines/[id]/steps/route.ts
+++ b/src/app/api/operations/routines/[id]/steps/route.ts
@@ -1,0 +1,145 @@
+/**
+ * POST /api/operations/routines/[id]/steps
+ *
+ * Creates an ordered sub-step on a routine. user_id and entity_id are
+ * inherited from the parent routine (server-derived, client values ignored).
+ * step_order is server-computed as max+1 within the routine (α-1 race-
+ * acceptance: concurrent creates can collide, resolvable via PATCH).
+ *
+ * Audits operations_routine_step_created.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { writeAuditLog } from '@/lib/audit/writeAuditLog';
+import { isValidUuid } from '@/lib/operations/parseUuid';
+import { parseTimeOrNull } from '@/lib/operations/parseTime';
+
+function trimNullable(v: unknown): string | null {
+  if (typeof v !== 'string') return null;
+  const t = v.trim();
+  return t.length > 0 ? t : null;
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const user = await prisma.users.findFirst({
+      where: { email: { equals: userEmail, mode: 'insensitive' } },
+    });
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+
+    const { id } = await params;
+    if (!isValidUuid(id)) {
+      return NextResponse.json(
+        { error: 'Validation', field: 'id', message: 'Invalid UUID format' },
+        { status: 400 }
+      );
+    }
+
+    const routine = await prisma.operations_routines.findFirst({
+      where: { id, user_id: user.id },
+    });
+    if (!routine) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+
+    const body = await request.json();
+
+    const activity = trimNullable(body.activity);
+    if (!activity) {
+      return NextResponse.json(
+        { error: 'Validation', field: 'activity', message: 'activity is required' },
+        { status: 400 }
+      );
+    }
+    if (activity.length > 200) {
+      return NextResponse.json(
+        { error: 'Validation', field: 'activity', message: 'activity exceeds 200 characters' },
+        { status: 400 }
+      );
+    }
+
+    const subActivity = trimNullable(body.sub_activity);
+    if (subActivity && subActivity.length > 200) {
+      return NextResponse.json(
+        { error: 'Validation', field: 'sub_activity', message: 'sub_activity exceeds 200 characters' },
+        { status: 400 }
+      );
+    }
+
+    const location = trimNullable(body.location);
+    if (location && location.length > 200) {
+      return NextResponse.json(
+        { error: 'Validation', field: 'location', message: 'location exceeds 200 characters' },
+        { status: 400 }
+      );
+    }
+
+    const notes = trimNullable(body.notes);
+
+    let durationMinutes: number | null = null;
+    if (body.duration_minutes !== undefined && body.duration_minutes !== null && body.duration_minutes !== '') {
+      const n = Number(body.duration_minutes);
+      if (!Number.isInteger(n) || n < 0) {
+        return NextResponse.json(
+          { error: 'Validation', field: 'duration_minutes', message: 'must be a non-negative integer' },
+          { status: 400 }
+        );
+      }
+      durationMinutes = n;
+    }
+
+    const timeResult = parseTimeOrNull(body.time_of_day, 'time_of_day');
+    if (timeResult.error) return timeResult.error;
+
+    // step_order = max+1 within the routine (α-1 documented race-acceptance).
+    const maxOrder = await prisma.operations_routine_steps.findFirst({
+      where: { routine_id: routine.id },
+      orderBy: { step_order: 'desc' },
+      select: { step_order: true },
+    });
+    const stepOrder = maxOrder ? maxOrder.step_order + 1 : 0;
+
+    const step = await prisma.operations_routine_steps.create({
+      data: {
+        routine_id: routine.id,
+        user_id: routine.user_id,
+        entity_id: routine.entity_id,
+        step_order: stepOrder,
+        time_of_day: timeResult.value,
+        activity,
+        sub_activity: subActivity,
+        location,
+        duration_minutes: durationMinutes,
+        notes,
+        created_by: userEmail,
+      },
+    });
+
+    await writeAuditLog({
+      actor: { user_id: user.id, email: userEmail, type: 'human_user' },
+      action: {
+        type: 'operations_routine_step_created',
+        description: `Created step "${activity}" on routine "${routine.name}"`,
+      },
+      target: { table: 'operations_routine_steps', id: step.id },
+      payload: {
+        after: step,
+        metadata: { routine_id: routine.id, routine_name: routine.name },
+      },
+    });
+
+    return NextResponse.json({ step, isCreate: true }, { status: 201 });
+  } catch (error) {
+    console.error('[Routine Step POST]', error);
+    return NextResponse.json(
+      { error: 'Failed to create routine step', message: error instanceof Error ? error.message : 'unknown' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/operations/routines/route.ts
+++ b/src/app/api/operations/routines/route.ts
@@ -132,6 +132,9 @@ export async function GET(request: NextRequest) {
         { next_due_at: { sort: 'asc', nulls: 'last' } },
         { name: 'asc' },
       ],
+      include: {
+        steps: { orderBy: { step_order: 'asc' } },
+      },
     });
 
     return NextResponse.json({ routines });

--- a/src/app/api/operations/routines/route.ts
+++ b/src/app/api/operations/routines/route.ts
@@ -20,6 +20,7 @@ import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { writeAuditLog } from '@/lib/audit/writeAuditLog';
 import { compileFormToRRule, expandForward } from '@/lib/operations/rruleHelpers';
 import type { RoutineForm } from '@/components/workbench/operations/routines/types';
+import { parseTimeOrNull } from '@/lib/operations/parseTime';
 
 /**
  * Parse an optional YYYY-MM-DD date-bound value. Empty/null/undefined → null
@@ -58,52 +59,6 @@ function parseDateOrNull(
       ),
     };
   }
-  return { value: d, error: null };
-}
-
-/**
- * Parse an HH:MM time string into a JS Date with a 1970-01-01 anchor
- * (Prisma @db.Time round-trip expects a Date; the date part is ignored).
- * Returns { value: null, error: null } for null/empty input.
- * Returns { value: null, error: 400-response } for invalid format.
- */
-function parseTimeOrNull(
-  v: unknown,
-  field: string
-): { value: Date | null; error: NextResponse | null } {
-  if (v === null || v === undefined || v === '') return { value: null, error: null };
-  if (typeof v !== 'string') {
-    return {
-      value: null,
-      error: NextResponse.json(
-        { error: 'Validation', field, message: 'must be string HH:MM or null' },
-        { status: 400 }
-      ),
-    };
-  }
-  const match = /^(\d{2}):(\d{2})$/.exec(v);
-  if (!match) {
-    return {
-      value: null,
-      error: NextResponse.json(
-        { error: 'Validation', field, message: 'must match HH:MM' },
-        { status: 400 }
-      ),
-    };
-  }
-  const hh = Number(match[1]);
-  const mm = Number(match[2]);
-  if (hh < 0 || hh > 23 || mm < 0 || mm > 59) {
-    return {
-      value: null,
-      error: NextResponse.json(
-        { error: 'Validation', field, message: 'hour 00-23, minute 00-59' },
-        { status: 400 }
-      ),
-    };
-  }
-  // Prisma @db.Time accepts a Date — 1970-01-01 anchor; Postgres discards the date part.
-  const d = new Date(Date.UTC(1970, 0, 1, hh, mm, 0, 0));
   return { value: d, error: null };
 }
 

--- a/src/app/api/operations/routines/steps/[stepId]/route.ts
+++ b/src/app/api/operations/routines/steps/[stepId]/route.ts
@@ -1,0 +1,206 @@
+/**
+ * /api/operations/routines/steps/[stepId]
+ *
+ * PATCH  — update a routine step. Mutable: step_order, time_of_day, activity,
+ *          sub_activity, location, duration_minutes, notes. Immutable:
+ *          id, routine_id, user_id, entity_id, created_by, created_at.
+ *          Reordering is a step_order PATCH (audits as _updated).
+ * DELETE — hard delete; full row captured in the audit payload_before.
+ *
+ * Both scope by user_id (denormalized on the step row) with defensive 404.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { Prisma } from '@prisma/client';
+import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { writeAuditLog } from '@/lib/audit/writeAuditLog';
+import { isValidUuid } from '@/lib/operations/parseUuid';
+import { parseTimeOrNull } from '@/lib/operations/parseTime';
+import { loadAuthorizedRoutineStep } from '@/lib/operations/loadAuthorizedRoutineStep';
+
+function trimNullable(v: unknown): string | null {
+  if (typeof v !== 'string') return null;
+  const t = v.trim();
+  return t.length > 0 ? t : null;
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ stepId: string }> }
+) {
+  try {
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const user = await prisma.users.findFirst({
+      where: { email: { equals: userEmail, mode: 'insensitive' } },
+    });
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+
+    const { stepId } = await params;
+    if (!isValidUuid(stepId)) {
+      return NextResponse.json(
+        { error: 'Validation', field: 'stepId', message: 'Invalid UUID format' },
+        { status: 400 }
+      );
+    }
+
+    const existing = await loadAuthorizedRoutineStep(stepId, user.id);
+    if (!existing) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+
+    const body = await request.json();
+    const data: Prisma.operations_routine_stepsUpdateInput = {};
+
+    if (body.activity !== undefined) {
+      const a = trimNullable(body.activity);
+      if (!a) {
+        return NextResponse.json(
+          { error: 'Validation', field: 'activity', message: 'activity cannot be empty' },
+          { status: 400 }
+        );
+      }
+      if (a.length > 200) {
+        return NextResponse.json(
+          { error: 'Validation', field: 'activity', message: 'activity exceeds 200 characters' },
+          { status: 400 }
+        );
+      }
+      data.activity = a;
+    }
+
+    if (body.sub_activity !== undefined) {
+      const s = trimNullable(body.sub_activity);
+      if (s && s.length > 200) {
+        return NextResponse.json(
+          { error: 'Validation', field: 'sub_activity', message: 'sub_activity exceeds 200 characters' },
+          { status: 400 }
+        );
+      }
+      data.sub_activity = s;
+    }
+
+    if (body.location !== undefined) {
+      const l = trimNullable(body.location);
+      if (l && l.length > 200) {
+        return NextResponse.json(
+          { error: 'Validation', field: 'location', message: 'location exceeds 200 characters' },
+          { status: 400 }
+        );
+      }
+      data.location = l;
+    }
+
+    if (body.notes !== undefined) {
+      data.notes = trimNullable(body.notes);
+    }
+
+    if (body.duration_minutes !== undefined) {
+      if (body.duration_minutes === null || body.duration_minutes === '') {
+        data.duration_minutes = null;
+      } else {
+        const n = Number(body.duration_minutes);
+        if (!Number.isInteger(n) || n < 0) {
+          return NextResponse.json(
+            { error: 'Validation', field: 'duration_minutes', message: 'must be a non-negative integer' },
+            { status: 400 }
+          );
+        }
+        data.duration_minutes = n;
+      }
+    }
+
+    if (body.step_order !== undefined) {
+      const n = Number(body.step_order);
+      if (!Number.isInteger(n) || n < 0) {
+        return NextResponse.json(
+          { error: 'Validation', field: 'step_order', message: 'must be a non-negative integer' },
+          { status: 400 }
+        );
+      }
+      data.step_order = n;
+    }
+
+    if (body.time_of_day !== undefined) {
+      const timeResult = parseTimeOrNull(body.time_of_day, 'time_of_day');
+      if (timeResult.error) return timeResult.error;
+      data.time_of_day = timeResult.value;
+    }
+
+    const step = await prisma.operations_routine_steps.update({
+      where: { id: stepId },
+      data,
+    });
+
+    await writeAuditLog({
+      actor: { user_id: user.id, email: userEmail, type: 'human_user' },
+      action: {
+        type: 'operations_routine_step_updated',
+        description: `Updated routine step "${step.activity}"`,
+      },
+      target: { table: 'operations_routine_steps', id: step.id },
+      payload: {
+        before: existing,
+        after: step,
+        metadata: { routine_id: existing.routine_id },
+      },
+    });
+
+    return NextResponse.json({ step });
+  } catch (error) {
+    console.error('[Routine Step PATCH]', error);
+    return NextResponse.json(
+      { error: 'Failed to update routine step', message: error instanceof Error ? error.message : 'unknown' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ stepId: string }> }
+) {
+  try {
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const user = await prisma.users.findFirst({
+      where: { email: { equals: userEmail, mode: 'insensitive' } },
+    });
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+
+    const { stepId } = await params;
+    if (!isValidUuid(stepId)) {
+      return NextResponse.json(
+        { error: 'Validation', field: 'stepId', message: 'Invalid UUID format' },
+        { status: 400 }
+      );
+    }
+
+    const existing = await loadAuthorizedRoutineStep(stepId, user.id);
+    if (!existing) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+
+    await prisma.operations_routine_steps.delete({ where: { id: stepId } });
+
+    await writeAuditLog({
+      actor: { user_id: user.id, email: userEmail, type: 'human_user' },
+      action: {
+        type: 'operations_routine_step_deleted',
+        description: `Deleted routine step "${existing.activity}"`,
+      },
+      target: { table: 'operations_routine_steps', id: existing.id },
+      payload: {
+        before: existing,
+        metadata: { routine_id: existing.routine_id },
+      },
+    });
+
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    console.error('[Routine Step DELETE]', error);
+    return NextResponse.json(
+      { error: 'Failed to delete routine step', message: error instanceof Error ? error.message : 'unknown' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/operations/routines/today/route.ts
+++ b/src/app/api/operations/routines/today/route.ts
@@ -101,6 +101,9 @@ export async function GET(_request: NextRequest) {
     const routines = await prisma.operations_routines.findMany({
       where: { user_id: user.id, is_active: true },
       orderBy: { name: 'asc' },
+      include: {
+        steps: { orderBy: { step_order: 'asc' } },
+      },
     });
 
     const entries: Array<{

--- a/src/components/workbench/operations/dailyplan/DailyPlanRoutineRow.tsx
+++ b/src/components/workbench/operations/dailyplan/DailyPlanRoutineRow.tsx
@@ -9,6 +9,7 @@
 
 'use client';
 
+import { useState } from 'react';
 import type { TodayRoutineEntry, TodayStatus } from '../routines/types';
 
 function formatTime(iso: string, tz?: string): string {
@@ -45,6 +46,10 @@ interface Props {
 }
 
 export function DailyPlanRoutineRow({ entry }: Props) {
+  const [showSteps, setShowSteps] = useState(false);
+  const steps = entry.routine.steps ?? [];
+  const hasSteps = steps.length > 0;
+
   return (
     <div className="bg-white border border-border rounded p-3 space-y-2">
       <div className="flex items-start justify-between gap-2">
@@ -76,7 +81,45 @@ export function DailyPlanRoutineRow({ entry }: Props) {
             <span>
               🔥 {entry.routine.consecutive_completion_streak} ✓ / {entry.routine.consecutive_miss_streak} ✗
             </span>
+            {hasSteps && (
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setShowSteps((x) => !x);
+                }}
+                className="text-text-muted hover:text-text-primary"
+                title={showSteps ? 'hide steps' : 'show steps'}
+              >
+                {showSteps ? '▾' : '▸'} {steps.length} {steps.length === 1 ? 'step' : 'steps'}
+              </button>
+            )}
           </div>
+
+          {showSteps && hasSteps && (
+            <div className="mt-2 pl-2 border-l-2 border-border-light space-y-1">
+              {steps.map((step) => (
+                <div key={step.id} className="text-xs font-mono text-text-muted">
+                  <div className="flex items-baseline gap-2 flex-wrap">
+                    {step.time_of_day && (
+                      <span className="text-text-primary shrink-0">
+                        {step.time_of_day.slice(11, 16)}
+                      </span>
+                    )}
+                    <span className="text-text-primary truncate">{step.activity}</span>
+                    {step.sub_activity && <span>· {step.sub_activity}</span>}
+                    {step.location && <span className="shrink-0">@ {step.location}</span>}
+                    {step.duration_minutes !== null && (
+                      <span className="shrink-0">{step.duration_minutes} min</span>
+                    )}
+                  </div>
+                  {step.notes && (
+                    <div className="text-text-muted italic pl-2 mt-0.5">{step.notes}</div>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
 
           {entry.routine.description && (
             <div className="text-xs font-mono text-text-muted mt-1 italic whitespace-pre-wrap">

--- a/src/components/workbench/operations/routines/RoutineRow.tsx
+++ b/src/components/workbench/operations/routines/RoutineRow.tsx
@@ -18,6 +18,7 @@ import { useState } from 'react';
 import type { Routine, RoutineForm } from './types';
 import { DEFAULT_ROUTINE_FORM } from './types';
 import RRULEBuilder from './RRULEBuilder';
+import { RoutineStepList } from './RoutineStepList';
 
 interface Entity {
   id: string;
@@ -263,6 +264,8 @@ export default function RoutineRow({ routine, entities, onUpdate, onDelete }: Pr
               <div className="text-text-primary">{routine.ideal_time_label ?? '—'}</div>
             </div>
           </div>
+
+          <RoutineStepList routine={routine} onUpdate={onUpdate} />
 
           <div className="flex items-center gap-2 pt-2 border-t border-border-light">
             <button

--- a/src/components/workbench/operations/routines/RoutineStepList.tsx
+++ b/src/components/workbench/operations/routines/RoutineStepList.tsx
@@ -1,0 +1,495 @@
+/**
+ * RoutineStepList — ordered sub-step editor for a routine.
+ *
+ * Self-contained child of RoutineRow's expanded view (mirrors the TaskList
+ * pattern under ProjectRow): reads routine.steps from props, mutates via the
+ * PR-Ops-4.8.6b CRUD endpoints, and calls onUpdate() to trigger a parent
+ * refetch after every mutation.
+ *
+ * time_of_day arrives JSON-serialized from Prisma @db.Time as
+ * '1970-01-01THH:MM:SS.000Z' — every read extracts HH:MM via .slice(11, 16).
+ */
+
+'use client';
+
+import { useState } from 'react';
+import type { Routine, RoutineStep } from './types';
+
+const STEP_DEFAULT_INTERVAL_MINUTES = 15;
+
+const inputClass =
+  'w-full px-2 py-1 border border-border rounded text-xs font-mono text-text-primary focus:outline-none focus:border-brand-purple';
+const labelClass = 'text-text-faint uppercase tracking-wide mb-1 text-xs font-mono';
+
+interface StepForm {
+  activity: string;
+  time_of_day: string;
+  location: string;
+  sub_activity: string;
+  duration_minutes: string;
+  notes: string;
+}
+
+const EMPTY_FORM: StepForm = {
+  activity: '',
+  time_of_day: '',
+  location: '',
+  sub_activity: '',
+  duration_minutes: '',
+  notes: '',
+};
+
+function stepToForm(s: RoutineStep): StepForm {
+  return {
+    activity: s.activity,
+    time_of_day: s.time_of_day ? s.time_of_day.slice(11, 16) : '',
+    location: s.location ?? '',
+    sub_activity: s.sub_activity ?? '',
+    duration_minutes: s.duration_minutes !== null ? String(s.duration_minutes) : '',
+    notes: s.notes ?? '',
+  };
+}
+
+function formToBody(f: StepForm) {
+  return {
+    activity: f.activity,
+    time_of_day: f.time_of_day || null,
+    location: f.location || null,
+    sub_activity: f.sub_activity || null,
+    duration_minutes: f.duration_minutes !== '' ? Number(f.duration_minutes) : null,
+    notes: f.notes || null,
+  };
+}
+
+/**
+ * Auto-fill a new step's time_of_day from the parent routine's start_time,
+ * advancing STEP_DEFAULT_INTERVAL_MINUTES per existing step. '' if the parent
+ * has no start_time.
+ */
+function getAutoFillTime(routine: Routine, currentSteps: RoutineStep[]): string {
+  if (!routine.start_time) return '';
+  const startHHMM = routine.start_time.slice(11, 16);
+  const [hStr, mStr] = startHHMM.split(':');
+  const startMinutes = parseInt(hStr, 10) * 60 + parseInt(mStr, 10);
+  const newStepOrder = currentSteps.length;
+  const totalMinutes = startMinutes + newStepOrder * STEP_DEFAULT_INTERVAL_MINUTES;
+  const hh = Math.floor(totalMinutes / 60) % 24;
+  const mm = totalMinutes % 60;
+  return `${String(hh).padStart(2, '0')}:${String(mm).padStart(2, '0')}`;
+}
+
+interface Props {
+  routine: Routine;
+  onUpdate: () => void;
+}
+
+export function RoutineStepList({ routine, onUpdate }: Props) {
+  const steps = [...routine.steps].sort((a, b) => a.step_order - b.step_order);
+
+  const [error, setError] = useState<string | null>(null);
+  const [openAdd, setOpenAdd] = useState(false);
+  const [addForm, setAddForm] = useState<StepForm>(EMPTY_FORM);
+  const [creating, setCreating] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editForm, setEditForm] = useState<StepForm>(EMPTY_FORM);
+  const [saving, setSaving] = useState(false);
+  const [busy, setBusy] = useState(false);
+
+  const startAdd = () => {
+    setAddForm({ ...EMPTY_FORM, time_of_day: getAutoFillTime(routine, steps) });
+    setError(null);
+    setOpenAdd(true);
+  };
+
+  const handleCreate = async () => {
+    if (addForm.activity.trim().length === 0) {
+      setError('activity is required');
+      return;
+    }
+    setCreating(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/operations/routines/${routine.id}/steps`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(formToBody(addForm)),
+      });
+      const body = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setError(body?.message ?? body?.error ?? 'failed to create step');
+        return;
+      }
+      setOpenAdd(false);
+      setAddForm(EMPTY_FORM);
+      onUpdate();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'failed to create step');
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const enterEdit = (step: RoutineStep) => {
+    setEditForm(stepToForm(step));
+    setEditingId(step.id);
+    setError(null);
+  };
+
+  const handleSave = async (stepId: string) => {
+    if (editForm.activity.trim().length === 0) {
+      setError('activity is required');
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/operations/routines/steps/${stepId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(formToBody(editForm)),
+      });
+      const body = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setError(body?.message ?? body?.error ?? 'failed to save step');
+        return;
+      }
+      setEditingId(null);
+      onUpdate();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'failed to save step');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async (step: RoutineStep) => {
+    if (!window.confirm(`Delete step "${step.activity}"?`)) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/operations/routines/steps/${step.id}`, {
+        method: 'DELETE',
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        setError(body?.message ?? body?.error ?? 'failed to delete step');
+        return;
+      }
+      onUpdate();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'failed to delete step');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  // Swap step_order with the adjacent step. α-1 race-acceptance: concurrent
+  // reorders on a single-user system may collide; resolvable by re-reordering.
+  const handleMove = async (index: number, direction: -1 | 1) => {
+    const target = steps[index];
+    const adjacent = steps[index + direction];
+    if (!target || !adjacent) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const patch = (id: string, step_order: number) =>
+        fetch(`/api/operations/routines/steps/${id}`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ step_order }),
+        });
+      const [r1, r2] = await Promise.all([
+        patch(target.id, adjacent.step_order),
+        patch(adjacent.id, target.step_order),
+      ]);
+      if (!r1.ok || !r2.ok) {
+        setError('failed to reorder steps');
+        return;
+      }
+      onUpdate();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'failed to reorder steps');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const arrowClass =
+    'px-1.5 py-0.5 border border-border rounded hover:bg-bg-row disabled:opacity-30 text-xs font-mono';
+  const actionClass =
+    'px-2 py-0.5 border border-border text-text-muted rounded hover:bg-bg-row disabled:opacity-50 text-xs font-mono';
+
+  return (
+    <div className="pt-2 border-t border-border-light space-y-2">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <span className={labelClass}>steps</span>
+          <span className="text-text-muted text-xs font-mono">
+            {steps.length} {steps.length === 1 ? 'step' : 'steps'}
+          </span>
+        </div>
+        {!openAdd && (
+          <button
+            type="button"
+            onClick={(e) => { e.stopPropagation(); startAdd(); }}
+            className={actionClass}
+          >
+            + add step
+          </button>
+        )}
+      </div>
+
+      {error && (
+        <div className="px-3 py-2 rounded border bg-red-50 border-red-200 text-red-800 text-xs font-mono">
+          {error}
+        </div>
+      )}
+
+      {steps.length === 0 && !openAdd && (
+        <div className="text-text-muted italic text-xs font-mono">no steps yet</div>
+      )}
+
+      {steps.map((step, index) => (
+        <div
+          key={step.id}
+          className="border border-border-light rounded bg-white px-3 py-2 text-xs font-mono"
+        >
+          {editingId === step.id ? (
+            <div className="space-y-2">
+              <div className="grid grid-cols-2 gap-2">
+                <div className="col-span-2">
+                  <div className={labelClass}>activity</div>
+                  <input
+                    type="text"
+                    value={editForm.activity}
+                    onChange={(e) => setEditForm({ ...editForm, activity: e.target.value })}
+                    className={inputClass}
+                    maxLength={200}
+                  />
+                </div>
+                <div>
+                  <div className={labelClass}>time of day</div>
+                  <input
+                    type="time"
+                    value={editForm.time_of_day}
+                    onChange={(e) => setEditForm({ ...editForm, time_of_day: e.target.value })}
+                    className={inputClass}
+                  />
+                </div>
+                <div>
+                  <div className={labelClass}>duration (min)</div>
+                  <input
+                    type="number"
+                    min={0}
+                    value={editForm.duration_minutes}
+                    onChange={(e) => setEditForm({ ...editForm, duration_minutes: e.target.value })}
+                    className={inputClass}
+                  />
+                </div>
+                <div>
+                  <div className={labelClass}>location</div>
+                  <input
+                    type="text"
+                    value={editForm.location}
+                    onChange={(e) => setEditForm({ ...editForm, location: e.target.value })}
+                    className={inputClass}
+                    maxLength={200}
+                  />
+                </div>
+                <div>
+                  <div className={labelClass}>sub-activity</div>
+                  <input
+                    type="text"
+                    value={editForm.sub_activity}
+                    onChange={(e) => setEditForm({ ...editForm, sub_activity: e.target.value })}
+                    className={inputClass}
+                    maxLength={200}
+                  />
+                </div>
+                <div className="col-span-2">
+                  <div className={labelClass}>notes</div>
+                  <textarea
+                    value={editForm.notes}
+                    onChange={(e) => setEditForm({ ...editForm, notes: e.target.value })}
+                    rows={2}
+                    className={inputClass}
+                  />
+                </div>
+              </div>
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={() => handleSave(step.id)}
+                  disabled={saving}
+                  className="px-3 py-1 border border-brand-purple bg-brand-purple text-white rounded hover:opacity-90 disabled:opacity-50 text-xs font-mono"
+                >
+                  {saving ? 'saving…' : 'save'}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setEditingId(null)}
+                  disabled={saving}
+                  className="px-3 py-1 border border-border rounded hover:bg-bg-row disabled:opacity-50 text-xs font-mono"
+                >
+                  cancel
+                </button>
+              </div>
+            </div>
+          ) : (
+            <div className="space-y-1">
+              <div className="flex items-center justify-between gap-2">
+                <div className="flex items-center gap-2 min-w-0 flex-1">
+                  <div className="flex flex-col">
+                    <button
+                      type="button"
+                      onClick={() => handleMove(index, -1)}
+                      disabled={busy || index === 0}
+                      className={arrowClass}
+                      title="move up"
+                    >
+                      ↑
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => handleMove(index, 1)}
+                      disabled={busy || index === steps.length - 1}
+                      className={arrowClass}
+                      title="move down"
+                    >
+                      ↓
+                    </button>
+                  </div>
+                  {step.time_of_day && (
+                    <span className="text-text-muted shrink-0">
+                      {step.time_of_day.slice(11, 16)}
+                    </span>
+                  )}
+                  <span className="text-text-primary truncate">{step.activity}</span>
+                  {step.sub_activity && (
+                    <span className="text-text-muted truncate">· {step.sub_activity}</span>
+                  )}
+                  {step.location && (
+                    <span className="text-text-muted shrink-0">@ {step.location}</span>
+                  )}
+                  {step.duration_minutes !== null && (
+                    <span className="text-text-muted shrink-0">{step.duration_minutes} min</span>
+                  )}
+                </div>
+                <div className="flex items-center gap-2 shrink-0">
+                  <button
+                    type="button"
+                    onClick={() => enterEdit(step)}
+                    disabled={busy}
+                    className={actionClass}
+                  >
+                    edit
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => handleDelete(step)}
+                    disabled={busy}
+                    className="px-2 py-0.5 border border-red-300 text-red-700 rounded hover:bg-red-50 disabled:opacity-50 text-xs font-mono"
+                  >
+                    delete
+                  </button>
+                </div>
+              </div>
+              {step.notes && (
+                <div className="text-text-muted italic whitespace-pre-wrap pl-8">{step.notes}</div>
+              )}
+            </div>
+          )}
+        </div>
+      ))}
+
+      {openAdd && (
+        <div className="border border-brand-purple rounded p-3 bg-purple-50/30 space-y-2">
+          <div className="font-mono text-xs font-bold text-text-primary">new step</div>
+          <div className="grid grid-cols-2 gap-2">
+            <div className="col-span-2">
+              <div className={labelClass}>activity</div>
+              <input
+                type="text"
+                value={addForm.activity}
+                onChange={(e) => setAddForm({ ...addForm, activity: e.target.value })}
+                className={inputClass}
+                maxLength={200}
+                placeholder="e.g., Shower"
+              />
+            </div>
+            <div>
+              <div className={labelClass}>time of day</div>
+              <input
+                type="time"
+                value={addForm.time_of_day}
+                onChange={(e) => setAddForm({ ...addForm, time_of_day: e.target.value })}
+                className={inputClass}
+              />
+            </div>
+            <div>
+              <div className={labelClass}>duration (min)</div>
+              <input
+                type="number"
+                min={0}
+                value={addForm.duration_minutes}
+                onChange={(e) => setAddForm({ ...addForm, duration_minutes: e.target.value })}
+                className={inputClass}
+              />
+            </div>
+            <div>
+              <div className={labelClass}>location</div>
+              <input
+                type="text"
+                value={addForm.location}
+                onChange={(e) => setAddForm({ ...addForm, location: e.target.value })}
+                className={inputClass}
+                maxLength={200}
+              />
+            </div>
+            <div>
+              <div className={labelClass}>sub-activity</div>
+              <input
+                type="text"
+                value={addForm.sub_activity}
+                onChange={(e) => setAddForm({ ...addForm, sub_activity: e.target.value })}
+                className={inputClass}
+                maxLength={200}
+              />
+            </div>
+            <div className="col-span-2">
+              <div className={labelClass}>notes</div>
+              <textarea
+                value={addForm.notes}
+                onChange={(e) => setAddForm({ ...addForm, notes: e.target.value })}
+                rows={2}
+                className={inputClass}
+              />
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={handleCreate}
+              disabled={creating}
+              className="px-3 py-1 border border-brand-purple bg-brand-purple text-white rounded hover:opacity-90 disabled:opacity-50 text-xs font-mono"
+            >
+              {creating ? 'creating…' : 'create step'}
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setOpenAdd(false);
+                setAddForm(EMPTY_FORM);
+                setError(null);
+              }}
+              disabled={creating}
+              className="px-3 py-1 border border-border rounded hover:bg-bg-row disabled:opacity-50 text-xs font-mono"
+            >
+              cancel
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/workbench/operations/routines/types.ts
+++ b/src/components/workbench/operations/routines/types.ts
@@ -55,6 +55,33 @@ export interface Routine {
   created_at: string;
   updated_at: string;
   created_by: string | null;
+  steps: RoutineStep[];
+}
+
+/**
+ * One ordered sub-step of a routine. Matches operations_routine_steps row 1:1.
+ */
+export interface RoutineStep {
+  id: string;
+  routine_id: string;
+  user_id: string;
+  entity_id: string;
+  step_order: number;
+  /**
+   * Time-of-day (HH:MM, interpreted in parent routine.timezone).
+   * Prisma maps @db.Time to a JS Date; this field arrives JSON-serialized as
+   * '1970-01-01THH:MM:SS.000Z'. Frontend MUST extract HH:MM via .slice(11, 16)
+   * before display or binding to <input type="time">.
+   */
+  time_of_day: string | null;
+  activity: string;
+  sub_activity: string | null;
+  location: string | null;
+  duration_minutes: number | null;
+  notes: string | null;
+  created_at: string;
+  updated_at: string;
+  created_by: string | null;
 }
 
 export interface RoutineCompletion {

--- a/src/lib/operations/loadAuthorizedRoutineStep.ts
+++ b/src/lib/operations/loadAuthorizedRoutineStep.ts
@@ -1,0 +1,12 @@
+import { prisma } from '@/lib/prisma';
+
+/**
+ * Returns the routine step if it exists AND is owned by userId.
+ * Returns null for any other case (not found OR cross-user) — defensive
+ * non-disclosure per Citadel posture.
+ */
+export async function loadAuthorizedRoutineStep(stepId: string, userId: string) {
+  return prisma.operations_routine_steps.findFirst({
+    where: { id: stepId, user_id: userId },
+  });
+}

--- a/src/lib/operations/parseTime.ts
+++ b/src/lib/operations/parseTime.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from 'next/server';
+
+/**
+ * Parse an HH:MM time string into a JS Date with a 1970-01-01 anchor
+ * (Prisma @db.Time round-trip expects a Date; the date part is ignored).
+ * Returns { value: null, error: null } for null/empty input.
+ * Returns { value: null, error: 400-response } for invalid format.
+ */
+export function parseTimeOrNull(
+  v: unknown,
+  field: string
+): { value: Date | null; error: NextResponse | null } {
+  if (v === null || v === undefined || v === '') return { value: null, error: null };
+  if (typeof v !== 'string') {
+    return {
+      value: null,
+      error: NextResponse.json(
+        { error: 'Validation', field, message: 'must be string HH:MM or null' },
+        { status: 400 }
+      ),
+    };
+  }
+  const match = /^(\d{2}):(\d{2})$/.exec(v);
+  if (!match) {
+    return {
+      value: null,
+      error: NextResponse.json(
+        { error: 'Validation', field, message: 'must match HH:MM' },
+        { status: 400 }
+      ),
+    };
+  }
+  const hh = Number(match[1]);
+  const mm = Number(match[2]);
+  if (hh < 0 || hh > 23 || mm < 0 || mm > 59) {
+    return {
+      value: null,
+      error: NextResponse.json(
+        { error: 'Validation', field, message: 'hour 00-23, minute 00-59' },
+        { status: 400 }
+      ),
+    };
+  }
+  // Prisma @db.Time accepts a Date — 1970-01-01 anchor; Postgres discards the date part.
+  const d = new Date(Date.UTC(1970, 0, 1, hh, mm, 0, 0));
+  return { value: d, error: null };
+}


### PR DESCRIPTION
## What ships

Routines now decompose into ordered sub-steps. A routine like "Health Routine" breaks into Shower (6:00) → Brush Teeth (6:15) → Scooter (6:20) → Pull-Ups (6:30) — each step with its own time, activity, location, duration, and notes. Full CRUD surface, inline editor in Routines tab, read-only display on Daily Plan.

This is the foundation for content production overlay (PR-Ops-4.8.7) which will attach scene/filming metadata to individual steps.

## Architecture (locked)

**Parent-child pattern with denormalized scope.** `operations_routine_steps` carries denormalized `user_id` AND `entity_id` (inherited from parent routine at create). This matches the `operations_project_tasks` precedent and enables one-shot defensive-404 ownership via `loadAuthorizedRoutineStep` (single `findFirst` per request, no parent-load round-trip).

**Eager include over lazy fetch.** GET routines (list, /[id], /today) include `steps: { orderBy: { step_order: 'asc' } }` in the Prisma query. Avoids N+1 fetch on the Daily Plan (one request per routine card would be unacceptable). Mirrors the `calendar_blocks`-in-`operations_daily_plan_items` precedent from PR-Ops-4.1.

**Step mutations get their own nested endpoints.** Only the read is folded into the parent. `RoutineStepList` calls `POST /routines/[id]/steps`, `PATCH /routines/steps/[stepId]`, `DELETE /routines/steps/[stepId]`. Then triggers `onUpdate()` → parent routine refetch. Exactly the `TaskList` pattern from projects.

**Reorder via PATCH on step_order, not a separate endpoint.** Audits as `operations_routine_step_updated` (matches project task display_order precedent). No `_reordered` enum value. Up/down arrow buttons swap step_order with adjacent step via `Promise.all` of two PATCHes. α-1 race-acceptance documented (single-user system, simultaneous reorder collisions resolve via subsequent reorder).

**Time-of-day with auto-fill.** `time_of_day` is `@db.Time NULLABLE`. Frontend constant `STEP_DEFAULT_INTERVAL_MINUTES = 15` (matches your spreadsheet pattern of 15-min increments). When operator adds a new step, time auto-fills from `parent.start_time + step_order * 15min` — operator can override or leave blank. Renaissance principle: defaults that lead toward correct behavior, no forced precision.

**Prisma `@db.Time` ISO serialization gotcha caught and prevented.** Same lesson as PR-Ops-4.8.5: Prisma serializes `@db.Time` as `'1970-01-01THH:MM:SS.000Z'`, NOT `'HH:MM'`. Every read site (auto-fill helper, edit form seed, view-mode display in RoutineStepList, view-mode display in DailyPlanRoutineRow) uses `.slice(11, 16)`. The gotcha is documented on the `RoutineStep.time_of_day` JSDoc.

**Daily Plan is read-only for steps.** Compact "N steps" indicator + ▸/▾ caret on `DailyPlanRoutineRow`. Click to expand into a read-only ordered list. Full editing remains in the Routines tab. Bridgewater principle: don't fragment the management surface across tabs — one place owns mutations, one place owns viewing.

**`parseTimeOrNull` extracted to shared util.** Helper used at 4+ sites (POST routines, PATCH routines, POST steps, PATCH steps) — past the 3-place inline threshold. Now lives at `src/lib/operations/parseTime.ts` and imports replaced inline copies in the two pre-existing files.

## Schema changes

**Migration 1: `20260518300000_pr_ops_4_8_6_routine_steps`** (additive table creation):
- New table `operations_routine_steps`:
  - `id UUID PK`
  - `routine_id UUID FK` → operations_routines (ON DELETE CASCADE)
  - `user_id TEXT`, `entity_id TEXT` (denormalized from parent)
  - `step_order INT DEFAULT 0`
  - `time_of_day TIME NULLABLE`
  - `activity VARCHAR(200) NOT NULL`
  - `sub_activity VARCHAR(200) NULLABLE`
  - `location VARCHAR(200) NULLABLE`
  - `duration_minutes INT NULLABLE`
  - `notes TEXT NULLABLE`
  - audit columns (created_at, updated_at, created_by)
- Indexes: `(routine_id, step_order)`, `(routine_id)`, `(user_id)`
- New Prisma relation `steps operations_routine_steps[]` on `operations_routines`

**Migration 2: `20260518400000_pr_ops_4_8_6_routine_step_audit_enums`** (enum value additions):
- `operations_routine_step_created`
- `operations_routine_step_updated`
- `operations_routine_step_deleted`

Both migrations additive only. Zero backfill. Existing routines remain unchanged with empty steps array.

## Endpoint changes

**New endpoints (3):**
- `POST /api/operations/routines/[id]/steps` — create step, inherits user_id + entity_id from parent routine, server-computes step_order as max+1
- `PATCH /api/operations/routines/steps/[stepId]` — update mutable fields (step_order, time_of_day, activity, sub_activity, location, duration_minutes, notes)
- `DELETE /api/operations/routines/steps/[stepId]` — hard delete with full payload.before audit

**Modified endpoints (3):**
- `GET /api/operations/routines` — includes steps eagerly
- `GET /api/operations/routines/[id]` (via loadAuthorizedRoutine helper) — includes steps eagerly
- `GET /api/operations/routines/today` — includes steps eagerly, flow through TodayRoutineEntry.routine

**Unchanged:**
- POST/PATCH/DELETE on the routine itself (steps managed separately)
- `/upcoming` endpoint
- `/completions` endpoints
- All scheduling logic (RRULE expansion, next_due_at, miss/pending — steps are intent metadata, not scheduling anchors)

## New helpers

- `src/lib/operations/loadAuthorizedRoutineStep.ts` — single-query ownership check via denormalized user_id (matches loadAuthorizedCalendarBlock pattern)
- `src/lib/operations/parseTime.ts` — extracted `parseTimeOrNull` helper, now shared across 4 endpoints

## Frontend changes

**New component:** `src/components/workbench/operations/routines/RoutineStepList.tsx` (498 lines, single file)
- Self-contained child of RoutineRow (mirrors TaskList pattern under ProjectRow)
- Inline add form with 15-min auto-fill
- Inline edit per step (toggle via `editingId === step.id`)
- Up/down arrow reordering (Promise.all of two PATCHes)
- Delete with window.confirm
- All time reads use `.slice(11, 16)` (verified at 3 sites)

**RoutineRow modification:** mounts `<RoutineStepList routine={routine} onUpdate={onUpdate} />` in expanded view, after metadata cluster, before action buttons.

**DailyPlanRoutineRow modification:** 
- Local `showSteps` state (no parent coordination)
- Compact "N steps" indicator with ▸/▾ caret in metadata cluster
- Expanded read-only list mirrors calendar_blocks border-left pattern
- No editing affordances on Daily Plan

## What's NOT in this PR

- Content production overlay (PR-Ops-4.8.7) — scene metadata, filming location, camera angles attached to routine OR step
- Drag-and-drop reordering — up/down arrows ship clean, drag is a bigger investment requiring a library
- Step completion tracking (operator marks individual sub-steps as done) — out of scope; routines complete atomically for now
- Bulk step import (paste a list of steps and parse) — operator manually adds each step
- Calendar visualization (PR-Ops-4.8.4 — still awaiting screenshot)
- Step-level audit lineage independent of routine — audit_log captures all step mutations but no separate query surface

## Verification

- All four commits tsc-clean
- Audit-before-action followed (CC self-recognized two prior executions across the session — truth-first behavior preserved)
- `.slice(11, 16)` extraction verified at every read site (stepToForm, view-mode display in RoutineStepList, auto-fill helper, view-mode display in DailyPlanRoutineRow)
- Denormalized user_id + entity_id pattern matches operations_project_tasks (proven defensive-404 ergonomics)
- Eager include pattern matches operations_daily_plan_items.calendar_blocks (proven N+1 avoidance)
- Race-acceptance α-1 documented inline in code comments where it applies (step_order on create, reorder collisions)
- Two migrations both additive, zero backfill, non-breaking

## Commits (4)

- f2e00e7 — schema + types + GET includes
- 219c3bd — CRUD endpoints + audit enum migration + ownership helper
- 68338c3 — frontend step editor (RoutineStepList)
- 96d1565 — Daily Plan integration (DailyPlanRoutineRow)

## Branch

`claude/pr-ops-4.8.6-routine-steps`