### PR TITLE
travel(PR-9): five-fix bundle — Viator orchestration + Adventure rena…

### DIFF
--- a/audit-reports/travel-pr-9.md
+++ b/audit-reports/travel-pr-9.md
@@ -1,0 +1,180 @@
+# Travel PR-9 — Five-Fix Bundle
+
+**Branch:** `claude/travel-pr-9`
+**Scope:** Viator orchestration reversal · `sports_fitness → adventure` rename ·
+intent-specific search terms · 250-result/category cap with pagination ·
+LiteAPI coordinate-based search.
+**Spirit:** "no gatekeeping, by god for the people" — open the floodgates so
+each carousel surfaces distinct, intent-matched inventory instead of the same
+generic city-tour pool.
+
+## Files Touched
+
+| File | Lines | Purpose |
+|---|---|---|
+| `src/lib/viatorClient.ts` | +71 / −30 | Fix 1 (orchestration), 2 (rename in set), 3 (terms), 4 (pagination) |
+| `src/lib/liteapiClient.ts` | +46 / −12 | Fix 5 (coordinate-radius search) |
+| `src/lib/destinations.ts` | +14 / 0 | `findDestinationCoords` helper |
+| `src/lib/travelCOA.ts` | +3 / −3 | Fix 2 (rename in COA + alias) |
+| `src/lib/travelCategories.ts` | +6 / −5 | Fix 2 (rename in legend + category map) |
+| `src/lib/travelSourceRegistry.ts` | +1 / −1 | Fix 2 (rename in registry) |
+| `src/components/trips/TripPlannerAI.tsx` | +1 / −1 | Fix 2 (rename in carousel order) |
+| `src/app/api/trips/[id]/ai-assistant/route.ts` | +13 / −6 | Fix 4 (viatorMax=250) + Fix 5 (plumb coords) |
+
+## Fix 1 — Viator orchestration reversal
+
+### Diagnosis (per `audit-reports/travel-viator-category-filter-audit.md`)
+
+`searchViatorProducts` previously executed `/products/search` *first*, which
+returns Viator's destination-wide product pool unfiltered. Because every
+category started with the *same* pool, the per-category freetext step (gated
+by `allProducts.length < maxResults` and capped at `slice(0, 3)` terms) rarely
+ran for popular destinations — so every carousel rendered the same top 33.
+
+### Change (`viatorClient.ts:351-410`)
+
+- **PRIMARY** is now `/search/freetext` per intent-specific term, paginated.
+- **FALLBACK** is `/products/search` (broadcast, paginated) — only fires when
+  freetext returned **zero** results (e.g. a niche category with no inventory
+  for this destination).
+- No-`destId` branch unchanged in spirit (city-suffixed freetext) — kept so
+  long-tail user-typed cities still work.
+
+### Why the failure mode flips
+
+Each carousel now starts with **its own** keyword search; only carousels that
+literally find nothing fall back to the destination-wide cast. The four Viator
+categories will surface inventory that actually matches their intent.
+
+## Fix 2 — `sports_fitness → adventure` rename
+
+Six files updated; ten code-level references replaced. The COA key change is
+the source of truth; the alias map keeps any pre-existing `sports_fitness`
+keys in `trip_events.source` resolving to the new `adventure` legend group.
+
+### Migration of legacy rows
+
+Existing `trip_scanner_results` / `places_cache` rows keyed by
+`'sports_fitness'`: **leave them**. Rationale:
+
+1. `trip_scanner_results` is per-trip-per-destination-per-category — new
+   scans simply write to the new `adventure` row; old rows just go unread
+   (next scan upserts on a new composite key).
+2. `places_cache` has its own TTL (24h-7d depending on entry) and ages out
+   naturally.
+3. No user-visible data lives in those rows; nothing breaks if they linger.
+
+No data migration script ships with this PR.
+
+### Aliases preserved
+
+`travelCategories.ts:31-32` keeps both `sportsFitness: 'adventure'` and
+`sports_fitness: 'adventure'` so any persisted event source or legacy URL
+parameter still resolves to the new category. Same applies to
+`travelCOA.ts:332` (calendar source config aliases `activities` /
+`activity` → `'adventure'`).
+
+## Fix 3 — Intent-specific, non-overlapping search terms
+
+`viatorClient.ts:204-212` replaces the old broad-term map. Three terms per
+category, chosen so different carousels return different inventory:
+
+```ts
+adventure:    ['surfing lesson', 'diving snorkeling', 'hiking trek']
+arts_culture: ['temple tour', 'cultural show', 'traditional dance']
+wellness:     ['yoga class', 'spa massage', 'meditation retreat']
+bucket_list:  ['private day tour', 'luxury experience', 'multi day tour']
+```
+
+The dropped categories (`nightlife`, `festivals`, `ground_transport`) are no
+longer routed to Viator in `SOURCE_BY_CATEGORY` — they were dead entries.
+`VIATOR_CATEGORIES` set updated to match.
+
+## Fix 4 — 250-result cap per category, paginated
+
+### Search-side (viatorClient.ts)
+
+- `searchV2Products` and `searchV2Freetext` now both accept a `start` param
+  (default 1). Each Viator V2 endpoint caps `count` at 50 per page; the
+  orchestrator drives pagination at 50/page.
+- Per-term loop in the orchestrator paginates until: `allProducts.length >=
+  maxResults`, an empty page, or a short page (< PAGE_SIZE).
+- Across-term loop short-circuits as soon as cap is reached.
+
+### Route-side (`ai-assistant/route.ts:248`)
+
+Bumped the Viator branch to `viatorMax = Math.max(maxResults, 250)` —
+client-passed values below 250 are floored up; >250 is honoured. The final
+`.slice(0, viatorMax)` matches so the UI receives the full pool.
+
+### Call budget
+
+Worst case: ~5 pages × 3 terms × 4 categories ≈ **60 calls per scan**.
+Viator's documented limit is 150 req / 10s, so a single scan fits inside one
+rolling window even sequentially. (Per-category isolation is already enforced
+by the registry-dispatch + per-category `Promise.allSettled` upstream.)
+
+## Fix 5 — LiteAPI coordinate-radius search
+
+### Diagnosis (per `audit-reports/travel-accommodation-thin-audit.md`)
+
+LiteAPI's `cityName` filter is brittle for parenthesised labels (e.g.
+`"Bali (Canggu)"`) and city/neighborhood ambiguity. `extractCityName`
+strips the parens, but the resulting `"Canggu"` doesn't always match
+LiteAPI's catalog spelling, returning zero hotels.
+
+### Change
+
+- `SearchHotelsParams` gains optional `latitude`, `longitude`, and
+  `radiusMeters` (default `25_000`).
+- When lat/lng are passed, the request body uses `(latitude, longitude,
+  radius, countryCode)` instead of `cityName` — LiteAPI's documented
+  geosearch path.
+- `findDestinationCoords(city, country)` helper added to `destinations.ts`,
+  reading the existing `lat` / `lng` fields on `ALL_DESTINATIONS` entries.
+- Route plumbs coords into `searchHotelRates` when found; falls through to
+  `cityName` for long-tail user-typed cities not in the static catalog.
+- One-line `[LiteAPI rates] mode=...` log so production traffic shows
+  which path each request took.
+
+### Behaviour for catalog cities
+
+Of the destinations populated in `destinations.ts`, the vast majority carry
+`lat`/`lng`. PR-9 expects coordinate-radius hits to replace zero-result
+`cityName` misses for "Bali (Canggu)", "Bangkok", "Tokyo", "Paris", etc.
+
+## Verification
+
+- `npx tsc --noEmit` — **exit 0** (clean).
+- `npm run lint` — no **new** errors introduced; pre-existing baseline
+  unchanged. (`next.config.ts: eslint.ignoreDuringBuilds: true` per repo
+  convention.)
+- `grep -rn "sports_fitness" src/` returns only the two intentional alias
+  rows in `travelCategories.ts:31-32` (legacy event-source → new legend
+  group); all primary references renamed.
+
+## Protected Invariants (unchanged by this PR)
+
+- Commit → budget spine: untouched (recommendation shape stable).
+- Registry `hardBookable` semantics: untouched (`adventure` inherits the
+  prior `sports_fitness` row's `viator + hardBookable: true`).
+- PR-3b reservation tables: untouched (this PR only changes search-time
+  routing).
+- PR-4 carousel UI: only one constant key swapped (`sports_fitness →
+  adventure`); component code unchanged.
+- PR-7 diagnostic logs: kept, plus one new `[LiteAPI rates] mode=...` log
+  for Fix 5 path observability.
+- Fail-loud errors: typed errors (`ViatorApiError`, `LiteApiError`,
+  `MissingViatorKeyError`) still re-thrown on 4xx + missing-key paths.
+
+## Scope Discipline
+
+Fix 4 (pagination) and Fix 5 (coords) both fit within their expected
+surface area:
+
+- Fix 4: two function signatures (added optional `start`), one orchestrator
+  block rewritten, one route-side max-bump. No new modules.
+- Fix 5: one interface widened, one body builder branched, one route-side
+  plumb call, one helper. No new modules.
+
+No scope expansion — proceeding to commit.

--- a/src/app/api/trips/[id]/ai-assistant/route.ts
+++ b/src/app/api/trips/[id]/ai-assistant/route.ts
@@ -7,7 +7,7 @@ import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { ACTIVITY_SEARCH_EXPANSIONS, ACTIVITY_LABELS } from '@/lib/activities';
 import { TRAVEL_COA, getCOAScanQueries } from '@/lib/travelCOA';
 import { searchViatorProducts, viatorProductToRecommendation } from '@/lib/viatorClient';
-import { findViatorDestIdFor } from '@/lib/destinations';
+import { findViatorDestIdFor, findDestinationCoords } from '@/lib/destinations';
 import { searchHotelRates, liteApiHotelToRecommendation } from '@/lib/liteapiClient';
 import { googleFetch, GooglePlacesQuotaError } from '@/lib/googlePlacesQuota';
 import {
@@ -194,12 +194,18 @@ export async function POST(
       const checkin = trip.startDate.toISOString().slice(0, 10);
       const checkout = trip.endDate.toISOString().slice(0, 10);
 
-      console.log(`[LiteAPI] ${category}: ${city}, ${country} (${checkin} → ${checkout}, ${adults} adults)`);
+      // PR-9 Fix 5: prefer the catalog's lat/lng over cityName when available.
+      // Brittle for parenthesised labels like "Bali (Canggu)" — coord-radius
+      // search avoids that whole class of zero-result misses. Falls through
+      // to cityName when the destination isn't in the static catalog.
+      const coords = findDestinationCoords(city, country);
+      console.log(`[LiteAPI] ${category}: ${city}, ${country} (${checkin} → ${checkout}, ${adults} adults)${coords ? ` coords=${coords.lat},${coords.lng}` : ''}`);
       try {
         const hotels = await searchHotelRates({
           city, country, checkin, checkout,
           occupancies: [{ adults }],
           maxResults,
+          ...(coords ? { latitude: coords.lat, longitude: coords.lng } : {}),
         });
 
         const finalResults = hotels
@@ -244,7 +250,12 @@ export async function POST(
         // call entirely. Returns null for long-tail cities — the dynamic
         // fallback (loadDestinations + in-lambda memo) still kicks in for them.
         const preResolvedDestId = findViatorDestIdFor(city, country);
-        const viatorProducts = await searchViatorProducts(city, country, category, tripActivities, maxResults, preResolvedDestId);
+        // PR-9 Fix 4: lift per-category cap to 250 ("show all") so each Viator
+        // carousel has enough distinct inventory to dedupe + sort. Stays
+        // inside Viator's 150-req/10s window: ~5 pages × 3 terms × 4
+        // categories ≈ 60 calls per scan. See PR-9 audit notes.
+        const viatorMax = Math.max(maxResults, 250);
+        const viatorProducts = await searchViatorProducts(city, country, category, tripActivities, viatorMax, preResolvedDestId);
 
         const viatorResults = viatorProducts.map((p, idx) => {
           const rec = viatorProductToRecommendation(p, category, 'midrange');
@@ -253,7 +264,7 @@ export async function POST(
 
         const finalResults = viatorResults
           .sort((a, b) => b.compositeScore - a.compositeScore)
-          .slice(0, maxResults);
+          .slice(0, viatorMax);
 
         console.log(`[Viator] ${category}: ${finalResults.length} results (hardBookable=${hardBookable})`);
 

--- a/src/components/trips/TripPlannerAI.tsx
+++ b/src/components/trips/TripPlannerAI.tsx
@@ -879,7 +879,7 @@ export default function TripPlannerAI({ tripId, city, country, activity, activit
 // Discovery (Google) last so eyes land on bookable rows before browsable ones.
 const CAROUSEL_ORDER = [
   'accommodation',     // Stays (LiteAPI)
-  'sports_fitness',    // Things to do — Sports & fitness (Viator)
+  'adventure',         // Things to do — Adventure (Viator)
   'arts_culture',      // Things to do — Arts & culture (Viator)
   'wellness',          // Wellness & spas (Viator)
   'bucket_list',       // Bucket-list experiences (Viator)

--- a/src/lib/destinations.ts
+++ b/src/lib/destinations.ts
@@ -570,6 +570,20 @@ export function findViatorDestIdFor(cityName: string, _country?: string): number
   return match?.viatorDestId ?? null;
 }
 
+/**
+ * Look up the static lat/lng for a city in the catalog. Returns null when
+ * the destination isn't in the catalog (long-tail user-typed cities) or
+ * doesn't have coordinates populated. Used by LiteAPI to prefer a
+ * coordinate-radius search over `cityName` matching — LiteAPI's `cityName`
+ * filter is brittle for parenthesised labels (e.g. "Bali (Canggu)") and
+ * city/neighborhood ambiguity. PR-9 Fix 5.
+ */
+export function findDestinationCoords(cityName: string, _country?: string): { lat: number; lng: number } | null {
+  const match = ALL_DESTINATIONS.find(d => d.name === cityName && d.type === 'city');
+  if (match?.lat != null && match?.lng != null) return { lat: match.lat, lng: match.lng };
+  return null;
+}
+
 // =============================================================================
 // STATS
 // =============================================================================

--- a/src/lib/liteapiClient.ts
+++ b/src/lib/liteapiClient.ts
@@ -124,6 +124,15 @@ export interface SearchHotelsParams {
   guestNationality?: string;
   /** Cap on results returned by this client. */
   maxResults?: number;
+  /** PR-9 Fix 5: when provided, coordinate-radius search is preferred over
+   *  cityName matching. LiteAPI accepts (latitude, longitude, radius) on
+   *  `/hotels/rates` and the result is more tolerant of city-name spelling
+   *  variants ("Bali (Canggu)" vs "Canggu") + neighborhood ambiguity. */
+  latitude?: number;
+  longitude?: number;
+  /** Search radius in meters. Defaults to 25_000 (25km) — covers a metro
+   *  area plus its nearby beach towns / suburbs. */
+  radiusMeters?: number;
 }
 
 /** Raw hotel + rate as LiteAPI returns it. Keep loose — LiteAPI's V3 response
@@ -167,20 +176,41 @@ interface LiteApiHotelRate {
  *  Throws `MissingLiteApiKeyError` if no key set, `LiteApiError` on non-2xx. */
 export async function searchHotelRates(params: SearchHotelsParams): Promise<LiteApiHotelRate[]> {
   const countryCode = countryNameToIso2(params.country);
-  const body = {
-    cityName: extractCityName(params.city),
-    countryCode,
-    checkin: params.checkin,
-    checkout: params.checkout,
-    occupancies: params.occupancies,
-    currency: params.currency || 'USD',
-    guestNationality: params.guestNationality || 'US',
-    // Per LiteAPI's docs (Rate-and-Hotel-Query guide), hotel metadata (name,
-    // photo, address, rating, tags) is included when this flag is true. Auto-
-    // enabled for cityName filter, but we pass it explicitly so the behaviour
-    // never silently changes if LiteAPI flips the default.
-    includeHotelData: true,
-  };
+  // PR-9 Fix 5: prefer coordinate-radius search when lat/lng are on file.
+  // LiteAPI's `cityName` filter is brittle for parenthesised labels (e.g.
+  // "Bali (Canggu)") and city/neighborhood ambiguity. When the catalog has
+  // coords we send (latitude, longitude, radius); otherwise fall back to
+  // cityName so long-tail user-typed destinations still work.
+  const useCoords = typeof params.latitude === 'number' && typeof params.longitude === 'number';
+  const radius = params.radiusMeters ?? 25_000;
+  const body: Record<string, unknown> = useCoords
+    ? {
+        latitude: params.latitude,
+        longitude: params.longitude,
+        radius,
+        countryCode,
+        checkin: params.checkin,
+        checkout: params.checkout,
+        occupancies: params.occupancies,
+        currency: params.currency || 'USD',
+        guestNationality: params.guestNationality || 'US',
+        includeHotelData: true,
+      }
+    : {
+        cityName: extractCityName(params.city),
+        countryCode,
+        checkin: params.checkin,
+        checkout: params.checkout,
+        occupancies: params.occupancies,
+        currency: params.currency || 'USD',
+        guestNationality: params.guestNationality || 'US',
+        // Per LiteAPI's docs (Rate-and-Hotel-Query guide), hotel metadata
+        // (name, photo, address, rating, tags) is included when this flag is
+        // true. Auto-enabled for cityName filter, but we pass it explicitly
+        // so behaviour never silently changes if LiteAPI flips the default.
+        includeHotelData: true,
+      };
+  console.log(`[LiteAPI rates] mode=${useCoords ? `coords lat=${params.latitude} lng=${params.longitude} radius=${radius}m` : `cityName=${extractCityName(params.city)}`} country=${countryCode}`);
 
   const url = `${LITEAPI_BASE}/hotels/rates`;
   const res = await fetch(url, {

--- a/src/lib/travelCOA.ts
+++ b/src/lib/travelCOA.ts
@@ -81,8 +81,8 @@ export const TRAVEL_COA: Record<string, COACategory> = {
     defaultFrequency: 'per_visit',
     vendorApi: 'activities', optionType: 'activity', multiDay: false,
   },
-  sports_fitness: {
-    label: 'Sports & Fitness',
+  adventure: {
+    label: 'Adventure',
     color: '#2ecc71',
     bg: 'bg-green-100', dot: 'bg-green-500', badge: 'bg-green-500',
     coaPersonal: 'P-9410', coaBusiness: null,
@@ -329,7 +329,7 @@ export function buildCalendarSourceConfig(): Record<string, { label: string; ico
   // Backward-compat aliases: map old event source keys to COA categories
   const ALIASES: Record<string, string> = {
     flight: 'flights', lodging: 'accommodation', brunchCoffee: 'brunch_coffee',
-    activities: 'sports_fitness', activity: 'sports_fitness',
+    activities: 'adventure', activity: 'adventure',
     transfer: 'ground_transport', vehicle: 'ground_transport',
     toiletries: 'shopping',
   };

--- a/src/lib/travelCategories.ts
+++ b/src/lib/travelCategories.ts
@@ -15,7 +15,7 @@ const TRAVEL_CATEGORIES: Record<string, TravelCategory> = {
   brunch_coffee:  { key: 'brunch_coffee',  label: 'Brunch & Coffee',    section: 'dining',     coaCode: '9310', calendarColor: '#F59E0B' },
   dinner:         { key: 'dinner',         label: 'Dinner',             section: 'dining',     coaCode: '9320', calendarColor: '#F59E0B' },
   arts_culture:   { key: 'arts_culture',   label: 'Activities',         section: 'activities', coaCode: '9420', calendarColor: '#8B5CF6' },
-  sports_fitness: { key: 'sports_fitness', label: 'Sports & Fitness',   section: 'activities', coaCode: '9410', calendarColor: '#10B981' },
+  adventure:      { key: 'adventure',      label: 'Adventure',          section: 'activities', coaCode: '9410', calendarColor: '#10B981' },
   nightlife:      { key: 'nightlife',      label: 'Activities',         section: 'activities', coaCode: '9430', calendarColor: '#8B5CF6' },
   festivals:      { key: 'festivals',      label: 'Activities',         section: 'activities', coaCode: '9440', calendarColor: '#8B5CF6' },
   bucket_list:    { key: 'bucket_list',    label: 'Activities',         section: 'activities', coaCode: '9450', calendarColor: '#8B5CF6' },
@@ -28,7 +28,8 @@ const TRAVEL_CATEGORIES: Record<string, TravelCategory> = {
 const ALIASES: Record<string, string> = {
   brunchCoffee: 'brunch_coffee',
   artsCulture: 'arts_culture',
-  sportsFitness: 'sports_fitness',
+  sportsFitness: 'adventure',
+  sports_fitness: 'adventure',
   bucketList: 'bucket_list',
   groundTransport: 'transport',
   ground_transport: 'transport',
@@ -106,7 +107,7 @@ export function getExcludeFromActivitiesKeys(): Set<string> {
 
 // Consolidated legend labels — groups sub-categories under unified labels
 // Only these appear in the calendar legend:
-//   Flights, Accommodation, Dining, Activities, Sports & Fitness
+//   Flights, Accommodation, Dining, Activities, Adventure
 const LEGEND_GROUPS: Record<string, {
   label: string;
   color: string;
@@ -118,7 +119,7 @@ const LEGEND_GROUPS: Record<string, {
   accommodation:  { label: 'Accommodation',    color: '#60A5FA', bg: 'bg-blue-100',   dot: 'bg-blue-400',   badge: 'bg-blue-400' },
   dining:         { label: 'Dining',           color: '#F59E0B', bg: 'bg-amber-100',  dot: 'bg-amber-400',  badge: 'bg-amber-400' },
   activities:     { label: 'Activities',       color: '#8B5CF6', bg: 'bg-violet-100', dot: 'bg-violet-400', badge: 'bg-violet-400' },
-  sports_fitness: { label: 'Sports & Fitness', color: '#10B981', bg: 'bg-green-100',  dot: 'bg-green-500',  badge: 'bg-green-500' },
+  adventure:      { label: 'Adventure',        color: '#10B981', bg: 'bg-green-100',  dot: 'bg-green-500',  badge: 'bg-green-500' },
 };
 
 // Map every possible event source key to its legend group
@@ -128,7 +129,7 @@ function legendGroupFor(source: string): string {
   if (!cat) return 'activities';
   if (cat.section === 'lodging') return 'accommodation';
   if (cat.section === 'dining') return 'dining';
-  if (cat.key === 'sports_fitness') return 'sports_fitness';
+  if (cat.key === 'adventure') return 'adventure';
   return 'activities';
 }
 

--- a/src/lib/travelSourceRegistry.ts
+++ b/src/lib/travelSourceRegistry.ts
@@ -65,7 +65,7 @@ export const SOURCE_BY_CATEGORY: Record<string, SourceAssignment> = {
   // LIVE on Viator — Activities / Tours / Wellness / Sports / Bucket-list.
   // hardBookable: a Google "yoga studio" POI is not a bookable Viator
   // experience, so empty Viator stays empty (no Google masking).
-  sports_fitness:   { source: 'viator', hardBookable: true },
+  adventure:        { source: 'viator', hardBookable: true },
   arts_culture:     { source: 'viator', hardBookable: true },
   wellness:         { source: 'viator', hardBookable: true },
   bucket_list:      { source: 'viator', hardBookable: true },

--- a/src/lib/viatorClient.ts
+++ b/src/lib/viatorClient.ts
@@ -201,14 +201,15 @@ function normalizeV2Product(p: any): ViatorProduct {
 
 // ─── COA Category → Search Terms ─────────────────────────────────────────────
 
+// PR-9 Fix 3: tightened, intent-specific, non-overlapping search terms — three
+// per category, chosen so each Viator carousel returns distinct inventory
+// rather than the same generic "city tour" pool. See
+// audit-reports/travel-viator-category-filter-audit.md.
 const COA_TO_VIATOR_SEARCH: Record<string, string[]> = {
-  sports_fitness: ['outdoor activities', 'water sports', 'hiking', 'surfing', 'diving', 'yoga'],
-  arts_culture: ['museums', 'cultural tours', 'cooking classes', 'art galleries', 'temples', 'historical tours', 'food tours'],
-  nightlife: ['nightlife', 'pub crawls', 'dinner shows', 'evening tours', 'bar tours'],
-  festivals: ['festivals', 'events', 'concerts', 'cultural events'],
-  wellness: ['spa', 'wellness', 'yoga retreat', 'massage'],
-  bucket_list: ['adventure', 'unique experiences', 'safari', 'hot air balloon', 'volcano tours'],
-  ground_transport: ['airport transfers', 'private transfers', 'car rental', 'transportation'],
+  adventure: ['surfing lesson', 'diving snorkeling', 'hiking trek'],
+  arts_culture: ['temple tour', 'cultural show', 'traditional dance'],
+  wellness: ['yoga class', 'spa massage', 'meditation retreat'],
+  bucket_list: ['private day tour', 'luxury experience', 'multi day tour'],
 };
 
 function buildSearchTerms(coaCategory: string, userInterests: string[]): string[] {
@@ -245,13 +246,13 @@ function buildAffiliateUrl(productCode: string): string {
 // ─── Product Search ──────────────────────────────────────────────────────────
 
 /** V2 /products/search — best for destination-based filtering with tags */
-async function searchV2Products(destId: number, maxCount: number, tagIds?: number[]): Promise<ViatorProduct[]> {
+async function searchV2Products(destId: number, maxCount: number, tagIds?: number[], start: number = 1): Promise<ViatorProduct[]> {
   const body: Record<string, any> = {
     filtering: {
       destination: String(destId),
     },
     sorting: { sort: 'DEFAULT' },
-    pagination: { start: 1, count: Math.min(maxCount, 50) },
+    pagination: { start, count: Math.min(maxCount, 50) },
     currency: 'USD',
   };
   if (tagIds && tagIds.length > 0) {
@@ -273,10 +274,10 @@ async function searchV2Products(destId: number, maxCount: number, tagIds?: numbe
 }
 
 /** V2 /search/freetext — best for keyword-based searching */
-async function searchV2Freetext(searchTerm: string, destId: number | null, maxCount: number): Promise<ViatorProduct[]> {
+async function searchV2Freetext(searchTerm: string, destId: number | null, maxCount: number, start: number = 1): Promise<ViatorProduct[]> {
   const body: Record<string, any> = {
     searchTerm,
-    searchTypes: [{ searchType: 'PRODUCTS', pagination: { start: 1, count: Math.min(maxCount, 50) } }],
+    searchTypes: [{ searchType: 'PRODUCTS', pagination: { start, count: Math.min(maxCount, 50) } }],
     currency: 'USD',
     // /search/freetext accepts REVIEW_AVG_RATING (per Viator's documented
     // enum); TRAVELER_RATING is only valid on /products/search. Using the
@@ -348,31 +349,70 @@ export async function searchViatorProducts(
     if (err instanceof ViatorApiError && err.status >= 400 && err.status < 500) throw err;
   };
 
-  // 1. Try V2 /products/search if we have a destId (fastest, best filtering)
-  if (destId) {
-    try {
-      const products = await searchV2Products(destId, Math.min(maxResults, 50));
-      addProducts(products);
-      console.log(`[Viator] V2 /products/search: ${products.length} results for destId ${destId}`);
-    } catch (err) {
-      rethrowIfHardFailure(err);
-      console.error('[Viator] V2 /products/search transient error:', err);
-    }
-  }
+  // PR-9 Fix 1+4: PRIMARY path is /search/freetext per intent-specific term,
+  // paginated up to maxResults. This is what surfaces distinct inventory per
+  // carousel — the prior `/products/search`-first path returned the same
+  // destination-wide pool for every category. See
+  // audit-reports/travel-viator-category-filter-audit.md. Per-term pagination
+  // budget: ~5 pages × 3 terms × 4 categories ≈ 60 calls per scan, well
+  // inside Viator's 150-req/10s window.
+  const PAGE_SIZE = 50;
 
-  // 2. Supplement with V2 freetext for each search term (more targeted)
-  if (allProducts.length < maxResults) {
-    for (const term of searchTerms.slice(0, 3)) {
+  if (destId) {
+    for (const term of searchTerms) {
+      if (allProducts.length >= maxResults) break;
+      let start = 1;
+      // Paginate this term until we hit maxResults, an empty page, or a short page.
+      while (allProducts.length < maxResults) {
+        try {
+          const page = await searchV2Freetext(term, destId, PAGE_SIZE, start);
+          if (page.length === 0) break;
+          const beforeCount = allProducts.length;
+          addProducts(page);
+          console.log(`[Viator] freetext "${term}" page start=${start}: +${allProducts.length - beforeCount} new (${page.length} returned)`);
+          if (page.length < PAGE_SIZE) break;
+          start += PAGE_SIZE;
+        } catch (err) {
+          rethrowIfHardFailure(err);
+          console.error(`[Viator] V2 freetext transient error for "${term}" start=${start}:`, err);
+          break;
+        }
+      }
+    }
+  } else {
+    // No destId — city-suffixed freetext (legacy path for long-tail cities).
+    for (const term of searchTerms) {
       if (allProducts.length >= maxResults) break;
       try {
-        const searchQuery = destId ? term : `${term} ${city}`;
-        const products = await searchV2Freetext(searchQuery, destId, Math.min(maxResults, 50));
+        const products = await searchV2Freetext(`${term} ${city}`, null, PAGE_SIZE, 1);
         addProducts(products);
       } catch (err) {
         rethrowIfHardFailure(err);
-        console.error(`[Viator] V2 freetext transient error for "${term}":`, err);
+        console.error(`[Viator] V2 freetext transient error for "${term} ${city}":`, err);
       }
     }
+  }
+
+  // FALLBACK: when intent-specific freetext yielded nothing (e.g. niche
+  // category with no inventory for this destination), broadcast-fetch the
+  // destination via /products/search so the UI isn't empty for popular cities
+  // that do have generic tours. Paginated to the same maxResults cap.
+  if (destId && allProducts.length === 0) {
+    let start = 1;
+    while (allProducts.length < maxResults) {
+      try {
+        const page = await searchV2Products(destId, PAGE_SIZE, undefined, start);
+        if (page.length === 0) break;
+        addProducts(page);
+        if (page.length < PAGE_SIZE) break;
+        start += PAGE_SIZE;
+      } catch (err) {
+        rethrowIfHardFailure(err);
+        console.error(`[Viator] V2 /products/search fallback transient error start=${start}:`, err);
+        break;
+      }
+    }
+    console.log(`[Viator] /products/search fallback for destId ${destId}: ${allProducts.length} results`);
   }
 
   // V1 fallback paths were removed in PR-5 — the V1 host (viatorapi.viator.com)
@@ -483,14 +523,13 @@ export function viatorProductToRecommendation(
 
 // ─── Categories that use Viator vs Google Places ─────────────────────────────
 
+// Mirrors SOURCE_BY_CATEGORY in travelSourceRegistry.ts — these are the four
+// COA categories actually routed to Viator. Kept in sync with the registry.
 export const VIATOR_CATEGORIES = new Set([
-  'sports_fitness',
+  'adventure',
   'arts_culture',
-  'nightlife',
-  'festivals',
   'wellness',
   'bucket_list',
-  'ground_transport',
 ]);
 
 export function isViatorCategory(category: string): boolean {


### PR DESCRIPTION
…me + tight terms + 250 cap + LiteAPI coords

Fix 1: Reverse Viator orchestration — searchV2Freetext per intent term is PRIMARY (paginated); /products/search is FALLBACK only when freetext is empty. Was the opposite, which is why every carousel returned the same destination-wide pool. Per audit travel-viator-category-filter-audit.md.

Fix 2: Rename sports_fitness → adventure (key + label) across COA, registry, category map, legend, carousel order, and Viator categories set. Legacy key alias preserved so persisted event-source rows still resolve.

Fix 3: Replace COA_TO_VIATOR_SEARCH with three intent-specific, non-overlapping terms per category — adventure / arts_culture / wellness / bucket_list. Dropped dead nightlife/festivals/ground_transport entries (not routed to Viator in SOURCE_BY_CATEGORY).

Fix 4: Lift per-category cap to 250 with /50-per-page pagination on both searchV2Freetext and searchV2Products. Budget ~5 pages × 3 terms × 4 categories ≈ 60 calls/scan, inside Viator's 150-req/10s window.

Fix 5: LiteAPI coordinate-radius search — SearchHotelsParams gains latitude/longitude/radiusMeters (default 25km); preferred over cityName when destinations.ts has coords for the city. New findDestinationCoords helper. Fixes Bali (Canggu) and similar parenthesised-label misses.

Audit: audit-reports/travel-pr-9.md.
Verification: tsc --noEmit clean; no new lint errors; no sports_fitness references remain outside the two intentional alias rows.

https://claude.ai/code/session_01SzdMRckkgo78XAuLBek5m7