### PR TITLE
PR-Ops-4.9.3g: Content tab polish (empty state, skeleton, entity filt…

### DIFF
--- a/src/components/workbench/operations/content/ContentTable.tsx
+++ b/src/components/workbench/operations/content/ContentTable.tsx
@@ -37,6 +37,7 @@ export type Step = {
 export type Routine = {
   id: string;
   name: string;
+  entity_id: string;
   schedule_rrule: string | null;
   steps: Step[];
   /** Present when the routine has been scenified; null/absent otherwise. */
@@ -46,6 +47,7 @@ export type Routine = {
 export type Scene = {
   id: string;
   routine_id: string;
+  entity_id: string;
   scene_number: number;
   scene_title: string;
   focus_category: string | null;
@@ -57,6 +59,7 @@ export type Scene = {
 export type Take = {
   id: string;
   routine_step_id: string;
+  entity_id: string;
   filming_location_specific: string | null;
   camera_needed: string | null;
   filming_angle: string | null;

--- a/src/components/workbench/operations/content/ContentTableSkeleton.tsx
+++ b/src/components/workbench/operations/content/ContentTableSkeleton.tsx
@@ -1,0 +1,40 @@
+/**
+ * ContentTableSkeleton — shimmer placeholder for the Content tab loading
+ * state. Mirrors ContentTable's 14-column structure with animate-pulse
+ * blocks so the layout doesn't jump when the real data arrives.
+ *
+ * No props, no state — pure presentational. Sets the operations-surface
+ * skeleton convention (no precedent existed prior to PR-Ops-4.9.3g).
+ */
+
+const COLUMN_COUNT = 14;
+const ROW_COUNT = 4;
+
+export default function ContentTableSkeleton() {
+  return (
+    <div className="text-xs font-mono overflow-x-auto" aria-busy="true" aria-label="Loading content">
+      <table className="w-full">
+        <thead>
+          <tr className="text-text-faint uppercase tracking-wide">
+            {Array.from({ length: COLUMN_COUNT }).map((_, i) => (
+              <th key={i} className="text-left pb-1 px-2">
+                <div className="h-3 w-16 bg-gray-200 rounded animate-pulse" />
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {Array.from({ length: ROW_COUNT }).map((_, r) => (
+            <tr key={r} className="border-t border-border-light">
+              {Array.from({ length: COLUMN_COUNT }).map((_, c) => (
+                <td key={c} className="py-1 px-2">
+                  <div className="h-3 w-full bg-gray-200 rounded animate-pulse" />
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/components/workbench/operations/content/SectionG_Content.tsx
+++ b/src/components/workbench/operations/content/SectionG_Content.tsx
@@ -20,24 +20,33 @@ import { useEffect, useState } from 'react';
 import ContentTable, { type Scene, type Take, type Routine } from './ContentTable';
 import AvailableRoutinesList from './AvailableRoutinesList';
 import ScriptDrawer from './ScriptDrawer';
+import ContentTableSkeleton from './ContentTableSkeleton';
+
+interface EntityLite {
+  id: string;
+  name: string;
+}
 
 export default function SectionG_Content() {
   const [scenes, setScenes] = useState<Scene[] | null>(null);
   const [takes, setTakes] = useState<Take[] | null>(null);
   const [routines, setRoutines] = useState<Routine[] | null>(null);
+  const [entities, setEntities] = useState<EntityLite[] | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [scriptDrawerScene, setScriptDrawerScene] = useState<Scene | null>(null);
+  const [entityFilter, setEntityFilter] = useState<string>('all');
 
   useEffect(() => {
     let cancelled = false;
 
     async function load() {
       try {
-        const [scenesRes, takesRes, routinesRes] = await Promise.all([
+        const [scenesRes, takesRes, routinesRes, entitiesRes] = await Promise.all([
           fetch('/api/operations/content/scenes', { credentials: 'include' }),
           fetch('/api/operations/content/takes', { credentials: 'include' }),
           fetch('/api/operations/routines', { credentials: 'include' }),
+          fetch('/api/entities', { credentials: 'include' }),
         ]);
 
         const parse = async (res: Response, label: string) => {
@@ -48,16 +57,18 @@ export default function SectionG_Content() {
           return res.json();
         };
 
-        const [scenesBody, takesBody, routinesBody] = await Promise.all([
+        const [scenesBody, takesBody, routinesBody, entitiesBody] = await Promise.all([
           parse(scenesRes, 'scenes'),
           parse(takesRes, 'takes'),
           parse(routinesRes, 'routines'),
+          parse(entitiesRes, 'entities'),
         ]);
 
         if (cancelled) return;
         setScenes(scenesBody.scenes);
         setTakes(takesBody.takes);
         setRoutines(routinesBody.routines);
+        setEntities(entitiesBody.entities);
         setLoading(false);
       } catch (e) {
         if (cancelled) return;
@@ -183,18 +194,21 @@ export default function SectionG_Content() {
       </h2>
 
       {loading ? (
-        <p className="text-sm font-mono text-text-faint">Loading content...</p>
+        <ContentTableSkeleton />
       ) : error ? (
         <div className="text-xs font-mono px-3 py-2 rounded border bg-red-50 border-red-200 text-red-800">
           {error}
         </div>
-      ) : !scenes || !routines || !takes ? (
+      ) : !scenes || !routines || !takes || !entities ? (
         <p className="text-sm font-mono text-text-faint">Data missing.</p>
       ) : (
         <ContentSummary
           scenes={scenes}
           takes={takes}
           routines={routines}
+          entities={entities}
+          entityFilter={entityFilter}
+          onEntityFilterChange={setEntityFilter}
           onScenify={handleScenify}
           onSceneUpdate={handleSceneUpdate}
           onTakeUpdate={handleTakeUpdate}
@@ -218,6 +232,9 @@ function ContentSummary({
   scenes,
   takes,
   routines,
+  entities,
+  entityFilter,
+  onEntityFilterChange,
   onScenify,
   onSceneUpdate,
   onTakeUpdate,
@@ -226,6 +243,9 @@ function ContentSummary({
   scenes: Scene[];
   takes: Take[];
   routines: Routine[];
+  entities: EntityLite[];
+  entityFilter: string;
+  onEntityFilterChange: (next: string) => void;
   onScenify: (newScene: Scene) => void;
   onSceneUpdate: (
     sceneId: string,
@@ -239,30 +259,79 @@ function ContentSummary({
   ) => Promise<void>;
   onScriptClick: (scene: Scene) => void;
 }) {
+  // Entity options = entities that actually appear in this user's content
+  // data (union of scenes + routines entity_ids). Names come from the
+  // /api/entities response; falls back to the id if the entity row was
+  // deleted but content still references it.
+  const entityNameById = new Map(entities.map((e) => [e.id, e.name]));
+  const referencedIds = new Set<string>();
+  for (const s of scenes) referencedIds.add(s.entity_id);
+  for (const r of routines) referencedIds.add(r.entity_id);
+  const entityOptions = Array.from(referencedIds)
+    .map((id) => ({ id, name: entityNameById.get(id) ?? id }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  // Apply filter to all three arrays in one place so child components stay
+  // unaware of the filter.
+  const filteredScenes =
+    entityFilter === 'all' ? scenes : scenes.filter((s) => s.entity_id === entityFilter);
+  const filteredTakes =
+    entityFilter === 'all' ? takes : takes.filter((t) => t.entity_id === entityFilter);
+  const filteredRoutines =
+    entityFilter === 'all'
+      ? routines
+      : routines.filter((r) => r.entity_id === entityFilter);
+
+  const badgeClass =
+    'px-2 py-0.5 text-xs font-mono rounded border border-border-light bg-bg-row text-text-primary';
+
   return (
     <div className="space-y-3">
-      <p className="text-sm text-text-secondary">
-        {scenes.length} scenes · {takes.length} takes · {routines.length} routines
-      </p>
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <span className={badgeClass}>{filteredScenes.length} scenes</span>
+          <span className={badgeClass}>{filteredTakes.length} takes</span>
+          <span className={badgeClass}>{filteredRoutines.length} routines</span>
+        </div>
+        <select
+          value={entityFilter}
+          onChange={(e) => onEntityFilterChange(e.target.value)}
+          className="px-2 py-1 border border-border rounded text-xs font-mono text-text-primary focus:outline-none focus:border-brand-purple"
+          aria-label="Filter by entity"
+        >
+          <option value="all">All entities</option>
+          {entityOptions.map(({ id, name }) => (
+            <option key={id} value={id}>
+              {name}
+            </option>
+          ))}
+        </select>
+      </div>
 
-      {scenes.length === 0 ? (
+      {filteredScenes.length === 0 ? (
         <>
-          <p className="text-sm text-text-secondary">
-            No scenes yet. Pick a routine to start filming.
-          </p>
-          <AvailableRoutinesList routines={routines} onScenify={onScenify} />
+          <div className="flex flex-col items-center justify-center py-8 px-4 border border-border-light rounded bg-bg-row text-center">
+            <div className="text-2xl mb-2" aria-hidden="true">🎬</div>
+            <div className="text-sm font-mono font-semibold text-text-primary">
+              No scenes yet
+            </div>
+            <div className="text-xs font-mono text-text-muted mt-1">
+              Pick a routine below to start filming.
+            </div>
+          </div>
+          <AvailableRoutinesList routines={filteredRoutines} onScenify={onScenify} />
         </>
       ) : (
         <>
           <ContentTable
-            scenes={scenes}
-            takes={takes}
-            routines={routines}
+            scenes={filteredScenes}
+            takes={filteredTakes}
+            routines={filteredRoutines}
             onSceneUpdate={onSceneUpdate}
             onTakeUpdate={onTakeUpdate}
             onScriptClick={onScriptClick}
           />
-          <AvailableRoutinesList routines={routines} onScenify={onScenify} />
+          <AvailableRoutinesList routines={filteredRoutines} onScenify={onScenify} />
         </>
       )}
     </div>


### PR DESCRIPTION
…er, badges)

Final PR in the 4.9.3 series. Visual layer pass on the Content tab — no new data shapes, no new interactions, no API changes.

Polish applied:
- Empty state hero: subtle bordered container with 🎬 icon, 'No scenes yet' heading, and subtext directing to the AvailableRoutinesList below. Operations aesthetic, ~80px tall, not a marketing hero.
- Skeleton loader: new ContentTableSkeleton component replaces the plain 'Loading content...' text. Renders 14-column header
  + 4 placeholder rows with animate-pulse shimmer so the layout doesn't jump when real data arrives. Sets the operations- surface skeleton convention (no precedent existed prior).
- Entity filter dropdown: local React state (not URL param, matching the operations convention — 10 existing select uses across SectionC/D, RoutineList, etc., none URL-backed). Filters scenes/takes/routines together; AvailableRoutinesList receives the pre-filtered routines so its un-scenified list is also scoped. Options derived from the union of scenes and routines entity_ids; entity names looked up from a 4th parallel fetch against the existing /api/entities endpoint. Falls back to the entity_id string if the entity row was deleted but content still references it.
- Count badges: three pill-style spans replace the plain dot- separated count line. Counts reflect the filtered set.

Type files:
- ContentTable.tsx Scene, Take, Routine types gained entity_id: string. DB columns and GET responses already carry these fields; the TS types just hadn't declared them. Type-only change, no runtime impact.

Local-state filter chosen over URL params per codebase consistency — no other operations surface uses URL filters. Cross-cutting URL state can be a future design-system concern.

Twelve PRs in the 4.9.3 series. Content domain is now functionally complete: scenify (4.9.3c), take-ify (4.9.3d), inline cell editing (4.9.3e), script drawer (4.9.3f), polish (this). AI assistance (PR-Ops-4.9.5+) is the next horizon.

Author: Temple Stuart <astuart@templestuart.com>