### PR TITLE
Travel-PR-28a: source-separated scan sections, reordered (Ground Tran…

### DIFF
--- a/audit-reports/travel-pr-28a-impl.md
+++ b/audit-reports/travel-pr-28a-impl.md
@@ -1,0 +1,90 @@
+# TRAVEL — PR-28a Implementation: source-separated scan sections (reorder + headers/counts)
+
+**Branch:** `claude/travel-pr-28a`
+**Date:** 2026-05-30
+**Scope:** Structure + ordering + section headers/counts ONLY. No filtering (28b),
+no enrichment (28c), no population change (28d), no visual overhaul (28e). 1 file
++ report. 0 deps, 0 schema, 0 new fetches.
+
+---
+
+## STEP 1 — Reorder `CAROUSEL_ORDER`
+
+`TripPlannerAI.tsx` — the rendered planner sequence (beneath the Flights card).
+
+**Before** (`:955-972` on main):
+`accommodation → activities → brunch_coffee → dinner → nightlife → coworking →
+shopping → ground_transport`
+
+**After** (`:952-973`):
+```
+accommodation       // Hotels (LiteAPI)
+ground_transport    // Ground Transport (Mozio — 501 "coming soon", PR-24)
+activities          // Activities (Viator)
+brunch_coffee       // ┐
+dinner              // │ Google discovery
+nightlife           // │
+coworking           // │
+shopping            // ┘
+```
+`ground_transport` moved from **last → 2nd**, so the rendered order is
+**Hotels → Ground Transport → Activities(Viator) → Google**.
+
+**Flights stay above the planner — unchanged.** `FlightPicker` renders in its own
+card at `page.tsx:1028-1033`, before `<TripPlannerAI>` (`page.tsx:1098`). So the
+full page sequence is **Flights → Hotels → Ground Transport → Activities →
+Google**, the target order. No `page.tsx` change needed (confirmed; not in diff).
+
+## STEP 2 — Section header: name + source badge + result count
+
+Each section is a `TravelCarousel` whose header already carried the section name
++ source badge (`:1020-1024`). PR-28a adds the **result count**:
+- New `sourceNoun(source, n)` helper (`TripPlannerAI.tsx:992-1002`) → "hotel(s)"
+  / "activity/activities" / "place(s)" / "option(s)" / "result(s)".
+- Header (`:1025-1036`): label + `{items.length} {sourceNoun(...)}` (e.g.
+  "12 hotels"), from `byCategory[catKey]` items. Gated `items.length > 0` so it's
+  hidden while loading/empty/errored. The source badge (`sourceAttribution`)
+  stays on the right.
+
+Section comment updated to describe the new order (`:915-920`).
+
+## STEP 3 — No behavior change beyond order + headers
+
+| Deferred to | Touched here? |
+|---|---|
+| Filtering UI (28b) | ❌ not added |
+| `/data/hotel` enrichment (28c) | ❌ not called |
+| Fetch limits / population (28d) | ❌ unchanged |
+| Card styling / gradient placeholders (28e) | ❌ untouched |
+
+Cards, `HScrollRow` arrows (PR-27), pricing, fetch logic — all unchanged, just
+reordered + wrapped with the count in the existing header.
+
+**`ground_transport` 501 intact in its new position:** its source is still
+`mozio` (`travelSourceRegistry.ts:86`); the route still validates it (PR-24) →
+`getSource` = mozio → `UnimplementedSourceError` → 501 "coming soon". The
+registry/route are not in this diff — position in `CAROUSEL_ORDER` doesn't change
+its dispatch. So it renders honestly in the 2nd slot.
+
+---
+
+## Hard-constraint compliance
+
+| Constraint | Status |
+|---|---|
+| Structure + order + headers/counts only | ✅ |
+| ground_transport now 2nd, 501 intact | ✅ registry/route untouched (PR-24 behavior) |
+| Carousels + HScrollRow arrows preserved | ✅ TravelCarousel body unchanged |
+| 0 deps, 0 schema, 0 new fetches | ✅ |
+| `tsc --noEmit` | ✅ exit 0 |
+| eslint changed file | ✅ 2 errors (pre-existing, identical to main — 0 added) |
+| git diff = TripPlannerAI.tsx (+ report) | ✅ `git diff --name-only main` = TripPlannerAI.tsx only |
+
+---
+
+## Result
+The planner now renders clean source-separated sections in the target order
+(Hotels → Ground Transport → Activities → Google, with Flights above), each
+header showing the section name, source badge, and a live result count — the
+structural foundation for 28b (filtering), 28c (enrichment), 28d (population),
+and 28e (polish).

--- a/src/components/trips/TripPlannerAI.tsx
+++ b/src/components/trips/TripPlannerAI.tsx
@@ -912,10 +912,12 @@ export default function TripPlannerAI({ tripId, city, country, activity, activit
         </div>
       )}
 
-      {/* ── PR-4 carousels: one row per active category, ordered by the curated
-            layout (Stays first → Things to do → Where to eat → discovery).
-            Each row independently shows items / skeleton / error banner so a
-            single failing category never blanks the rest of the page. ── */}
+      {/* ── PR-28a source-separated sections: Hotels → Ground Transport →
+            Activities (Viator) → Google discovery (Flights render above, in the
+            FlightPicker card in page.tsx). Each section header carries the
+            source badge + a result count. Each row independently shows items /
+            skeleton / error banner so a single failing source never blanks the
+            rest of the page. ── */}
       <div className="space-y-6 pt-2">
         {CAROUSEL_ORDER
           .filter(catKey => ACTIVE_SCAN_SET.has(catKey))
@@ -949,18 +951,22 @@ export default function TripPlannerAI({ tripId, city, country, activity, activit
   );
 }
 
-// ─── Carousel layout order (PR-4 locked design) ─────────────────────────────
-// Stays first (highest commission). Things to do second (Viator bookable).
-// Discovery (Google) last so eyes land on bookable rows before browsable ones.
+// ─── Carousel layout order (PR-28a: source-separated sections) ──────────────
+// Sequence beneath the Flights card (FlightPicker, in page.tsx, renders first):
+//   Hotels → Ground Transport → Activities (Viator) → Google categories.
+// PR-28a moved ground_transport up to 2nd (was last) so all bookable inventory
+// (hotels, transfers, activities) leads, and browsable Google discovery trails.
 const CAROUSEL_ORDER = [
-  'accommodation',     // Stays (LiteAPI)
+  'accommodation',     // Hotels (LiteAPI)
+  'ground_transport',  // Ground Transport (Mozio — 501 "coming soon" today, PR-24)
   // PR-11: single "Activities" row replaces the four Viator carousels
   // (adventure / arts_culture / wellness / bucket_list). The carousel
   // surfaces every Viator product for the active destination. COA-level
   // budget categories are preserved in TRAVEL_COA for manual entries +
   // historic data; only the visual + scanned surface collapses.
-  'activities',        // Things to do — Activities (Viator, unified)
-  'brunch_coffee',     // Where to eat — Brunch & coffee (Google)
+  'activities',        // Activities (Viator, unified)
+  // ─── Google discovery categories (browsable, not bookable) ───────────────
+  'brunch_coffee',     // Brunch & coffee (Google)
   'dinner',            // Dinner (Google)
   'nightlife',         // Nightlife (Google)
   'coworking',         // Coworking (Google)
@@ -968,7 +974,6 @@ const CAROUSEL_ORDER = [
   // PR-10 Fix 6: Conferences removed — Google returns venues, not actual
   // upcoming conferences. Queued for a future PR with a real conference
   // API (Eventbrite / 10times / Bizzabo).
-  'ground_transport',  // Transfers (Mozio — fails loud "not connected" today)
 ] as const;
 
 const ACTIVE_SCAN_SET = new Set(getActiveScanCategories([], ''));
@@ -984,6 +989,17 @@ function sourceAttribution(source: Source): string {
     case 'airalo':      return 'Airalo (coming soon)';
     case 'covergenius': return 'Cover Genius (coming soon)';
   }
+}
+
+// PR-28a: result-count noun per source (e.g. "12 hotels"). Pluralised on count.
+function sourceNoun(source: Source, n: number): string {
+  const base = source === 'liteapi' ? 'hotel'
+    : source === 'viator' ? 'activity'
+    : source === 'google' ? 'place'
+    : source === 'mozio' ? 'option'
+    : 'result';
+  if (base === 'activity') return n === 1 ? 'activity' : 'activities';
+  return n === 1 ? base : `${base}s`;
 }
 
 // PR-14: maps PR-13's six standard facility strings to lucide-react icons.
@@ -1015,7 +1031,13 @@ function TravelCarousel({ catKey, label, source, isLoading, items, error, onCard
   return (
     <div>
       <div className="flex items-baseline justify-between mb-2 px-1">
-        <h3 className="text-base font-semibold text-text-primary">{label}</h3>
+        <div className="flex items-baseline gap-2 min-w-0">
+          <h3 className="text-base font-semibold text-text-primary">{label}</h3>
+          {/* PR-28a: result count (from byCategory items). Hidden while loading/empty. */}
+          {items.length > 0 && (
+            <span className="text-xs text-text-muted tabular-nums">{items.length} {sourceNoun(source, items.length)}</span>
+          )}
+        </div>
         <span className={`text-[10px] font-medium ${source === 'google' ? 'text-text-faint' : 'text-brand-purple'}`}>
           {sourceAttribution(source)}
         </span>


### PR DESCRIPTION
…sport up), headers+counts