### PR TITLE
feat(pr-ops-5.6): wire time-block routines onto Hub calendar (pattern…

### DIFF
--- a/src/app/api/hub/operations-routines/route.ts
+++ b/src/app/api/hub/operations-routines/route.ts
@@ -1,0 +1,185 @@
+/**
+ * GET /api/hub/operations-routines?from=YYYY-MM-DD&to=YYYY-MM-DD
+ *
+ * Expands every active routine's RRULE into individual occurrences inside
+ * the given window. Used by the Hub calendar (PR-Ops-5.6) to render
+ * recurring time-block routines as discrete dated entries — one tile per
+ * occurrence — alongside the existing Operations one-time blocks and
+ * other Hub sources.
+ *
+ * Auth mirrors /api/operations/routines/today: getVerifiedEmail + user
+ * lookup; scoped to user.id; rrule expansion via shipped helpers; routine
+ * start_date/end_date bounds applied per the same idiom as /today
+ * (compare in the routine's local timezone). On-the-fly only — no
+ * materialized routine_occurrences table.
+ *
+ * Performance guards (REQUIRED per PR-Ops-5.6 spec):
+ *   - Window length capped at MAX_WINDOW_DAYS (92, ~one quarter). Reject
+ *     larger windows with 400 — no silent narrowing.
+ *   - Total occurrences across all routines capped at MAX_OCCURRENCES
+ *     (500). When the cap is hit, response includes truncated: true so
+ *     the caller can surface a warning (no silent drop — North Star).
+ *
+ * Routines with NO time component in their RRULE shouldn't exist
+ * (compileFormToRRule always writes BYHOUR/BYMINUTE) but if a hand-
+ * authored "custom" rrule omits BYHOUR, the occurrence still carries
+ * a default time; the client renders the resulting HH:MM as-is.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { expandBetween } from '@/lib/operations/rruleHelpers';
+
+const MAX_WINDOW_DAYS = 92;
+const MAX_OCCURRENCES = 500;
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+function parseDate(s: string | null): Date | null {
+  if (!s || !DATE_RE.test(s)) return null;
+  const d = new Date(`${s}T00:00:00.000Z`);
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
+function formatLocalDate(d: Date, timezone: string): string {
+  try {
+    return new Intl.DateTimeFormat('en-CA', {
+      timeZone: timezone,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    }).format(d);
+  } catch {
+    return d.toISOString().slice(0, 10);
+  }
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const user = await prisma.users.findFirst({
+      where: { email: { equals: userEmail, mode: 'insensitive' } },
+    });
+    if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+
+    const sp = request.nextUrl.searchParams;
+    const from = parseDate(sp.get('from'));
+    if (!from) {
+      return NextResponse.json(
+        { error: 'Validation', field: 'from', message: 'from is required (YYYY-MM-DD)' },
+        { status: 400 }
+      );
+    }
+    const to = parseDate(sp.get('to'));
+    if (!to) {
+      return NextResponse.json(
+        { error: 'Validation', field: 'to', message: 'to is required (YYYY-MM-DD)' },
+        { status: 400 }
+      );
+    }
+    if (from.getTime() > to.getTime()) {
+      return NextResponse.json(
+        { error: 'Validation', field: 'to', message: 'to must be on or after from' },
+        { status: 400 }
+      );
+    }
+    const windowDays = Math.floor((to.getTime() - from.getTime()) / MS_PER_DAY) + 1;
+    if (windowDays > MAX_WINDOW_DAYS) {
+      return NextResponse.json(
+        {
+          error: 'Validation',
+          field: 'to',
+          message: `window must be <= ${MAX_WINDOW_DAYS} days (got ${windowDays})`,
+        },
+        { status: 400 }
+      );
+    }
+
+    // Use end-of-day for `to` so the last day's occurrences are included.
+    const windowEnd = new Date(to.getTime() + MS_PER_DAY - 1);
+
+    const routines = await prisma.operations_routines.findMany({
+      where: { user_id: user.id, is_active: true },
+      orderBy: { name: 'asc' },
+    });
+
+    type RoutineWindowEntry = {
+      routine_id: string;
+      name: string;
+      entity_id: string;
+      timezone: string;
+      start_time: string | null;
+      end_time: string | null;
+      occurrences: string[];
+    };
+
+    const out: RoutineWindowEntry[] = [];
+    let totalOccurrences = 0;
+    let truncated = false;
+
+    for (const r of routines) {
+      if (totalOccurrences >= MAX_OCCURRENCES) {
+        truncated = true;
+        break;
+      }
+
+      // Apply routine's own start_date/end_date bounds (mirroring
+      // /api/operations/routines/today/route.ts:124-135). The bounds
+      // columns are @db.Date — compare in the routine's local timezone
+      // via formatLocalDate, not UTC, to avoid edge-of-day off-by-ones.
+      const fromLocal = formatLocalDate(from, r.timezone);
+      const toLocal = formatLocalDate(windowEnd, r.timezone);
+      if (r.start_date) {
+        const startDateStr = formatLocalDate(r.start_date, 'UTC');
+        if (startDateStr > toLocal) continue; // routine starts after window
+      }
+      if (r.end_date) {
+        const endDateStr = formatLocalDate(r.end_date, 'UTC');
+        if (endDateStr < fromLocal) continue; // routine ended before window
+      }
+
+      let occurrences: Date[] = [];
+      try {
+        occurrences = expandBetween(r.schedule_rrule, r.timezone, from, windowEnd);
+      } catch (e) {
+        // Skip malformed rrule rather than failing the whole request —
+        // log so the gap is visible. Same idiom as /today endpoint.
+        console.error(`[Hub Routines] RRULE expand failed for ${r.id}:`, e);
+        continue;
+      }
+
+      // Cap per-routine if the global ceiling would be exceeded.
+      const remaining = MAX_OCCURRENCES - totalOccurrences;
+      const taken =
+        occurrences.length > remaining ? occurrences.slice(0, remaining) : occurrences;
+      if (occurrences.length > remaining) truncated = true;
+      totalOccurrences += taken.length;
+
+      if (taken.length === 0) continue;
+
+      out.push({
+        routine_id: r.id,
+        name: r.name,
+        entity_id: r.entity_id,
+        timezone: r.timezone,
+        start_time: r.start_time ? r.start_time.toISOString() : null,
+        end_time: r.end_time ? r.end_time.toISOString() : null,
+        occurrences: taken.map((d) => d.toISOString()),
+      });
+    }
+
+    return NextResponse.json({ routines: out, truncated });
+  } catch (error) {
+    console.error('[Hub Routines GET]', error);
+    return NextResponse.json(
+      {
+        error: 'Failed to load routines window',
+        message: error instanceof Error ? error.message : 'unknown',
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/hub/page.tsx
+++ b/src/app/hub/page.tsx
@@ -8,6 +8,7 @@ import BudgetDrillDown from '@/components/hub/BudgetDrillDown';
 import HubEventCard from '@/components/hub/HubEventCard';
 import CalendarGrid, { CalendarEvent as GridEvent, SourceConfig } from '@/components/shared/CalendarGrid';
 import { mapOperationsBlocks } from '@/lib/hub/mapOperationsBlocks';
+import { mapOperationsRoutines, type RoutinesWindowResponse } from '@/lib/hub/mapOperationsRoutines';
 import type { DailyPlanItem, CalendarBlockSummary } from '@/components/workbench/operations/dailyplan/types';
 
 import dynamic from 'next/dynamic';
@@ -58,6 +59,9 @@ const SOURCE_CONFIG: Record<string, { icon: string; color: string; bgColor: stri
   // Operations (PR-Ops-5.3) — task time-blocks scheduled via the workbench.
   // Indigo distinguishes from health (emerald), growth (brand-purple/blue), and trip (cyan).
   operations: { icon: '🎯', color: 'text-indigo-600', bgColor: 'bg-indigo-50', dotColor: 'bg-indigo-500', calendarColor: 'bg-indigo-400' },
+  // Routines (PR-Ops-5.6) — recurring time-block routines expanded from RRULE.
+  // Teal distinguishes from operations indigo, growth blue/brand-purple, trip cyan.
+  routines: { icon: '🔁', color: 'text-teal-600', bgColor: 'bg-teal-50', dotColor: 'bg-teal-500', calendarColor: 'bg-teal-400' },
 };
 
 // CalendarGrid-compatible config derived from SOURCE_CONFIG
@@ -137,6 +141,12 @@ export default function HubPage() {
   // the existing calendar_events sources.
   const [operationsItems, setOperationsItems] = useState<DailyPlanItem[]>([]);
 
+  // Operations routines window for the visible month (PR-Ops-5.6) — RRULE
+  // occurrences pre-expanded server-side via /api/hub/operations-routines.
+  // One CalendarEvent per (routine, occurrence) pair is emitted by
+  // mapOperationsRoutines and concatenated into gridEvents below.
+  const [routinesWindow, setRoutinesWindow] = useState<RoutinesWindowResponse>({ routines: [], truncated: false });
+
   // Info-card selection (PR-Ops-5.5). Set when an Operations event tile is
   // clicked; the parent item + block are resolved from operationsItems by
   // event.id (= block.id) so the card can render rich context without a
@@ -167,7 +177,7 @@ export default function HubPage() {
     entityType: string;
   } | null>(null);
 
-  useEffect(() => { loadCalendar(); loadOperationsBlocks(); }, [selectedYear, selectedMonth]);
+  useEffect(() => { loadCalendar(); loadOperationsBlocks(); loadOperationsRoutines(); }, [selectedYear, selectedMonth]);
 
   const loadCalendar = async () => {
     try {
@@ -206,6 +216,41 @@ export default function HubPage() {
     } catch (err) {
       console.error('Failed to load operations blocks:', err);
       setOperationsItems([]);
+    }
+  };
+
+  /**
+   * Fetch Operations routines window for the visible month (PR-Ops-5.6).
+   * Mirrors loadOperationsBlocks' pattern. The endpoint expands each
+   * active routine's RRULE server-side; this client just concatenates
+   * the resulting occurrences into gridEvents.
+   *
+   * Performance: the endpoint caps total occurrences at 500 and signals
+   * `truncated: true` when the cap is hit. We surface that via console.warn
+   * — never silently dropped per the North Star.
+   */
+  const loadOperationsRoutines = async () => {
+    try {
+      const pad = (n: number) => String(n).padStart(2, '0');
+      const monthIdx = selectedMonth;
+      const from = `${selectedYear}-${pad(monthIdx + 1)}-01`;
+      const lastDay = new Date(selectedYear, monthIdx + 1, 0).getDate();
+      const to = `${selectedYear}-${pad(monthIdx + 1)}-${pad(lastDay)}`;
+      const res = await fetch(`/api/hub/operations-routines?from=${from}&to=${to}`);
+      if (res.ok) {
+        const data: RoutinesWindowResponse = await res.json();
+        setRoutinesWindow(data);
+        if (data.truncated) {
+          console.warn(
+            '[Hub] Routines window truncated — occurrence cap reached. Not all recurring routines may be visible in this view.'
+          );
+        }
+      } else {
+        setRoutinesWindow({ routines: [], truncated: false });
+      }
+    } catch (err) {
+      console.error('Failed to load operations routines:', err);
+      setRoutinesWindow({ routines: [], truncated: false });
     }
   };
 
@@ -289,9 +334,9 @@ export default function HubPage() {
   const yearlyBusinessActual = businessBudget.actualGrandTotal;
   const effectiveYearlyCost = homeMonthsCombined + travelMonthsTravelBudget + yearlyBusinessBudget;
 
-  // Transform hub events to CalendarGrid format. Operations blocks are
-  // mapped via mapOperationsBlocks and concatenated — additive, doesn't
-  // affect the existing source rendering.
+  // Transform hub events to CalendarGrid format. Operations blocks +
+  // routine occurrences are mapped via their respective helpers and
+  // concatenated — purely additive, doesn't change existing rendering.
   const gridEvents: GridEvent[] = useMemo(() => {
     const calendarSourceEvents: GridEvent[] = events.map(e => ({
       id: e.id,
@@ -305,8 +350,9 @@ export default function HubPage() {
       budgetAmount: e.budget_amount,
     }));
     const operationsEvents = mapOperationsBlocks(operationsItems);
-    return [...calendarSourceEvents, ...operationsEvents];
-  }, [events, operationsItems]);
+    const routineEvents = mapOperationsRoutines(routinesWindow);
+    return [...calendarSourceEvents, ...operationsEvents, ...routineEvents];
+  }, [events, operationsItems, routinesWindow]);
 
   return (
     <AppLayout>

--- a/src/lib/hub/mapOperationsRoutines.ts
+++ b/src/lib/hub/mapOperationsRoutines.ts
@@ -1,0 +1,77 @@
+/**
+ * Map the /api/hub/operations-routines response → CalendarGrid events.
+ *
+ * Emits one CalendarEvent per (routine, occurrence) pair so each
+ * occurrence renders as its own tile on the Hub calendar.
+ *
+ * Timezone strategy: mirrors mapOperationsBlocks.ts — the server has
+ * already DST-corrected each occurrence ISO via expandBetween, so we
+ * extract LOCAL (browser-timezone) YYYY-MM-DD + HH:MM here. The Hub
+ * renders in the browser's timezone; a routine scheduled at 8am PT
+ * shows up at 11am ET for an ET viewer (correct).
+ *
+ * endTime intentionally omitted in v1: routine.end_time is wall-clock
+ * in routine.timezone (e.g., "10:00 in PT"), and converting that to
+ * the browser's wall-clock for a specific occurrence date requires
+ * additional timezone math. CalendarGrid handles missing endTime
+ * gracefully — defaults to a 120-minute visual block (CalendarGrid.tsx
+ * around line 105). Proper end-time rendering can be a follow-up PR
+ * once the timezone conversion is locked.
+ */
+
+import type { CalendarEvent } from '@/components/shared/CalendarGrid';
+
+export interface RoutineWindowEntry {
+  routine_id: string;
+  name: string;
+  entity_id: string;
+  timezone: string;
+  start_time: string | null;
+  end_time: string | null;
+  occurrences: string[];
+}
+
+export interface RoutinesWindowResponse {
+  routines: RoutineWindowEntry[];
+  truncated: boolean;
+}
+
+const ROUTINES_SOURCE = 'routines';
+const ROUTINES_HREF = '/operations/routines';
+
+function pad(n: number): string {
+  return String(n).padStart(2, '0');
+}
+
+/** UTC ISO → local (browser timezone) YYYY-MM-DD + HH:MM components. */
+function toLocalDateAndTime(iso: string): { date: string; time: string } {
+  const d = new Date(iso);
+  return {
+    date: `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`,
+    time: `${pad(d.getHours())}:${pad(d.getMinutes())}`,
+  };
+}
+
+export function mapOperationsRoutines(response: RoutinesWindowResponse): CalendarEvent[] {
+  const events: CalendarEvent[] = [];
+
+  for (const routine of response.routines) {
+    for (const occISO of routine.occurrences) {
+      const local = toLocalDateAndTime(occISO);
+      events.push({
+        // Composite id: unique per (routine, occurrence) so CalendarGrid
+        // doesn't collide tiles when the same routine fires multiple
+        // times in the window.
+        id: `routine:${routine.routine_id}:${occISO}`,
+        source: ROUTINES_SOURCE,
+        title: routine.name,
+        startDate: local.date,
+        startTime: local.time,
+        isRecurring: true,
+        href: ROUTINES_HREF,
+      });
+    }
+  }
+
+  return events;
+}


### PR DESCRIPTION
… a, on-the-fly rrule expansion)

Routines now render on the Hub. The Phase 1 audit (commit 8aca18f) confirmed: real RFC 5545 recurrence already shipped, expandBetween helper already shipped, no schema gap for pattern (a). The only missing piece was a Hub-facing endpoint that loops expansion across all active routines — added here.

Pattern coverage:
- (a) Time-block routine — WIRED. Each occurrence renders as its own CalendarEvent in the visible Hub month.
- (b) Recurring expense — DEFERRED. Requires schema migration to add cost columns to operations_routines (not present today).
- (c) Both — DEFERRED. Same prerequisite as (b).

Files (2 new + 1 modified):

src/app/api/hub/operations-routines/route.ts (NEW, ~160 lines)
- GET /api/hub/operations-routines?from=YYYY-MM-DD&to=YYYY-MM-DD
- Auth mirrors /api/operations/routines/today exactly: getVerifiedEmail → user lookup → scope by user.id.
- Validates from/to (required YYYY-MM-DD), rejects from > to.
- Window length capped at MAX_WINDOW_DAYS = 92 (one quarter); larger windows return 400 — no silent narrowing.
- Loads all is_active routines for the user.
- Per-routine: applies start_date/end_date bounds in the routine's local timezone via formatLocalDate (mirroring today/route.ts:124-135), then expandBetween(rrule, tz, from, windowEnd).
- Performance guard: caps total occurrences across all routines at MAX_OCCURRENCES = 500. When the cap is reached the response includes truncated: true so the client can surface a warning (no silent drop — North Star).
- Returns { routines: [{ routine_id, name, entity_id, timezone, start_time, end_time, occurrences: ISO[] }], truncated }.

src/lib/hub/mapOperationsRoutines.ts (NEW, ~75 lines)
- Pure mapper: RoutinesWindowResponse → CalendarEvent[]. One event per (routine, occurrence) pair.
- id = `routine:<routine_id>:<occurrenceISO>` — unique per instance, no tile collisions when a routine fires multiple times in the window.
- source: 'routines', title: routine.name, isRecurring: true, href: '/operations/routines' (live route; the dead-link bug from 5.3 was fixed in 5.5).
- Timezone: occurrence ISO → browser-local YYYY-MM-DD + HH:MM via Date components — same shape as mapOperationsBlocks.toLocalDateAndTime. expandBetween has already DST-corrected the occurrence in routine.timezone, so browser extraction gives the right wall-clock for the Hub viewer (a routine at 8am PT shows up at 11am ET for an ET viewer — correct).
- endTime intentionally OMITTED in v1: routine.end_time is wall-clock in routine.timezone, and converting that to the browser's wall-clock for a specific occurrence date requires additional timezone math. CalendarGrid handles missing endTime gracefully (defaults to 120-min visual block). Proper end-time rendering can be a follow-up PR once the timezone conversion is locked.

src/app/hub/page.tsx (MODIFIED)
- SOURCE_CONFIG gains 'routines' entry: 🔁 teal (teal-50/500/400). Teal is distinct from operations indigo, growth blue/brand-purple, trip cyan — confirmed open by grep before assignment.
- routinesWindow state holds the endpoint response.
- loadOperationsRoutines() mirrors loadOperationsBlocks: computes the same from/to window from selectedYear/selectedMonth state, fetches, sets state. On truncated:true, console.warn so the performance cap is visible to whoever opened the dev tools. Same error-handling idiom as the existing 4 fetches (console.error
  + empty state).
- useEffect deps unchanged; the new fetch joins the existing chain.
- gridEvents useMemo concatenates routine events alongside operations
  + calendar_events sources — purely additive, doesn't affect other sources' rendering.

Cadence-only routines (no start_time / end_time columns): still emit events. The occurrence ISO from expandBetween carries the rrule's BYHOUR/BYMINUTE in the routine's tz, which produces a valid HH:MM when extracted in browser-local. compileFormToRRule always writes BYHOUR/BYMINUTE so this is universal in practice.

Verification:
- npx tsc --noEmit: exit 0
- npm run lint per touched file: operations-routines/route.ts — 0 errors, 0 warnings
    mapOperationsRoutines.ts     — 0 errors, 0 warnings
    hub/page.tsx                 — 0 errors, 17 warnings (all
                                   pre-existing on untouched lines:
                                   unused Card/Badge/MapContainer/
                                   TileLayer imports, etc. — identical
                                   count to what PR-Ops-5.3 / 5.5 shipped)
  Net: zero new lint problems on touched files. LINT-BACKLOG.md
  discipline maintained.

Out of scope (deferred):
- Expense patterns (b)/(c): need cost-fields migration on operations_routines first
- Routines-specific info card (mirror PR-Ops-5.5 HubEventCard for routines): v1 href = /operations/routines, card is future
- Completed/missed occurrence overlay (join completions + audit log on the Hub): polish layer
- Entity filtering on the Hub
- Proper endTime rendering with full timezone awareness

Author: Temple Stuart <astuart@templestuart.com>