### PR TITLE
PR-Ops-4.9.3f: script drawer for long-form scene.script editing

### DIFF
--- a/src/components/workbench/operations/content/ContentTable.tsx
+++ b/src/components/workbench/operations/content/ContentTable.tsx
@@ -130,6 +130,7 @@ export default function ContentTable({
   routines,
   onSceneUpdate,
   onTakeUpdate,
+  onScriptClick,
 }: {
   scenes: Scene[];
   takes: Take[];
@@ -144,6 +145,7 @@ export default function ContentTable({
     field: string,
     value: string | number | null
   ) => Promise<void>;
+  onScriptClick: (scene: Scene) => void;
 }) {
   const routinesById = new Map(routines.map((r) => [r.id, r]));
   const takesByStepId = new Map(takes.map((t) => [t.routine_step_id, t]));
@@ -181,6 +183,7 @@ export default function ContentTable({
                   scene={scene}
                   routine={routine}
                   onSceneUpdate={onSceneUpdate}
+                  onScriptClick={onScriptClick}
                 />
                 {steps.map((step) => (
                   <TakeRow

--- a/src/components/workbench/operations/content/SceneHeaderRow.tsx
+++ b/src/components/workbench/operations/content/SceneHeaderRow.tsx
@@ -19,6 +19,7 @@ export default function SceneHeaderRow({
   scene,
   routine,
   onSceneUpdate,
+  onScriptClick,
 }: {
   scene: Scene;
   routine: Routine;
@@ -27,6 +28,7 @@ export default function SceneHeaderRow({
     field: string,
     value: string | number | null
   ) => Promise<void>;
+  onScriptClick: (scene: Scene) => void;
 }) {
   const cellClass = 'py-1 px-2';
   return (
@@ -72,7 +74,16 @@ export default function SceneHeaderRow({
       <td className={cellClass} />
       <td className={cellClass} />
       <td className={cellClass} />
-      <td className={cellClass}>{truncateScript(scene.script)}</td>
+      <td className={cellClass}>
+        <button
+          type="button"
+          onClick={() => onScriptClick(scene)}
+          className="block w-full text-left cursor-pointer hover:text-brand-purple"
+          title="click to edit script"
+        >
+          {truncateScript(scene.script)}
+        </button>
+      </td>
     </tr>
   );
 }

--- a/src/components/workbench/operations/content/ScriptDrawer.tsx
+++ b/src/components/workbench/operations/content/ScriptDrawer.tsx
@@ -1,0 +1,128 @@
+/**
+ * ScriptDrawer — long-form editor for scene.script.
+ *
+ * Right-side slide-in panel triggered by clicking the truncated script
+ * preview cell in SceneHeaderRow. Full script pre-populated in a
+ * textarea filling the panel's vertical space.
+ *
+ * Close behavior (locked): NO click-outside, NO Escape, NO close-X.
+ * Only Save (on success) or Cancel button closes the drawer.
+ *
+ * No backdrop — the spreadsheet behind the drawer stays fully readable.
+ * The drawer is `fixed right-0 top-0`, so the table is also still
+ * interactable behind it; this is intentional.
+ *
+ * Save semantics: empty trimmed → null; no-change → close without
+ * firing PATCH; otherwise the parent's handleSceneUpdate (shipped in
+ * 4.9.3e) drives optimistic update + rollback. The parent closes the
+ * drawer on success; a thrown error keeps the drawer open with the
+ * message inline above the buttons.
+ *
+ * Whitespace note: this drawer trims leading/trailing whitespace before
+ * sending so the optimistic state matches what the server stores (the
+ * scenes PATCH endpoint applies the same trim).
+ */
+
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export default function ScriptDrawer({
+  scene,
+  open,
+  onSave,
+  onCancel,
+}: {
+  scene: {
+    id: string;
+    scene_number: number;
+    scene_title: string;
+    script: string | null;
+  };
+  open: boolean;
+  onSave: (script: string | null) => Promise<void>;
+  onCancel: () => void;
+}) {
+  const [draftScript, setDraftScript] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (open) {
+      setDraftScript(scene.script ?? '');
+      setError(null);
+      setSaving(false);
+    }
+  }, [open, scene.id]);
+
+  if (!open) return null;
+
+  const handleSave = async () => {
+    if (saving) return;
+    const trimmed = draftScript.trim();
+    const next: string | null = trimmed === '' ? null : trimmed;
+    if (next === (scene.script ?? null)) {
+      onCancel();
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    try {
+      await onSave(next);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleCancel = () => {
+    if (saving) return;
+    onCancel();
+  };
+
+  return (
+    <div className="fixed right-0 top-0 h-full w-[35%] min-w-[400px] max-w-[600px] bg-white border-l border-border shadow-lg flex flex-col z-50">
+      <div className="px-4 py-3 border-b border-border-light font-mono text-xs font-semibold text-text-primary">
+        Scene {scene.scene_number} · {scene.scene_title}
+      </div>
+
+      <div className="flex-1 px-4 py-3 overflow-hidden">
+        <textarea
+          value={draftScript}
+          onChange={(e) => setDraftScript(e.target.value)}
+          disabled={saving}
+          autoFocus
+          placeholder="Write the script for this scene..."
+          className="w-full h-full resize-none border border-border rounded px-3 py-2 font-mono text-xs text-text-primary focus:outline-none focus:border-brand-purple disabled:opacity-50"
+        />
+      </div>
+
+      <div className="px-4 py-3 border-t border-border-light flex flex-col gap-2">
+        {error && (
+          <div className="text-xs font-mono text-red-700 bg-red-50 border border-red-200 px-2 py-1 rounded">
+            {error}
+          </div>
+        )}
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={handleCancel}
+            disabled={saving}
+            className="px-3 py-1.5 text-xs font-mono border border-border rounded hover:bg-bg-row disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleSave}
+            disabled={saving}
+            className="px-3 py-1.5 text-xs font-mono border border-brand-purple bg-brand-purple text-white rounded hover:opacity-90 disabled:opacity-50"
+          >
+            {saving ? 'Saving…' : 'Save'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/workbench/operations/content/SectionG_Content.tsx
+++ b/src/components/workbench/operations/content/SectionG_Content.tsx
@@ -19,6 +19,7 @@
 import { useEffect, useState } from 'react';
 import ContentTable, { type Scene, type Take, type Routine } from './ContentTable';
 import AvailableRoutinesList from './AvailableRoutinesList';
+import ScriptDrawer from './ScriptDrawer';
 
 export default function SectionG_Content() {
   const [scenes, setScenes] = useState<Scene[] | null>(null);
@@ -26,6 +27,7 @@ export default function SectionG_Content() {
   const [routines, setRoutines] = useState<Routine[] | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [scriptDrawerScene, setScriptDrawerScene] = useState<Scene | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -156,6 +158,24 @@ export default function SectionG_Content() {
     }
   };
 
+  // Script drawer plumbing (PR-Ops-4.9.3f). Open by clicking the
+  // truncated script cell on SceneHeaderRow; reuses handleSceneUpdate
+  // for the PATCH so the optimistic + rollback behavior matches the
+  // other scene fields.
+  const handleScriptClick = (scene: Scene) => {
+    setScriptDrawerScene(scene);
+  };
+
+  const handleScriptCancel = () => {
+    setScriptDrawerScene(null);
+  };
+
+  const handleScriptSave = async (newScript: string | null) => {
+    if (!scriptDrawerScene) return;
+    await handleSceneUpdate(scriptDrawerScene.id, 'script', newScript);
+    setScriptDrawerScene(null);
+  };
+
   return (
     <section className="bg-white rounded border border-border shadow-sm p-5 space-y-4">
       <h2 className="font-mono text-sm font-bold tracking-wide text-text-primary">
@@ -178,6 +198,16 @@ export default function SectionG_Content() {
           onScenify={handleScenify}
           onSceneUpdate={handleSceneUpdate}
           onTakeUpdate={handleTakeUpdate}
+          onScriptClick={handleScriptClick}
+        />
+      )}
+
+      {scriptDrawerScene && (
+        <ScriptDrawer
+          scene={scriptDrawerScene}
+          open
+          onSave={handleScriptSave}
+          onCancel={handleScriptCancel}
         />
       )}
     </section>
@@ -191,6 +221,7 @@ function ContentSummary({
   onScenify,
   onSceneUpdate,
   onTakeUpdate,
+  onScriptClick,
 }: {
   scenes: Scene[];
   takes: Take[];
@@ -206,6 +237,7 @@ function ContentSummary({
     field: string,
     value: string | number | null
   ) => Promise<void>;
+  onScriptClick: (scene: Scene) => void;
 }) {
   return (
     <div className="space-y-3">
@@ -228,6 +260,7 @@ function ContentSummary({
             routines={routines}
             onSceneUpdate={onSceneUpdate}
             onTakeUpdate={onTakeUpdate}
+            onScriptClick={onScriptClick}
           />
           <AvailableRoutinesList routines={routines} onScenify={onScenify} />
         </>


### PR DESCRIPTION
Adds a right-side slide-in drawer for editing scene.script. Click the truncated script preview cell on SceneHeaderRow → drawer opens with full script pre-populated in a textarea.

Architecture:
- ScriptDrawer (new): fixed right-position panel, ~35% viewport width (min 400px, max 600px), no backdrop — the spreadsheet behind stays fully readable and clickable. Header shows 'Scene N · Title' (read-only). Body is a single textarea filling vertical space. Footer has Save + Cancel buttons.
- SceneHeaderRow modified: script cell is now a button that invokes onScriptClick(scene); mirrors EditableCell's block w-full text-left hover:text-brand-purple click-target.
- SectionG_Content owns scriptDrawerScene state; reuses the shipped handleSceneUpdate (from 4.9.3e) for PATCH + optimistic
  + rollback. Drawer renders at the section root so it survives ContentSummary branch switches.
- ContentTable threads onScriptClick prop through to SceneHeaderRow.

Close behavior (locked):
- NO click-outside, NO Escape, NO close-X button. Only Save (on success) or Cancel button closes the drawer.

Save semantics:
- Empty trimmed textarea → PATCH script: null (clears).
- No-change Save → close without firing PATCH.
- Otherwise → PATCH script: <trimmed value>.
- Server already trims leading/trailing whitespace; drawer sends trimmed value so optimistic state matches DB truth (one spec deviation, deliberate to keep optimistic UI in sync with server).
- Failed PATCH → inline error in drawer footer, drawer stays open, user retries.

No backdrop, no toast, no retries, no fallbacks. Drawer is scene.script only; not generalized for other fields.

Codebase note: the existing operations 'InspectionDrawer' (used by ProjectRow, SectionD, AITaskPreview, SectionK) is an inline expand/ collapse panel despite the 'Drawer' name — not a side-panel precedent. The right-side slide-in pattern closest in the codebase is hub/BudgetDrillDown; ScriptDrawer adopts that structural shape with operations aesthetics (font-mono, border-border, brand-purple).

Author: Temple Stuart <astuart@templestuart.com>