### PR TITLE
fix(pr-ops-5.7): correct timezone offset sign in rruleHelpers (was 2x…

### DIFF
--- a/src/lib/operations/rruleHelpers.ts
+++ b/src/lib/operations/rruleHelpers.ts
@@ -214,7 +214,14 @@ function getTimezoneOffsetMs(instant: Date, timezone: string): number {
     get('minute'),
     get('second')
   );
-  return tzAsUtc - instant.getTime();
+  // PR-Ops-5.7: sign corrected. Prior implementation returned
+  // `tzAsUtc - instant.getTime()` which had the opposite sign of what the
+  // docstring above promises (negative for behind-UTC zones), causing
+  // shiftFloatingToZone to shift every routine occurrence 2× the timezone
+  // offset in the WRONG direction. Manifested as Alex's SLEEP routine
+  // displaying "expected: 16:00 / missed" for a 00:00–06:00 window in
+  // America/New_York. See audit-reports/pr-ops-5.7-phase-1.md.
+  return instant.getTime() - tzAsUtc;
 }
 
 function addYears(d: Date, n: number): Date {


### PR DESCRIPTION
…-off for non-UTC routines)

One-line fix at the source. Phase 1 audit (commit d01e1cf) traced the exact root cause: getTimezoneOffsetMs's docstring at rruleHelpers.ts: 190-194 promised "positive when the timezone is BEHIND UTC", but the implementation at :217 returned the negation. shiftFloatingToZone:187 then did `utcMs + offset`, so every routine occurrence shifted 2× the timezone offset in the WRONG direction.

Manifestation: Alex's indefinite SLEEP routine (BYHOUR=0, window 00:00–06:00) in America/New_York displayed "expected: 16:00 / missed" the moment he created it. The wrong-signed shift moved May 22 00:00Z to May 21 20:00Z, which formats as 16:00 EDT, then "now > expectedAt
+ fail_threshold" triggered missed instantly. See audit-reports/pr-ops-5.7-phase-1.md for the full trace.

Fix: src/lib/operations/rruleHelpers.ts:217 changed from
  `return tzAsUtc - instant.getTime();`
to
  `return instant.getTime() - tzAsUtc;`

The flipped sign now matches the docstring's stated semantic (positive for behind-UTC zones), and shiftFloatingToZone's `utcMs + offset` now produces the correct UTC instant for the routine's wall-clock occurrence.

Verified re-traces:
  - BYHOUR=0 SLEEP in NY (Alex's case): expectedAt now = May 22 04:00Z, renders as 00:00 EDT — inside the 00:00–06:00 window, upcoming (not missed). ✓
  - BYHOUR=8 in LA (docstring example): expectedAt now = May 8 15:00Z, matches the docstring's stated "we want 15:00 UTC" expectation. ✓

Caller audit confirmed safe to flip at the source:
  - getTimezoneOffsetMs has EXACTLY ONE caller (shiftFloatingToZone at :186), grep verified. No other consumer was compensating for the wrong sign, so the source fix can't break a downstream caller.
  - All 7 downstream consumers of expandBetween/expandForward (today, upcoming, completions, routines POST, routines PATCH, hub-5.6, Inngest evaluator) start showing correct times immediately on deploy.

Self-healing: stored next_due_at values in the DB are currently wrong but the read paths (today/upcoming/Hub) live-compute via the helpers, so display corrects on deploy. Stored next_due_at self-heals on the next cron run or the next routine PATCH. NO migration, NO data backfill required.

Blast radius corrected: every routine for every non-UTC user has been silently 2× off since rruleHelpers shipped. UTC users were unaffected (offset 0). Alex (User #1) hit it because his 00:00 window made the wrong "expected" visibly outside the intent window, AND that wrong time landed in the past, triggering missed immediately.

Regression test: deferred (test infrastructure does not exist in this repo — no test runner in package.json scripts, no test framework in devDependencies, no *.test.ts/*.spec.ts files, no jest/vitest config). Per Alex's call: ship the fix alone now, add the regression test in a separate test-infra PR once the framework is chosen.

Verification:
- npx tsc --noEmit: exit 0
- npx eslint <touched file>: 0 errors, 2 warnings (both pre-existing on line 17 — unused CadenceMode/WeekDay imports that predate this PR; the :217 change introduces zero new warnings).

Out of scope (deferred):
- Regression test (blocked on test-infra decision)
- Admin one-time recompute of stored next_due_at (audit confirmed self-healing; nice-to-have)

Author: Temple Stuart <astuart@templestuart.com>