### PR TITLE
fix(pr-ops-5.1.5): restore lint harness (next lint -> eslint .), docu…

### DIFF
--- a/LINT-BACKLOG.md
+++ b/LINT-BACKLOG.md
@@ -1,0 +1,32 @@
+# Lint Backlog (as of PR-Ops-5.1.5)
+
+The lint harness was fixed in PR-Ops-5.1.5 (was previously broken — `next lint` exited before linting). On restoration, `eslint .` surfaces 1028 pre-existing problems across 242 files. These are documented here and scheduled for cleanup in dedicated themed PRs.
+
+## Current counts (run `npm run lint` for live numbers)
+- 694 errors + 334 warnings = 1028 total
+- 0 auto-fixable (every fix requires human judgment)
+
+## Top rules
+- 551× @typescript-eslint/no-explicit-any
+- 282× @typescript-eslint/no-unused-vars
+- 85× react/no-unescaped-entities
+- 37× react-hooks/exhaustive-deps
+- 14× next/next
+- 12× next/image
+- 10× @typescript-eslint/no-require-imports
+- 3× import/no-anonymous-default-export
+- 2× next/link
+
+## Cleanup plan (themed PRs, run in parallel with Phase 1 features)
+- PR-Ops-5.1.5.1 — no-unused-vars (282, mechanical, low risk)
+- PR-Ops-5.1.5.2 — no-explicit-any in API handlers (highest-value subset)
+- PR-Ops-5.1.5.3 — react-hooks/exhaustive-deps (37, each a potential runtime bug)
+- PR-Ops-5.1.5.4 — react/no-unescaped-entities (85, mechanical JSX)
+- PR-Ops-5.1.5.5 — no-explicit-any in components (remaining)
+- PR-Ops-5.1.5.6 — misc (next/image, next/link, require-imports, anonymous-default)
+
+## Verification discipline until backlog cleared
+Every feature PR: run `npm run lint`, confirm the files YOU touched introduce no NEW errors. The repo-wide count should trend DOWN, never up. New code ships lint-clean.
+
+## End state
+When the backlog hits zero, flip CI to `npm run lint:strict` (--max-warnings 0) as a hard gate.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev:inngest": "npx inngest-cli@latest dev -u http://localhost:3000/api/inngest",
     "build": "prisma generate && prisma migrate deploy && next build",
     "start": "next start",
-    "lint": "next lint",
+    "lint": "eslint .",
+    "lint:strict": "eslint . --max-warnings 0",
     "postinstall": "prisma generate",
     "tax:export:2025": "tsx scripts/tax-export-2025.ts",
     "seed:regulatory": "tsx src/lib/regulatory/seedRegulatorySources.ts"


### PR DESCRIPTION
…ment 1028-problem backlog

The lint harness had been silently broken since Next 15: `next lint` ships in 15.5.9 but its shim passes legacy ESLint-8-CLIEngine options (useEslintrc, extensions, resolvePluginsRelativeTo, rulePaths, ignorePath, reportUnusedDisableDirectives) that modern ESLint's options-validator rejects. Result: `npm run lint` exited 1 before linting a single file. Every PR since 5.1 had been verified on `tsc --noEmit` only, missing real lint coverage.

Fix (Phase 1 audit commit 75a1288 chose Path A):
- package.json:10 — change "lint": "next lint" to "lint": "eslint ."
- package.json — add "lint:strict": "eslint . --max-warnings 0" as the eventual zero-tolerance gate, ready to flip on once the backlog is cleared.

The eslint.config.mjs flat config was already correctly in place (uses FlatCompat to extend next/core-web-vitals + next/typescript); no config changes needed. eslint-config-next 15.5.2 + eslint 8.57.1 already installed.

Backlog visible after restoration: 1028 problems (694 errors + 334 warnings) across 242 of 596 .ts/.tsx files. Zero auto-fixable (verified via --fix-dry-run). Documented in LINT-BACKLOG.md with top-rule frequencies and a themed cleanup plan (5.1.5.1 through 5.1.5.6, grouped by rule).

Institutional stance: the harness reports the truth. No --max-warnings 99999 to hide the backlog; the 1028-problem count is honestly surfaced on every run. Each subsequent feature PR adopts a "no new lint problems in touched files" discipline. The repo-wide count should trend down, never up.

Out of scope (deliberately not touched):
- Any of the 1028 backlog problems (themed cleanup PRs)
- eslint.config.mjs (already correct)
- next.config.ts (build-lint separation by ignoreDuringBuilds is fine)
- Any .ts/.tsx source file

Author: Temple Stuart <astuart@templestuart.com>