### PR TITLE
PR-Ops-4.9.1a: add operations_content_scenes schema

### DIFF
--- a/prisma/migrations/20260518500000_operations_content_scenes/migration.sql
+++ b/prisma/migrations/20260518500000_operations_content_scenes/migration.sql
@@ -1,0 +1,49 @@
+-- PR-Ops-4.9.1a: operations_content_scenes — scene-level content overlay
+--
+-- A "scene" is a 1:1 content-production overlay on an existing routine
+-- (UNIQUE routine_id). It annotates the routine with filming/editing
+-- metadata; it does not replace the routine.
+--
+-- entity_id + user_id are denormalized loose scalars (TEXT), matching the
+-- operations_routine_steps / operations_project_tasks precedent — no FK to
+-- entities/users (entities.id is TEXT and operations_* models stay loosely
+-- coupled to tenancy). Only routine_id carries a real FK.
+--
+-- No status enum in v1; categorical fields (focus_category,
+-- filming_location_base) are free-text. estimated_hours is DECIMAL(5,2).
+
+BEGIN;
+
+CREATE TABLE "operations_content_scenes" (
+  "id"                    UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  "user_id"               TEXT NOT NULL,
+  "entity_id"             TEXT NOT NULL,
+  "routine_id"            UUID NOT NULL,
+  "scene_number"          INT NOT NULL,
+  "scene_title"           VARCHAR(500) NOT NULL,
+  "focus_category"        VARCHAR(200),
+  "filming_location_base" VARCHAR(200),
+  "estimated_hours"       DECIMAL(5,2),
+  "script"                TEXT,
+  "created_at"            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  "updated_at"            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT "operations_content_scenes_routine_id_fkey"
+    FOREIGN KEY ("routine_id") REFERENCES "operations_routines"("id") ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX "operations_content_scenes_routine_id_key"
+  ON "operations_content_scenes"("routine_id");
+
+CREATE UNIQUE INDEX "uniq_user_scene_number"
+  ON "operations_content_scenes"("user_id", "scene_number");
+
+CREATE INDEX "operations_content_scenes_user_id_idx"
+  ON "operations_content_scenes"("user_id");
+
+CREATE INDEX "operations_content_scenes_entity_id_idx"
+  ON "operations_content_scenes"("entity_id");
+
+CREATE INDEX "operations_content_scenes_routine_id_idx"
+  ON "operations_content_scenes"("routine_id");
+
+COMMIT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2640,7 +2640,7 @@ model operations_daily_plan_items {
   updated_at         DateTime @updatedAt @db.Timestamptz(6)
   created_by         String?
 
-  task            operations_project_tasks?   @relation(fields: [task_id], references: [id], onDelete: SetNull)
+  task            operations_project_tasks?    @relation(fields: [task_id], references: [id], onDelete: SetNull)
   calendar_blocks operations_calendar_blocks[]
 
   @@index([user_id, plan_date])
@@ -2731,8 +2731,9 @@ model operations_routines {
   updated_at                    DateTime  @updatedAt @db.Timestamptz(6)
   created_by                    String?
 
-  completions operations_routine_completions[]
-  steps       operations_routine_steps[]
+  completions   operations_routine_completions[]
+  steps         operations_routine_steps[]
+  content_scene operations_content_scenes?
 
   @@unique([user_id, name])
   @@index([user_id, is_active, next_due_at])
@@ -2781,6 +2782,29 @@ model operations_routine_completions {
   @@index([routine_id, expected_at])
   @@index([user_id, completed_at])
   @@map("operations_routine_completions")
+}
+
+model operations_content_scenes {
+  id                    String   @id @default(uuid()) @db.Uuid
+  user_id               String
+  entity_id             String
+  routine_id            String   @unique @db.Uuid
+  scene_number          Int
+  scene_title           String   @db.VarChar(500)
+  focus_category        String?  @db.VarChar(200)
+  filming_location_base String?  @db.VarChar(200)
+  estimated_hours       Decimal? @db.Decimal(5, 2)
+  script                String?  @db.Text
+  created_at            DateTime @default(now()) @db.Timestamptz(6)
+  updated_at            DateTime @updatedAt @db.Timestamptz(6)
+
+  routine operations_routines @relation(fields: [routine_id], references: [id], onDelete: Cascade)
+
+  @@unique([user_id, scene_number], name: "uniq_user_scene_number")
+  @@index([user_id])
+  @@index([entity_id])
+  @@index([routine_id])
+  @@map("operations_content_scenes")
 }
 
 model operations_ai_usage {


### PR DESCRIPTION
Introduces the scene-level content data model — a 1:1 overlay on operations_routines that annotates a routine with content-production metadata (scene_number, scene_title, focus_category, filming_location_base, estimated_hours, script).

Per architectural decisions:
- UNIQUE(routine_id): one scene per routine max
- UNIQUE(user_id, scene_number): scene numbering per-user
- No status enum in v1 (deferred until real capture data informs the workflow)
- All categorical fields are free-text in v1; enum-ification is later

entity_id/user_id are denormalized loose scalars (no FK), matching the operations_routine_steps precedent — entities.id is TEXT, so the originally-spec'd entity_id UUID FK would have failed on deploy.

Schema only. CRUD API is PR-Ops-4.9.2a. UI is PR-Ops-4.9.3+.

Author: Temple Stuart <astuart@templestuart.com>