### PR TITLE
Ops-Grid-PR-1: rename content tables to grid vocabulary (scene/piece/…

### DIFF
--- a/audit-reports/ops-grid-pr-1-impl.md
+++ b/audit-reports/ops-grid-pr-1-impl.md
@@ -1,0 +1,181 @@
+# OPS-GRID-PR-1 — Content-table naming lock (rename to Alex's grid vocabulary)
+
+**Branch:** `claude/ops-grid-pr-1`
+**Date:** 2026-06-03
+**One concept:** the **naming lock** — rename the (barely-used) content tables to Alex's
+grid vocabulary **before** building the grid, so no rename migration is needed later.
+Per `audit-reports/ops-content-table-audit.md` sign-off #1.
+**Rename only.** No new tables, no new fields, no view changes.
+
+> **Sign-off obtained (this PR):** the rename collides on the name `operations_content_scenes`.
+> Alex chose **(1)** resolve it **non-destructively** (rename the container out of the way —
+> no data dropped) and **(2)** scope **= schema + model refs only** (leave API route URLs,
+> component filenames, and audit-enum labels for a follow-up). Both answers drive what's below.
+
+---
+
+## 1. Current models, references, and data-volume basis (cited)
+
+### The two models (pre-rename)
+| Model | Lines | Grain | Fields | Relation |
+|---|---|---|---|---|
+| `operations_content_scenes` | `prisma/schema.prisma:2873-2894` | **per routine** (`routine_id @unique :2877`) | `scene_number/scene_title/focus_category/filming_location_base/estimated_hours/script` | `operations_routines.content_scene` (1:1, `:2821`) |
+| `operations_content_takes` | `:2896-2914` | **per routine_step** (`routine_step_id @unique :2900`) | `filming_location_specific/camera_needed/filming_angle/notes` | `operations_routine_steps.content_take` (1:1, `:2847`) |
+
+### Blast radius (all references)
+- **Schema:** 2 models + 2 `@@map` + 2 relation fields (`content_scene :2821`, `content_take :2847`).
+- **Prisma client calls:** 19 `prisma.operations_content_{scenes,takes}.*` across the 4 content
+  routes (`content/scenes/route.ts`, `content/scenes/[id]/route.ts`, `content/takes/route.ts`,
+  `content/takes/[id]/route.ts`), incl. 2 `Prisma.*UpdateInput` types
+  (`scenes/[id]:100`, `takes/[id]:99`).
+- **Relation-field usages** (`content_scene`/`content_take` in includes/selects/property
+  access): **49** across **13 files** — the 4 content routes, the 2 routines routes
+  (`routines/route.ts`, `routines/[id]/route.ts`), and 7 components
+  (`ContentTable.tsx`, `SectionG_Content.tsx`, `ScenifyButton.tsx`, `TakeifyButton.tsx`,
+  `AvailableRoutinesList.tsx`, `RoutineList.tsx`, `routines/types.ts`).
+- **Audit-action enum** `AuditActionType.operations_content_{scene,take}_{created,updated,deleted}`
+  (`:2134-2139`) + 10 string usages — **left unchanged** (see §4).
+
+### Data volume — basis
+**Not knowable from the repo.** Rows live in **Azure**, not in source; the only migration is
+the table *creation* (`prisma/migrations/20260518500000_operations_content_scenes/migration.sql`)
+— **no seed INSERTs**. The audit's "barely used" is a usage-surface inference, not a row count.
+**Alex should confirm via psql** (`SELECT count(*) FROM operations_content_scenes;` /
+`…_takes;`). This uncertainty is *why* the destructive option was refused — **we never drop
+rows we can't prove are empty.** The chosen path (RENAME) is safe regardless of row count.
+
+---
+
+## 2. The rename map (old → new) — Alex's vocabulary
+
+Alex's locked grid vocabulary: **SCENE = a row (stable shot)**, PIECE = a column (a day, later),
+TAKE = a cell (per-day script, later). The existing names are inverted, so:
+
+| # | Thing | Old | New | Kind |
+|---|---|---|---|---|
+| a | container model (per routine) | `operations_content_scenes` | **`operations_content_scene_groups`** | RENAME (non-destructive) |
+| b | container `@@map` / table | `operations_content_scenes` | **`operations_content_scene_groups`** | `ALTER…RENAME TO` |
+| c | row model (per step = SCENE) | `operations_content_takes` | **`operations_content_scenes`** | RENAME (non-destructive) |
+| d | row `@@map` / table | `operations_content_takes` | **`operations_content_scenes`** | `ALTER…RENAME TO` |
+| e | routine relation field | `content_scene` → container | **`content_scene_group`** | field rename |
+| f | routine_step relation field | `content_take` → row | **`content_scene`** | field rename |
+
+Reserved for later PRs (not created here): `operations_content_takes` = the **cell**,
+`operations_content_pieces` = the **day column**.
+
+### Destructive steps: **NONE.**
+Every change is an `ALTER TABLE … RENAME` (or a schema-field rename) — **all rows preserved**.
+The container is **renamed, not dropped** (Alex's choice). No `DROP`/`CREATE`-with-data anywhere.
+The two table renames **cross** (`takes→scenes` while `scenes→scene_groups`), so the order
+matters: **vacate `scenes` first**, then the row takes the freed name (see §3 SQL).
+
+---
+
+## 3. The change — schema diff + the exact psql SQL
+
+### schema.prisma diff (rename-only, 6 insertions / 6 deletions)
+```diff
+ model operations_routines {
+-  content_scene operations_content_scenes?
++  content_scene_group operations_content_scene_groups?
+ }
+ model operations_routine_steps {
+-  content_take operations_content_takes?
++  content_scene operations_content_scenes?
+ }
+-model operations_content_scenes {            # the per-routine CONTAINER
++model operations_content_scene_groups {
+   ... (fields unchanged) ...
+-  @@map("operations_content_scenes")
++  @@map("operations_content_scene_groups")
+ }
+-model operations_content_takes {             # the per-step ROW = Alex's SCENE
++model operations_content_scenes {
+   ... (fields unchanged) ...
+-  @@map("operations_content_takes")
++  @@map("operations_content_scenes")
+ }
+```
+(Field lists, `@unique`s, `@@index`es, and back-relations `routine`/`routine_step` are
+**unchanged** — names only.)
+
+### The psql RENAME — Alex runs this in Azure **BEFORE** merge
+```sql
+BEGIN;
+-- 1) vacate the name: the per-routine CONTAINER steps aside (data preserved)
+ALTER TABLE operations_content_scenes RENAME TO operations_content_scene_groups;
+-- 2) the stable-shot ROW takes the freed name (Alex's SCENE = a row; data preserved)
+ALTER TABLE operations_content_takes  RENAME TO operations_content_scenes;
+COMMIT;
+```
+- **Order is required** (collision): step 1 frees `operations_content_scenes` before step 2
+  reuses it. Wrapped in a transaction — both or neither.
+- **Indexes/constraints keep their old names** (e.g. `operations_content_scenes_routine_id_key`
+  now sits on `operations_content_scene_groups`; `operations_content_takes_routine_step_id_key`
+  now on `operations_content_scenes`). This is **cosmetic** — `prisma generate` reads
+  `schema.prisma` only and does **not** introspect the DB, so runtime is unaffected. No name
+  collision occurs (the two index-name families stay distinct). Optional tidy-rename later.
+
+---
+
+## 4. Code references updated (cited) + what was intentionally left
+
+### Updated so tsc compiles (55 insertions / 55 deletions, 14 files)
+- **Schema** (`prisma/schema.prisma`): models a/c, `@@map` b/d, relation fields e/f.
+- **Content routes** (19 prisma calls + 2 input types): `content/scenes/route.ts`,
+  `content/scenes/[id]/route.ts` (`Prisma.operations_content_scene_groupsUpdateInput`),
+  `content/takes/route.ts`, `content/takes/[id]/route.ts`
+  (`Prisma.operations_content_scenesUpdateInput`). Each call now targets the table holding
+  **the same physical data it did before** (pure rename, no logic change): the `/scenes`
+  route operates on the container (`…_scene_groups`), the `/takes` route on the row (`…_scenes`).
+- **Routines routes** (`routines/route.ts`, `routines/[id]/route.ts`): include keys
+  `content_scene_group`.
+- **Components**: `ContentTable.tsx`, `SectionG_Content.tsx`, `ScenifyButton.tsx`,
+  `TakeifyButton.tsx`, `AvailableRoutinesList.tsx`, `RoutineList.tsx`, `routines/types.ts` —
+  relation-field property accesses + type fields (`content_scene_group`/`content_scene`).
+
+### Intentionally LEFT (per "schema + model refs only" scope) — flagged for a follow-up PR
+1. **API route URL paths** (`/api/operations/content/{scenes,takes}`) and **component
+   filenames** (`ScenifyButton.tsx`/`TakeifyButton.tsx`) — unchanged. **Consequence:** the
+   URL `/content/scenes` now CRUDs the *container* model `operations_content_scene_groups`,
+   and `/content/takes` now CRUDs the *row* model `operations_content_scenes` — a
+   route↔model mismatch that compiles and works, to be reconciled when the grid routes are built.
+2. **Audit-action enum values** `operations_content_{scene,take}_{created,updated,deleted}`
+   (`:2134-2139`) — unchanged. Renaming an enum *value* would orphan historical `audit_log`
+   rows that already store those strings; safer to leave and reconcile app-wide later.
+   (They are labels, not model refs — tsc is unaffected.)
+3. **Local TS interface names** `Scene`/`Take`/`Routine`/`Step` in `ContentTable.tsx` —
+   unchanged (UI-layer cosmetic; not prisma refs).
+
+---
+
+## 5. Verify (cited)
+
+- **schema renamed + all model refs updated:** `grep operations_content_takes / \bcontent_take\b`
+  across `prisma/ src/` → **0 stale refs**. Schema shows `model operations_content_scene_groups`
+  (`:2873`) + `model operations_content_scenes` (`:2896`) with matching `@@map`s.
+- **tsc:** `npx prisma generate` (schema valid) → `npx tsc --noEmit` → **exit 0**.
+- **lint:** the rename touches **0 new** lint findings. ESLint reports 3 errors at
+  `RoutineList.tsx:327` (`react/no-unescaped-entities` in JSX prose) — **pre-existing on
+  `origin/main`** (verified by checking out main's copy and re-linting: same 3 errors) and
+  **unrelated** to the rename (my diff in that file only touches the `content_scene_group`/
+  `content_scene` optimistic-update lines, not line 327). Left as-is to honor "rename only."
+- **No data dropped:** RENAME-only; container preserved (Alex's choice). No `DROP`.
+- **No new tables/fields/views:** field lists/indexes/constraints unchanged; only names.
+- **/operations content surfaces compile** against the new names (the 13 files above; tsc 0).
+
+---
+
+## 6. ORDERING reminder (learned rule)
+
+1. **Alex runs the psql `ALTER…RENAME` in Azure FIRST** (the SQL in §3).
+2. Then **`npx prisma generate`** (regenerate the client against the renamed schema).
+3. **Then merge** this PR (the code referencing the new names).
+
+The renamed table must exist in Azure **before** the code that references it deploys.
+prisma + raw SQL move in parallel; Alex runs psql; RENAME before merge.
+
+---
+
+**git diff = `prisma/schema.prisma` + the 13 updated code files (+ this report).**
+**Migration is run by Alex (psql) — not applied from the repo.** Rename only; no data touched.

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2818,7 +2818,7 @@ model operations_routines {
 
   completions   operations_routine_completions[]
   steps         operations_routine_steps[]
-  content_scene operations_content_scenes?
+  content_scene_group operations_content_scene_groups?
 
   @@unique([user_id, name])
   @@index([user_id, is_active, next_due_at])
@@ -2844,7 +2844,7 @@ model operations_routine_steps {
   created_by       String?
 
   routine      operations_routines       @relation(fields: [routine_id], references: [id], onDelete: Cascade)
-  content_take operations_content_takes?
+  content_scene operations_content_scenes?
 
   @@index([routine_id, step_order])
   @@index([routine_id])
@@ -2870,7 +2870,7 @@ model operations_routine_completions {
   @@map("operations_routine_completions")
 }
 
-model operations_content_scenes {
+model operations_content_scene_groups {
   id                    String   @id @default(uuid()) @db.Uuid
   user_id               String
   entity_id             String
@@ -2890,10 +2890,10 @@ model operations_content_scenes {
   @@index([user_id])
   @@index([entity_id])
   @@index([routine_id])
-  @@map("operations_content_scenes")
+  @@map("operations_content_scene_groups")
 }
 
-model operations_content_takes {
+model operations_content_scenes {
   id                        String   @id @default(uuid()) @db.Uuid
   user_id                   String
   entity_id                 String
@@ -2910,7 +2910,7 @@ model operations_content_takes {
   @@index([user_id])
   @@index([entity_id])
   @@index([routine_step_id])
-  @@map("operations_content_takes")
+  @@map("operations_content_scenes")
 }
 
 model operations_ai_usage {

--- a/src/app/api/operations/content/scenes/[id]/route.ts
+++ b/src/app/api/operations/content/scenes/[id]/route.ts
@@ -49,7 +49,7 @@ export async function GET(
       );
     }
 
-    const scene = await prisma.operations_content_scenes.findFirst({
+    const scene = await prisma.operations_content_scene_groups.findFirst({
       where: { id, user_id: user.id },
     });
     if (!scene) return NextResponse.json({ error: 'Not found' }, { status: 404 });
@@ -97,7 +97,7 @@ export async function PATCH(
       }
     }
 
-    const data: Prisma.operations_content_scenesUpdateInput = {};
+    const data: Prisma.operations_content_scene_groupsUpdateInput = {};
 
     if (body.scene_title !== undefined) {
       if (typeof body.scene_title !== 'string') {
@@ -199,12 +199,12 @@ export async function PATCH(
       }
     }
 
-    const existing = await prisma.operations_content_scenes.findFirst({
+    const existing = await prisma.operations_content_scene_groups.findFirst({
       where: { id, user_id: user.id },
     });
     if (!existing) return NextResponse.json({ error: 'Not found' }, { status: 404 });
 
-    const updated = await prisma.operations_content_scenes.update({
+    const updated = await prisma.operations_content_scene_groups.update({
       where: { id },
       data,
     });
@@ -215,7 +215,7 @@ export async function PATCH(
         type: 'operations_content_scene_updated',
         description: `Updated content scene ${id}`,
       },
-      target: { table: 'operations_content_scenes', id: updated.id },
+      target: { table: 'operations_content_scene_groups', id: updated.id },
       payload: {
         before: existing,
         after: updated,
@@ -257,12 +257,12 @@ export async function DELETE(
       );
     }
 
-    const existing = await prisma.operations_content_scenes.findFirst({
+    const existing = await prisma.operations_content_scene_groups.findFirst({
       where: { id, user_id: user.id },
     });
     if (!existing) return NextResponse.json({ error: 'Not found' }, { status: 404 });
 
-    await prisma.operations_content_scenes.delete({ where: { id } });
+    await prisma.operations_content_scene_groups.delete({ where: { id } });
 
     await writeAuditLog({
       actor: { user_id: user.id, email: userEmail, type: 'human_user' },
@@ -270,7 +270,7 @@ export async function DELETE(
         type: 'operations_content_scene_deleted',
         description: `Deleted content scene ${id}`,
       },
-      target: { table: 'operations_content_scenes', id },
+      target: { table: 'operations_content_scene_groups', id },
       payload: {
         before: existing,
         metadata: {

--- a/src/app/api/operations/content/scenes/route.ts
+++ b/src/app/api/operations/content/scenes/route.ts
@@ -1,7 +1,7 @@
 /**
  * /api/operations/content/scenes
  *
- * GET  — list operations_content_scenes for the authenticated user,
+ * GET  — list operations_content_scene_groups for the authenticated user,
  *        ordered by scene_number ASC. Optional ?entity_id filter.
  *        No audit (read-only).
  * POST — create a scene. routine_id must reference a routine owned by
@@ -41,7 +41,7 @@ export async function GET(request: NextRequest) {
       where.entity_id = entityId;
     }
 
-    const scenes = await prisma.operations_content_scenes.findMany({
+    const scenes = await prisma.operations_content_scene_groups.findMany({
       where,
       orderBy: { scene_number: 'asc' },
     });
@@ -181,7 +181,7 @@ export async function POST(request: NextRequest) {
     const entityId = routine.entity_id;
 
     // --- UNIQUE constraint pre-checks ---
-    const existingForRoutine = await prisma.operations_content_scenes.findFirst({
+    const existingForRoutine = await prisma.operations_content_scene_groups.findFirst({
       where: { routine_id: routineId },
     });
     if (existingForRoutine) {
@@ -191,7 +191,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const existingForNumber = await prisma.operations_content_scenes.findFirst({
+    const existingForNumber = await prisma.operations_content_scene_groups.findFirst({
       where: { user_id: user.id, scene_number: sceneNumber },
     });
     if (existingForNumber) {
@@ -201,7 +201,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const scene = await prisma.operations_content_scenes.create({
+    const scene = await prisma.operations_content_scene_groups.create({
       data: {
         user_id: user.id,
         entity_id: entityId,
@@ -221,7 +221,7 @@ export async function POST(request: NextRequest) {
         type: 'operations_content_scene_created',
         description: `Created content scene ${sceneNumber} for routine ${routineId}`,
       },
-      target: { table: 'operations_content_scenes', id: scene.id },
+      target: { table: 'operations_content_scene_groups', id: scene.id },
       payload: {
         after: scene,
         metadata: {

--- a/src/app/api/operations/content/takes/[id]/route.ts
+++ b/src/app/api/operations/content/takes/[id]/route.ts
@@ -48,7 +48,7 @@ export async function GET(
       );
     }
 
-    const take = await prisma.operations_content_takes.findFirst({
+    const take = await prisma.operations_content_scenes.findFirst({
       where: { id, user_id: user.id },
     });
     if (!take) return NextResponse.json({ error: 'Not found' }, { status: 404 });
@@ -96,7 +96,7 @@ export async function PATCH(
       }
     }
 
-    const data: Prisma.operations_content_takesUpdateInput = {};
+    const data: Prisma.operations_content_scenesUpdateInput = {};
 
     if (body.filming_location_specific !== undefined) {
       if (body.filming_location_specific === null) {
@@ -176,12 +176,12 @@ export async function PATCH(
       }
     }
 
-    const existing = await prisma.operations_content_takes.findFirst({
+    const existing = await prisma.operations_content_scenes.findFirst({
       where: { id, user_id: user.id },
     });
     if (!existing) return NextResponse.json({ error: 'Not found' }, { status: 404 });
 
-    const updated = await prisma.operations_content_takes.update({
+    const updated = await prisma.operations_content_scenes.update({
       where: { id },
       data,
     });
@@ -192,7 +192,7 @@ export async function PATCH(
         type: 'operations_content_take_updated',
         description: `Updated content take ${id}`,
       },
-      target: { table: 'operations_content_takes', id: updated.id },
+      target: { table: 'operations_content_scenes', id: updated.id },
       payload: {
         before: existing,
         after: updated,
@@ -234,12 +234,12 @@ export async function DELETE(
       );
     }
 
-    const existing = await prisma.operations_content_takes.findFirst({
+    const existing = await prisma.operations_content_scenes.findFirst({
       where: { id, user_id: user.id },
     });
     if (!existing) return NextResponse.json({ error: 'Not found' }, { status: 404 });
 
-    await prisma.operations_content_takes.delete({ where: { id } });
+    await prisma.operations_content_scenes.delete({ where: { id } });
 
     await writeAuditLog({
       actor: { user_id: user.id, email: userEmail, type: 'human_user' },
@@ -247,7 +247,7 @@ export async function DELETE(
         type: 'operations_content_take_deleted',
         description: `Deleted content take ${id}`,
       },
-      target: { table: 'operations_content_takes', id },
+      target: { table: 'operations_content_scenes', id },
       payload: {
         before: existing,
         metadata: {

--- a/src/app/api/operations/content/takes/route.ts
+++ b/src/app/api/operations/content/takes/route.ts
@@ -1,7 +1,7 @@
 /**
  * /api/operations/content/takes
  *
- * GET  — list operations_content_takes for the authenticated user,
+ * GET  — list operations_content_scenes for the authenticated user,
  *        ordered by created_at ASC. Optional ?entity_id filter.
  *        No audit (read-only).
  * POST — create a take. routine_step_id must reference a routine step
@@ -42,7 +42,7 @@ export async function GET(request: NextRequest) {
       where.entity_id = entityId;
     }
 
-    const takes = await prisma.operations_content_takes.findMany({
+    const takes = await prisma.operations_content_scenes.findMany({
       where,
       orderBy: { created_at: 'asc' },
     });
@@ -155,7 +155,7 @@ export async function POST(request: NextRequest) {
     const entityId = step.entity_id;
 
     // --- UNIQUE constraint pre-check ---
-    const existingForStep = await prisma.operations_content_takes.findFirst({
+    const existingForStep = await prisma.operations_content_scenes.findFirst({
       where: { routine_step_id: routineStepId },
     });
     if (existingForStep) {
@@ -165,7 +165,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const take = await prisma.operations_content_takes.create({
+    const take = await prisma.operations_content_scenes.create({
       data: {
         user_id: user.id,
         entity_id: entityId,
@@ -183,7 +183,7 @@ export async function POST(request: NextRequest) {
         type: 'operations_content_take_created',
         description: `Created content take for routine step ${routineStepId}`,
       },
-      target: { table: 'operations_content_takes', id: take.id },
+      target: { table: 'operations_content_scenes', id: take.id },
       payload: {
         after: take,
         metadata: {

--- a/src/app/api/operations/routines/[id]/route.ts
+++ b/src/app/api/operations/routines/[id]/route.ts
@@ -68,9 +68,9 @@ async function loadAuthorizedRoutine(routineId: string, userId: string) {
     include: {
       steps: {
         orderBy: { step_order: 'asc' },
-        include: { content_take: true },
+        include: { content_scene: true },
       },
-      content_scene: true,
+      content_scene_group: true,
     },
   });
 }

--- a/src/app/api/operations/routines/route.ts
+++ b/src/app/api/operations/routines/route.ts
@@ -90,9 +90,9 @@ export async function GET(request: NextRequest) {
       include: {
         steps: {
           orderBy: { step_order: 'asc' },
-          include: { content_take: true },
+          include: { content_scene: true },
         },
-        content_scene: true,
+        content_scene_group: true,
       },
     });
 

--- a/src/components/workbench/operations/content/AvailableRoutinesList.tsx
+++ b/src/components/workbench/operations/content/AvailableRoutinesList.tsx
@@ -1,7 +1,7 @@
 /**
  * AvailableRoutinesList — interactive list of not-yet-scenified routines.
  *
- * Filters the supplied routines to those without a content_scene and
+ * Filters the supplied routines to those without a content_scene_group and
  * renders each with a ScenifyButton. Mounted on the Content tab below
  * the ContentTable. When every routine has a scene, shows a done state.
  */
@@ -18,7 +18,7 @@ export default function AvailableRoutinesList({
   routines: Routine[];
   onScenify: (newScene: Scene) => void;
 }) {
-  const available = routines.filter((r) => !r.content_scene);
+  const available = routines.filter((r) => !r.content_scene_group);
 
   return (
     <div className="space-y-2">

--- a/src/components/workbench/operations/content/ContentTable.tsx
+++ b/src/components/workbench/operations/content/ContentTable.tsx
@@ -31,7 +31,7 @@ export type Step = {
   time_of_day: string | null;
   step_order: number;
   /** Present when the step has been take-ified; null/absent otherwise. */
-  content_take?: { id: string } | null;
+  content_scene?: { id: string } | null;
 };
 
 export type Routine = {
@@ -41,7 +41,7 @@ export type Routine = {
   schedule_rrule: string | null;
   steps: Step[];
   /** Present when the routine has been scenified; null/absent otherwise. */
-  content_scene?: { id: string } | null;
+  content_scene_group?: { id: string } | null;
 };
 
 export type Scene = {

--- a/src/components/workbench/operations/content/ScenifyButton.tsx
+++ b/src/components/workbench/operations/content/ScenifyButton.tsx
@@ -19,7 +19,7 @@ import ScenifyModal from './ScenifyModal';
 type ScenifyRoutine = {
   id: string;
   name: string;
-  content_scene?: { id: string } | null;
+  content_scene_group?: { id: string } | null;
 };
 
 export default function ScenifyButton({
@@ -31,7 +31,7 @@ export default function ScenifyButton({
 }) {
   const [open, setOpen] = useState(false);
 
-  if (routine.content_scene) {
+  if (routine.content_scene_group) {
     return (
       <span
         className="px-2 py-1 border border-border rounded bg-purple-50 text-brand-purple text-xs font-mono"

--- a/src/components/workbench/operations/content/SectionG_Content.tsx
+++ b/src/components/workbench/operations/content/SectionG_Content.tsx
@@ -10,7 +10,7 @@
  * error and empty states stay as plain text.
  *
  * "Scenified" status is derived client-side: GET /api/operations/
- * routines does not include the content_scene relation, so we join
+ * routines does not include the content_scene_group relation, so we join
  * on routine_id against the scenes list.
  */
 
@@ -91,7 +91,7 @@ export default function SectionG_Content() {
       prev
         ? prev.map((r) =>
             r.id === newScene.routine_id
-              ? { ...r, content_scene: { id: newScene.id } }
+              ? { ...r, content_scene_group: { id: newScene.id } }
               : r
           )
         : prev

--- a/src/components/workbench/operations/content/TakeifyButton.tsx
+++ b/src/components/workbench/operations/content/TakeifyButton.tsx
@@ -23,7 +23,7 @@ import type { Take } from './ContentTable';
 
 type TakeifyStep = {
   id: string;
-  content_take?: { id: string } | null;
+  content_scene?: { id: string } | null;
 };
 
 export default function TakeifyButton({
@@ -36,7 +36,7 @@ export default function TakeifyButton({
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  if (step.content_take) {
+  if (step.content_scene) {
     return (
       <span
         className="px-2 py-0.5 border border-border rounded bg-purple-50 text-brand-purple text-xs font-mono"

--- a/src/components/workbench/operations/routines/RoutineList.tsx
+++ b/src/components/workbench/operations/routines/RoutineList.tsx
@@ -73,19 +73,19 @@ export default function RoutineList({ entities, onCommitted }: Props) {
     onCommitted?.();
   };
 
-  // Optimistic update — a successful scenify POST adds the content_scene
+  // Optimistic update — a successful scenify POST adds the content_scene_group
   // relation to the routine so the 🎬 badge appears without a refetch.
   const handleScenify = (newScene: Scene) => {
     setRoutines((prev) =>
       prev.map((r) =>
         r.id === newScene.routine_id
-          ? { ...r, content_scene: { id: newScene.id } }
+          ? { ...r, content_scene_group: { id: newScene.id } }
           : r
       )
     );
   };
 
-  // Optimistic update — a successful take-ify POST adds the content_take
+  // Optimistic update — a successful take-ify POST adds the content_scene
   // relation to the matching step so its 🎬 badge appears without a refetch.
   const handleTakeify = (newTake: Take) => {
     setRoutines((prev) =>
@@ -93,7 +93,7 @@ export default function RoutineList({ entities, onCommitted }: Props) {
         ...r,
         steps: r.steps.map((s) =>
           s.id === newTake.routine_step_id
-            ? { ...s, content_take: { id: newTake.id } }
+            ? { ...s, content_scene: { id: newTake.id } }
             : s
         ),
       }))

--- a/src/components/workbench/operations/routines/types.ts
+++ b/src/components/workbench/operations/routines/types.ts
@@ -59,9 +59,9 @@ export interface Routine {
   /**
    * The content scene this routine has been scenified into, if any.
    * Populated by GET /api/operations/routines (and /[id]) via the
-   * content_scene include; absent on endpoints that don't include it.
+   * content_scene_group include; absent on endpoints that don't include it.
    */
-  content_scene?: { id: string } | null;
+  content_scene_group?: { id: string } | null;
 }
 
 /**
@@ -91,10 +91,10 @@ export interface RoutineStep {
   /**
    * The content take this step has been take-ified into, if any.
    * Populated by GET /api/operations/routines (and /[id]) via the
-   * nested steps→content_take include; absent on endpoints that
+   * nested steps→content_scene include; absent on endpoints that
    * don't include it.
    */
-  content_take?: { id: string } | null;
+  content_scene?: { id: string } | null;
 }
 
 export interface RoutineCompletion {


### PR DESCRIPTION
…take) — naming lock before build