### PR TITLE
PR-Ops-4.9.1c: add content scene audit action types

### DIFF
--- a/prisma/migrations/20260518500002_pr_ops_4_9_1c_content_scene_audit_enums/migration.sql
+++ b/prisma/migrations/20260518500002_pr_ops_4_9_1c_content_scene_audit_enums/migration.sql
@@ -1,0 +1,6 @@
+-- PR-Ops-4.9.1c: add audit action types for content scene CRUD
+-- Note: ALTER TYPE ADD VALUE cannot run in BEGIN/COMMIT block.
+
+ALTER TYPE "AuditActionType" ADD VALUE IF NOT EXISTS 'operations_content_scene_created';
+ALTER TYPE "AuditActionType" ADD VALUE IF NOT EXISTS 'operations_content_scene_updated';
+ALTER TYPE "AuditActionType" ADD VALUE IF NOT EXISTS 'operations_content_scene_deleted';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2059,6 +2059,9 @@ enum AuditActionType {
   operations_routine_step_created
   operations_routine_step_updated
   operations_routine_step_deleted
+  operations_content_scene_created
+  operations_content_scene_updated
+  operations_content_scene_deleted
   operations_issue_logged
   operations_issue_updated
   operations_issue_status_changed


### PR DESCRIPTION
Adds three values to the AuditActionType enum:
  operations_content_scene_created
  operations_content_scene_updated
  operations_content_scene_deleted

Prerequisite for PR-Ops-4.9.2a (scene CRUD API) — writeAuditLog's action.type is the Prisma-generated AuditActionType enum, so the scene mutation endpoints cannot audit-log without these values.

Migration uses ALTER TYPE ADD VALUE IF NOT EXISTS with no BEGIN/COMMIT wrapper (Postgres forbids ALTER TYPE ADD VALUE inside a transaction), matching the PR-Ops-4.8.6b routine_step audit-enum precedent.

Author: Temple Stuart <astuart@templestuart.com>