### PR TITLE
fix(pr-ops-5.8): Hub reads routine intent-window directly; time-less …

### DIFF
--- a/src/lib/hub/mapOperationsRoutines.ts
+++ b/src/lib/hub/mapOperationsRoutines.ts
@@ -4,19 +4,38 @@
  * Emits one CalendarEvent per (routine, occurrence) pair so each
  * occurrence renders as its own tile on the Hub calendar.
  *
- * Timezone strategy: mirrors mapOperationsBlocks.ts — the server has
- * already DST-corrected each occurrence ISO via expandBetween, so we
- * extract LOCAL (browser-timezone) YYYY-MM-DD + HH:MM here. The Hub
- * renders in the browser's timezone; a routine scheduled at 8am PT
- * shows up at 11am ET for an ET viewer (correct).
+ * Display strategy (PR-Ops-5.8):
  *
- * endTime intentionally omitted in v1: routine.end_time is wall-clock
- * in routine.timezone (e.g., "10:00 in PT"), and converting that to
- * the browser's wall-clock for a specific occurrence date requires
- * additional timezone math. CalendarGrid handles missing endTime
- * gracefully — defaults to a 120-minute visual block (CalendarGrid.tsx
- * around line 105). Proper end-time rendering can be a follow-up PR
- * once the timezone conversion is locked.
+ *   TIMED routines (routine.start_time present):
+ *     - startTime / endTime are extracted DIRECTLY from routine.start_time /
+ *       routine.end_time via .slice(11, 16), mirroring the routines-page
+ *       convention (DailyPlanRoutineRow.tsx:65-79 / RoutineRow.tsx:211-222).
+ *       These are the user's intent-window — the literal HH:MM they typed —
+ *       so the Hub and the routines page now agree on what time a routine is.
+ *     - The rrule's BYHOUR/BYMINUTE is cron metadata for miss-evaluation, NOT
+ *       a display source. PR-Ops-5.6 incorrectly extracted display time from
+ *       the occurrence ISO via browser-local getHours(), causing the Hub to
+ *       disagree with the routines page (e.g., gym intent 07:00–09:00 rendered
+ *       at 02:00 on the Hub for some viewer-timezone × routine-timezone combos).
+ *
+ *   TIME-LESS routines (routine.start_time is null — cadence-only):
+ *     - Emitted WITHOUT startTime, which CalendarGrid interprets as an all-day
+ *       event (CalendarGrid.tsx:109 skips timed-block builder for events
+ *       without startTime; :350 collects them into the all-day row at the
+ *       top of the calendar, same mechanism as the existing AT&T / Food /
+ *       Coffee sources).
+ *     - This is a DELIBERATE, Alex-approved design choice per PR-Ops-5.8:
+ *       a routine with no intent-window start is not a timed event; placing
+ *       it in the hourly grid would assert a time it doesn't have. All-day
+ *       placement is the honest representation.
+ *     - Cost/expense semantics for these come LATER with the cost-fields
+ *       schema migration; this PR is display placement only.
+ *
+ * startDate is always converted from the occurrence ISO to YYYY-MM-DD IN THE
+ * ROUTINE'S TIMEZONE (via Intl.DateTimeFormat), not the viewer's browser
+ * timezone, so the tile lands on the correct calendar day regardless of
+ * where the Hub is being viewed. Mirrors the server's own formatLocalDate
+ * helper at /api/hub/operations-routines/route.ts:45-55.
  */
 
 import type { CalendarEvent } from '@/components/shared/CalendarGrid';
@@ -26,9 +45,9 @@ export interface RoutineWindowEntry {
   name: string;
   entity_id: string;
   timezone: string;
-  start_time: string | null;
+  start_time: string | null;  // "1970-01-01THH:MM:SS.000Z" or null (cadence-only)
   end_time: string | null;
-  occurrences: string[];
+  occurrences: string[];      // ISO instants from expandBetween
 }
 
 export interface RoutinesWindowResponse {
@@ -39,37 +58,67 @@ export interface RoutinesWindowResponse {
 const ROUTINES_SOURCE = 'routines';
 const ROUTINES_HREF = '/operations/routines';
 
-function pad(n: number): string {
-  return String(n).padStart(2, '0');
-}
-
-/** UTC ISO → local (browser timezone) YYYY-MM-DD + HH:MM components. */
-function toLocalDateAndTime(iso: string): { date: string; time: string } {
-  const d = new Date(iso);
-  return {
-    date: `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`,
-    time: `${pad(d.getHours())}:${pad(d.getMinutes())}`,
-  };
+/**
+ * Convert a UTC ISO instant to YYYY-MM-DD in the given IANA timezone.
+ * Falls back to UTC date if the timezone is malformed (defensive — every
+ * routine has a real timezone in practice, but Intl.DateTimeFormat can
+ * throw on bogus zone strings).
+ */
+function formatDateInZone(iso: string, timezone: string): string {
+  try {
+    return new Intl.DateTimeFormat('en-CA', {
+      timeZone: timezone,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    }).format(new Date(iso));
+  } catch {
+    return new Date(iso).toISOString().slice(0, 10);
+  }
 }
 
 export function mapOperationsRoutines(response: RoutinesWindowResponse): CalendarEvent[] {
   const events: CalendarEvent[] = [];
 
   for (const routine of response.routines) {
+    // Intent-window times — literal HH:MM the user typed, no tz math.
+    // Matches DailyPlanRoutineRow.tsx:65-79 exactly.
+    const startTime = routine.start_time ? routine.start_time.slice(11, 16) : null;
+    const endTime = routine.end_time ? routine.end_time.slice(11, 16) : null;
+
     for (const occISO of routine.occurrences) {
-      const local = toLocalDateAndTime(occISO);
-      events.push({
-        // Composite id: unique per (routine, occurrence) so CalendarGrid
-        // doesn't collide tiles when the same routine fires multiple
-        // times in the window.
-        id: `routine:${routine.routine_id}:${occISO}`,
-        source: ROUTINES_SOURCE,
-        title: routine.name,
-        startDate: local.date,
-        startTime: local.time,
-        isRecurring: true,
-        href: ROUTINES_HREF,
-      });
+      const startDate = formatDateInZone(occISO, routine.timezone);
+
+      if (startTime) {
+        // Timed routine → hourly-grid block at the user's intent window.
+        events.push({
+          id: `routine:${routine.routine_id}:${occISO}`,
+          source: ROUTINES_SOURCE,
+          title: routine.name,
+          startDate,
+          startTime,
+          endTime: endTime ?? undefined,
+          isRecurring: true,
+          href: ROUTINES_HREF,
+        });
+      } else {
+        // Time-less routine → all-day event at the top of the calendar.
+        // CalendarGrid uses the absence of startTime as the all-day signal
+        // (CalendarGrid.tsx:350 — `dayEvts.filter(e => !e.startTime)`).
+        // Deliberate per PR-Ops-5.8: a routine with no intent-window start
+        // is not a timed event; rendering it in the hourly grid would assert
+        // a time it doesn't have. Same visual treatment as the existing
+        // AT&T / Food / Coffee all-day sources.
+        events.push({
+          id: `routine:${routine.routine_id}:${occISO}`,
+          source: ROUTINES_SOURCE,
+          title: routine.name,
+          startDate,
+          // startTime intentionally omitted → CalendarGrid renders all-day
+          isRecurring: true,
+          href: ROUTINES_HREF,
+        });
+      }
     }
   }
 


### PR DESCRIPTION
…routines render all-day

The Phase 1 audit (commit cd026ef) traced an architectural divergence: mapOperationsRoutines.ts (PR-Ops-5.6) never read routine.start_time — it derived display time from the rrule occurrence ISO via browser-local getHours()/getMinutes(). That extracts the rrule's BYHOUR (cron metadata) through the VIEWER's browser timezone, while the routines page reads routine.start_time.slice(11, 16) directly (literal HH:MM the user typed, no tz math). The two paths agreed only by coincidence; in practice the Hub showed gym (intent 07:00–09:00) at 02:00 and sleep (00:00–06:00) as a lone "6:00 AM" tile.

The fix is a rewrite of mapOperationsRoutines.ts's per-routine block:

1. TIMED routines (routine.start_time present):
   - startTime = routine.start_time.slice(11, 16) — mirrors DailyPlanRoutineRow.tsx:65-79 / RoutineRow.tsx:211-222 exactly
   - endTime = routine.end_time.slice(11, 16) — restores the full window display that v1 omitted (no tz math required now; we just read the stored chars, same as the routines page)
   - startDate computed in routine.timezone via Intl.DateTimeFormat (mirrors the server's formatLocalDate helper at operations- routines/route.ts:45-55) so the tile lands on the correct calendar day regardless of viewer browser tz
   - Browser-local getHours/Date extraction removed entirely

2. TIME-LESS routines (routine.start_time null — cadence-only):
   - Emitted WITHOUT startTime. CalendarGrid's existing all-day mechanism (CalendarGrid.tsx:109 skips them in the timed-block builder; :350 collects via `dayEvts.filter(e => !e.startTime)` into the all-day row at the top) handles them automatically — same visual treatment as the existing AT&T / Food / Coffee sources. No CalendarEvent interface change, no isAllDay flag, no new mechanism — reuse what's there.
   - DELIBERATE design choice per Alex (PR-Ops-5.8 spec): a routine with no intent-window start is not a timed event; placing it in the hourly grid would assert a time it doesn't have. The all-day row is the honest representation. Documented in a code comment so it's not mistaken for a silent default.

Worked traces (browser-tz-independent now):
  - Gym (start_time 07:00, end 09:00, tz LA): slice → "07:00" / "09:00" → timed grid block 07:00–09:00 ✓ matches routines page
  - Sleep (start_time 00:00, end 06:00): slice → "00:00" / "06:00" → timed grid block 00:00–06:00 ✓ matches routines page (was a lone "6:00 AM" pre-fix)
  - Cadence-only routine (start_time null): no startTime emitted → CalendarGrid renders all-day at top ✓

Files (1 modified):
- src/lib/hub/mapOperationsRoutines.ts — full rewrite of the per- routine mapping loop; new formatDateInZone helper (5 lines, mirrors the server's formatLocalDate); browser-local getHours/Date derivation removed. ~50 net lines added including new docstring.

What did NOT change (out of scope):
- /api/hub/operations-routines/route.ts: the endpoint already returned start_time, end_time, timezone in RoutineWindowEntry — the data was always available; the mapper just ignored it.
- CalendarGrid.tsx: no structural change needed; the all-day mechanism was already in place (the AT&T / Food sources use it today).
- CalendarEvent interface: unchanged. Both startTime and endTime are already optional, so omitting startTime for time-less routines is a type-safe path that the existing code already handles.
- mapOperationsBlocks.ts (PR-Ops-5.3 task blocks): has a similar browser-tz extraction pattern but is a SEPARATE concept (one-time scheduled commitments, not recurring routines with intent windows). Deliberately not bundled per the spec.

Verification:
- npx tsc --noEmit: exit 0
- npx eslint <touched file>: exit 0, zero errors, zero warnings

Out of scope deferred:
- Routine cost/expense display on the Hub (waits for the cost-fields schema migration)
- mapOperationsBlocks browser-tz pattern review (separate audit)
- Regression test (test infra still absent in the repo per PR-Ops-5.7 Phase 2 — keep deferred posture until test framework is decided)
- Editable routine rows (the parallel PR-Ops-5.8 branch on a different concern)

Author: Temple Stuart <astuart@templestuart.com>