### PR TITLE
feat(pr-ops-5.2): inline + schedule block form in DailyPlanItemRow wi…

### DIFF
--- a/src/components/workbench/operations/dailyplan/DailyPlanItemRow.tsx
+++ b/src/components/workbench/operations/dailyplan/DailyPlanItemRow.tsx
@@ -2,10 +2,16 @@
  * DailyPlanItemRow — one operations_daily_plan_items row on the Daily Plan page.
  *
  * Task-linked items render the linked task's title + status pill; ad-hoc items
- * render ad_hoc_title/description. calendar_blocks are listed read-only beneath
- * (block creation/editing is PR-Ops-4.5). Inline edit covers notes +
- * display_order for all items, plus ad_hoc_title/description for ad-hoc items
- * (task_id / entity_id / plan_date are immutable per the PR-Ops-4.1 endpoint).
+ * render ad_hoc_title/description. calendar_blocks are listed read-only beneath,
+ * with an inline "+ schedule block" affordance (PR-Ops-5.2) that POSTs to
+ * /api/operations/daily-plan/items/[itemId]/blocks. Server-side conflict
+ * detection returns 409 with conflicting_block_ids; the form stays open,
+ * surfaces the conflict inline, and offers a "schedule anyway" toggle that
+ * resubmits with allow_conflicts:true.
+ *
+ * Inline edit covers notes + display_order for all items, plus ad_hoc_title/
+ * description for ad-hoc items (task_id / entity_id / plan_date are immutable
+ * per the PR-Ops-4.1 endpoint).
  */
 
 'use client';
@@ -26,6 +32,34 @@ function formatTime(iso: string): string {
   return new Date(iso).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', hour12: false });
 }
 
+/**
+ * Convert a Date to the value format expected by <input type="datetime-local">:
+ * "YYYY-MM-DDTHH:mm" in the user's LOCAL timezone (no Z suffix).
+ */
+function toDatetimeLocal(d: Date): string {
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+/**
+ * Default block window for a new "+ schedule block" form:
+ *   - start = the latest existing block's scheduled_end if any, else plan_date at 09:00 local
+ *   - end   = start + 60 minutes (no estimated_minutes available on the linked task summary;
+ *             a per-task default would need a new fetch — out of scope per PR-Ops-5.2)
+ */
+function defaultBlockWindow(item: DailyPlanItem): { start: Date; end: Date } {
+  let start: Date;
+  if (item.calendar_blocks.length > 0) {
+    const lastEnd = item.calendar_blocks[item.calendar_blocks.length - 1].scheduled_end;
+    start = new Date(lastEnd);
+  } else {
+    const datePart = item.plan_date.slice(0, 10); // YYYY-MM-DD
+    start = new Date(`${datePart}T09:00`);
+  }
+  const end = new Date(start.getTime() + 60 * 60 * 1000);
+  return { start, end };
+}
+
 export default function DailyPlanItemRow({ item, onUpdate, onDelete }: Props) {
   const isAdHoc = !item.task;
 
@@ -39,6 +73,101 @@ export default function DailyPlanItemRow({ item, onUpdate, onDelete }: Props) {
   const [saving, setSaving] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  // "+ schedule block" inline form state (PR-Ops-5.2). Separate from the
+  // item-level error/saving state so block-form errors never bleed into
+  // item-level errors and vice versa.
+  const [showBlockForm, setShowBlockForm] = useState(false);
+  const [blockStart, setBlockStart] = useState('');
+  const [blockEnd, setBlockEnd] = useState('');
+  const [blockNotes, setBlockNotes] = useState('');
+  const [blockSaving, setBlockSaving] = useState(false);
+  const [blockError, setBlockError] = useState<string | null>(null);
+  const [blockAllowConflicts, setBlockAllowConflicts] = useState(false);
+  const [blockConflictDetected, setBlockConflictDetected] = useState(false);
+
+  const openBlockForm = () => {
+    const { start, end } = defaultBlockWindow(item);
+    setBlockStart(toDatetimeLocal(start));
+    setBlockEnd(toDatetimeLocal(end));
+    setBlockNotes('');
+    setBlockError(null);
+    setBlockAllowConflicts(false);
+    setBlockConflictDetected(false);
+    setShowBlockForm(true);
+  };
+
+  const closeBlockForm = () => {
+    setShowBlockForm(false);
+    setBlockStart('');
+    setBlockEnd('');
+    setBlockNotes('');
+    setBlockError(null);
+    setBlockAllowConflicts(false);
+    setBlockConflictDetected(false);
+  };
+
+  const handleScheduleBlock = async () => {
+    if (blockSaving) return;
+
+    // Client-side guards — the server validates authoritatively regardless,
+    // but these prevent obviously-invalid POSTs from firing.
+    if (!blockStart || !blockEnd) {
+      setBlockError('Start and end are both required');
+      return;
+    }
+    const startDate = new Date(blockStart);
+    const endDate = new Date(blockEnd);
+    if (Number.isNaN(startDate.getTime()) || Number.isNaN(endDate.getTime())) {
+      setBlockError('Invalid date/time');
+      return;
+    }
+    if (endDate.getTime() <= startDate.getTime()) {
+      setBlockError('End must be after start');
+      return;
+    }
+
+    setBlockSaving(true);
+    setBlockError(null);
+    try {
+      const notesTrimmed = blockNotes.trim();
+      const body: Record<string, unknown> = {
+        scheduled_start: startDate.toISOString(),
+        scheduled_end: endDate.toISOString(),
+      };
+      if (notesTrimmed.length > 0) body.notes = notesTrimmed;
+      if (blockAllowConflicts) body.allow_conflicts = true;
+
+      const res = await fetch(`/api/operations/daily-plan/items/${item.id}/blocks`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+
+      if (res.status === 409) {
+        // Conflict — keep the form open, surface the conflict inline, reveal
+        // the "schedule anyway" toggle so the user can override deliberately.
+        setBlockConflictDetected(true);
+        setBlockError('This overlaps an existing block. Adjust the time, or schedule anyway.');
+        return;
+      }
+
+      const resBody = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setBlockError(resBody?.message ?? resBody?.error ?? `failed to schedule block (${res.status})`);
+        return;
+      }
+
+      // 201 — block created. Refresh the items list so the new block shows
+      // up in the read-only display via the server's nested include.
+      closeBlockForm();
+      onUpdate();
+    } catch (e) {
+      setBlockError(e instanceof Error ? e.message : 'failed to schedule block');
+    } finally {
+      setBlockSaving(false);
+    }
+  };
 
   const enterEdit = () => {
     setForm({
@@ -160,6 +289,94 @@ export default function DailyPlanItemRow({ item, onUpdate, onDelete }: Props) {
               {formatTime(b.scheduled_start)}–{formatTime(b.scheduled_end)} · {b.status}
             </div>
           ))}
+        </div>
+      )}
+
+      {!showBlockForm && !editing && (
+        <button
+          type="button"
+          onClick={openBlockForm}
+          className="px-2 py-0.5 border border-border text-text-muted rounded hover:bg-bg-row text-xs font-mono"
+        >
+          + schedule block
+        </button>
+      )}
+
+      {showBlockForm && (
+        <div
+          className="mt-1 p-2 border border-border-light rounded bg-bg-row text-xs font-mono space-y-2"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <div className="flex items-center gap-2 flex-wrap">
+            <label className="flex items-center gap-1">
+              <span className="text-text-muted">start</span>
+              <input
+                type="datetime-local"
+                value={blockStart}
+                onChange={(e) => setBlockStart(e.target.value)}
+                disabled={blockSaving}
+                className="px-2 py-0.5 border border-border rounded text-text-primary disabled:opacity-50"
+              />
+            </label>
+            <label className="flex items-center gap-1">
+              <span className="text-text-muted">end</span>
+              <input
+                type="datetime-local"
+                value={blockEnd}
+                onChange={(e) => setBlockEnd(e.target.value)}
+                disabled={blockSaving}
+                className="px-2 py-0.5 border border-border rounded text-text-primary disabled:opacity-50"
+              />
+            </label>
+            <label className="flex items-center gap-1 flex-1 min-w-[160px]">
+              <span className="text-text-muted">notes</span>
+              <input
+                type="text"
+                value={blockNotes}
+                onChange={(e) => setBlockNotes(e.target.value)}
+                disabled={blockSaving}
+                placeholder="(optional)"
+                className="flex-1 px-2 py-0.5 border border-border rounded text-text-primary disabled:opacity-50"
+              />
+            </label>
+          </div>
+
+          {blockConflictDetected && (
+            <label className="flex items-center gap-2 text-text-muted">
+              <input
+                type="checkbox"
+                checked={blockAllowConflicts}
+                onChange={(e) => setBlockAllowConflicts(e.target.checked)}
+                disabled={blockSaving}
+              />
+              <span>schedule anyway (overlaps an existing block)</span>
+            </label>
+          )}
+
+          {blockError && (
+            <div className="px-3 py-2 rounded border bg-red-50 border-red-200 text-red-800">
+              {blockError}
+            </div>
+          )}
+
+          <div className="flex items-center gap-2 pt-1 border-t border-border-light">
+            <button
+              type="button"
+              onClick={handleScheduleBlock}
+              disabled={blockSaving || !blockStart || !blockEnd}
+              className="px-3 py-0.5 border border-brand-purple bg-brand-purple text-white rounded hover:opacity-90 disabled:opacity-50"
+            >
+              {blockSaving ? 'scheduling…' : 'schedule'}
+            </button>
+            <button
+              type="button"
+              onClick={closeBlockForm}
+              disabled={blockSaving}
+              className="px-3 py-0.5 border border-border text-text-muted rounded hover:bg-white disabled:opacity-50"
+            >
+              cancel
+            </button>
+          </div>
         </div>
       )}
 


### PR DESCRIPTION
…th 409 conflict handling

Adds the missing UI surface for creating calendar blocks on a daily plan item. Backend was fully built (POST /api/operations/daily-plan/ items/[itemId]/blocks shipped pre-5.x with conflict detection, audit trail, and ownership scoping); only the frontend was missing per the PR-Ops-5.2 Phase 1 audit (commit e324d00).

Placement (E1 per Phase 1 recommendation):
- "+ schedule block" button below the existing read-only block list in DailyPlanItemRow. Daily Plan tab is the canonical time-scheduling surface; item already in scope means single API call, no orphan-item risk, no new endpoint or filter expansion.

Form fields:
- start (datetime-local, defaults to latest existing block.scheduled_end if any, else plan_date at 09:00 local)
- end (datetime-local, defaults to start + 60 min)
- notes (text, optional, trimmed)

Duration default = 60 min, deliberate per audit: LinkedTaskSummary (dailyplan/types.ts:13-17) carries only id/title/status — not estimated_minutes — and the spec explicitly prohibits a new fetch just for that. Future PR can lift estimated_minutes into the items GET include if a smarter default proves worthwhile.

Timezone handling: datetime-local emits local-timezone "YYYY-MM-DDTHH:mm" without TZ suffix. Client converts via new Date(local).toISOString() before POST, so server (which uses new Date(v) internally) receives unambiguous UTC. Server stores in timestamptz; read-back via existing formatTime helper renders in local TZ.

Conflict handling (409, conflicting_block_ids surfaced):
- Form stays open (no toast — matches the 4.9.3 inline-error convention)
- Inline error: "This overlaps an existing block. Adjust the time, or schedule anyway."
- "schedule anyway" checkbox revealed (allow_conflicts:true on resubmit)
- User can either edit start/end + resubmit, or toggle the checkbox and resubmit. The checkbox state stays sticky until the form is cancelled — deliberate, lets the user override on purpose.

Refetch mechanism: existing onUpdate callback (= fetchItems from SectionC_DailyPlan :64-80, wired at :347). On 201 the block appears via the GET items include (calendar_blocks ordered by scheduled_start). No optimistic state needed; refetch is the single source of truth.

State isolation: a separate blockError state keeps block-form errors from bleeding into item-level (save/delete) errors and vice versa.

Out of scope (deferred):
- Block PATCH/DELETE (this PR is creation only)
- E2 task-list scheduling shortcut on TaskRow (would need ?task_id= GET filter or new endpoint — separate PR)
- estimated_minutes-aware default duration (would need GET include expansion)

Verification:
- npx tsc --noEmit exit 0
- npx eslint <touched file> exit 0 — zero new lint errors introduced (LINT-BACKLOG.md discipline maintained)

Author: Temple Stuart <astuart@templestuart.com>