### PR TITLE
PR-Ops-4.9.3c: Scenify affordance + interactive Available Routines

### DIFF
--- a/src/app/api/operations/routines/[id]/route.ts
+++ b/src/app/api/operations/routines/[id]/route.ts
@@ -67,6 +67,7 @@ async function loadAuthorizedRoutine(routineId: string, userId: string) {
     where: { id: routineId, user_id: userId },
     include: {
       steps: { orderBy: { step_order: 'asc' } },
+      content_scene: true,
     },
   });
 }

--- a/src/app/api/operations/routines/route.ts
+++ b/src/app/api/operations/routines/route.ts
@@ -89,6 +89,7 @@ export async function GET(request: NextRequest) {
       ],
       include: {
         steps: { orderBy: { step_order: 'asc' } },
+        content_scene: true,
       },
     });
 

--- a/src/components/workbench/operations/content/AvailableRoutinesList.tsx
+++ b/src/components/workbench/operations/content/AvailableRoutinesList.tsx
@@ -1,0 +1,42 @@
+/**
+ * AvailableRoutinesList — interactive list of not-yet-scenified routines.
+ *
+ * Filters the supplied routines to those without a content_scene and
+ * renders each with a ScenifyButton. Mounted on the Content tab below
+ * the ContentTable. When every routine has a scene, shows a done state.
+ */
+
+'use client';
+
+import type { Scene, Routine } from './ContentTable';
+import ScenifyButton from './ScenifyButton';
+
+export default function AvailableRoutinesList({
+  routines,
+  onScenify,
+}: {
+  routines: Routine[];
+  onScenify: (newScene: Scene) => void;
+}) {
+  const available = routines.filter((r) => !r.content_scene);
+
+  return (
+    <div className="space-y-2">
+      <h3 className="text-xs font-mono text-text-faint uppercase tracking-wide">
+        Available Routines
+      </h3>
+      {available.length === 0 ? (
+        <p className="text-sm text-text-secondary">All routines scenified. 🎬</p>
+      ) : (
+        <ul className="space-y-1">
+          {available.map((r) => (
+            <li key={r.id} className="flex flex-wrap items-center gap-2">
+              <span className="text-sm text-text-secondary">{r.name}</span>
+              <ScenifyButton routine={r} onScenify={onScenify} />
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/components/workbench/operations/content/ContentTable.tsx
+++ b/src/components/workbench/operations/content/ContentTable.tsx
@@ -37,6 +37,8 @@ export type Routine = {
   name: string;
   schedule_rrule: string | null;
   steps: Step[];
+  /** Present when the routine has been scenified; null/absent otherwise. */
+  content_scene?: { id: string } | null;
 };
 
 export type Scene = {

--- a/src/components/workbench/operations/content/ScenifyButton.tsx
+++ b/src/components/workbench/operations/content/ScenifyButton.tsx
@@ -1,0 +1,67 @@
+/**
+ * ScenifyButton — the 🎬 Scenify affordance for a routine.
+ *
+ * If the routine already has a scene, renders a non-interactive
+ * "🎬 Scenified" badge. Otherwise renders a button that toggles the
+ * inline ScenifyModal form. On a successful POST the modal calls
+ * onScenify with the new scene so the parent can update state.
+ *
+ * Used on the Routines tab (via RoutineRow) and the Content tab
+ * (via AvailableRoutinesList).
+ */
+
+'use client';
+
+import { useState } from 'react';
+import type { Scene } from './ContentTable';
+import ScenifyModal from './ScenifyModal';
+
+type ScenifyRoutine = {
+  id: string;
+  name: string;
+  content_scene?: { id: string } | null;
+};
+
+export default function ScenifyButton({
+  routine,
+  onScenify,
+}: {
+  routine: ScenifyRoutine;
+  onScenify: (newScene: Scene) => void;
+}) {
+  const [open, setOpen] = useState(false);
+
+  if (routine.content_scene) {
+    return (
+      <span
+        className="px-2 py-1 border border-border rounded bg-purple-50 text-brand-purple text-xs font-mono"
+        title="this routine already has a scene"
+      >
+        🎬 Scenified
+      </span>
+    );
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={(e) => {
+          e.stopPropagation();
+          setOpen(true);
+        }}
+        className="px-2 py-1 border border-border rounded hover:bg-bg-row text-xs font-mono"
+      >
+        🎬 Scenify
+      </button>
+      {open && (
+        <ScenifyModal
+          routine={{ id: routine.id, name: routine.name }}
+          open={open}
+          onClose={() => setOpen(false)}
+          onSuccess={onScenify}
+        />
+      )}
+    </>
+  );
+}

--- a/src/components/workbench/operations/content/ScenifyModal.tsx
+++ b/src/components/workbench/operations/content/ScenifyModal.tsx
@@ -1,0 +1,224 @@
+/**
+ * ScenifyModal — inline form for converting a routine into a content scene.
+ *
+ * Operations-surface convention: this is an inline expanding form (not an
+ * overlay dialog) — matching RoutineList's create form. It renders nothing
+ * when `open` is false.
+ *
+ * POSTs to /api/operations/content/scenes. scene_number and scene_title are
+ * required; the four content fields are optional. UNIQUE conflicts (409) and
+ * validation errors (400) surface inline above the action buttons — no toast.
+ */
+
+'use client';
+
+import { useState } from 'react';
+import type { Scene } from './ContentTable';
+
+const inputClass =
+  'w-full px-2 py-1 border border-border rounded text-xs font-mono text-text-primary focus:outline-none focus:border-brand-purple';
+const labelClass = 'text-text-faint uppercase tracking-wide mb-1 text-xs font-mono';
+
+export default function ScenifyModal({
+  routine,
+  open,
+  onClose,
+  onSuccess,
+}: {
+  routine: { id: string; name: string };
+  open: boolean;
+  onClose: () => void;
+  onSuccess: (newScene: Scene) => void;
+}) {
+  const [sceneNumber, setSceneNumber] = useState<number | ''>('');
+  const [sceneTitle, setSceneTitle] = useState('');
+  const [focusCategory, setFocusCategory] = useState('');
+  const [filmingLocationBase, setFilmingLocationBase] = useState('');
+  const [estimatedHours, setEstimatedHours] = useState('');
+  const [script, setScript] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  if (!open) return null;
+
+  const handleSubmit = async () => {
+    setError(null);
+
+    if (
+      typeof sceneNumber !== 'number' ||
+      !Number.isInteger(sceneNumber) ||
+      sceneNumber <= 0
+    ) {
+      setError('Scene number must be a positive integer');
+      return;
+    }
+    const title = sceneTitle.trim();
+    if (title.length === 0) {
+      setError('Scene title is required');
+      return;
+    }
+
+    const body: Record<string, unknown> = {
+      routine_id: routine.id,
+      scene_number: sceneNumber,
+      scene_title: title,
+    };
+    if (focusCategory.trim()) body.focus_category = focusCategory.trim();
+    if (filmingLocationBase.trim()) body.filming_location_base = filmingLocationBase.trim();
+    if (estimatedHours.trim()) body.estimated_hours = parseFloat(estimatedHours);
+    if (script.trim()) body.script = script.trim();
+
+    setSubmitting(true);
+    try {
+      const res = await fetch('/api/operations/content/scenes', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+
+      let parsed: { error?: string; message?: string; scene?: Scene } = {};
+      try {
+        parsed = await res.json();
+      } catch {
+        // non-JSON response — fall through to a status-based message
+      }
+
+      if (!res.ok) {
+        if (res.status === 401) {
+          setError('Unauthorized — please log in again');
+        } else {
+          setError(parsed.message ?? parsed.error ?? `Request failed (${res.status})`);
+        }
+        setSubmitting(false);
+        return;
+      }
+
+      if (!parsed.scene) {
+        setError('Scene created but the response was malformed');
+        setSubmitting(false);
+        return;
+      }
+
+      onSuccess(parsed.scene);
+      setSubmitting(false);
+      onClose();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'failed to create scene');
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="w-full border border-brand-purple rounded p-3 bg-purple-50/30 text-xs font-mono space-y-3">
+      <div className="font-bold text-text-primary">🎬 Scenify "{routine.name}"</div>
+
+      {error && (
+        <div className="px-3 py-2 rounded border bg-red-50 border-red-200 text-red-800">
+          {error}
+        </div>
+      )}
+
+      <div className="grid grid-cols-2 gap-3">
+        <div>
+          <div className={labelClass}>scene number *</div>
+          <input
+            type="number"
+            min={1}
+            value={sceneNumber}
+            onChange={(e) => {
+              setError(null);
+              setSceneNumber(e.target.value === '' ? '' : Number(e.target.value));
+            }}
+            className={inputClass}
+          />
+        </div>
+        <div>
+          <div className={labelClass}>estimated hours (optional)</div>
+          <input
+            type="number"
+            step={0.01}
+            min={0}
+            max={999.99}
+            value={estimatedHours}
+            onChange={(e) => {
+              setError(null);
+              setEstimatedHours(e.target.value);
+            }}
+            className={inputClass}
+          />
+        </div>
+        <div className="col-span-2">
+          <div className={labelClass}>scene title *</div>
+          <input
+            type="text"
+            maxLength={500}
+            value={sceneTitle}
+            onChange={(e) => {
+              setError(null);
+              setSceneTitle(e.target.value);
+            }}
+            className={inputClass}
+          />
+        </div>
+        <div>
+          <div className={labelClass}>focus category (optional)</div>
+          <input
+            type="text"
+            maxLength={200}
+            value={focusCategory}
+            onChange={(e) => {
+              setError(null);
+              setFocusCategory(e.target.value);
+            }}
+            className={inputClass}
+          />
+        </div>
+        <div>
+          <div className={labelClass}>filming location base (optional)</div>
+          <input
+            type="text"
+            maxLength={200}
+            value={filmingLocationBase}
+            onChange={(e) => {
+              setError(null);
+              setFilmingLocationBase(e.target.value);
+            }}
+            className={inputClass}
+          />
+        </div>
+        <div className="col-span-2">
+          <div className={labelClass}>script (optional)</div>
+          <textarea
+            value={script}
+            onChange={(e) => {
+              setError(null);
+              setScript(e.target.value);
+            }}
+            rows={3}
+            className={inputClass}
+          />
+        </div>
+      </div>
+
+      <div className="flex items-center gap-2 pt-2 border-t border-border-light">
+        <button
+          type="button"
+          onClick={handleSubmit}
+          disabled={submitting}
+          className="px-3 py-1 border border-brand-purple bg-brand-purple text-white rounded hover:opacity-90 disabled:opacity-50"
+        >
+          {submitting ? 'creating…' : 'create scene'}
+        </button>
+        <button
+          type="button"
+          onClick={onClose}
+          disabled={submitting}
+          className="px-3 py-1 border border-border rounded hover:bg-bg-row disabled:opacity-50"
+        >
+          cancel
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/workbench/operations/content/SectionG_Content.tsx
+++ b/src/components/workbench/operations/content/SectionG_Content.tsx
@@ -18,6 +18,7 @@
 
 import { useEffect, useState } from 'react';
 import ContentTable, { type Scene, type Take, type Routine } from './ContentTable';
+import AvailableRoutinesList from './AvailableRoutinesList';
 
 export default function SectionG_Content() {
   const [scenes, setScenes] = useState<Scene[] | null>(null);
@@ -69,6 +70,21 @@ export default function SectionG_Content() {
     };
   }, []);
 
+  // Optimistic update — a successful scenify POST adds the new scene to
+  // the table and marks its routine scenified, without a refetch.
+  const handleScenify = (newScene: Scene) => {
+    setScenes((prev) => [...(prev ?? []), newScene]);
+    setRoutines((prev) =>
+      prev
+        ? prev.map((r) =>
+            r.id === newScene.routine_id
+              ? { ...r, content_scene: { id: newScene.id } }
+              : r
+          )
+        : prev
+    );
+  };
+
   return (
     <section className="bg-white rounded border border-border shadow-sm p-5 space-y-4">
       <h2 className="font-mono text-sm font-bold tracking-wide text-text-primary">
@@ -84,7 +100,12 @@ export default function SectionG_Content() {
       ) : !scenes || !routines || !takes ? (
         <p className="text-sm font-mono text-text-faint">Data missing.</p>
       ) : (
-        <ContentSummary scenes={scenes} takes={takes} routines={routines} />
+        <ContentSummary
+          scenes={scenes}
+          takes={takes}
+          routines={routines}
+          onScenify={handleScenify}
+        />
       )}
     </section>
   );
@@ -94,13 +115,13 @@ function ContentSummary({
   scenes,
   takes,
   routines,
+  onScenify,
 }: {
   scenes: Scene[];
   takes: Take[];
   routines: Routine[];
+  onScenify: (newScene: Scene) => void;
 }) {
-  const scenifiedRoutineIds = new Set(scenes.map((s) => s.routine_id));
-
   return (
     <div className="space-y-3">
       <p className="text-sm text-text-secondary">
@@ -112,28 +133,12 @@ function ContentSummary({
           <p className="text-sm text-text-secondary">
             No scenes yet. Pick a routine to start filming.
           </p>
-          <h3 className="text-xs font-mono text-text-faint uppercase tracking-wide">
-            Available Routines
-          </h3>
-          <ul className="text-sm text-text-secondary list-disc pl-5">
-            {routines.map((r) => (
-              <li key={r.id}>{r.name} (not scenified)</li>
-            ))}
-          </ul>
+          <AvailableRoutinesList routines={routines} onScenify={onScenify} />
         </>
       ) : (
         <>
           <ContentTable scenes={scenes} takes={takes} routines={routines} />
-          <h3 className="text-xs font-mono text-text-faint uppercase tracking-wide">
-            Available Routines
-          </h3>
-          <ul className="text-sm text-text-secondary list-disc pl-5">
-            {routines
-              .filter((r) => !scenifiedRoutineIds.has(r.id))
-              .map((r) => (
-                <li key={r.id}>{r.name}</li>
-              ))}
-          </ul>
+          <AvailableRoutinesList routines={routines} onScenify={onScenify} />
         </>
       )}
     </div>

--- a/src/components/workbench/operations/routines/RoutineList.tsx
+++ b/src/components/workbench/operations/routines/RoutineList.tsx
@@ -18,6 +18,7 @@ import RoutineRow from './RoutineRow';
 import RRULEBuilder from './RRULEBuilder';
 import type { CadenceGroup, Routine, RoutineForm } from './types';
 import { CADENCE_GROUP_LABELS, CADENCE_GROUP_ORDER, DEFAULT_ROUTINE_FORM } from './types';
+import type { Scene } from '../content/ContentTable';
 
 interface Entity {
   id: string;
@@ -70,6 +71,18 @@ export default function RoutineList({ entities, onCommitted }: Props) {
   const refresh = () => {
     fetchRoutines();
     onCommitted?.();
+  };
+
+  // Optimistic update — a successful scenify POST adds the content_scene
+  // relation to the routine so the 🎬 badge appears without a refetch.
+  const handleScenify = (newScene: Scene) => {
+    setRoutines((prev) =>
+      prev.map((r) =>
+        r.id === newScene.routine_id
+          ? { ...r, content_scene: { id: newScene.id } }
+          : r
+      )
+    );
   };
 
   const startCreate = () => {
@@ -316,6 +329,7 @@ export default function RoutineList({ entities, onCommitted }: Props) {
                       entities={entities}
                       onUpdate={refresh}
                       onDelete={refresh}
+                      onScenify={handleScenify}
                     />
                   ))}
                 </div>

--- a/src/components/workbench/operations/routines/RoutineRow.tsx
+++ b/src/components/workbench/operations/routines/RoutineRow.tsx
@@ -19,6 +19,8 @@ import type { Routine, RoutineForm } from './types';
 import { DEFAULT_ROUTINE_FORM } from './types';
 import RRULEBuilder from './RRULEBuilder';
 import { RoutineStepList } from './RoutineStepList';
+import ScenifyButton from '../content/ScenifyButton';
+import type { Scene } from '../content/ContentTable';
 
 interface Entity {
   id: string;
@@ -30,6 +32,7 @@ interface Props {
   entities: Entity[];
   onUpdate: () => void;
   onDelete: () => void;
+  onScenify: (newScene: Scene) => void;
 }
 
 function routineToForm(r: Routine): RoutineForm {
@@ -68,7 +71,7 @@ function formatDateTime(iso: string | null, tz: string): string {
   });
 }
 
-export default function RoutineRow({ routine, entities, onUpdate, onDelete }: Props) {
+export default function RoutineRow({ routine, entities, onUpdate, onDelete, onScenify }: Props) {
   const [expanded, setExpanded] = useState(false);
   const [editing, setEditing] = useState(false);
   const [form, setForm] = useState<RoutineForm>(() => routineToForm(routine));
@@ -267,7 +270,7 @@ export default function RoutineRow({ routine, entities, onUpdate, onDelete }: Pr
 
           <RoutineStepList routine={routine} onUpdate={onUpdate} />
 
-          <div className="flex items-center gap-2 pt-2 border-t border-border-light">
+          <div className="flex flex-wrap items-center gap-2 pt-2 border-t border-border-light">
             <button
               type="button"
               onClick={(e) => { e.stopPropagation(); enterEdit(); }}
@@ -291,6 +294,7 @@ export default function RoutineRow({ routine, entities, onUpdate, onDelete }: Pr
             >
               {deleting ? 'deleting…' : 'delete'}
             </button>
+            <ScenifyButton routine={routine} onScenify={onScenify} />
           </div>
         </div>
       )}

--- a/src/components/workbench/operations/routines/types.ts
+++ b/src/components/workbench/operations/routines/types.ts
@@ -56,6 +56,12 @@ export interface Routine {
   updated_at: string;
   created_by: string | null;
   steps: RoutineStep[];
+  /**
+   * The content scene this routine has been scenified into, if any.
+   * Populated by GET /api/operations/routines (and /[id]) via the
+   * content_scene include; absent on endpoints that don't include it.
+   */
+  content_scene?: { id: string } | null;
 }
 
 /**


### PR DESCRIPTION
First interactive PR in the 4.9.3 series. Adds end-to-end flow for converting a routine into a scene.

Backend (atomic include addition):
- GET /api/operations/routines and GET /api/operations/routines/[id] now include { content_scene: true } so both tabs render the 🎬 badge from their own fetch (no cross-tab data dependency). The [id] include lives in the shared loadAuthorizedRoutine helper, so PATCH/DELETE also surface the relation in audit payload_before.

New components (content/):
- ScenifyButton — shows 🎬 Scenified badge if routine.content_scene exists, else a button toggling the inline ScenifyModal form
- ScenifyModal — inline expanding form (operations-surface convention; the surface has no overlay modals). scene_number + scene_title required, four optionals. POSTs to scenes API. Inline 409/400/401 error display, no toast.
- AvailableRoutinesList — shared interactive list of unscenified routines, used on the Content tab in both empty and populated states (replacing the prior plain <ul> in each)

Optimistic state updates on success — no refetch. New scene added to the scenes array; routine.content_scene populated locally.

Routines tab integration:
- ScenifyButton sits in RoutineRow's expanded action row next to edit/deactivate/delete (the compact header has no buttons)
- RoutineList wires handleScenify to optimistically set the routine's content_scene relation

Type definitions: content_scene added to the shared Routine interface (routines/types.ts) and ContentTable's exported Routine type — both required to carry the new relation.

Schema unchanged. Scene number is user-picked, not auto-incremented.

Take-ify on RoutineStep lands in 4.9.3d. Inline editing in 4.9.3e. Script drawer in 4.9.3f.

Author: Temple Stuart <astuart@templestuart.com>