### PR TITLE
fix(pr-ops-5.1.7): thread entity_id prop to TaskList for immediate CO…

### DIFF
--- a/src/components/workbench/operations/projects/ProjectRow.tsx
+++ b/src/components/workbench/operations/projects/ProjectRow.tsx
@@ -381,7 +381,7 @@ export default function ProjectRow({ project, entities, allProjects, onUpdate, o
           </div>
           <div className="pt-2 border-t border-border-light">
             <div className={labelClass}>5 · execute (tasks)</div>
-            <TaskList projectId={project.id} />
+            <TaskList projectId={project.id} entity_id={project.entity_id} />
           </div>
           <div className="pt-2 border-t border-border-light">
             <div className={labelClass}>6 · dependencies</div>

--- a/src/components/workbench/operations/projects/TaskList.tsx
+++ b/src/components/workbench/operations/projects/TaskList.tsx
@@ -3,8 +3,8 @@
  *
  * Self-fetches via GET /api/operations/projects/[projectId]/tasks on mount
  * and on any onUpdate/onDelete callback from a TaskRow. Self-contained:
- * the parent ProjectRow just renders <TaskList projectId={...} /> and never
- * needs to know about task state.
+ * the parent ProjectRow just renders <TaskList projectId={...} entity_id={...} />
+ * and never needs to know about task state.
  *
  * "+ add task" affordance toggles an inline create form ABOVE the task list.
  * Bridgewater step-5 framing: this is the execute layer; the project's
@@ -20,9 +20,10 @@ import { DEFAULT_TASK_FORM } from './types';
 
 interface Props {
   projectId: string;
+  entity_id: string;
 }
 
-export default function TaskList({ projectId }: Props) {
+export default function TaskList({ projectId, entity_id }: Props) {
   const [tasks, setTasks] = useState<Task[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -32,10 +33,10 @@ export default function TaskList({ projectId }: Props) {
   const [createSaving, setCreateSaving] = useState(false);
   const [createError, setCreateError] = useState<string | null>(null);
 
-  // COA accounts for the category dropdown — fetched once per (projectId, entity_id).
-  // entity_id is derived from the first loaded task (tasks share the project's
-  // entity_id, denormalized server-side). For empty projects we skip the fetch
-  // entirely — there are no rows to edit so the dropdown isn't needed.
+  // COA accounts for the category dropdown — fetched once per entity_id.
+  // entity_id is sourced from the project (via prop), not derived from the
+  // first existing task, so brand-new projects with zero tasks can still
+  // populate the dropdown on the very first task's create form.
   const [coaAccounts, setCoaAccounts] = useState<CoaAccountSummary[]>([]);
   const [coaFetchedForEntityId, setCoaFetchedForEntityId] = useState<string | null>(null);
 
@@ -63,22 +64,30 @@ export default function TaskList({ projectId }: Props) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [projectId]);
 
-  // Lazy COA fetch — runs once per entity_id discovered in this project's tasks.
-  // Failure logs to console and leaves coaAccounts empty; TaskRow handles the
-  // empty-list case gracefully (dropdown shows only "— None —"; expanded body
-  // falls back to displaying the raw code).
+  // Eager COA fetch — fires on mount as soon as entity_id is known, so
+  // even brand-new projects with zero tasks have the dropdown populated
+  // when the user opens the create form. Failure logs to console and
+  // leaves coaAccounts empty; TaskRow/create-form both handle the empty
+  // list gracefully (dropdown shows only "— None —"; expanded body falls
+  // back to displaying the raw code).
   useEffect(() => {
-    const entityId = tasks[0]?.entity_id;
-    if (!entityId || coaFetchedForEntityId === entityId) return;
+    if (!entity_id) {
+      // Defensive: should never happen — every project has an entity_id —
+      // but if it does, skip the fetch rather than crash. Dropdown falls
+      // back to "— None —" only, preserving the prior empty-list behavior.
+      console.warn('[TaskList] missing entity_id prop; skipping COA fetch');
+      return;
+    }
+    if (coaFetchedForEntityId === entity_id) return;
     let cancelled = false;
     (async () => {
       try {
-        const res = await fetch(`/api/chart-of-accounts?entity_id=${encodeURIComponent(entityId)}`);
+        const res = await fetch(`/api/chart-of-accounts?entity_id=${encodeURIComponent(entity_id)}`);
         if (!res.ok) {
           console.error('[TaskList] COA fetch failed:', res.status);
           if (!cancelled) {
             setCoaAccounts([]);
-            setCoaFetchedForEntityId(entityId);
+            setCoaFetchedForEntityId(entity_id);
           }
           return;
         }
@@ -92,19 +101,19 @@ export default function TaskList({ projectId }: Props) {
           entity_id: a.entity_id,
         }));
         setCoaAccounts(list);
-        setCoaFetchedForEntityId(entityId);
+        setCoaFetchedForEntityId(entity_id);
       } catch (e) {
         console.error('[TaskList] COA fetch error:', e);
         if (!cancelled) {
           setCoaAccounts([]);
-          setCoaFetchedForEntityId(entityId);
+          setCoaFetchedForEntityId(entity_id);
         }
       }
     })();
     return () => {
       cancelled = true;
     };
-  }, [tasks, coaFetchedForEntityId]);
+  }, [entity_id, coaFetchedForEntityId]);
 
   const startCreate = () => {
     setCreateForm(DEFAULT_TASK_FORM);


### PR DESCRIPTION
…A fetch on new projects

Closes the Truth-First limitation flagged in PR-Ops-5.1.6: brand-new projects with zero existing tasks couldn't populate the category dropdown because the COA fetch was gated on tasks[0]?.entity_id — no first task meant no entity_id meant no fetch. First task of any project was forced to be uncategorized at creation.

Fix: source entity_id from the project itself (always present at project creation) instead of deriving it from existing tasks.

TaskList.tsx
- Adds entity_id: string as a required Props field
- Removes the tasks[0]?.entity_id derivation
- COA useEffect now depends on [entity_id, coaFetchedForEntityId] and fires as soon as entity_id is known (i.e., on mount)
- Defensive: empty entity_id (shouldn't happen — every project has one) logs a console.warn and skips the fetch rather than crashing; dropdown falls back to "— None —" only

ProjectRow.tsx
- Passes entity_id={project.entity_id} to <TaskList /> (single callsite; project.entity_id is already in scope and used elsewhere in the row for entity-name display)

Verification:
- npx tsc --noEmit exit 0; the new required prop is the safety net that catches any missed callsite (only one exists)
- Mental flow: brand-new project → TaskList mounts with entity_id → COA fetch fires immediately → "+ add task" → category dropdown populated → first task can be created with category assigned

Note on sequencing: PR-Ops-5.1.6 (commit 11ee207) is currently on its branch unmerged; 5.1.6 and this PR (5.1.7) touch orthogonal sections of TaskList (5.1.6 = create-form grid; 5.1.7 = COA-fetch useEffect + Props). No line-level conflict. Both PRs can merge independently in any order.

Author: Temple Stuart <astuart@templestuart.com>