### PR TITLE
feat(pr-ops-5.1): surface coa_code + actual_cost_usd + actual_minutes…

### DIFF
--- a/src/app/api/operations/projects/[id]/tasks/[taskId]/route.ts
+++ b/src/app/api/operations/projects/[id]/tasks/[taskId]/route.ts
@@ -187,6 +187,88 @@ export async function PATCH(
       }
     }
 
+    if (body.actual_minutes !== undefined) {
+      const v = body.actual_minutes;
+      if (v === null || v === '') {
+        data.actual_minutes = null;
+      } else {
+        const n = Number(v);
+        if (!Number.isFinite(n) || n < 0 || !Number.isInteger(n)) {
+          return NextResponse.json(
+            { error: 'Validation', field: 'actual_minutes', message: 'must be a non-negative integer' },
+            { status: 400 }
+          );
+        }
+        data.actual_minutes = n;
+      }
+    }
+
+    if (body.actual_cost_usd !== undefined) {
+      const v = body.actual_cost_usd;
+      if (v === null || v === '') {
+        data.actual_cost_usd = null;
+      } else if (typeof v === 'string' && v.trim().length > 0) {
+        const n = Number(v);
+        if (!Number.isFinite(n) || n < 0) {
+          return NextResponse.json(
+            { error: 'Validation', field: 'actual_cost_usd', message: 'must be a non-negative number' },
+            { status: 400 }
+          );
+        }
+        data.actual_cost_usd = new Prisma.Decimal(v.trim());
+      } else if (typeof v === 'number') {
+        if (!Number.isFinite(v) || v < 0) {
+          return NextResponse.json(
+            { error: 'Validation', field: 'actual_cost_usd', message: 'must be a non-negative number' },
+            { status: 400 }
+          );
+        }
+        data.actual_cost_usd = new Prisma.Decimal(v);
+      }
+    }
+
+    if (body.coa_code !== undefined) {
+      const c = trimNonEmpty(body.coa_code);
+      if (c === null) {
+        data.coa_code = null;
+      } else {
+        if (c.length > 50) {
+          return NextResponse.json(
+            { error: 'Validation', field: 'coa_code', message: 'max 50 chars' },
+            { status: 400 }
+          );
+        }
+        // Strict existence check against the user's chart_of_accounts for the
+        // task's entity. Uses the @@unique([userId, entity_id, code]) composite
+        // (precedent: src/app/api/trading/commit-to-ledger/route.ts:45).
+        const account = await prisma.chart_of_accounts.findUnique({
+          where: {
+            userId_entity_id_code: {
+              userId: user.id,
+              entity_id: existing.entity_id,
+              code: c,
+            },
+          },
+        });
+        if (!account || account.is_archived) {
+          const available = await prisma.chart_of_accounts.findMany({
+            where: { userId: user.id, entity_id: existing.entity_id, is_archived: false },
+            select: { code: true },
+            orderBy: { code: 'asc' },
+          });
+          return NextResponse.json(
+            {
+              error: 'Validation',
+              field: 'coa_code',
+              message: `Unknown coa_code "${c}" for this entity. Available codes: ${available.map((a) => a.code).join(', ')}`,
+            },
+            { status: 400 }
+          );
+        }
+        data.coa_code = c;
+      }
+    }
+
     if (body.display_order !== undefined) {
       const n = Number(body.display_order);
       if (!Number.isFinite(n)) {

--- a/src/app/api/operations/projects/[id]/tasks/route.ts
+++ b/src/app/api/operations/projects/[id]/tasks/route.ts
@@ -152,6 +152,44 @@ export async function POST(
       estimated_cost_usd = new Prisma.Decimal(body.estimated_cost_usd);
     }
 
+    // coa_code is optional at create; if supplied, must reference an
+    // existing non-archived chart_of_accounts row owned by this user for
+    // the project's entity. Strict-existence mirror of the PATCH check in
+    // src/app/api/operations/projects/[id]/tasks/[taskId]/route.ts.
+    let coa_code: string | null = trimNullable(body.coa_code);
+    if (coa_code !== null) {
+      if (coa_code.length > 50) {
+        return NextResponse.json(
+          { error: 'Validation', field: 'coa_code', message: 'max 50 chars' },
+          { status: 400 }
+        );
+      }
+      const account = await prisma.chart_of_accounts.findUnique({
+        where: {
+          userId_entity_id_code: {
+            userId: user.id,
+            entity_id: project.entity_id,
+            code: coa_code,
+          },
+        },
+      });
+      if (!account || account.is_archived) {
+        const available = await prisma.chart_of_accounts.findMany({
+          where: { userId: user.id, entity_id: project.entity_id, is_archived: false },
+          select: { code: true },
+          orderBy: { code: 'asc' },
+        });
+        return NextResponse.json(
+          {
+            error: 'Validation',
+            field: 'coa_code',
+            message: `Unknown coa_code "${coa_code}" for this entity. Available codes: ${available.map((a) => a.code).join(', ')}`,
+          },
+          { status: 400 }
+        );
+      }
+    }
+
     // α-1: server-computed display_order = max(existing) + 1.
     // Race-acceptance asterisk: two simultaneous POSTs against the same
     // project can read the same max and collide. Acceptable for single-
@@ -176,6 +214,7 @@ export async function POST(
         deadline,
         estimated_minutes,
         estimated_cost_usd,
+        coa_code,
         display_order,
         created_by: userEmail,
       },

--- a/src/components/workbench/operations/projects/TaskList.tsx
+++ b/src/components/workbench/operations/projects/TaskList.tsx
@@ -15,7 +15,7 @@
 
 import { useEffect, useState } from 'react';
 import TaskRow from './TaskRow';
-import type { Task, TaskForm } from './types';
+import type { Task, TaskForm, CoaAccountSummary } from './types';
 import { DEFAULT_TASK_FORM } from './types';
 
 interface Props {
@@ -31,6 +31,13 @@ export default function TaskList({ projectId }: Props) {
   const [createForm, setCreateForm] = useState<TaskForm>(DEFAULT_TASK_FORM);
   const [createSaving, setCreateSaving] = useState(false);
   const [createError, setCreateError] = useState<string | null>(null);
+
+  // COA accounts for the category dropdown — fetched once per (projectId, entity_id).
+  // entity_id is derived from the first loaded task (tasks share the project's
+  // entity_id, denormalized server-side). For empty projects we skip the fetch
+  // entirely — there are no rows to edit so the dropdown isn't needed.
+  const [coaAccounts, setCoaAccounts] = useState<CoaAccountSummary[]>([]);
+  const [coaFetchedForEntityId, setCoaFetchedForEntityId] = useState<string | null>(null);
 
   const fetchTasks = async () => {
     setLoading(true);
@@ -55,6 +62,49 @@ export default function TaskList({ projectId }: Props) {
     fetchTasks();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [projectId]);
+
+  // Lazy COA fetch — runs once per entity_id discovered in this project's tasks.
+  // Failure logs to console and leaves coaAccounts empty; TaskRow handles the
+  // empty-list case gracefully (dropdown shows only "— None —"; expanded body
+  // falls back to displaying the raw code).
+  useEffect(() => {
+    const entityId = tasks[0]?.entity_id;
+    if (!entityId || coaFetchedForEntityId === entityId) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch(`/api/chart-of-accounts?entity_id=${encodeURIComponent(entityId)}`);
+        if (!res.ok) {
+          console.error('[TaskList] COA fetch failed:', res.status);
+          if (!cancelled) {
+            setCoaAccounts([]);
+            setCoaFetchedForEntityId(entityId);
+          }
+          return;
+        }
+        const body = await res.json();
+        if (cancelled) return;
+        type CoaResponseRow = { code: string; name: string; accountType: string; entity_id: string };
+        const list: CoaAccountSummary[] = (body.accounts ?? []).map((a: CoaResponseRow) => ({
+          code: a.code,
+          name: a.name,
+          account_type: a.accountType,
+          entity_id: a.entity_id,
+        }));
+        setCoaAccounts(list);
+        setCoaFetchedForEntityId(entityId);
+      } catch (e) {
+        console.error('[TaskList] COA fetch error:', e);
+        if (!cancelled) {
+          setCoaAccounts([]);
+          setCoaFetchedForEntityId(entityId);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [tasks, coaFetchedForEntityId]);
 
   const startCreate = () => {
     setCreateForm(DEFAULT_TASK_FORM);
@@ -223,6 +273,7 @@ export default function TaskList({ projectId }: Props) {
               task={t}
               projectId={projectId}
               index={i + 1}
+              coaAccounts={coaAccounts}
               onUpdate={fetchTasks}
               onDelete={fetchTasks}
             />

--- a/src/components/workbench/operations/projects/TaskRow.tsx
+++ b/src/components/workbench/operations/projects/TaskRow.tsx
@@ -15,13 +15,14 @@
 
 import { useState } from 'react';
 import { ExternalLink } from 'lucide-react';
-import type { Task, TaskForm, TaskStatus } from './types';
+import type { Task, TaskForm, TaskStatus, CoaAccountSummary } from './types';
 import { TASK_STATUS_LABELS, TASK_STATUS_PILL_CLASSES } from './types';
 
 interface Props {
   task: Task;
   projectId: string;
   index: number; // 1-based display index
+  coaAccounts: CoaAccountSummary[];
   onUpdate: () => void;
   onDelete: () => void;
 }
@@ -54,6 +55,9 @@ function taskToForm(t: Task): TaskForm {
     unblocks_label: t.unblocks_label ?? '',
     link_url: t.link_url ?? '',
     notes: t.notes ?? '',
+    coa_code: t.coa_code ?? '',
+    actual_minutes: t.actual_minutes !== null ? String(t.actual_minutes) : '',
+    actual_cost_usd: t.actual_cost_usd ?? '',
   };
 }
 
@@ -62,7 +66,7 @@ function formatDate(iso: string | null): string {
   return new Date(iso).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
 }
 
-export default function TaskRow({ task, projectId, index, onUpdate, onDelete }: Props) {
+export default function TaskRow({ task, projectId, index, coaAccounts, onUpdate, onDelete }: Props) {
   const [expanded, setExpanded] = useState(false);
   const [notesOpen, setNotesOpen] = useState(false);
   const [editing, setEditing] = useState(false);
@@ -485,6 +489,40 @@ export default function TaskRow({ task, projectId, index, onUpdate, onDelete }: 
               <div className="text-text-primary">{task.estimated_cost_usd ?? '—'}</div>
             </div>
             <div>
+              <div className={labelClass}>category</div>
+              {(() => {
+                if (task.coa_code === null) {
+                  return <div className="text-text-muted">—</div>;
+                }
+                const match = coaAccounts.find((a) => a.code === task.coa_code);
+                if (match) {
+                  return (
+                    <div className="text-text-primary">
+                      <span className="font-mono">{match.code}</span>
+                      <span className="text-text-muted"> · {match.name}</span>
+                    </div>
+                  );
+                }
+                return (
+                  <div
+                    className="text-amber-700 italic"
+                    title="Code not found in current chart of accounts"
+                  >
+                    <span className="font-mono">{task.coa_code}</span>
+                    <span className="ml-1">⚠</span>
+                  </div>
+                );
+              })()}
+            </div>
+            <div>
+              <div className={labelClass}>actual minutes</div>
+              <div className="text-text-primary">{task.actual_minutes ?? '—'}</div>
+            </div>
+            <div>
+              <div className={labelClass}>actual cost (usd)</div>
+              <div className="text-text-primary">{task.actual_cost_usd ?? '—'}</div>
+            </div>
+            <div>
               <div className={labelClass}>completed at</div>
               <div className="text-text-primary">{formatDate(task.completed_at)}</div>
             </div>
@@ -518,8 +556,8 @@ export default function TaskRow({ task, projectId, index, onUpdate, onDelete }: 
             </div>
           )}
 
-          <div className="grid grid-cols-2 gap-3">
-            <div className="col-span-2">
+          <div className="grid grid-cols-3 gap-3">
+            <div className="col-span-3">
               <div className={labelClass}>title</div>
               <input
                 type="text"
@@ -551,6 +589,27 @@ export default function TaskRow({ task, projectId, index, onUpdate, onDelete }: 
                 onChange={(e) => setForm({ ...form, deadline: e.target.value })}
                 className={inputClass}
               />
+            </div>
+            <div>
+              <div className={labelClass}>category</div>
+              <select
+                value={form.coa_code}
+                onChange={(e) => setForm({ ...form, coa_code: e.target.value })}
+                className={inputClass}
+              >
+                <option value="">— None —</option>
+                {/* If the task's current code isn't in the dropdown options
+                    (e.g., archived or out-of-entity), still surface it so the
+                    user isn't silently re-categorized when they save. */}
+                {form.coa_code !== '' && !coaAccounts.some((a) => a.code === form.coa_code) && (
+                  <option value={form.coa_code}>{form.coa_code} ⚠ (not in current COA)</option>
+                )}
+                {coaAccounts.map((a) => (
+                  <option key={a.code} value={a.code}>
+                    {a.code} · {a.name}
+                  </option>
+                ))}
+              </select>
             </div>
           </div>
 
@@ -588,6 +647,18 @@ export default function TaskRow({ task, projectId, index, onUpdate, onDelete }: 
               />
             </div>
             <div>
+              <div className={labelClass}>actual minutes</div>
+              <input
+                type="number"
+                min={0}
+                step={1}
+                value={form.actual_minutes}
+                onChange={(e) => setForm({ ...form, actual_minutes: e.target.value })}
+                className={inputClass}
+                placeholder="(empty)"
+              />
+            </div>
+            <div>
               <div className={labelClass}>est. cost (usd)</div>
               <input
                 type="text"
@@ -595,6 +666,18 @@ export default function TaskRow({ task, projectId, index, onUpdate, onDelete }: 
                 onChange={(e) => setForm({ ...form, estimated_cost_usd: e.target.value })}
                 className={inputClass}
                 placeholder="0.00"
+              />
+            </div>
+            <div>
+              <div className={labelClass}>actual cost (usd)</div>
+              <input
+                type="number"
+                min={0}
+                step={0.01}
+                value={form.actual_cost_usd}
+                onChange={(e) => setForm({ ...form, actual_cost_usd: e.target.value })}
+                className={inputClass}
+                placeholder="(empty)"
               />
             </div>
           </div>

--- a/src/components/workbench/operations/projects/types.ts
+++ b/src/components/workbench/operations/projects/types.ts
@@ -132,6 +132,9 @@ export interface Task {
   unblocks_label: string | null;
   link_url: string | null;
   notes: string | null;
+  coa_code: string | null;
+  actual_cost_usd: string | null;
+  actual_minutes: number | null;
   display_order: number;
   completed_at: string | null;
   created_at: string;
@@ -155,6 +158,9 @@ export interface TaskForm {
   unblocks_label: string;
   link_url?: string;
   notes?: string;
+  coa_code: string;                 // '' represents null
+  actual_minutes: string;           // '' represents null; string for input binding
+  actual_cost_usd: string;          // '' represents null; string for decimal fidelity
 }
 
 export const DEFAULT_TASK_FORM: TaskForm = {
@@ -165,7 +171,22 @@ export const DEFAULT_TASK_FORM: TaskForm = {
   estimated_cost_usd: '',
   deadline: '',
   unblocks_label: '',
+  coa_code: '',
+  actual_minutes: '',
+  actual_cost_usd: '',
 };
+
+/**
+ * Minimal COA-account shape used by the task UI's category dropdown.
+ * Sourced from GET /api/chart-of-accounts?entity_id=<eid>. The /api endpoint
+ * filters out archived rows server-side, so consumers can trust the list.
+ */
+export interface CoaAccountSummary {
+  code: string;
+  name: string;
+  account_type: string;
+  entity_id: string;
+}
 
 export const TASK_STATUS_LABELS: Record<TaskStatus, string> = {
   open: 'new',


### PR DESCRIPTION
… on tasks

Phase 2 of PR-Ops-5.1 — closes the gaps audited in commits b33242d and a67a97c on the audit branch. No schema migration (those three columns shipped in PR-Ops-4.0 migration 20260516000000); this PR closes the matching API + UI gaps in one atomic concept.

API: PATCH allow-list (tasks/[taskId]/route.ts)
- coa_code (nullable string, max 50): trims, treats '' as null, then validates via prisma.chart_of_accounts.findUnique on the composite unique [userId, entity_id, code] (precedent: trading/commit-to- ledger/route.ts:45-51). On unknown code returns 400 with the list of available codes for that entity, so the client surfaces a useful error inline rather than a generic 'invalid'.
- actual_minutes (nullable non-negative integer)
- actual_cost_usd (nullable non-negative Decimal — string or number)
- All three flow through to the existing audit payload (`before`/ `after` diff already includes the full task row), so changes appear in the task-history audit trail without extra plumbing.

API: POST allow-list (tasks/route.ts)
- coa_code added with the same strict existence check against the parent project's entity_id. actual_* deliberately omitted from POST — those are populated post-execution, not at creation.

Types (projects/types.ts)
- Task gains coa_code, actual_cost_usd, actual_minutes
- TaskForm gains coa_code, actual_minutes, actual_cost_usd as strings ('' represents null)
- DEFAULT_TASK_FORM seeds them as ''
- New CoaAccountSummary interface for the dropdown population

TaskList
- Fetches /api/chart-of-accounts?entity_id=<eid> lazily, gated on tasks[0]?.entity_id (tasks share the project's entity_id, so the first task is sufficient). Cached per entity_id; one fetch per mount. Empty projects skip the fetch entirely — they have no edit forms to populate.
- Failure path logs to console and leaves the list empty; TaskRow handles the empty-list case (dropdown shows only "— None —"; expanded body falls back to raw code with a warning icon).
- Passes coaAccounts to every TaskRow.

TaskRow
- Expanded body grid extends from 3 cells to 6: est. minutes / est. cost / category | actual minutes / actual cost / completed at
- Category cell looks up the task's coa_code in coaAccounts: found → '<code> · <name>', not found → '<code> ⚠' italic amber with tooltip "Code not found in current chart of accounts"
- Edit form: header row grows from 2 cols (status / deadline) to 3 cols with category dropdown next to deadline. Estimates row grows from 2 cols to 4 cells: est min / actual min / est cost / actual cost.
- Category dropdown defensively includes the task's current coa_code as a "(not in current COA)" option when the code isn't in the fetched list — prevents silent re-categorization on save.
- handleSave sends the form directly (existing convention); the server PATCH handler already coerces '' to null for all three new fields per the same per-field pattern used for estimated_*.

Known limitations / followups:
- No shared <COASelect> component extracted (4 callsites still inline <select>) — future cleanup PR.
- No inline EditableCell on TaskRow — future dedicated PR.
- Bulk-create route (tasks/bulk-create/route.ts) does not yet accept coa_code — out of scope for 5.1.
- npm run lint is broken at the toolchain level (deprecated `next lint` with removed ESLint options) — pre-existing, not introduced by this PR.

Author: Temple Stuart <astuart@templestuart.com>