### PR TITLE
PR-Ops-4.9.1d: add content take audit action types

### DIFF
--- a/prisma/migrations/20260518500003_pr_ops_4_9_1d_content_take_audit_enums/migration.sql
+++ b/prisma/migrations/20260518500003_pr_ops_4_9_1d_content_take_audit_enums/migration.sql
@@ -1,0 +1,6 @@
+-- PR-Ops-4.9.1d: add audit action types for content take CRUD
+-- Note: ALTER TYPE ADD VALUE cannot run in BEGIN/COMMIT block.
+
+ALTER TYPE "AuditActionType" ADD VALUE IF NOT EXISTS 'operations_content_take_created';
+ALTER TYPE "AuditActionType" ADD VALUE IF NOT EXISTS 'operations_content_take_updated';
+ALTER TYPE "AuditActionType" ADD VALUE IF NOT EXISTS 'operations_content_take_deleted';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2062,6 +2062,9 @@ enum AuditActionType {
   operations_content_scene_created
   operations_content_scene_updated
   operations_content_scene_deleted
+  operations_content_take_created
+  operations_content_take_updated
+  operations_content_take_deleted
   operations_issue_logged
   operations_issue_updated
   operations_issue_status_changed


### PR DESCRIPTION
Adds three AuditActionType enum values used by the upcoming take CRUD API (PR-Ops-4.9.2b):
  - operations_content_take_created
  - operations_content_take_updated
  - operations_content_take_deleted

Migration uses bare ALTER TYPE ADD VALUE statements without BEGIN/COMMIT wrapping per Postgres restriction (ALTER TYPE ADD VALUE cannot run inside a transaction with other statements). Matches PR-Ops-4.9.1c precedent.

Schema/enum only. CRUD wiring is PR-Ops-4.9.2b.

Author: Temple Stuart <astuart@templestuart.com>