### PR TITLE
PR-Ops-4.9.1b: add operations_content_takes schema

### DIFF
--- a/prisma/migrations/20260518500001_operations_content_takes/migration.sql
+++ b/prisma/migrations/20260518500001_operations_content_takes/migration.sql
@@ -1,0 +1,47 @@
+-- PR-Ops-4.9.1b: operations_content_takes — take-level content overlay
+--
+-- A "take" is a 1:1 content-production overlay on an existing routine_step
+-- (UNIQUE routine_step_id). It annotates the step with filming-production
+-- metadata; it does not replace the step.
+--
+-- entity_id + user_id are denormalized loose scalars (TEXT), matching the
+-- operations_content_scenes / operations_routine_steps precedent — no FK to
+-- entities/users. Only routine_step_id carries a real FK.
+--
+-- No take_number column: display ordering is derived at render-time from
+-- scene.scene_number + routine_step.step_order. No direct scene_id link —
+-- takes reach their scene transitively via routine_step -> routine -> scene.
+--
+-- No status enum in v1; categorical fields (filming_location_specific,
+-- camera_needed, filming_angle) are free-text.
+
+BEGIN;
+
+CREATE TABLE "operations_content_takes" (
+  "id"                        UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  "user_id"                   TEXT NOT NULL,
+  "entity_id"                 TEXT NOT NULL,
+  "routine_step_id"           UUID NOT NULL,
+  "filming_location_specific" VARCHAR(200),
+  "camera_needed"             VARCHAR(200),
+  "filming_angle"             VARCHAR(200),
+  "notes"                     TEXT,
+  "created_at"                TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  "updated_at"                TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT "operations_content_takes_routine_step_id_fkey"
+    FOREIGN KEY ("routine_step_id") REFERENCES "operations_routine_steps"("id") ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX "operations_content_takes_routine_step_id_key"
+  ON "operations_content_takes"("routine_step_id");
+
+CREATE INDEX "operations_content_takes_user_id_idx"
+  ON "operations_content_takes"("user_id");
+
+CREATE INDEX "operations_content_takes_entity_id_idx"
+  ON "operations_content_takes"("entity_id");
+
+CREATE INDEX "operations_content_takes_routine_step_id_idx"
+  ON "operations_content_takes"("routine_step_id");
+
+COMMIT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2758,7 +2758,8 @@ model operations_routine_steps {
   updated_at       DateTime  @updatedAt @db.Timestamptz(6)
   created_by       String?
 
-  routine operations_routines @relation(fields: [routine_id], references: [id], onDelete: Cascade)
+  routine      operations_routines       @relation(fields: [routine_id], references: [id], onDelete: Cascade)
+  content_take operations_content_takes?
 
   @@index([routine_id, step_order])
   @@index([routine_id])
@@ -2805,6 +2806,26 @@ model operations_content_scenes {
   @@index([entity_id])
   @@index([routine_id])
   @@map("operations_content_scenes")
+}
+
+model operations_content_takes {
+  id                        String   @id @default(uuid()) @db.Uuid
+  user_id                   String
+  entity_id                 String
+  routine_step_id           String   @unique @db.Uuid
+  filming_location_specific String?  @db.VarChar(200)
+  camera_needed             String?  @db.VarChar(200)
+  filming_angle             String?  @db.VarChar(200)
+  notes                     String?  @db.Text
+  created_at                DateTime @default(now()) @db.Timestamptz(6)
+  updated_at                DateTime @updatedAt @db.Timestamptz(6)
+
+  routine_step operations_routine_steps @relation(fields: [routine_step_id], references: [id], onDelete: Cascade)
+
+  @@index([user_id])
+  @@index([entity_id])
+  @@index([routine_step_id])
+  @@map("operations_content_takes")
 }
 
 model operations_ai_usage {


### PR DESCRIPTION
Introduces the take-level content data model — a 1:1 overlay on operations_routine_steps that annotates a step with filming-production metadata (filming_location_specific, camera_needed, filming_angle, notes).

Per architectural decisions:
- UNIQUE(routine_step_id): one take per step max
- No take_number column — display ordering derived at render-time from scene.scene_number + routine_step ordering
- Loose scalars for user_id/entity_id (no FK to entities/users) — matches operations_* pattern locked in 4.9.1a
- Only enforced FK is routine_step_id -> operations_routine_steps with ON DELETE CASCADE
- Categorical fields free-text in v1; enum-ification deferred

Schema only. CRUD API is PR-Ops-4.9.2b. UI is PR-Ops-4.9.3+.

Author: Temple Stuart <astuart@templestuart.com>