### PR TITLE
PR-Ops-4.9.3d: Take-ify affordance on RoutineStep

### DIFF
--- a/src/app/api/operations/routines/[id]/route.ts
+++ b/src/app/api/operations/routines/[id]/route.ts
@@ -66,7 +66,10 @@ async function loadAuthorizedRoutine(routineId: string, userId: string) {
   return prisma.operations_routines.findFirst({
     where: { id: routineId, user_id: userId },
     include: {
-      steps: { orderBy: { step_order: 'asc' } },
+      steps: {
+        orderBy: { step_order: 'asc' },
+        include: { content_take: true },
+      },
       content_scene: true,
     },
   });

--- a/src/app/api/operations/routines/route.ts
+++ b/src/app/api/operations/routines/route.ts
@@ -88,7 +88,10 @@ export async function GET(request: NextRequest) {
         { name: 'asc' },
       ],
       include: {
-        steps: { orderBy: { step_order: 'asc' } },
+        steps: {
+          orderBy: { step_order: 'asc' },
+          include: { content_take: true },
+        },
         content_scene: true,
       },
     });

--- a/src/components/workbench/operations/content/ContentTable.tsx
+++ b/src/components/workbench/operations/content/ContentTable.tsx
@@ -30,6 +30,8 @@ export type Step = {
   sub_activity: string | null;
   time_of_day: string | null;
   step_order: number;
+  /** Present when the step has been take-ified; null/absent otherwise. */
+  content_take?: { id: string } | null;
 };
 
 export type Routine = {

--- a/src/components/workbench/operations/content/TakeifyButton.tsx
+++ b/src/components/workbench/operations/content/TakeifyButton.tsx
@@ -1,0 +1,104 @@
+/**
+ * TakeifyButton — the 🎬 Take affordance for a routine step.
+ *
+ * If the step already has a take, renders a non-interactive
+ * "🎬 Take" badge. Otherwise renders a clickable button that
+ * POSTs a bare { routine_step_id } to /api/operations/content/takes.
+ * On success calls onTakeify with the new take so the parent can
+ * update state.
+ *
+ * Step-level mirror of ScenifyButton. Bare POST — no inline form
+ * for take details (filming_location_specific / camera_needed /
+ * filming_angle / notes are edited later from the Content tab
+ * via inline cells; landing in 4.9.3e).
+ *
+ * Sized to step-row density (py-0.5) to match RoutineStepList's
+ * existing edit/delete buttons.
+ */
+
+'use client';
+
+import { useState } from 'react';
+import type { Take } from './ContentTable';
+
+type TakeifyStep = {
+  id: string;
+  content_take?: { id: string } | null;
+};
+
+export default function TakeifyButton({
+  step,
+  onTakeify,
+}: {
+  step: TakeifyStep;
+  onTakeify: (newTake: Take) => void;
+}) {
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  if (step.content_take) {
+    return (
+      <span
+        className="px-2 py-0.5 border border-border rounded bg-purple-50 text-brand-purple text-xs font-mono"
+        title="this step already has a take"
+      >
+        🎬 Take
+      </span>
+    );
+  }
+
+  const handleClick = async () => {
+    if (submitting) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/operations/content/takes', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ routine_step_id: step.id }),
+      });
+      if (!res.ok) {
+        let msg = res.statusText;
+        try {
+          const body = await res.json();
+          msg = body.message || body.error || msg;
+        } catch {
+          // non-JSON response — fall back to statusText
+        }
+        setError(msg);
+        console.error('Take-ify failed:', msg);
+        return;
+      }
+      const { take } = await res.json();
+      onTakeify(take);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : 'Network error';
+      setError(msg);
+      console.error('Take-ify network error:', e);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={(e) => {
+          e.stopPropagation();
+          handleClick();
+        }}
+        disabled={submitting}
+        className="px-2 py-0.5 border border-border rounded hover:bg-bg-row disabled:opacity-50 text-xs font-mono"
+      >
+        {submitting ? '…' : '🎬 Take'}
+      </button>
+      {error && (
+        <span className="text-red-700 text-xs font-mono" title={error}>
+          {error}
+        </span>
+      )}
+    </>
+  );
+}

--- a/src/components/workbench/operations/routines/RoutineList.tsx
+++ b/src/components/workbench/operations/routines/RoutineList.tsx
@@ -18,7 +18,7 @@ import RoutineRow from './RoutineRow';
 import RRULEBuilder from './RRULEBuilder';
 import type { CadenceGroup, Routine, RoutineForm } from './types';
 import { CADENCE_GROUP_LABELS, CADENCE_GROUP_ORDER, DEFAULT_ROUTINE_FORM } from './types';
-import type { Scene } from '../content/ContentTable';
+import type { Scene, Take } from '../content/ContentTable';
 
 interface Entity {
   id: string;
@@ -82,6 +82,21 @@ export default function RoutineList({ entities, onCommitted }: Props) {
           ? { ...r, content_scene: { id: newScene.id } }
           : r
       )
+    );
+  };
+
+  // Optimistic update — a successful take-ify POST adds the content_take
+  // relation to the matching step so its 🎬 badge appears without a refetch.
+  const handleTakeify = (newTake: Take) => {
+    setRoutines((prev) =>
+      prev.map((r) => ({
+        ...r,
+        steps: r.steps.map((s) =>
+          s.id === newTake.routine_step_id
+            ? { ...s, content_take: { id: newTake.id } }
+            : s
+        ),
+      }))
     );
   };
 
@@ -330,6 +345,7 @@ export default function RoutineList({ entities, onCommitted }: Props) {
                       onUpdate={refresh}
                       onDelete={refresh}
                       onScenify={handleScenify}
+                      onTakeify={handleTakeify}
                     />
                   ))}
                 </div>

--- a/src/components/workbench/operations/routines/RoutineRow.tsx
+++ b/src/components/workbench/operations/routines/RoutineRow.tsx
@@ -20,7 +20,7 @@ import { DEFAULT_ROUTINE_FORM } from './types';
 import RRULEBuilder from './RRULEBuilder';
 import { RoutineStepList } from './RoutineStepList';
 import ScenifyButton from '../content/ScenifyButton';
-import type { Scene } from '../content/ContentTable';
+import type { Scene, Take } from '../content/ContentTable';
 
 interface Entity {
   id: string;
@@ -33,6 +33,7 @@ interface Props {
   onUpdate: () => void;
   onDelete: () => void;
   onScenify: (newScene: Scene) => void;
+  onTakeify: (newTake: Take) => void;
 }
 
 function routineToForm(r: Routine): RoutineForm {
@@ -71,7 +72,7 @@ function formatDateTime(iso: string | null, tz: string): string {
   });
 }
 
-export default function RoutineRow({ routine, entities, onUpdate, onDelete, onScenify }: Props) {
+export default function RoutineRow({ routine, entities, onUpdate, onDelete, onScenify, onTakeify }: Props) {
   const [expanded, setExpanded] = useState(false);
   const [editing, setEditing] = useState(false);
   const [form, setForm] = useState<RoutineForm>(() => routineToForm(routine));
@@ -268,7 +269,7 @@ export default function RoutineRow({ routine, entities, onUpdate, onDelete, onSc
             </div>
           </div>
 
-          <RoutineStepList routine={routine} onUpdate={onUpdate} />
+          <RoutineStepList routine={routine} onUpdate={onUpdate} onTakeify={onTakeify} />
 
           <div className="flex flex-wrap items-center gap-2 pt-2 border-t border-border-light">
             <button

--- a/src/components/workbench/operations/routines/RoutineStepList.tsx
+++ b/src/components/workbench/operations/routines/RoutineStepList.tsx
@@ -14,6 +14,8 @@
 
 import { useState } from 'react';
 import type { Routine, RoutineStep } from './types';
+import type { Take } from '../content/ContentTable';
+import TakeifyButton from '../content/TakeifyButton';
 
 const STEP_DEFAULT_INTERVAL_MINUTES = 15;
 
@@ -81,9 +83,10 @@ function getAutoFillTime(routine: Routine, currentSteps: RoutineStep[]): string 
 interface Props {
   routine: Routine;
   onUpdate: () => void;
+  onTakeify: (newTake: Take) => void;
 }
 
-export function RoutineStepList({ routine, onUpdate }: Props) {
+export function RoutineStepList({ routine, onUpdate, onTakeify }: Props) {
   const steps = [...routine.steps].sort((a, b) => a.step_order - b.step_order);
 
   const [error, setError] = useState<string | null>(null);
@@ -392,6 +395,7 @@ export function RoutineStepList({ routine, onUpdate }: Props) {
                   >
                     delete
                   </button>
+                  <TakeifyButton step={step} onTakeify={onTakeify} />
                 </div>
               </div>
               {step.notes && (

--- a/src/components/workbench/operations/routines/types.ts
+++ b/src/components/workbench/operations/routines/types.ts
@@ -88,6 +88,13 @@ export interface RoutineStep {
   created_at: string;
   updated_at: string;
   created_by: string | null;
+  /**
+   * The content take this step has been take-ified into, if any.
+   * Populated by GET /api/operations/routines (and /[id]) via the
+   * nested steps→content_take include; absent on endpoints that
+   * don't include it.
+   */
+  content_take?: { id: string } | null;
 }
 
 export interface RoutineCompletion {


### PR DESCRIPTION
Step-level mirror of 4.9.3c. Adds per-step 🎬 affordance in RoutineStepList — bare POST creates an operations_content_takes row with all four optional fields null. Detail editing happens later via Content tab inline cells (4.9.3e).

Backend:
- GET /api/operations/routines and GET /api/operations/routines/[id] extend their steps include to nest content_take, mirroring 4.9.3c's content_scene pattern. The [id] route uses the shared loadAuthorizedRoutine helper so PATCH/DELETE also surface the relation in audit payload_before.

New component:
- TakeifyButton — 🎬 read-only badge when step.content_take exists, else clickable button POSTing { routine_step_id }. Inline error display next to the button on failure; debounced via submitting state. No toast, no silent retry.

Type files extended:
- routines/types.ts RoutineStep gets content_take?
- ContentTable.tsx local Step type also extended (Step is locally defined there, not consumed via shared import).

TakeifyButton uses the shared Take type from ContentTable rather than a local minimal redefinition — mirrors 4.9.3c's use of shared Scene, avoids function-param variance friction across RoutineStepList/RoutineRow/RoutineList. Button + badge sized py-0.5 to match step-row density (existing actionClass is px-2 py-0.5) — codebase consistency wins over abstract design.

Optimistic update walks the routines array, maps the matching step's content_take into place — badge appears without refetch.

Cross-tab refresh limitation acknowledged: takes created on Routines tab don't appear on Content tab until user navigates and refetches. Same as 4.9.3c's scenes; acceptable per institutional decision. Inline editing of take details lands in 4.9.3e.

Author: Temple Stuart <astuart@templestuart.com>