### PR TITLE
feat(pr-ops-5.3): wire Operations calendar blocks into Hub with cost/…

### DIFF
--- a/src/app/api/operations/daily-plan/items/route.ts
+++ b/src/app/api/operations/daily-plan/items/route.ts
@@ -91,7 +91,16 @@ export async function GET(request: NextRequest) {
       where: { user_id: user.id, plan_date: { gte: from, lte: to } },
       include: {
         calendar_blocks: { orderBy: { scheduled_start: 'asc' } },
-        task: { select: { id: true, title: true, status: true } },
+        task: {
+          select: {
+            id: true,
+            title: true,
+            status: true,
+            coa_code: true,
+            estimated_cost_usd: true,
+            actual_cost_usd: true,
+          },
+        },
       },
       orderBy: [{ plan_date: 'asc' }, { display_order: 'asc' }],
     });

--- a/src/app/hub/page.tsx
+++ b/src/app/hub/page.tsx
@@ -6,6 +6,8 @@ import { useSession } from 'next-auth/react';
 import { AppLayout, Card, Badge } from '@/components/ui';
 import BudgetDrillDown from '@/components/hub/BudgetDrillDown';
 import CalendarGrid, { CalendarEvent as GridEvent, SourceConfig } from '@/components/shared/CalendarGrid';
+import { mapOperationsBlocks } from '@/lib/hub/mapOperationsBlocks';
+import type { DailyPlanItem } from '@/components/workbench/operations/dailyplan/types';
 
 import dynamic from 'next/dynamic';
 
@@ -52,6 +54,9 @@ const SOURCE_CONFIG: Record<string, { icon: string; color: string; bgColor: stri
   health: { icon: '💪', color: 'text-emerald-600', bgColor: 'bg-emerald-50', dotColor: 'bg-emerald-500', calendarColor: 'bg-emerald-400' },
   growth: { icon: '📚', color: 'text-brand-purple', bgColor: 'bg-brand-purple-wash', dotColor: 'bg-brand-purple-wash0', calendarColor: 'bg-blue-400' },
   trip: { icon: '✈️', color: 'text-cyan-600', bgColor: 'bg-cyan-50', dotColor: 'bg-cyan-500', calendarColor: 'bg-cyan-400' },
+  // Operations (PR-Ops-5.3) — task time-blocks scheduled via the workbench.
+  // Indigo distinguishes from health (emerald), growth (brand-purple/blue), and trip (cyan).
+  operations: { icon: '🎯', color: 'text-indigo-600', bgColor: 'bg-indigo-50', dotColor: 'bg-indigo-500', calendarColor: 'bg-indigo-400' },
 };
 
 // CalendarGrid-compatible config derived from SOURCE_CONFIG
@@ -117,13 +122,19 @@ export default function HubPage() {
     actualGrandTotal: number;
   }>({ budgetData: {}, actualData: {}, coaNames: {}, budgetGrandTotal: 0, actualGrandTotal: 0 });
 
-  const [businessBudget, setBusinessBudget] = useState<{ 
-    budgetData: Record<string, Record<number, number>>; 
+  const [businessBudget, setBusinessBudget] = useState<{
+    budgetData: Record<string, Record<number, number>>;
     actualData: Record<string, Record<number, number>>;
-    coaNames: Record<string, string>; 
+    coaNames: Record<string, string>;
     budgetGrandTotal: number;
     actualGrandTotal: number;
   }>({ budgetData: {}, actualData: {}, coaNames: {}, budgetGrandTotal: 0, actualGrandTotal: 0 });
+
+  // Operations daily-plan items for the visible month — items carry their
+  // calendar_blocks nested via the GET include (PR-Ops-5.3). Stored raw so
+  // the gridEvents memo below can map them to CalendarGrid events alongside
+  // the existing calendar_events sources.
+  const [operationsItems, setOperationsItems] = useState<DailyPlanItem[]>([]);
 
 
   const [drillDown, setDrillDown] = useState<{
@@ -135,7 +146,7 @@ export default function HubPage() {
     entityType: string;
   } | null>(null);
 
-  useEffect(() => { loadCalendar(); }, [selectedYear, selectedMonth]);
+  useEffect(() => { loadCalendar(); loadOperationsBlocks(); }, [selectedYear, selectedMonth]);
 
   const loadCalendar = async () => {
     try {
@@ -147,6 +158,34 @@ export default function HubPage() {
       }
     } catch (err) { console.error('Failed to load calendar:', err); }
     finally { setLoading(false); }
+  };
+
+  /**
+   * Fetch Operations daily-plan items for the visible month. Mirrors the
+   * other Hub fetches' error-handling pattern (console.error on failure,
+   * empty state). The items GET nests calendar_blocks + task summary so
+   * a single fetch is enough to feed the calendar.
+   */
+  const loadOperationsBlocks = async () => {
+    try {
+      const pad = (n: number) => String(n).padStart(2, '0');
+      const monthIdx = selectedMonth; // 0-based
+      const from = `${selectedYear}-${pad(monthIdx + 1)}-01`;
+      // Last day of the visible month — Date(yyyy, monthIdx+1, 0) returns the
+      // last day of monthIdx (because month rollover with day 0 = previous day).
+      const lastDay = new Date(selectedYear, monthIdx + 1, 0).getDate();
+      const to = `${selectedYear}-${pad(monthIdx + 1)}-${pad(lastDay)}`;
+      const res = await fetch(`/api/operations/daily-plan/items?from=${from}&to=${to}`);
+      if (res.ok) {
+        const data = await res.json();
+        setOperationsItems(data.items || []);
+      } else {
+        setOperationsItems([]);
+      }
+    } catch (err) {
+      console.error('Failed to load operations blocks:', err);
+      setOperationsItems([]);
+    }
   };
 
   const loadCommittedTrips = async () => {
@@ -229,18 +268,24 @@ export default function HubPage() {
   const yearlyBusinessActual = businessBudget.actualGrandTotal;
   const effectiveYearlyCost = homeMonthsCombined + travelMonthsTravelBudget + yearlyBusinessBudget;
 
-  // Transform hub events to CalendarGrid format
-  const gridEvents: GridEvent[] = useMemo(() => events.map(e => ({
-    id: e.id,
-    source: e.source,
-    title: e.title,
-    icon: e.icon,
-    startDate: e.start_date,
-    endDate: e.end_date,
-    isRecurring: e.is_recurring,
-    location: e.location,
-    budgetAmount: e.budget_amount,
-  })), [events]);
+  // Transform hub events to CalendarGrid format. Operations blocks are
+  // mapped via mapOperationsBlocks and concatenated — additive, doesn't
+  // affect the existing source rendering.
+  const gridEvents: GridEvent[] = useMemo(() => {
+    const calendarSourceEvents: GridEvent[] = events.map(e => ({
+      id: e.id,
+      source: e.source,
+      title: e.title,
+      icon: e.icon,
+      startDate: e.start_date,
+      endDate: e.end_date,
+      isRecurring: e.is_recurring,
+      location: e.location,
+      budgetAmount: e.budget_amount,
+    }));
+    const operationsEvents = mapOperationsBlocks(operationsItems);
+    return [...calendarSourceEvents, ...operationsEvents];
+  }, [events, operationsItems]);
 
   return (
     <AppLayout>

--- a/src/components/shared/CalendarGrid.tsx
+++ b/src/components/shared/CalendarGrid.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useMemo, useRef, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
 
 // ═══════════════════════════════════════════════════════════════
 // TYPES
@@ -18,7 +19,14 @@ export interface CalendarEvent {
   isRecurring?: boolean;
   location?: string | null;
   budgetAmount?: number;
-  details?: string[];        // compact detail lines (e.g. "PYPL | Iron Condor")
+  details?: string[];        // compact detail lines (e.g. "PYPL | Iron Condor", "B-6210 · $250")
+  /**
+   * Internal navigation target. When set, clicking the event routes to
+   * this path via the Next router (client-side). Takes precedence over
+   * onEventClick so per-event click targets work without requiring every
+   * caller to thread a callback. PR-Ops-5.3.
+   */
+  href?: string;
 }
 
 export interface SourceConfig {
@@ -139,9 +147,24 @@ export default function CalendarGrid({
   showCategoryLegend = false,
   compact = false,
 }: CalendarGridProps) {
+  const router = useRouter();
   const now = new Date();
   const anchor = anchorDate ? parseDate(anchorDate) : now;
   const scrollRef = useRef<HTMLDivElement>(null);
+
+  /**
+   * Tile-click dispatch: per-event `href` (PR-Ops-5.3) takes precedence
+   * over the legacy onEventClick callback so per-source click targets
+   * (e.g., Operations blocks → /workbench/operations) work without
+   * every caller threading a handler.
+   */
+  const handleTileClick = (event: CalendarEvent, nativeEvent: MouseEvent) => {
+    if (event.href) {
+      router.push(event.href);
+      return;
+    }
+    onEventClick?.(event, nativeEvent);
+  };
 
   const [calendarView, setCalendarView] = useState<'week' | 'month'>(defaultView);
   const [selectedYear, setSelectedYear] = useState(anchor.getFullYear());
@@ -341,8 +364,8 @@ export default function CalendarGrid({
                             const config = sourceConfig[event.source] || { badge: 'bg-gray-400', dot: 'bg-gray-400' };
                             return (
                               <div key={event.id || i}
-                                onClick={(e) => onEventClick?.(event, e.nativeEvent)}
-                                className={`${config.badge || config.dot} text-white text-[10px] px-1.5 py-0.5 rounded truncate mb-0.5 ${onEventClick ? 'cursor-pointer hover:opacity-90' : ''}`}
+                                onClick={(e) => handleTileClick(event, e.nativeEvent)}
+                                className={`${config.badge || config.dot} text-white text-[10px] px-1.5 py-0.5 rounded truncate mb-0.5 ${(event.href || onEventClick) ? 'cursor-pointer hover:opacity-90' : ''}`}
                                 title={event.title}>
                                 {event.title}
                               </div>
@@ -414,8 +437,8 @@ export default function CalendarGrid({
                           return (
                             <div
                               key={`${block.event.id}-${blockIdx}`}
-                              onClick={(e) => onEventClick?.(block.event, e.nativeEvent)}
-                              className={`absolute left-0.5 right-0.5 ${badgeColor} text-white ${roundClass} overflow-hidden z-10 ${onEventClick ? 'cursor-pointer hover:opacity-90' : ''} transition-opacity`}
+                              onClick={(e) => handleTileClick(block.event, e.nativeEvent)}
+                              className={`absolute left-0.5 right-0.5 ${badgeColor} text-white ${roundClass} overflow-hidden z-10 ${(block.event.href || onEventClick) ? 'cursor-pointer hover:opacity-90' : ''} transition-opacity`}
                               style={{ top: `${top}px`, height: `${height}px` }}
                               title={`${block.label}${block.event.budgetAmount ? ' - ' + formatCurrency(block.event.budgetAmount) : ''}`}
                             >
@@ -429,6 +452,9 @@ export default function CalendarGrid({
                                 )}
                                 {block.event.location && (
                                   <div className="text-[10px] opacity-70 leading-tight mt-0.5 truncate">{block.event.location}</div>
+                                )}
+                                {block.event.details && block.event.details[0] && (
+                                  <div className="text-[10px] opacity-80 leading-tight mt-0.5 truncate">{block.event.details[0]}</div>
                                 )}
                                 {!block.event.startTime && block.event.budgetAmount && block.event.budgetAmount > 0 && (
                                   <div className="text-[10px] opacity-80 leading-tight mt-0.5">{formatCurrency(block.event.budgetAmount)}</div>

--- a/src/components/workbench/operations/dailyplan/types.ts
+++ b/src/components/workbench/operations/dailyplan/types.ts
@@ -14,6 +14,16 @@ export type LinkedTaskSummary = {
   id: string;
   title: string;
   status: OperationsTaskStatus;
+  /**
+   * Universal triple (date/time/cost/category) plumbing — surfaced
+   * on the linked task summary so the Hub (and any other calendar
+   * surface) can render cost/category badges on Operations blocks
+   * without a second fetch. Selected in /api/operations/daily-plan/
+   * items GET as of PR-Ops-5.3.
+   */
+  coa_code: string | null;
+  estimated_cost_usd: string | null;  // Prisma Decimal serialized as string
+  actual_cost_usd: string | null;
 };
 
 export type DailyPlanItem = {

--- a/src/lib/hub/mapOperationsBlocks.ts
+++ b/src/lib/hub/mapOperationsBlocks.ts
@@ -1,0 +1,80 @@
+/**
+ * Map Operations daily-plan items → CalendarGrid events.
+ *
+ * One CalendarEvent per calendar_block. Surfaces the universal triple:
+ *   - date  : LOCAL YYYY-MM-DD from block.scheduled_start (UTC timestamptz → local)
+ *   - time  : LOCAL HH:MM start/end
+ *   - cost  : task.actual_cost_usd → falls back to estimated_cost_usd
+ *   - category: task.coa_code
+ *
+ * The `details` slot carries a single rendered line "<coa_code> · $<cost>"
+ * (omits either half if missing) — CalendarGrid renders details[0] as a
+ * small muted line under the time range (PR-Ops-5.3).
+ *
+ * `href` routes clicks to the workbench input/action surface for Operations,
+ * intercepted client-side by CalendarGrid's per-event router dispatch.
+ */
+
+import type { CalendarEvent } from '@/components/shared/CalendarGrid';
+import type { DailyPlanItem } from '@/components/workbench/operations/dailyplan/types';
+
+const OPERATIONS_SOURCE = 'operations';
+const OPERATIONS_HREF = '/workbench/operations';
+
+function pad(n: number): string {
+  return String(n).padStart(2, '0');
+}
+
+/** UTC timestamptz ISO string → local YYYY-MM-DD + HH:MM components. */
+function toLocalDateAndTime(iso: string): { date: string; time: string } {
+  const d = new Date(iso);
+  return {
+    date: `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`,
+    time: `${pad(d.getHours())}:${pad(d.getMinutes())}`,
+  };
+}
+
+function formatCostUsd(n: number): string {
+  return `$${n.toLocaleString('en-US', { maximumFractionDigits: 0 })}`;
+}
+
+export function mapOperationsBlocks(items: DailyPlanItem[]): CalendarEvent[] {
+  const out: CalendarEvent[] = [];
+
+  for (const item of items) {
+    const title = item.task?.title ?? item.ad_hoc_title ?? 'Untitled';
+
+    // Cost: prefer actual (post-execution truth) over estimate. Prisma
+    // Decimals serialize as strings; Number() converts. null → no badge.
+    const costStr = item.task?.actual_cost_usd ?? item.task?.estimated_cost_usd ?? null;
+    const costNum = costStr != null ? Number(costStr) : null;
+    const costValid = costNum != null && Number.isFinite(costNum);
+
+    const coa = item.task?.coa_code ?? null;
+
+    const detailParts: string[] = [];
+    if (coa) detailParts.push(coa);
+    if (costValid) detailParts.push(formatCostUsd(costNum as number));
+    const detailLine = detailParts.length > 0 ? detailParts.join(' · ') : null;
+
+    for (const block of item.calendar_blocks) {
+      const start = toLocalDateAndTime(block.scheduled_start);
+      const end = toLocalDateAndTime(block.scheduled_end);
+
+      out.push({
+        id: block.id,
+        source: OPERATIONS_SOURCE,
+        title,
+        startDate: start.date,
+        endDate: end.date !== start.date ? end.date : null,
+        startTime: start.time,
+        endTime: end.time,
+        budgetAmount: costValid ? (costNum as number) : undefined,
+        details: detailLine ? [detailLine] : undefined,
+        href: OPERATIONS_HREF,
+      });
+    }
+  }
+
+  return out;
+}


### PR DESCRIPTION
…category badges + click-to-workbench

The universal triple (date/time/cost/category) renders end-to-end: operations_calendar_blocks scheduled in the Operations workbench now appear on the Hub's CalendarGrid alongside the existing 7 sources (home/auto/shopping/personal/health/growth/trip), with a one-line "<coa_code> · $<cost>" badge under the time range and a click that routes to the workbench.

API (server, one-line expansion):
- /api/operations/daily-plan/items GET — task select extended from { id, title, status } to also include coa_code, estimated_cost_usd, actual_cost_usd. Single-line additive change; no migration; no new endpoint. Cost preferred = actual_cost_usd (post-execution truth) with fallback to estimated_cost_usd.

Shared types:
- dailyplan/types.ts LinkedTaskSummary extended with the three new optional-but-always-present-from-server fields. DailyPlanItemRow's existing consumption (id/title/status) is unaffected.

CalendarGrid (shared component, two additive changes):
- CalendarEvent gains an optional `href?: string`. When set, clicking the event tile navigates via Next router (client-side), taking precedence over onEventClick. Backward compat preserved: src/app/budgets/trips/[id]/page.tsx still uses onEventClick (no href) and its existing behavior is untouched.
- Time-based event tile renders event.details[0] as a small muted line when present (was already in the interface, never rendered in tiles). Other sources don't populate details so they see no change. Operations populates details[0] = "<coa_code> · $<cost>".

Hub (single page extension):
- SOURCE_CONFIG gains an 'operations' entry: 🎯 indigo (distinct from health emerald, growth brand-purple/blue, trip cyan).
- 5th data fetch: GET /api/operations/daily-plan/items?from=&to= over the visible month (same month-selector state as the existing 4 fetches; mirrors their error-handling pattern). Refetches on selectedYear/selectedMonth change.
- src/lib/hub/mapOperationsBlocks.ts (new helper, pure, no fetch) — converts DailyPlanItem[] → CalendarEvent[]. One event per block. Timezone: UTC timestamptz → local YYYY-MM-DD + HH:MM via Date components (matches CalendarGrid's parseDate + formatTime semantics; no new tz approach introduced).
- gridEvents useMemo concatenates calendar_events sources + ops events. Existing sources rendered identically; ops events are purely additive.

Verification:
- npx tsc --noEmit: exit 0
- npm run lint (touched files):
    items/route.ts          — 0 errors, 0 warnings
    dailyplan/types.ts      — 0 errors, 0 warnings
    CalendarGrid.tsx        — 0 errors, 2 warnings (BOTH pre-existing
                              on untouched lines: :148 unused 'compact'
                              prop, :263 useEffect deps on getEventsForDate
                              and weekDays)
    hub/page.tsx            — 0 errors, 17 warnings (16 pre-existing on
                              untouched lines; the 17th is the existing
                              useEffect-deps warning whose message expanded
                              to mention 'loadOperationsBlocks' alongside
                              the already-missing 'loadCalendar' —
                              SAME warning, expanded message, file's
                              total count unchanged)
    mapOperationsBlocks.ts  — 0 errors, 0 warnings
  Net: zero new lint rules triggered, zero new warnings on touched files.

Out of scope (deferred):
- Operations-budget panel (planned vs actual aggregation off operations_project_tasks, NOT ledger_entries; Operations doesn't emit journal entries — explicit architectural note from Phase 1 audit, must not be conflated with the existing ledger-based business-budget/year-calendar/nomad-budget aggregations).
- Block edit/delete from the Hub (Operations workbench owns mutation).
- Drag-to-reschedule.
- Hover tooltip on Operations event with full task notes.

Author: Temple Stuart <astuart@templestuart.com>