### PR TITLE
PR-Ops-4.9.3b: ContentTable + SceneHeaderRow + TakeRow

### DIFF
--- a/src/components/workbench/operations/content/ContentTable.tsx
+++ b/src/components/workbench/operations/content/ContentTable.tsx
@@ -1,0 +1,179 @@
+/**
+ * ContentTable — read-only spreadsheet view of scenes and their takes.
+ *
+ * 14-column layout: one bold scene header row per scene followed by
+ * one take row per routine step (ordered by step_order ASC). Scene-
+ * level columns are filled on the header row and empty on take rows;
+ * take-level columns are the inverse.
+ *
+ * Data is stitched client-side: routines (with their nested steps)
+ * and takes arrive as flat arrays; lookup maps join them to each
+ * scene. A scene whose routine_id is absent from the routines map is
+ * skipped with a console.warn — no placeholder row.
+ *
+ * The Day column derives from the routine's RFC 5545 schedule_rrule
+ * via rruleFromString — operations_routines has no weekday column.
+ */
+
+import { Fragment } from 'react';
+import { rruleFromString } from '@/lib/operations/rruleHelpers';
+import {
+  WEEKDAY_LABELS,
+  WEEKDAY_ORDER,
+} from '@/components/workbench/operations/routines/types';
+import SceneHeaderRow from './SceneHeaderRow';
+import TakeRow from './TakeRow';
+
+export type Step = {
+  id: string;
+  activity: string;
+  sub_activity: string | null;
+  time_of_day: string | null;
+  step_order: number;
+};
+
+export type Routine = {
+  id: string;
+  name: string;
+  schedule_rrule: string | null;
+  steps: Step[];
+};
+
+export type Scene = {
+  id: string;
+  routine_id: string;
+  scene_number: number;
+  scene_title: string;
+  focus_category: string | null;
+  filming_location_base: string | null;
+  estimated_hours: string | number | null;
+  script: string | null;
+};
+
+export type Take = {
+  id: string;
+  routine_step_id: string;
+  filming_location_specific: string | null;
+  camera_needed: string | null;
+  filming_angle: string | null;
+  notes: string | null;
+};
+
+/**
+ * Derive the Day column from a routine's RRULE. Returns "—" when the
+ * rule has no explicit BYDAY weekday set (e.g. plain FREQ=DAILY, or a
+ * monthly nth-weekday rule) — no fallback to a coarse cadence label.
+ */
+export function formatDay(schedule_rrule: string | null): string {
+  if (!schedule_rrule) return '—';
+  let byweekday: number[] | null;
+  try {
+    byweekday = rruleFromString(schedule_rrule).options.byweekday;
+  } catch (e) {
+    console.warn('[ContentTable] malformed schedule_rrule:', schedule_rrule, e);
+    return '—';
+  }
+  if (!byweekday || byweekday.length === 0) return '—';
+  if (byweekday.length === 7) return 'Daily';
+  // rrule.js byweekday integers are 0=Mon … 6=Sun — same index as WEEKDAY_ORDER.
+  const present = new Set(byweekday);
+  return WEEKDAY_ORDER.filter((_, idx) => present.has(idx))
+    .map((code) => WEEKDAY_LABELS[code])
+    .join(', ');
+}
+
+/** Extract HH:MM from a @db.Time value serialized as an ISO datetime string. */
+export function formatTime(time_of_day: string | null): string {
+  if (!time_of_day) return '—';
+  return time_of_day.slice(11, 16);
+}
+
+export function formatHours(estimated_hours: string | number | null): string {
+  if (estimated_hours === null || estimated_hours === undefined) return '—';
+  return `${String(estimated_hours)}h`;
+}
+
+export function truncateScript(script: string | null): string {
+  if (!script) return '—';
+  return script.length <= 50 ? script : `${script.slice(0, 50)}…`;
+}
+
+export function dashOrValue(v: string | null): string {
+  if (v === null || v === undefined || v === '') return '—';
+  return v;
+}
+
+const HEADERS = [
+  'Scene',
+  'Title',
+  'Focus',
+  'Hours',
+  'Day',
+  'Loc (Base)',
+  'Time',
+  'Activity',
+  'Sub-Activity',
+  'Loc (Specific)',
+  'Camera',
+  'Angle',
+  'Notes',
+  'Script',
+];
+
+export default function ContentTable({
+  scenes,
+  takes,
+  routines,
+}: {
+  scenes: Scene[];
+  takes: Take[];
+  routines: Routine[];
+}) {
+  const routinesById = new Map(routines.map((r) => [r.id, r]));
+  const takesByStepId = new Map(takes.map((t) => [t.routine_step_id, t]));
+
+  const orderedScenes = [...scenes].sort((a, b) => a.scene_number - b.scene_number);
+
+  return (
+    <div className="text-xs font-mono overflow-x-auto">
+      <table className="w-full">
+        <thead>
+          <tr className="text-text-faint uppercase tracking-wide">
+            {HEADERS.map((h) => (
+              <th key={h} className="text-left pb-1 px-2 whitespace-nowrap">
+                {h}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {orderedScenes.map((scene) => {
+            const routine = routinesById.get(scene.routine_id);
+            if (!routine) {
+              console.warn(
+                `[ContentTable] scene ${scene.id} references missing routine ` +
+                  `${scene.routine_id} — row skipped`
+              );
+              return null;
+            }
+            const steps = [...routine.steps].sort(
+              (a, b) => a.step_order - b.step_order
+            );
+            return (
+              <Fragment key={scene.id}>
+                <SceneHeaderRow scene={scene} routine={routine} />
+                {steps.map((step) => (
+                  <TakeRow
+                    key={step.id}
+                    step={step}
+                    take={takesByStepId.get(step.id)}
+                  />
+                ))}
+              </Fragment>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/components/workbench/operations/content/SceneHeaderRow.tsx
+++ b/src/components/workbench/operations/content/SceneHeaderRow.tsx
@@ -1,0 +1,37 @@
+/**
+ * SceneHeaderRow — the bold header row for one scene in ContentTable.
+ *
+ * Scene-level columns (Scene, Title, Focus, Hours, Day, Loc Base,
+ * Script) are filled; take-level columns are rendered as empty cells
+ * — they belong to the TakeRow children below.
+ */
+
+import type { Scene, Routine } from './ContentTable';
+import { formatDay, formatHours, truncateScript, dashOrValue } from './ContentTable';
+
+export default function SceneHeaderRow({
+  scene,
+  routine,
+}: {
+  scene: Scene;
+  routine: Routine;
+}) {
+  return (
+    <tr className="border-t border-border-light bg-bg-row font-semibold text-text-primary">
+      <td className="py-1 px-2">{scene.scene_number}</td>
+      <td className="py-1 px-2">{scene.scene_title}</td>
+      <td className="py-1 px-2">{dashOrValue(scene.focus_category)}</td>
+      <td className="py-1 px-2">{formatHours(scene.estimated_hours)}</td>
+      <td className="py-1 px-2">{formatDay(routine.schedule_rrule)}</td>
+      <td className="py-1 px-2">{dashOrValue(scene.filming_location_base)}</td>
+      <td className="py-1 px-2" />
+      <td className="py-1 px-2" />
+      <td className="py-1 px-2" />
+      <td className="py-1 px-2" />
+      <td className="py-1 px-2" />
+      <td className="py-1 px-2" />
+      <td className="py-1 px-2" />
+      <td className="py-1 px-2">{truncateScript(scene.script)}</td>
+    </tr>
+  );
+}

--- a/src/components/workbench/operations/content/SectionG_Content.tsx
+++ b/src/components/workbench/operations/content/SectionG_Content.tsx
@@ -5,9 +5,9 @@
  * pipelines the tab is built on — scenes, takes, routines — and
  * renders loading / error / empty / populated states.
  *
- * Render here is intentionally minimal: plain counts + a routine
- * name list with scenified status. The spreadsheet-style table
- * (ContentTable, SceneHeaderRow, TakeRow) lands in PR-Ops-4.9.3b.
+ * Populated state renders the spreadsheet-style ContentTable plus an
+ * Available Routines list (routines not yet scenified). Loading,
+ * error and empty states stay as plain text.
  *
  * "Scenified" status is derived client-side: GET /api/operations/
  * routines does not include the content_scene relation, so we join
@@ -17,23 +17,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-
-type Scene = {
-  id: string;
-  routine_id: string;
-  scene_number: number;
-  scene_title: string;
-};
-
-type Take = {
-  id: string;
-  routine_step_id: string;
-};
-
-type Routine = {
-  id: string;
-  name: string;
-};
+import ContentTable, { type Scene, type Take, type Routine } from './ContentTable';
 
 export default function SectionG_Content() {
   const [scenes, setScenes] = useState<Scene[] | null>(null);
@@ -139,15 +123,16 @@ function ContentSummary({
         </>
       ) : (
         <>
+          <ContentTable scenes={scenes} takes={takes} routines={routines} />
           <h3 className="text-xs font-mono text-text-faint uppercase tracking-wide">
-            Scenified Routines
+            Available Routines
           </h3>
           <ul className="text-sm text-text-secondary list-disc pl-5">
-            {routines.map((r) => (
-              <li key={r.id}>
-                {r.name} ({scenifiedRoutineIds.has(r.id) ? 'scenified' : 'not scenified'})
-              </li>
-            ))}
+            {routines
+              .filter((r) => !scenifiedRoutineIds.has(r.id))
+              .map((r) => (
+                <li key={r.id}>{r.name}</li>
+              ))}
           </ul>
         </>
       )}

--- a/src/components/workbench/operations/content/TakeRow.tsx
+++ b/src/components/workbench/operations/content/TakeRow.tsx
@@ -1,0 +1,40 @@
+/**
+ * TakeRow — one routine-step row beneath a SceneHeaderRow.
+ *
+ * Take-level columns (Time, Activity, Sub-Activity, Loc Specific,
+ * Camera, Angle, Notes) are filled; scene-level columns are empty.
+ * When no take is attached to the step, the take-owned columns
+ * render as en-dash placeholders.
+ */
+
+import type { Step, Take } from './ContentTable';
+import { formatTime, dashOrValue } from './ContentTable';
+
+export default function TakeRow({
+  step,
+  take,
+}: {
+  step: Step;
+  take: Take | undefined;
+}) {
+  return (
+    <tr className="border-t border-border-light text-text-muted">
+      <td className="py-1 px-2" />
+      <td className="py-1 px-2" />
+      <td className="py-1 px-2" />
+      <td className="py-1 px-2" />
+      <td className="py-1 px-2" />
+      <td className="py-1 px-2" />
+      <td className="py-1 px-2 pl-4">{formatTime(step.time_of_day)}</td>
+      <td className="py-1 px-2">{step.activity}</td>
+      <td className="py-1 px-2">{dashOrValue(step.sub_activity)}</td>
+      <td className="py-1 px-2">
+        {take ? dashOrValue(take.filming_location_specific) : '—'}
+      </td>
+      <td className="py-1 px-2">{take ? dashOrValue(take.camera_needed) : '—'}</td>
+      <td className="py-1 px-2">{take ? dashOrValue(take.filming_angle) : '—'}</td>
+      <td className="py-1 px-2">{take ? dashOrValue(take.notes) : '—'}</td>
+      <td className="py-1 px-2" />
+    </tr>
+  );
+}


### PR DESCRIPTION
Replaces the placeholder <ul> in SectionG_Content's populated branch with the spreadsheet-style content table.

14-column layout: Scene, Title, Focus, Hours, Day, Loc (Base), Time, Activity, Sub-Activity, Loc (Specific), Camera, Angle, Notes, Script.

One scene header row (scene-level columns filled, take-level empty) + N indented take rows (take-level columns filled, scene-level empty) per scene. Takes ordered by step_order ASC.

Schema-truthful field names per Phase 1 audit:
- Day derived from routine.schedule_rrule (RFC 5545) via existing rruleFromString helper (rruleHelpers.ts) — operations_routines has no weekday column; byweekday ints mapped via WEEKDAY_LABELS
- Activity column: step.activity (required)
- Sub-Activity column: step.sub_activity (nullable)
- Time column: step.time_of_day.slice(11,16) per @db.Time gotcha

Data join is client-side: lookup maps over routines and takes arrays; scenes whose routine_id is missing from the map are skipped with console.warn (no fallback placeholder).

Empty optional fields render as en-dash (—). Script preview truncated to 50 chars + ellipsis. Read-only.

Scenify/take-ify interactivity lands in 4.9.3c/d. Inline editing in 4.9.3e. Script drawer in 4.9.3f.

Author: Temple Stuart <astuart@templestuart.com>