### PR TITLE
Travel-PR-11: collapse 4 Viator carousels to single Activities row

### DIFF
--- a/src/components/trips/TripPlannerAI.tsx
+++ b/src/components/trips/TripPlannerAI.tsx
@@ -71,7 +71,11 @@ const CATEGORY_INFO: Record<string, { label: string; icon: string }> = {
   airportTransfers: { label: 'Airport Transfers', icon: '' },
   brunchCoffee: { label: 'Brunch & Coffee', icon: '' },
   dinner: { label: 'Dinner', icon: '' },
-  activities: { label: 'Activities/Tours', icon: '' },
+  // PR-11: 'activities' is the unified Viator carousel — label rendered as
+  // the carousel header next to the "via Viator" source attribution.
+  // Pre-PR-11 this entry read 'Activities/Tours' (legacy CATEGORY_SEARCHES
+  // key); now it doubles as the canonical label for the unified bucket.
+  activities: { label: 'Activities', icon: '' },
   nightlife: { label: 'Nightlife', icon: '' },
   toiletries: { label: 'Toiletries/Supplies', icon: '' },
   wellness: { label: 'Wellness/Gym', icon: '' },
@@ -883,10 +887,12 @@ export default function TripPlannerAI({ tripId, city, country, activity, activit
 // Discovery (Google) last so eyes land on bookable rows before browsable ones.
 const CAROUSEL_ORDER = [
   'accommodation',     // Stays (LiteAPI)
-  'adventure',         // Things to do — Adventure (Viator)
-  'arts_culture',      // Things to do — Arts & culture (Viator)
-  'wellness',          // Wellness & spas (Viator)
-  'bucket_list',       // Bucket-list experiences (Viator)
+  // PR-11: single "Activities" row replaces the four Viator carousels
+  // (adventure / arts_culture / wellness / bucket_list). The carousel
+  // surfaces every Viator product for the active destination. COA-level
+  // budget categories are preserved in TRAVEL_COA for manual entries +
+  // historic data; only the visual + scanned surface collapses.
+  'activities',        // Things to do — Activities (Viator, unified)
   'brunch_coffee',     // Where to eat — Brunch & coffee (Google)
   'dinner',            // Dinner (Google)
   'nightlife',         // Nightlife (Google)

--- a/src/lib/travelCOA.ts
+++ b/src/lib/travelCOA.ts
@@ -81,6 +81,25 @@ export const TRAVEL_COA: Record<string, COACategory> = {
     defaultFrequency: 'per_visit',
     vendorApi: 'activities', optionType: 'activity', multiDay: false,
   },
+  // PR-11: single bookable-activities bucket. Replaces the four Viator
+  // carousels (adventure / arts_culture / wellness / bucket_list) with one
+  // "Activities" carousel that surfaces every Viator product for the
+  // active destination. The four legacy categories stay in TRAVEL_COA
+  // below for manual budget entries and historic data — only the SCAN +
+  // CAROUSEL surface collapses. Budget code 9400 matches the existing
+  // VENDOR_TYPE_TO_COA['activity'] default (vendor-commit/route.ts:13)
+  // so the commit→budget spine keeps working without a new mapping.
+  activities: {
+    label: 'Activities',
+    color: '#8B5CF6',
+    bg: 'bg-violet-100', dot: 'bg-violet-400', badge: 'bg-violet-400',
+    coaPersonal: 'P-9400', coaBusiness: 'B-9400',
+    alwaysScan: true,
+    googlePlacesType: null,
+    scanQueries: [],
+    defaultFrequency: 'per_visit',
+    vendorApi: 'activities', optionType: 'activity', multiDay: false,
+  },
   adventure: {
     label: 'Adventure',
     color: '#2ecc71',
@@ -290,6 +309,12 @@ export function getActiveScanCategories(userInterests: string[], tripType: strin
     // re-enables the carousel. The TRAVEL_COA entry stays so the B-9500
     // budget mapping for hand-entered conference expenses keeps working.
     if (key === 'conferences') continue;
+    // PR-11: collapse 4 Viator carousels to 1. The legacy adventure /
+    // arts_culture / wellness / bucket_list keys are kept in TRAVEL_COA
+    // for manual budget entries and historic data, but no longer scan —
+    // the single 'activities' carousel above pulls all Viator inventory
+    // for the destination.
+    if (key === 'adventure' || key === 'arts_culture' || key === 'wellness' || key === 'bucket_list') continue;
     // Skip business meals unless business/mixed trip
     if (key === 'business_meals' && tripType !== 'business' && tripType !== 'mixed') continue;
     // Everything else gets scanned

--- a/src/lib/travelCategories.ts
+++ b/src/lib/travelCategories.ts
@@ -16,6 +16,11 @@ const TRAVEL_CATEGORIES: Record<string, TravelCategory> = {
   dinner:         { key: 'dinner',         label: 'Dinner',             section: 'dining',     coaCode: '9320', calendarColor: '#F59E0B' },
   arts_culture:   { key: 'arts_culture',   label: 'Activities',         section: 'activities', coaCode: '9420', calendarColor: '#8B5CF6' },
   adventure:      { key: 'adventure',      label: 'Adventure',          section: 'activities', coaCode: '9410', calendarColor: '#10B981' },
+  // PR-11: single bookable-activities bucket. Replaces the four Viator
+  // carousels (adventure / arts_culture / wellness / bucket_list) with one
+  // "Activities" carousel. Budget code 9400 aligns with the existing
+  // VENDOR_TYPE_TO_COA['activity'] default in vendor-commit/route.ts:13.
+  activities:     { key: 'activities',     label: 'Activities',         section: 'activities', coaCode: '9400', calendarColor: '#8B5CF6' },
   nightlife:      { key: 'nightlife',      label: 'Activities',         section: 'activities', coaCode: '9430', calendarColor: '#8B5CF6' },
   festivals:      { key: 'festivals',      label: 'Activities',         section: 'activities', coaCode: '9440', calendarColor: '#8B5CF6' },
   bucket_list:    { key: 'bucket_list',    label: 'Activities',         section: 'activities', coaCode: '9450', calendarColor: '#8B5CF6' },
@@ -43,8 +48,11 @@ const ALIASES: Record<string, string> = {
   cafe: 'brunch_coffee',
   business_meals: 'dinner',
   toiletries: 'shopping',
-  activities: 'arts_culture',
-  activity: 'arts_culture',
+  // PR-11: legacy 'activity' event-source key resolves to the new unified
+  // 'activities' bucket (was 'arts_culture' before the carousel collapse).
+  // 'activities' itself is now a real TRAVEL_CATEGORIES entry, so the
+  // resolver returns it directly without aliasing.
+  activity: 'activities',
   lodging: 'accommodation',
   flight: 'accommodation', // flights handled separately but alias for safety
   vehicle: 'transport',

--- a/src/lib/travelSourceRegistry.ts
+++ b/src/lib/travelSourceRegistry.ts
@@ -62,6 +62,15 @@ export const SOURCE_BY_CATEGORY: Record<string, SourceAssignment> = {
   // (prebook → book → payment) is a later PR.
   accommodation:    { source: 'liteapi', hardBookable: true },
 
+  // PR-11: 'activities' is the unified Viator bucket — single carousel,
+  // all bookable Viator inventory for the destination. The four legacy
+  // keys (adventure / arts_culture / wellness / bucket_list) stay on
+  // viator+hardBookable so any code path that still calls them fails
+  // loud (per registry semantics) rather than silently falling back to
+  // Google. They're just no longer in the active scan loop (see
+  // travelCOA.getActiveScanCategories).
+  activities:       { source: 'viator', hardBookable: true },
+
   // LIVE on Viator — Activities / Tours / Wellness / Sports / Bucket-list.
   // hardBookable: a Google "yoga studio" POI is not a bookable Viator
   // experience, so empty Viator stays empty (no Google masking).

--- a/src/lib/viatorClient.ts
+++ b/src/lib/viatorClient.ts
@@ -363,7 +363,31 @@ export async function searchViatorProducts(
   // inside Viator's 150-req/10s window.
   const PAGE_SIZE = 50;
 
-  if (destId) {
+  // PR-11: 'activities' is the unified bucket — every Viator product for the
+  // destination, no intent partitioning. Skip the per-term freetext loop and
+  // hit /products/search directly (paginated). Cuts the Viator call budget
+  // for activities from ~60 (4 cats × 3 terms × 5 pages) to ~5 pages × 1 call,
+  // and avoids the per-category dedupe problem entirely. Other COA keys
+  // (legacy adventure / arts_culture / wellness / bucket_list when they're
+  // still invoked from non-carousel code paths) keep the freetext orchestration.
+  if (destId && coaCategory === 'activities') {
+    let start = 1;
+    while (allProducts.length < maxResults) {
+      try {
+        const page = await searchV2Products(destId, PAGE_SIZE, undefined, start);
+        if (page.length === 0) break;
+        const beforeCount = allProducts.length;
+        addProducts(page);
+        console.log(`[Viator] /products/search activities page start=${start}: +${allProducts.length - beforeCount} new (${page.length} returned)`);
+        if (page.length < PAGE_SIZE) break;
+        start += PAGE_SIZE;
+      } catch (err) {
+        rethrowIfHardFailure(err);
+        console.error(`[Viator] V2 /products/search activities transient error start=${start}:`, err);
+        break;
+      }
+    }
+  } else if (destId) {
     for (const term of searchTerms) {
       if (allProducts.length >= maxResults) break;
       let start = 1;
@@ -401,8 +425,10 @@ export async function searchViatorProducts(
   // FALLBACK: when intent-specific freetext yielded nothing (e.g. niche
   // category with no inventory for this destination), broadcast-fetch the
   // destination via /products/search so the UI isn't empty for popular cities
-  // that do have generic tours. Paginated to the same maxResults cap.
-  if (destId && allProducts.length === 0) {
+  // that do have generic tours. Paginated to the same maxResults cap. The
+  // 'activities' bucket already used /products/search as the primary, so
+  // skipping the fallback for it avoids a redundant call.
+  if (destId && coaCategory !== 'activities' && allProducts.length === 0) {
     let start = 1;
     while (allProducts.length < maxResults) {
       try {


### PR DESCRIPTION
Replaces Adventure / Arts & Culture / Wellness / Bucket List with one "Activities" carousel that pulls every Viator product for the active destination via a single /v2/products/search call (paginated). COA-level budget categories preserved for budget commits and historic data — only the visual + scanned surface collapses.

Step 1 — TRAVEL_COA + registry (travelCOA.ts:84-101, travelCategories.ts:18-23, travelSourceRegistry.ts:65-73):
  - New TRAVEL_COA['activities'] entry with budget code P-9400 / B-9400 (matches the VENDOR_TYPE_TO_COA['activity'] default at vendor-commit/route.ts:13, so the commit→budget spine routes without a new mapping).
  - getActiveScanCategories skips adventure / arts_culture / wellness / bucket_list — those COA entries remain for manual budget entries and legacy committed rows, just no longer scan.
  - SOURCE_BY_CATEGORY adds 'activities: viator/hardBookable'. The four legacy keys stay registered (so any path still calling them fails loud per registry semantics; no silent Google fallback).
  - travelCategories.ts: TRAVEL_CATEGORIES gains 'activities' (coaCode 9400); ALIASES['activities']='arts_culture' is removed so the new real entry resolves directly; ALIASES['activity'] now points at 'activities' instead of 'arts_culture' (legacy event sources route to the unified bucket).

Step 2 — Viator client (viatorClient.ts:366-381, 425-431):
  - When coaCategory === 'activities', skip the per-term freetext loop entirely and call /v2/products/search paginated up to maxResults. No intent partitioning, no /search/freetext, no per-term dedupe problem. Viator call budget drops ~12x: from 4 cats × 3 terms × 5 pages ≈ 60 to 1 category × 5 pages ≈ 5 calls per scan.
  - Fallback block now skips when coaCategory === 'activities' since /products/search is already the primary for that bucket.

Step 3 — Carousel UI (TripPlannerAI.tsx:73-85, 884-893):
  - CAROUSEL_ORDER drops adventure / arts_culture / wellness / bucket_list, gains 'activities' between accommodation and the Google rows.
  - CATEGORY_INFO['activities'] label updated from legacy 'Activities/Tours' to 'Activities' (the canonical label for the unified bucket). 'adventure' defensive entry from PR-10 stays.

Step 4 — Commit-time routing (Option A, auto-default):
  Selected APPROACH: every Viator product committed from the Activities
  carousel carries rec.category='activities'. The commit flow at
  TripPlannerAI.tsx:499-577 reads TRAVEL_COA[rec.category] (which now
  resolves), writes a trip_activity_expenses row with
  category='activities', and the vendor-commit route's getCOACode call
  resolves through travelCategories.ts to budget code 9400. Final coa
  code: P-9400 (personal) or B-9400 (business). No code change in
  vendor-commit needed — the routing flows naturally through the new
  TRAVEL_COA / TRAVEL_CATEGORIES entries.

  Why not Option B (modal-on-commit) or Option C (smart-infer from
  Viator tags): both add complexity for limited value at this stage —
  the audit's stated intent is "one row, all Viator products" with
  fewer moving parts. Users can re-categorize from 'Activities' (9400)
  to Adventure / Arts / Wellness / Bucket List (9410 / 9420 / 9700 /
  9450) via the budget editor if the granularity matters; the COA
  entries remain available for that path.

Step 5 — Preserved COA categories:
  - adventure / arts_culture / wellness / bucket_list still exist in TRAVEL_COA, in TRAVEL_CATEGORIES, and in SOURCE_BY_CATEGORY.
  - PR-9's sports_fitness → adventure alias still resolves.
  - Calendar color / legend mapping for legacy committed rows (rec.category='adventure') still works via TRAVEL_CATEGORIES.

Behaviour change call-out:
  Pre-PR-11, a commit from the Adventure carousel wrote coa P-9410;
  Arts & Culture wrote P-9420; Wellness wrote P-9700; Bucket List wrote
  P-9450. Post-PR-11, all Viator commits write P-9400 (or B-9400). Old
  rows with the granular codes are unchanged. This is the documented
  trade for the carousel collapse — if granular routing matters in
  practice, a polish PR can add Option B (commit-time modal).

Verification:
  - npx tsc --noEmit clean (exit 0).
  - npm run lint — no new warnings; pre-existing baseline unchanged.
  - git diff main on protected surfaces: prisma/, liteapiClient.ts, vendor-commit route, scanner-results route — all unchanged.
  - PR-7 diagnostic logs preserved.
  - Carousel UI structure (TravelCarousel component, sourceAttribution) unchanged — only CAROUSEL_ORDER + CATEGORY_INFO edited.

Expected behaviour post-merge:
  - 4 Viator carousels → 1 "Activities" row labelled "via Viator".
  - All Viator products for the active destination in that one row.
  - Destination tab switching cleanly switches the Activities row.
  - Viator API calls per scan: 4 categories × 3-15 calls each = ~60 → 1 category × 5 calls = ~5.

https://claude.ai/code/session_01SzdMRckkgo78XAuLBek5m7