### PR TITLE
PR-Ops-4.9.0b: prune Roadmap/Travel/Money dead stub routes

### DIFF
--- a/src/app/operations/layout.tsx
+++ b/src/app/operations/layout.tsx
@@ -9,10 +9,7 @@ const OPERATIONS_TABS: SubNavTab[] = [
   { label: 'Daily Plan', href: '/operations', exact: true },
   { label: 'Projects', href: '/operations/projects' },
   { label: 'Routines', href: '/operations/routines' },
-  { label: 'Roadmap', href: '/operations/roadmap' },
   { label: 'Content', href: '/operations/content' },
-  { label: 'Travel', href: '/operations/travel' },
-  { label: 'Money', href: '/operations/money' },
   { label: 'Issue Log', href: '/operations/issues' },
   { label: 'Audit Tail', href: '/operations/audit-log' },
 ];

--- a/src/app/operations/money/page.tsx
+++ b/src/app/operations/money/page.tsx
@@ -1,5 +1,0 @@
-import PlaceholderCard from '@/components/workbench/operations/PlaceholderCard';
-
-export default function OperationsMoneyPage() {
-  return <PlaceholderCard letter="I" title="MONEY" unbuiltLabel="UNBUILT · PR-Ops-10" />;
-}

--- a/src/app/operations/roadmap/page.tsx
+++ b/src/app/operations/roadmap/page.tsx
@@ -1,5 +1,0 @@
-import PlaceholderCard from '@/components/workbench/operations/PlaceholderCard';
-
-export default function OperationsRoadmapPage() {
-  return <PlaceholderCard letter="F" title="ROADMAP" unbuiltLabel="UNBUILT · PR-Ops-7" />;
-}

--- a/src/app/operations/travel/page.tsx
+++ b/src/app/operations/travel/page.tsx
@@ -1,5 +1,0 @@
-import PlaceholderCard from '@/components/workbench/operations/PlaceholderCard';
-
-export default function OperationsTravelPage() {
-  return <PlaceholderCard letter="H" title="TRAVEL PROJECT" unbuiltLabel="UNBUILT · PR-Ops-9" />;
-}


### PR DESCRIPTION
Removes three /operations sub-routes that were 5-line PlaceholderCard stubs with no schema and no functionality. Per PR-Ops-4.9.0a audit, these were the only stubbed routes in the Operations area; Content remains as a stub pending rebuild in PR-Ops-4.9.1+.

Final Operations nav: Daily Plan, Projects, Routines, Content, Issue Log, Audit Tail.

Author: Temple Stuart <astuart@templestuart.com>