### PR TITLE
PR-Ops-4.9.3e: inline cell editing on ContentTable

### DIFF
--- a/src/components/workbench/operations/content/ContentTable.tsx
+++ b/src/components/workbench/operations/content/ContentTable.tsx
@@ -128,10 +128,22 @@ export default function ContentTable({
   scenes,
   takes,
   routines,
+  onSceneUpdate,
+  onTakeUpdate,
 }: {
   scenes: Scene[];
   takes: Take[];
   routines: Routine[];
+  onSceneUpdate: (
+    sceneId: string,
+    field: string,
+    value: string | number | null
+  ) => Promise<void>;
+  onTakeUpdate: (
+    takeId: string,
+    field: string,
+    value: string | number | null
+  ) => Promise<void>;
 }) {
   const routinesById = new Map(routines.map((r) => [r.id, r]));
   const takesByStepId = new Map(takes.map((t) => [t.routine_step_id, t]));
@@ -165,12 +177,17 @@ export default function ContentTable({
             );
             return (
               <Fragment key={scene.id}>
-                <SceneHeaderRow scene={scene} routine={routine} />
+                <SceneHeaderRow
+                  scene={scene}
+                  routine={routine}
+                  onSceneUpdate={onSceneUpdate}
+                />
                 {steps.map((step) => (
                   <TakeRow
                     key={step.id}
                     step={step}
                     take={takesByStepId.get(step.id)}
+                    onTakeUpdate={onTakeUpdate}
                   />
                 ))}
               </Fragment>

--- a/src/components/workbench/operations/content/EditableCell.tsx
+++ b/src/components/workbench/operations/content/EditableCell.tsx
@@ -1,0 +1,182 @@
+/**
+ * EditableCell — click-to-edit cell for the ContentTable spreadsheet.
+ *
+ * Default state renders value (with optional renderValue formatter) inside
+ * a click-target. Clicking enters edit mode: a plain <input> replaces the
+ * text, pre-filled and auto-focused. Blur OR Enter fires the caller's
+ * onSave; Escape cancels. While saving the input is disabled. On error
+ * the input gets a red border and an error message appears below it; the
+ * cell stays in edit mode so the user can correct and retry.
+ *
+ * The caller's onSave is async and MUST throw on failure — this component
+ * catches the throw and surfaces the message. The parent (SectionG_Content)
+ * owns the optimistic state update + rollback against scenes/takes.
+ *
+ * `required={true}` enables client-side empty-input rejection (used for
+ * scene_title). Otherwise empty text coerces to null.
+ *
+ * `renderValue` is the display-mode formatter (e.g., formatHours for the
+ * Hours column) — the underlying raw value is what's edited.
+ */
+
+'use client';
+
+import { useState } from 'react';
+
+export default function EditableCell({
+  value,
+  type,
+  onSave,
+  maxLength,
+  min,
+  max,
+  step,
+  placeholder,
+  required,
+  renderValue,
+  cellClassName = 'py-1 px-2',
+  inputClassName,
+}: {
+  value: string | number | null;
+  type: 'text' | 'number';
+  onSave: (newValue: string | number | null) => Promise<void>;
+  maxLength?: number;
+  min?: number;
+  max?: number;
+  step?: number;
+  placeholder?: string;
+  required?: boolean;
+  renderValue?: (v: string | number | null) => string;
+  cellClassName?: string;
+  inputClassName?: string;
+}) {
+  const [isEditing, setIsEditing] = useState(false);
+  const [draftValue, setDraftValue] = useState<string>('');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const enterEdit = () => {
+    setDraftValue(value == null ? '' : String(value));
+    setError(null);
+    setIsEditing(true);
+  };
+
+  const cancelEdit = () => {
+    setDraftValue(value == null ? '' : String(value));
+    setError(null);
+    setIsEditing(false);
+  };
+
+  const attemptSave = async () => {
+    if (saving) return;
+
+    let coerced: string | number | null;
+    if (type === 'number') {
+      const t = draftValue.trim();
+      if (t === '') {
+        if (required) {
+          setError('this field is required');
+          return;
+        }
+        coerced = null;
+      } else {
+        const n = parseFloat(t);
+        if (!Number.isFinite(n)) {
+          setError('must be a number');
+          return;
+        }
+        coerced = n;
+      }
+    } else {
+      const t = draftValue.trim();
+      if (t === '') {
+        if (required) {
+          setError('this field is required');
+          return;
+        }
+        coerced = null;
+      } else {
+        coerced = t;
+      }
+    }
+
+    // No-op short-circuit — compare normalized string forms so a Prisma
+    // string-decimal vs. number-decimal doesn't trigger a spurious save.
+    const before = value == null ? '' : String(value).trim();
+    const after = coerced == null ? '' : String(coerced).trim();
+    if (before === after) {
+      setError(null);
+      setIsEditing(false);
+      return;
+    }
+
+    setSaving(true);
+    setError(null);
+    try {
+      await onSave(coerced);
+      setIsEditing(false);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (!isEditing) {
+    const display = renderValue
+      ? renderValue(value)
+      : value == null || value === ''
+        ? '—'
+        : String(value);
+    return (
+      <td className={cellClassName}>
+        <button
+          type="button"
+          onClick={enterEdit}
+          className="block w-full text-left cursor-pointer hover:text-brand-purple"
+          title="click to edit"
+        >
+          {display}
+        </button>
+      </td>
+    );
+  }
+
+  const baseInput =
+    inputClassName ??
+    'w-full px-1 py-0 border rounded text-xs font-mono text-text-primary focus:outline-none disabled:opacity-50';
+  const borderClass = error
+    ? 'border-red-500 focus:border-red-500'
+    : 'border-border focus:border-brand-purple';
+
+  return (
+    <td className={cellClassName}>
+      <input
+        type={type}
+        value={draftValue}
+        onChange={(e) => setDraftValue(e.target.value)}
+        onBlur={attemptSave}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') {
+            e.preventDefault();
+            attemptSave();
+          } else if (e.key === 'Escape') {
+            e.preventDefault();
+            cancelEdit();
+          }
+        }}
+        maxLength={maxLength}
+        min={min}
+        max={max}
+        step={step}
+        disabled={saving}
+        placeholder={placeholder}
+        autoFocus
+        className={`${baseInput} ${borderClass}`}
+      />
+      {error && (
+        <div className="text-xs text-red-700 mt-0.5 whitespace-normal">{error}</div>
+      )}
+    </td>
+  );
+}

--- a/src/components/workbench/operations/content/SceneHeaderRow.tsx
+++ b/src/components/workbench/operations/content/SceneHeaderRow.tsx
@@ -4,34 +4,75 @@
  * Scene-level columns (Scene, Title, Focus, Hours, Day, Loc Base,
  * Script) are filled; take-level columns are rendered as empty cells
  * — they belong to the TakeRow children below.
+ *
+ * Editable cells (PR-Ops-4.9.3e): scene_title, focus_category,
+ * filming_location_base, estimated_hours. Click → input. Script stays
+ * read-only here (drawer in 4.9.3f); scene_number and Day are derived
+ * and never editable.
  */
 
 import type { Scene, Routine } from './ContentTable';
-import { formatDay, formatHours, truncateScript, dashOrValue } from './ContentTable';
+import { formatDay, formatHours, truncateScript } from './ContentTable';
+import EditableCell from './EditableCell';
 
 export default function SceneHeaderRow({
   scene,
   routine,
+  onSceneUpdate,
 }: {
   scene: Scene;
   routine: Routine;
+  onSceneUpdate: (
+    sceneId: string,
+    field: string,
+    value: string | number | null
+  ) => Promise<void>;
 }) {
+  const cellClass = 'py-1 px-2';
   return (
     <tr className="border-t border-border-light bg-bg-row font-semibold text-text-primary">
-      <td className="py-1 px-2">{scene.scene_number}</td>
-      <td className="py-1 px-2">{scene.scene_title}</td>
-      <td className="py-1 px-2">{dashOrValue(scene.focus_category)}</td>
-      <td className="py-1 px-2">{formatHours(scene.estimated_hours)}</td>
-      <td className="py-1 px-2">{formatDay(routine.schedule_rrule)}</td>
-      <td className="py-1 px-2">{dashOrValue(scene.filming_location_base)}</td>
-      <td className="py-1 px-2" />
-      <td className="py-1 px-2" />
-      <td className="py-1 px-2" />
-      <td className="py-1 px-2" />
-      <td className="py-1 px-2" />
-      <td className="py-1 px-2" />
-      <td className="py-1 px-2" />
-      <td className="py-1 px-2">{truncateScript(scene.script)}</td>
+      <td className={cellClass}>{scene.scene_number}</td>
+      <EditableCell
+        value={scene.scene_title}
+        type="text"
+        required
+        maxLength={500}
+        onSave={(v) => onSceneUpdate(scene.id, 'scene_title', v)}
+        cellClassName={cellClass}
+      />
+      <EditableCell
+        value={scene.focus_category}
+        type="text"
+        maxLength={200}
+        onSave={(v) => onSceneUpdate(scene.id, 'focus_category', v)}
+        cellClassName={cellClass}
+      />
+      <EditableCell
+        value={scene.estimated_hours}
+        type="number"
+        min={0.01}
+        max={999.99}
+        step={0.01}
+        renderValue={(v) => formatHours(v as string | number | null)}
+        onSave={(v) => onSceneUpdate(scene.id, 'estimated_hours', v)}
+        cellClassName={cellClass}
+      />
+      <td className={cellClass}>{formatDay(routine.schedule_rrule)}</td>
+      <EditableCell
+        value={scene.filming_location_base}
+        type="text"
+        maxLength={200}
+        onSave={(v) => onSceneUpdate(scene.id, 'filming_location_base', v)}
+        cellClassName={cellClass}
+      />
+      <td className={cellClass} />
+      <td className={cellClass} />
+      <td className={cellClass} />
+      <td className={cellClass} />
+      <td className={cellClass} />
+      <td className={cellClass} />
+      <td className={cellClass} />
+      <td className={cellClass}>{truncateScript(scene.script)}</td>
     </tr>
   );
 }

--- a/src/components/workbench/operations/content/SectionG_Content.tsx
+++ b/src/components/workbench/operations/content/SectionG_Content.tsx
@@ -85,6 +85,77 @@ export default function SectionG_Content() {
     );
   };
 
+  // Inline cell edit handlers (PR-Ops-4.9.3e). Each captures the previous
+  // row, updates state optimistically, fires PATCH, and rolls back +
+  // throws on failure so EditableCell can surface the message inline.
+  const handleSceneUpdate = async (
+    sceneId: string,
+    field: string,
+    value: string | number | null
+  ) => {
+    const previous = scenes?.find((s) => s.id === sceneId);
+    if (!previous) throw new Error('scene not found in local state');
+
+    setScenes((prev) =>
+      prev ? prev.map((s) => (s.id === sceneId ? { ...s, [field]: value } : s)) : prev
+    );
+
+    const res = await fetch(`/api/operations/content/scenes/${sceneId}`, {
+      method: 'PATCH',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ [field]: value }),
+    });
+
+    if (!res.ok) {
+      setScenes((prev) =>
+        prev ? prev.map((s) => (s.id === sceneId ? previous : s)) : prev
+      );
+      let msg = `${res.status} ${res.statusText}`;
+      try {
+        const body = await res.json();
+        msg = body.message || body.error || msg;
+      } catch {
+        // non-JSON response — fall through to status-based message
+      }
+      throw new Error(msg);
+    }
+  };
+
+  const handleTakeUpdate = async (
+    takeId: string,
+    field: string,
+    value: string | number | null
+  ) => {
+    const previous = takes?.find((t) => t.id === takeId);
+    if (!previous) throw new Error('take not found in local state');
+
+    setTakes((prev) =>
+      prev ? prev.map((t) => (t.id === takeId ? { ...t, [field]: value } : t)) : prev
+    );
+
+    const res = await fetch(`/api/operations/content/takes/${takeId}`, {
+      method: 'PATCH',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ [field]: value }),
+    });
+
+    if (!res.ok) {
+      setTakes((prev) =>
+        prev ? prev.map((t) => (t.id === takeId ? previous : t)) : prev
+      );
+      let msg = `${res.status} ${res.statusText}`;
+      try {
+        const body = await res.json();
+        msg = body.message || body.error || msg;
+      } catch {
+        // non-JSON response — fall through to status-based message
+      }
+      throw new Error(msg);
+    }
+  };
+
   return (
     <section className="bg-white rounded border border-border shadow-sm p-5 space-y-4">
       <h2 className="font-mono text-sm font-bold tracking-wide text-text-primary">
@@ -105,6 +176,8 @@ export default function SectionG_Content() {
           takes={takes}
           routines={routines}
           onScenify={handleScenify}
+          onSceneUpdate={handleSceneUpdate}
+          onTakeUpdate={handleTakeUpdate}
         />
       )}
     </section>
@@ -116,11 +189,23 @@ function ContentSummary({
   takes,
   routines,
   onScenify,
+  onSceneUpdate,
+  onTakeUpdate,
 }: {
   scenes: Scene[];
   takes: Take[];
   routines: Routine[];
   onScenify: (newScene: Scene) => void;
+  onSceneUpdate: (
+    sceneId: string,
+    field: string,
+    value: string | number | null
+  ) => Promise<void>;
+  onTakeUpdate: (
+    takeId: string,
+    field: string,
+    value: string | number | null
+  ) => Promise<void>;
 }) {
   return (
     <div className="space-y-3">
@@ -137,7 +222,13 @@ function ContentSummary({
         </>
       ) : (
         <>
-          <ContentTable scenes={scenes} takes={takes} routines={routines} />
+          <ContentTable
+            scenes={scenes}
+            takes={takes}
+            routines={routines}
+            onSceneUpdate={onSceneUpdate}
+            onTakeUpdate={onTakeUpdate}
+          />
           <AvailableRoutinesList routines={routines} onScenify={onScenify} />
         </>
       )}

--- a/src/components/workbench/operations/content/TakeRow.tsx
+++ b/src/components/workbench/operations/content/TakeRow.tsx
@@ -3,38 +3,80 @@
  *
  * Take-level columns (Time, Activity, Sub-Activity, Loc Specific,
  * Camera, Angle, Notes) are filled; scene-level columns are empty.
- * When no take is attached to the step, the take-owned columns
- * render as en-dash placeholders.
+ * When no take is attached to the step, the take-owned editable
+ * columns render as plain en-dash placeholders — the user must
+ * explicitly 🎬 Take the step via the Routines tab before those
+ * cells become editable (PR-Ops-4.9.3e).
  */
 
 import type { Step, Take } from './ContentTable';
 import { formatTime, dashOrValue } from './ContentTable';
+import EditableCell from './EditableCell';
 
 export default function TakeRow({
   step,
   take,
+  onTakeUpdate,
 }: {
   step: Step;
   take: Take | undefined;
+  onTakeUpdate: (
+    takeId: string,
+    field: string,
+    value: string | number | null
+  ) => Promise<void>;
 }) {
+  const cellClass = 'py-1 px-2';
   return (
     <tr className="border-t border-border-light text-text-muted">
-      <td className="py-1 px-2" />
-      <td className="py-1 px-2" />
-      <td className="py-1 px-2" />
-      <td className="py-1 px-2" />
-      <td className="py-1 px-2" />
-      <td className="py-1 px-2" />
+      <td className={cellClass} />
+      <td className={cellClass} />
+      <td className={cellClass} />
+      <td className={cellClass} />
+      <td className={cellClass} />
+      <td className={cellClass} />
       <td className="py-1 px-2 pl-4">{formatTime(step.time_of_day)}</td>
-      <td className="py-1 px-2">{step.activity}</td>
-      <td className="py-1 px-2">{dashOrValue(step.sub_activity)}</td>
-      <td className="py-1 px-2">
-        {take ? dashOrValue(take.filming_location_specific) : '—'}
-      </td>
-      <td className="py-1 px-2">{take ? dashOrValue(take.camera_needed) : '—'}</td>
-      <td className="py-1 px-2">{take ? dashOrValue(take.filming_angle) : '—'}</td>
-      <td className="py-1 px-2">{take ? dashOrValue(take.notes) : '—'}</td>
-      <td className="py-1 px-2" />
+      <td className={cellClass}>{step.activity}</td>
+      <td className={cellClass}>{dashOrValue(step.sub_activity)}</td>
+      {take ? (
+        <>
+          <EditableCell
+            value={take.filming_location_specific}
+            type="text"
+            maxLength={200}
+            onSave={(v) => onTakeUpdate(take.id, 'filming_location_specific', v)}
+            cellClassName={cellClass}
+          />
+          <EditableCell
+            value={take.camera_needed}
+            type="text"
+            maxLength={200}
+            onSave={(v) => onTakeUpdate(take.id, 'camera_needed', v)}
+            cellClassName={cellClass}
+          />
+          <EditableCell
+            value={take.filming_angle}
+            type="text"
+            maxLength={200}
+            onSave={(v) => onTakeUpdate(take.id, 'filming_angle', v)}
+            cellClassName={cellClass}
+          />
+          <EditableCell
+            value={take.notes}
+            type="text"
+            onSave={(v) => onTakeUpdate(take.id, 'notes', v)}
+            cellClassName={cellClass}
+          />
+        </>
+      ) : (
+        <>
+          <td className={cellClass}>—</td>
+          <td className={cellClass}>—</td>
+          <td className={cellClass}>—</td>
+          <td className={cellClass}>—</td>
+        </>
+      )}
+      <td className={cellClass} />
     </tr>
   );
 }


### PR DESCRIPTION
Spreadsheet cells become click-to-edit. EditableCell component owns input lifecycle (click → input → blur/enter → save → error or success). Parent SectionG_Content owns optimistic state with rollback on PATCH failure.

Editable cells:
- Scene-level (SceneHeaderRow): scene_title (required, max 500), focus_category (optional, max 200), filming_location_base (optional, max 200), estimated_hours (optional number, 0.01-999.99). Hours keeps formatHours display transform via EditableCell's renderValue prop.
- Take-level (TakeRow): filming_location_specific, camera_needed, filming_angle (each optional, max 200), notes (optional, uncapped). Only when take exists; steps without takes show plain '—' placeholders. User must explicitly 🎬 Take first.

Read-only cells unchanged: scene_number, Day, Time, Activity, Sub-Activity, Script (drawer in 4.9.3f), Hours-on-take-row (scene-level field).

Interaction: click cell → plain <input> auto-focused. Blur or Enter saves. Escape cancels. Empty draft + required → client-side error (no PATCH). Empty draft + optional → server stores null. Failed save: red-border input + inline error text below; stays in edit mode for retry. No toasts, no auto-retry, no fallbacks.

Optimistic UI: parent state updates immediately on save attempt; EditableCell awaits onSave promise — caller's handler captures the previous row, optimistically maps in the new value, fires PATCH, and on !ok rolls back state and throws so EditableCell surfaces the message. Single-field PATCH bodies leverage the endpoints' `if (body.X !== undefined)` gating shipped in PR-Ops-4.9.2a/b.

EditableCell is the first inline-cell-edit pattern in the codebase (no precedent — confirmed via grep onBlur/isEditing/ contentEditable). Designed consistent with operations form aesthetics: text-xs font-mono, border-border default, focus:border-brand-purple, border-red-500 on error.

Author: Temple Stuart <astuart@templestuart.com>