### PR TITLE
feat(pr-ops-5.5): Hub event info card (slide-in), fix dead /workbench…

### DIFF
--- a/src/app/hub/page.tsx
+++ b/src/app/hub/page.tsx
@@ -5,9 +5,10 @@ import { useRouter } from 'next/navigation';
 import { useSession } from 'next-auth/react';
 import { AppLayout, Card, Badge } from '@/components/ui';
 import BudgetDrillDown from '@/components/hub/BudgetDrillDown';
+import HubEventCard from '@/components/hub/HubEventCard';
 import CalendarGrid, { CalendarEvent as GridEvent, SourceConfig } from '@/components/shared/CalendarGrid';
 import { mapOperationsBlocks } from '@/lib/hub/mapOperationsBlocks';
-import type { DailyPlanItem } from '@/components/workbench/operations/dailyplan/types';
+import type { DailyPlanItem, CalendarBlockSummary } from '@/components/workbench/operations/dailyplan/types';
 
 import dynamic from 'next/dynamic';
 
@@ -135,6 +136,26 @@ export default function HubPage() {
   // the gridEvents memo below can map them to CalendarGrid events alongside
   // the existing calendar_events sources.
   const [operationsItems, setOperationsItems] = useState<DailyPlanItem[]>([]);
+
+  // Info-card selection (PR-Ops-5.5). Set when an Operations event tile is
+  // clicked; the parent item + block are resolved from operationsItems by
+  // event.id (= block.id) so the card can render rich context without a
+  // second fetch.
+  const [cardSelection, setCardSelection] = useState<{ item: DailyPlanItem; block: CalendarBlockSummary } | null>(null);
+
+  const handleEventClick = (event: GridEvent) => {
+    if (event.source !== 'operations') return;
+    for (const item of operationsItems) {
+      const block = item.calendar_blocks.find((b) => b.id === event.id);
+      if (block) {
+        setCardSelection({ item, block });
+        return;
+      }
+    }
+    // Stale state (block deleted server-side since last fetch, etc.) —
+    // do not open a broken card. Log so the gap is visible in dev.
+    console.warn('[Hub] Could not locate item+block for event id:', event.id);
+  };
 
 
   const [drillDown, setDrillDown] = useState<{
@@ -320,8 +341,17 @@ export default function HubPage() {
               defaultView="week"
               showBudgetTotals={true}
               showCategoryLegend={true}
+              onEventClick={handleEventClick}
             />
           </div>
+
+          {cardSelection && (
+            <HubEventCard
+              item={cardSelection.item}
+              block={cardSelection.block}
+              onClose={() => setCardSelection(null)}
+            />
+          )}
 
           {/* ═══════════════════════════════════════════════════════════════════ */}
           {/* BUDGET COMPARISON - WALL STREET STYLE */}

--- a/src/components/hub/HubEventCard.tsx
+++ b/src/components/hub/HubEventCard.tsx
@@ -1,0 +1,251 @@
+/**
+ * HubEventCard — read-only info card for a single Operations calendar block.
+ *
+ * Triggered by clicking an Operations event on the Hub's CalendarGrid
+ * (PR-Ops-5.5). Replaces the dead-link navigation from PR-Ops-5.3.
+ *
+ * Structural pattern mirrored from BudgetDrillDown.tsx:
+ *   - right-side slide-in panel (max-w-lg)
+ *   - bg-black/30 backdrop
+ *   - click-outside to close
+ *   - Escape to close
+ *   - × close button
+ *   - brand-purple header
+ *
+ * Renders only sections that have data — no empty rows, no placeholders.
+ * Dimension links in the footer are LIVE only (Projects + Daily Plan);
+ * category and bookkeeping deep-links are deferred until those routes
+ * support filter-by-code (locked decision, PR-Ops-5.5 Phase 1).
+ *
+ * Reads all data from the parent's already-fetched DailyPlanItem +
+ * CalendarBlockSummary — zero new fetches.
+ */
+
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { useRouter } from 'next/navigation';
+import type {
+  DailyPlanItem,
+  CalendarBlockSummary,
+} from '@/components/workbench/operations/dailyplan/types';
+
+interface Props {
+  item: DailyPlanItem;
+  block: CalendarBlockSummary;
+  onClose: () => void;
+}
+
+function pad(n: number): string {
+  return String(n).padStart(2, '0');
+}
+
+function formatTime12h(iso: string): string {
+  const d = new Date(iso);
+  const h = d.getHours();
+  const m = d.getMinutes();
+  const ampm = h >= 12 ? 'PM' : 'AM';
+  const h12 = h % 12 || 12;
+  return `${h12}:${pad(m)} ${ampm}`;
+}
+
+function formatDateLong(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleDateString(undefined, {
+    weekday: 'short',
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+function formatCostUsd(s: string | null): string | null {
+  if (s == null) return null;
+  const n = Number(s);
+  if (!Number.isFinite(n)) return null;
+  return `$${n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+}
+
+const pillClass =
+  'inline-block px-2 py-0.5 border border-border rounded text-xs font-mono text-text-muted';
+
+const labelClass = 'text-text-faint uppercase tracking-wide text-xs font-mono';
+
+export default function HubEventCard({ item, block, onClose }: Props) {
+  const router = useRouter();
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  // Click outside to close. Delay registration so the opening click
+  // (which bubbled from the calendar tile) doesn't immediately close.
+  useEffect(() => {
+    const handleClick = (e: MouseEvent) => {
+      if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
+        onClose();
+      }
+    };
+    const timer = setTimeout(() => document.addEventListener('mousedown', handleClick), 50);
+    return () => {
+      clearTimeout(timer);
+      document.removeEventListener('mousedown', handleClick);
+    };
+  }, [onClose]);
+
+  // Escape to close.
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handleKey);
+    return () => document.removeEventListener('keydown', handleKey);
+  }, [onClose]);
+
+  const title = item.task?.title ?? item.ad_hoc_title ?? 'Untitled';
+  const planned = formatCostUsd(item.task?.estimated_cost_usd ?? null);
+  const actual = formatCostUsd(item.task?.actual_cost_usd ?? null);
+  const hasActualTimes = block.actual_start != null && block.actual_end != null;
+  const hasAnyNote = (block.notes && block.notes.length > 0) || (item.notes && item.notes.length > 0);
+
+  return (
+    <div className="fixed inset-0 z-50 flex justify-end">
+      {/* Backdrop */}
+      <div className="absolute inset-0 bg-black/30" />
+
+      {/* Panel */}
+      <div
+        ref={panelRef}
+        className="relative w-full max-w-lg bg-white shadow-2xl flex flex-col animate-in slide-in-from-right duration-200"
+        style={{ animation: 'slideInRight 0.2s ease-out' }}
+      >
+        {/* Header */}
+        <div className="bg-brand-purple text-white px-5 py-4 flex items-start justify-between">
+          <div className="min-w-0 flex-1 pr-3">
+            <h3 className="text-sm font-semibold break-words">{title}</h3>
+            <p className="text-xs text-white/70 mt-0.5 font-mono">
+              Operations · {formatDateLong(block.scheduled_start)}
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-white/70 hover:text-white transition-colors p-1 -mr-1 -mt-1 shrink-0"
+            aria-label="Close"
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="flex-1 overflow-y-auto px-5 py-4 space-y-4 text-sm">
+          {/* Time + status */}
+          <div className="space-y-1">
+            <div className={labelClass}>scheduled</div>
+            <div className="font-mono text-text-primary">
+              {formatTime12h(block.scheduled_start)} – {formatTime12h(block.scheduled_end)}
+            </div>
+            <div>
+              <span className={pillClass}>{block.status}</span>
+            </div>
+            {hasActualTimes && (
+              <div className="text-xs font-mono text-text-muted">
+                actually: {formatTime12h(block.actual_start as string)} – {formatTime12h(block.actual_end as string)}
+              </div>
+            )}
+          </div>
+
+          {/* Task (when not ad-hoc) */}
+          {item.task && (
+            <div className="space-y-1 pt-3 border-t border-border-light">
+              <div className={labelClass}>task</div>
+              <div className="text-text-primary">{item.task.title}</div>
+              <div>
+                <span className={pillClass}>{item.task.status}</span>
+              </div>
+            </div>
+          )}
+
+          {/* Ad-hoc description (when ad-hoc) */}
+          {!item.task && item.ad_hoc_description && (
+            <div className="space-y-1 pt-3 border-t border-border-light">
+              <div className={labelClass}>description</div>
+              <div className="text-text-primary whitespace-pre-wrap">{item.ad_hoc_description}</div>
+            </div>
+          )}
+
+          {/* Category */}
+          {item.task?.coa_code && (
+            <div className="space-y-1 pt-3 border-t border-border-light">
+              <div className={labelClass}>category</div>
+              <div className="font-mono text-text-primary">{item.task.coa_code}</div>
+            </div>
+          )}
+
+          {/* Cost — render only sides that are populated */}
+          {(planned || actual) && (
+            <div className="space-y-1 pt-3 border-t border-border-light">
+              <div className={labelClass}>cost</div>
+              <div className="font-mono text-text-primary space-y-0.5">
+                {planned && (
+                  <div>
+                    <span className="text-text-muted">Planned:</span> {planned}
+                  </div>
+                )}
+                {actual && (
+                  <div>
+                    <span className="text-text-muted">Actual:</span> {actual}
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
+
+          {/* Notes — show both block + item when present, labeled by scope */}
+          {hasAnyNote && (
+            <div className="space-y-2 pt-3 border-t border-border-light">
+              <div className={labelClass}>notes</div>
+              {block.notes && (
+                <div>
+                  <div className="text-xs font-mono text-text-muted">Block note:</div>
+                  <div className="text-text-primary whitespace-pre-wrap">{block.notes}</div>
+                </div>
+              )}
+              {item.notes && (
+                <div>
+                  <div className="text-xs font-mono text-text-muted">Task note:</div>
+                  <div className="text-text-primary whitespace-pre-wrap">{item.notes}</div>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+
+        {/* Footer — LIVE dimension links only */}
+        <div className="border-t border-border bg-bg-row/50 px-5 py-3 flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => router.push('/operations/projects')}
+            className="px-3 py-1.5 text-xs font-mono border border-border rounded hover:bg-white text-text-primary"
+          >
+            Open in Projects →
+          </button>
+          <button
+            type="button"
+            onClick={() => router.push('/operations')}
+            className="px-3 py-1.5 text-xs font-mono border border-border rounded hover:bg-white text-text-primary"
+          >
+            Open Daily Plan →
+          </button>
+        </div>
+      </div>
+
+      {/* CSS animation */}
+      <style jsx>{`
+        @keyframes slideInRight {
+          from { transform: translateX(100%); }
+          to { transform: translateX(0); }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/src/lib/hub/mapOperationsBlocks.ts
+++ b/src/lib/hub/mapOperationsBlocks.ts
@@ -11,15 +11,17 @@
  * (omits either half if missing) — CalendarGrid renders details[0] as a
  * small muted line under the time range (PR-Ops-5.3).
  *
- * `href` routes clicks to the workbench input/action surface for Operations,
- * intercepted client-side by CalendarGrid's per-event router dispatch.
+ * Clicks are handled by the Hub's onEventClick (PR-Ops-5.5): the Hub
+ * opens an in-place info card (HubEventCard) instead of navigating away.
+ * This file deliberately does NOT set `href` — the previous '/workbench/
+ * operations' href shipped in PR-Ops-5.3 was a dead link (that route
+ * never existed); removing it fixes the 404 and lets onEventClick fire.
  */
 
 import type { CalendarEvent } from '@/components/shared/CalendarGrid';
 import type { DailyPlanItem } from '@/components/workbench/operations/dailyplan/types';
 
 const OPERATIONS_SOURCE = 'operations';
-const OPERATIONS_HREF = '/workbench/operations';
 
 function pad(n: number): string {
   return String(n).padStart(2, '0');
@@ -71,7 +73,6 @@ export function mapOperationsBlocks(items: DailyPlanItem[]): CalendarEvent[] {
         endTime: end.time,
         budgetAmount: costValid ? (costNum as number) : undefined,
         details: detailLine ? [detailLine] : undefined,
-        href: OPERATIONS_HREF,
       });
     }
   }


### PR DESCRIPTION
…/operations link

Replaces the navigate-on-click behavior shipped in PR-Ops-5.3 with an in-place info card. Closes the silent 404 bug Alex hit in prod (href='/workbench/operations' never existed; the real route is /operations) and gives clicks a useful destination: a slide-in card that surfaces the full block context, with two LIVE dimension links to the canonical workbench surfaces.

Files (1 new + 2 modified):

src/lib/hub/mapOperationsBlocks.ts
- Removed OPERATIONS_HREF constant and the href field on emitted events. Operations events no longer navigate; they fall through to CalendarGrid's onEventClick callback so the parent (the Hub) can open the info card.

src/components/hub/HubEventCard.tsx (NEW, ~210 lines)
- Right-side slide-in panel with bg-black/30 backdrop, click-outside to close, Escape to close, × close button, brand-purple header. Structural pattern mirrored from BudgetDrillDown.tsx — Hub-native convention. No generic-shell extraction (premature with one caller).
- Props: { item: DailyPlanItem, block: CalendarBlockSummary, onClose }. Parent resolves item+block from already-fetched operationsItems state by event.id (= block.id); no new fetch, no mapping expansion, no CalendarEvent interface change.
- Content sections render conditionally — no empty rows:
    * Header: title (task.title || ad_hoc_title || 'Untitled') + ×
    * Subhead: "Operations · <long date>"
    * Scheduled time range + status pill
    * Actual times line (only when actual_start/actual_end populated)
    * Task title + status pill (only when item.task present)
    * Ad-hoc description (only when present, on ad-hoc items)
    * Category code (only when task.coa_code; text only, no link in v1)
    * Cost: "Planned: $X" / "Actual: $Y" (each rendered only if populated)
    * Notes: BOTH block.notes and item.notes when present, each labeled ("Block note:" / "Task note:") so scope is unambiguous
- Footer: two LIVE dimension links — "Open in Projects" → /operations/ projects, "Open Daily Plan" → /operations. NO category/bookkeeping placeholders (locked decision: those destination routes don't yet support filter-by-code, so dead buttons would be noise).
- Self-contained formatters (formatTime12h, formatDateLong, formatCostUsd) keep the card free of cross-folder imports.

src/app/hub/page.tsx
- Imports HubEventCard + CalendarBlockSummary type.
- cardSelection state: { item, block } | null.
- handleEventClick(event): early-returns for non-operations sources; for operations, walks operationsItems to find the item whose calendar_blocks contains a block with id === event.id, opens the card with that pair. Logs a console.warn (no silent crash) if the lookup fails — handles stale state gracefully (e.g., block was deleted server-side since last fetch).
- onEventClick={handleEventClick} passed to CalendarGrid. CalendarGrid's existing handleTileClick dispatch (href precedence → onEventClick fall-through) handles routing: no href on Operations events means the callback fires.
- <HubEventCard /> rendered right after <CalendarGrid /> when cardSelection is set.

Backward compat:
- Non-operations Hub blocks: handleEventClick early-returns, no behavior change (they had no click target before).
- /budgets/trips/[id]/page.tsx (the other CalendarGrid consumer with its own onEventClick): completely unaffected — different page, different handler, different surface.
- CalendarGrid itself: untouched.

Verification:
- npx tsc --noEmit: exit 0
- npm run lint per file: mapOperationsBlocks.ts — 0 errors, 0 warnings
    HubEventCard.tsx       — 0 errors, 0 warnings
    hub/page.tsx           — 0 errors, 17 warnings (all pre-existing
                             on untouched lines: unused Card/Badge/
                             MapContainer imports, etc. — identical
                             count to what PR-Ops-5.3 shipped)
  Net: zero new lint problems on touched files. LINT-BACKLOG.md
  discipline maintained.

Out of scope (deferred):
- Category/bookkeeping dimension links (need filter-by-code support on /chart-of-accounts and /ledger pages first)
- Per-task deep-link route /operations/projects/[id] (would let "Open in Projects" land on the exact task instead of the list)
- Card editing / mutation (read-only v1)
- Multi-block sibling list on the card (calendar already shows them spatially)
- Generic shell extraction from BudgetDrillDown (premature)

Author: Temple Stuart <astuart@templestuart.com>