### PR TITLE
Travel-PR-10: Viator destination fix + alias route + TZ + LiteAPI sto…

### DIFF
--- a/src/app/api/trips/[id]/ai-assistant/route.ts
+++ b/src/app/api/trips/[id]/ai-assistant/route.ts
@@ -19,6 +19,7 @@ import {
   LiteApiError,
 } from '@/lib/travelErrors';
 import { getSource, UnimplementedSourceError } from '@/lib/travelSourceRegistry';
+import { getCategoryByKey } from '@/lib/travelCategories';
 
 // ─── Travel destination scan ─────────────────────────────────────────────────
 // COMPLIANCE: per Google Places API terms, Google Places data is NOT sent to any
@@ -135,9 +136,19 @@ export async function POST(
       minRating = 4.0,
       minReviews = 50,
       maxPriceLevel,
-      category,
+      category: rawCategory,
       maxResults: rawMaxResults,
     } = body;
+    // PR-10 Fix 2: alias-resolve legacy category keys before validation so
+    // stale client bundles (still sending 'sports_fitness') survive PR-9's
+    // rename to 'adventure'. getCategoryByKey() consults travelCategories.ts's
+    // ALIASES map (sports_fitness → adventure, sportsFitness → adventure, etc).
+    // Downstream code uses `category` (the resolved key) so registry dispatch,
+    // scanner_results upserts, and Viator/LiteAPI calls all see the canonical
+    // value regardless of what the client sent.
+    const category: string | undefined = rawCategory
+      ? getCategoryByKey(rawCategory)?.key || rawCategory
+      : rawCategory;
     categoryForError = category;
 
     if (!city || !country) {
@@ -145,9 +156,9 @@ export async function POST(
     }
 
     // Accept COA keys, legacy CATEGORY_SEARCHES keys, or interest slugs
-    const isCOACategory = !!TRAVEL_COA[category];
-    const isLegacyCategory = !!CATEGORY_SEARCHES[category];
-    const isInterestCategory = !!ACTIVITY_SEARCH_EXPANSIONS[category];
+    const isCOACategory = !!category && !!TRAVEL_COA[category];
+    const isLegacyCategory = !!category && !!CATEGORY_SEARCHES[category];
+    const isInterestCategory = !!category && !!ACTIVITY_SEARCH_EXPANSIONS[category];
     if (!category || (!isCOACategory && !isLegacyCategory && !isInterestCategory)) {
       return NextResponse.json({ error: 'Valid category required' }, { status: 400 });
     }
@@ -191,8 +202,24 @@ export async function POST(
       }
       const participantCount = await prisma.trip_participants.count({ where: { tripId } });
       const adults = Math.max(1, participantCount);
-      const checkin = trip.startDate.toISOString().slice(0, 10);
-      const checkout = trip.endDate.toISOString().slice(0, 10);
+      // PR-10 Fix 5 — STOPGAP pending PR-11 per-leg dates.
+      // Multi-destination trips currently store ONE startDate/endDate on
+      // `trips`; we don't yet have a `trip_destinations.startDate/endDate`
+      // schema. For a 185-night trip (Bali → Singapore → Phuket → …) we'd
+      // be asking LiteAPI for a property continuously available the full
+      // span — almost nothing qualifies, search returns 0–1 hotel, totals
+      // come back as e.g. $58k. As an explicit interim, cap the LiteAPI
+      // window to the first 7 nights from trip.startDate so the user sees
+      // realistic per-stay totals and a populated carousel. PR-11 lands
+      // the proper fix: per-destination startDate/endDate on
+      // trip_destinations + a per-chip date picker + destinationId
+      // plumbing into this route.
+      const STOPGAP_NIGHTS = 7;
+      const stopgapCheckin = new Date(trip.startDate);
+      const stopgapCheckout = new Date(stopgapCheckin);
+      stopgapCheckout.setDate(stopgapCheckout.getDate() + STOPGAP_NIGHTS);
+      const checkin = stopgapCheckin.toISOString().slice(0, 10);
+      const checkout = stopgapCheckout.toISOString().slice(0, 10);
 
       // PR-9 Fix 5: prefer the catalog's lat/lng over cityName when available.
       // Brittle for parenthesised labels like "Bali (Canggu)" — coord-radius

--- a/src/components/trips/ItineraryComparison.tsx
+++ b/src/components/trips/ItineraryComparison.tsx
@@ -88,7 +88,15 @@ export default function ItineraryComparison({
     const dates: string[] = [];
     for (let i = 0; i < daysTravel; i++) {
       const d = new Date(year, month - 1, startDay + i);
-      dates.push(d.toISOString().split('T')[0]);
+      // PR-10 Fix 4: format as local-time YYYY-MM-DD. `d.toISOString()`
+      // projects local midnight to UTC, which shifts the date backwards by
+      // one day for users in TZ ahead of UTC (Bali = UTC+8 → "Jun 30" for
+      // a "Jul 1" local date). Building the string manually keeps it in
+      // the local timezone without round-tripping through UTC.
+      const yyyy = d.getFullYear();
+      const mm = String(d.getMonth() + 1).padStart(2, '0');
+      const dd = String(d.getDate()).padStart(2, '0');
+      dates.push(`${yyyy}-${mm}-${dd}`);
     }
     return dates;
   }, [startDay, month, year, daysTravel]);

--- a/src/components/trips/TripPlannerAI.tsx
+++ b/src/components/trips/TripPlannerAI.tsx
@@ -75,6 +75,10 @@ const CATEGORY_INFO: Record<string, { label: string; icon: string }> = {
   nightlife: { label: 'Nightlife', icon: '' },
   toiletries: { label: 'Toiletries/Supplies', icon: '' },
   wellness: { label: 'Wellness/Gym', icon: '' },
+  // PR-10 Fix 3: defensive label entry so any stale client bundle / cache
+  // path still resolves to "Adventure" instead of falling through to a
+  // pre-PR-9 TRAVEL_COA snapshot that still says "Sports & Fitness".
+  adventure: { label: 'Adventure', icon: '' },
 };
 
 const FREQUENCY_OPTIONS = [
@@ -888,7 +892,9 @@ const CAROUSEL_ORDER = [
   'nightlife',         // Nightlife (Google)
   'coworking',         // Coworking (Google)
   'shopping',          // Shopping (Google)
-  'conferences',       // Conferences (Google — business/mixed trips only)
+  // PR-10 Fix 6: Conferences removed — Google returns venues, not actual
+  // upcoming conferences. Queued for a future PR with a real conference
+  // API (Eventbrite / 10times / Bizzabo).
   'ground_transport',  // Transfers (Mozio — fails loud "not connected" today)
 ] as const;
 

--- a/src/lib/travelCOA.ts
+++ b/src/lib/travelCOA.ts
@@ -283,6 +283,13 @@ export function getActiveScanCategories(userInterests: string[], tripType: strin
     if (key === 'flights') continue;
     // Skip communication and insurance — no scannable results
     if (key === 'communication' || key === 'insurance_fees') continue;
+    // PR-10 Fix 6: skip conferences. Google Places returns "venues that
+    // host events" (convention centers, ballrooms) — not actual upcoming
+    // conferences with dates, agendas, registration links. A future PR
+    // wires a real conference API (Eventbrite / 10times / Bizzabo) and
+    // re-enables the carousel. The TRAVEL_COA entry stays so the B-9500
+    // budget mapping for hand-entered conference expenses keeps working.
+    if (key === 'conferences') continue;
     // Skip business meals unless business/mixed trip
     if (key === 'business_meals' && tripType !== 'business' && tripType !== 'mixed') continue;
     // Everything else gets scanned

--- a/src/lib/viatorClient.ts
+++ b/src/lib/viatorClient.ts
@@ -285,7 +285,12 @@ async function searchV2Freetext(searchTerm: string, destId: number | null, maxCo
     productSorting: { sort: 'REVIEW_AVG_RATING', order: 'DESCENDING' },
   };
   if (destId) {
-    body.productFiltering = { destination: { type: 'DESTINATION', destId } };
+    // PR-10 Fix 1: Viator /search/freetext expects `destination` as a plain
+    // destId value, not the `{ type, destId }` shape used by /products/search.
+    // Sending the nested object returned BAD_REQUEST "Invalid value format
+    // for field: destination" on every freetext call — exposed once PR-9
+    // promoted freetext to the primary search path.
+    body.productFiltering = { destination: destId };
   }
 
   const res = await fetch(`${VIATOR_V2_BASE}/search/freetext`, {


### PR DESCRIPTION
…pgap + conferences removed

Six surgical fixes consolidating the post-PR-9 regression audit (audit-reports/travel-pr-9-regression-audit.md, commit 79dec9cf).

Fix 1 (viatorClient.ts:287-294): /search/freetext expects productFiltering.destination as a plain destId, not the nested { type: 'DESTINATION', destId } shape used by /products/search. PR-9 promoted freetext to primary, exposing this latent body bug as BAD_REQUEST "Invalid value format for field: destination" on the Arts/Wellness/Bucket-list carousels. One-line shape fix.

Fix 2 (ai-assistant/route.ts:131-163): alias-resolve the incoming category key against travelCategories.ts's ALIASES map before the TRAVEL_COA / CATEGORY_SEARCHES / ACTIVITY_SEARCH_EXPANSIONS validator, so stale client bundles sending sports_fitness still hit the Adventure path post-rename. Downstream code uses the resolved key (registry dispatch, scanner_results upserts, Viator/LiteAPI calls) so the canonical key reaches every consumer regardless of what the client sent.

Fix 3 (TripPlannerAI.tsx:78-81): defensive CATEGORY_INFO['adventure'] entry. No in-code source for "Sports & Fitness" remains after PR-9, but this guards against any cached resolver path still falling through to the old label.

Fix 4 (ItineraryComparison.tsx:89-99): replace
new Date(y,m-1,d).toISOString().split('T')[0] with a local-time YYYY-MM-DD builder. The UTC round-trip shifts dates backward by one day for users in TZ ahead of UTC (Bali = UTC+8 → "Jun 30" rendered for a "Jul 1" local date).

Fix 5 (ai-assistant/route.ts:200-218): STOPGAP — cap the LiteAPI search window to the first 7 nights from trip.startDate. trip_ destinations has no per-leg startDate/endDate yet; on a 185-night multi-destination trip we'd ask LiteAPI for a property continuously available the full span and get 0–1 hotels + $58k totals. Explicit stopgap, clearly commented; PR-11 lands the proper schema migration + per-chip date pickers + destinationId plumbing.

Fix 6 (travelCOA.ts:284-291 + TripPlannerAI.tsx:893-895): remove Conferences from the active scan. Google Places returns venues (halls, ballrooms), not actual upcoming conferences. TRAVEL_COA entry stays so historic B-9500 budget rows keep their label; a future PR wires a real conference API (Eventbrite / 10times / Bizzabo) and re-enables.

Verification:
- npx tsc --noEmit clean (exit 0).
- npm run lint — no new errors; pre-existing baseline unchanged.
- git diff main on protected surfaces: prisma/ untouched, travelSourceRegistry.ts untouched, liteapiClient.ts untouched, scanner_results shape untouched, carousel UI structure untouched (only CATEGORY_INFO map + CAROUSEL_ORDER list edited).
- PR-7 diagnostic logs preserved.

Honest call-out: LiteAPI hotels show a 7-day window from trip.startDate, NOT per-leg dates. PR-11 fixes that properly by adding trip_destinations.startDate/endDate + per-chip date pickers + destinationId plumbing into the ai-assistant route.

https://claude.ai/code/session_01SzdMRckkgo78XAuLBek5m7