### PR TITLE
feat(pr-ops-5.4): schedule picker defaults to task deadline, re-syncs…

### DIFF
--- a/src/components/workbench/operations/projects/TaskRow.tsx
+++ b/src/components/workbench/operations/projects/TaskRow.tsx
@@ -81,9 +81,31 @@ export default function TaskRow({ task, projectId, index, coaAccounts, onUpdate,
   const [historyError, setHistoryError] = useState<string | null>(null);
   const [scheduling, setScheduling] = useState(false);
   const [scheduleMenuOpen, setScheduleMenuOpen] = useState(false);
-  const [scheduleDate, setScheduleDate] = useState<string>(() =>
-    new Date().toISOString().slice(0, 10)
-  );
+
+  /**
+   * Default for the schedule date picker. Uses task.deadline (matching the
+   * edit-form's deadline.slice(0,10) extraction at taskToForm above) so the
+   * user doesn't re-enter the date they already typed when setting the
+   * deadline. Falls back to today's UTC date when no deadline is set.
+   * PR-Ops-5.4.
+   */
+  const defaultScheduleDate = (): string =>
+    task.deadline ? task.deadline.slice(0, 10) : new Date().toISOString().slice(0, 10);
+
+  const [scheduleDate, setScheduleDate] = useState<string>(defaultScheduleDate);
+
+  /**
+   * Toggle the schedule menu. On open (false → true) re-sync the date
+   * picker to the current deadline so a deadline edit after first render
+   * is honored. Close path keeps the existing toggle semantic (clicking
+   * ↗ schedule while open closes the menu).
+   */
+  const toggleScheduleMenu = () => {
+    if (!scheduleMenuOpen) {
+      setScheduleDate(defaultScheduleDate());
+    }
+    setScheduleMenuOpen((x) => !x);
+  };
   const [scheduleSuccess, setScheduleSuccess] = useState<string | null>(null);
 
   const enterEdit = () => {
@@ -194,13 +216,6 @@ export default function TaskRow({ task, projectId, index, coaAccounts, onUpdate,
     } catch (e) {
       alert(`Uncomplete failed: ${e instanceof Error ? e.message : 'unknown error'}`);
     }
-  };
-
-  const todayIso = () => new Date().toISOString().slice(0, 10);
-  const tomorrowIso = () => {
-    const d = new Date();
-    d.setUTCDate(d.getUTCDate() + 1);
-    return d.toISOString().slice(0, 10);
   };
 
   const handleSchedule = async (targetDate: string) => {
@@ -326,7 +341,7 @@ export default function TaskRow({ task, projectId, index, coaAccounts, onUpdate,
           {task.status !== 'completed' && task.status !== 'cancelled' && (
             <button
               type="button"
-              onClick={(e) => { e.stopPropagation(); setScheduleMenuOpen((x) => !x); }}
+              onClick={(e) => { e.stopPropagation(); toggleScheduleMenu(); }}
               disabled={scheduling}
               className="px-2 py-0.5 border border-border text-text-muted rounded hover:bg-bg-row disabled:opacity-50 text-xs font-mono"
               title="Schedule this task on a daily plan"
@@ -347,23 +362,6 @@ export default function TaskRow({ task, projectId, index, coaAccounts, onUpdate,
         >
           <div className="flex items-center gap-2 flex-wrap">
             <span className="text-text-muted">schedule for:</span>
-            <button
-              type="button"
-              onClick={(e) => { e.stopPropagation(); handleSchedule(todayIso()); }}
-              disabled={scheduling}
-              className="px-2 py-0.5 border border-border text-text-primary rounded hover:bg-white disabled:opacity-50"
-            >
-              today
-            </button>
-            <button
-              type="button"
-              onClick={(e) => { e.stopPropagation(); handleSchedule(tomorrowIso()); }}
-              disabled={scheduling}
-              className="px-2 py-0.5 border border-border text-text-primary rounded hover:bg-white disabled:opacity-50"
-            >
-              tomorrow
-            </button>
-            <span className="text-text-muted">or</span>
             <input
               type="date"
               value={scheduleDate}


### PR DESCRIPTION
… on open, remove today/tomorrow buttons

Closes the date-redundancy Alex found by using the system: a task's deadline now auto-flows forward into the schedule step instead of the user re-typing it. Per the Phase 1 audit (1f53422), this was the single redundancy point in the chain — the block step (PR-Ops-5.2) already pre-fills its date from plan_date, so date-flow is now end-to-end: deadline → plan_date → block start.

TaskRow.tsx changes (single-file PR):

1. defaultScheduleDate() helper extracted. Returns task.deadline.slice(0,10) when present, else today's UTC date. Matches the deadline.slice(0,10) convention already used by taskToForm — same canonical date string flows through edit-form → display → schedule picker → API plan_date.

2. scheduleDate useState initializer uses defaultScheduleDate().

3. toggleScheduleMenu() helper added. When transitioning closed→open, re-applies defaultScheduleDate() so the picker reflects the CURRENT deadline (not stale state from a deadline edit since first render). When transitioning open→closed, preserves the existing toggle-by- clicking-↗-schedule semantic (no re-sync; the menu just closes).

4. ↗ schedule button onClick wired to toggleScheduleMenu (was inline setScheduleMenuOpen toggle).

5. "today" and "tomorrow" quick buttons removed. The date picker now defaults correctly so the quick buttons are dead weight; the user adjusts to a different date in one tap if needed. todayIso() and tomorrowIso() helper definitions deleted (only callers were the removed buttons — kept clean, no orphan no-unused-vars warning). The "or" separator span between them and the date input also removed (no longer connects anything).

6. ↗ schedule POST body unchanged: { plan_date: scheduleDate, task_id } → /api/operations/daily-plan/items. No API change, no schema, no migration.

Default-date helper location: inline in TaskRow.tsx (defaultScheduleDate constant in component scope). Used in both the useState initializer and toggleScheduleMenu — single source of truth, no duplication.

Verification:
- npx tsc --noEmit: exit 0
- npx eslint <touched file>: exit 0 (zero errors, zero warnings — the removed helpers had a single caller each; deletion prevented the no-unused-vars warning that a less-careful change would have left)

Out of scope (deferred):
- Combined "schedule with time" one-step action (would merge Projects and Daily Plan surfaces — breaks the two-surface model; not justified)
- Block-form changes (5.2's defaultBlockWindow already pre-fills date from plan_date — confirmed in Phase 1 audit)

Author: Temple Stuart <astuart@templestuart.com>