### PR TITLE
feat(pr-ops-5.1.6): add coa_code dropdown to task create form (parity…

### DIFF
--- a/src/components/workbench/operations/projects/TaskList.tsx
+++ b/src/components/workbench/operations/projects/TaskList.tsx
@@ -207,7 +207,7 @@ export default function TaskList({ projectId }: Props) {
               placeholder="what does completing this unblock?"
             />
           </div>
-          <div className="grid grid-cols-3 gap-3">
+          <div className="grid grid-cols-4 gap-3">
             <div>
               <div className={labelClass}>deadline (optional)</div>
               <input
@@ -236,6 +236,21 @@ export default function TaskList({ projectId }: Props) {
                 className={inputClass}
                 placeholder="0.00"
               />
+            </div>
+            <div>
+              <div className={labelClass}>category (optional)</div>
+              <select
+                value={createForm.coa_code}
+                onChange={(e) => setCreateForm({ ...createForm, coa_code: e.target.value })}
+                className={inputClass}
+              >
+                <option value="">— None —</option>
+                {coaAccounts.map((a) => (
+                  <option key={a.code} value={a.code}>
+                    {a.code} · {a.name}
+                  </option>
+                ))}
+              </select>
             </div>
           </div>
           <div className="flex items-center gap-2 pt-2 border-t border-border-light">


### PR DESCRIPTION
… with edit)

PR-Ops-5.1 added coa_code to PATCH/POST allow-lists and to TaskRow's edit form, but missed the task CREATE form in TaskList. This PR closes the gap so users can categorize at creation rather than create-then-immediately-edit.

Single-line semantic change in TaskList.tsx — grid-cols-3 → grid-cols-4 with a new "category (optional)" <select> cell populated from the existing coaAccounts state (already fetched by the PR-Ops-5.1 useEffect; no new fetch, no prop threading required).

DEFAULT_TASK_FORM already seeds coa_code: '' (added in PR-Ops-5.1 types.ts), so cancelCreate and the post-submit reset paths work without changes. handleCreate sends JSON.stringify(createForm) unchanged; the server-side POST handler's trimNullable(body.coa_code) treats '' as null, matching the convention used for description and unblocks_label.

Known limitation flagged but not addressed here: the coaAccounts fetch is gated on tasks[0]?.entity_id (PR-Ops-5.1 design), so a brand-new project with zero existing tasks shows only "— None —" in the dropdown when creating the first task. The user creates uncategorized, then edits to assign. Subsequent task creates work normally. The fix is threading entity_id from ProjectRow → TaskList as a prop; deferred to a separate PR to keep this one minimal.

actual_cost_usd and actual_minutes are deliberately NOT added to the create form — they're populated post-execution, not at creation.

Author: Temple Stuart <astuart@templestuart.com>