### PR TITLE
Ops-CE-8F: task rows fully legible — labeled wrapped fields, no data …

### DIFF
--- a/audit-reports/ops-ce-8f-impl.md
+++ b/audit-reports/ops-ce-8f-impl.md
@@ -1,0 +1,87 @@
+# OPS-CE-8F — Full legibility for task rows (no data truncation on the content page)
+
+**Branch:** `claude/ops-ce-8f` (off `main`; CE-8E merged)
+**Date:** 2026-06-03
+**One concept:** task rows fully readable — every field labeled + wrapped, nothing
+clipped. **Presentation only; 0-schema; no payload/route changes.**
+
+> ✅ `git diff` = new shared `TaskBand.tsx` + the row renders/sweep
+> (`ScenifyDraft`, `DailyLog`, `ContentPipeline`, `PieceGrid`). No `prisma/schema.prisma`,
+> no `api/`. tsc exit 0; eslint exit 0.
+
+---
+
+## 1 · S2 + S3 task rows — labeled, wrapped fields (shared `TaskBand`)
+**Before:** one cramped flex line — `▦ {time} {title} · {project} {status}` ran
+together, title clipped ("Build the Co…"); duplicated in ScenifyDraft + DailyLog.
+
+**After:** a new shared **`TaskBand`** (used by both renders → no drift) lays out
+clearly separated, **labeled** fields (small purple uppercase labels mirroring the
+scene rows), all **wrapped**:
+- **TIME** — the actual/scheduled clock label (labeled which), or the inline
+  `TaskTimeCommit` form on planned rows.
+- **TASK** — full title, `break-words`, visually primary (`flex-1 min-w-[160px]`).
+- **PROJECT** — full name, `break-words`.
+- **STATUS** — badge.
+
+Each `renderTaskRow` (ScenifyDraft `colSpan={8}`, DailyLog `colSpan={6}`) now renders
+`<TaskBand .../>` inside the amber band `<td>` (chrome unchanged; padding `py-2`).
+Multi-line rows are fine — readable beats compact. `TaskTimeCommit` (CE-8E) is now
+invoked *inside* `TaskBand`, so both callers stay identical.
+
+## 2 · S1 task list — full wrap (sweep)
+`ContentPipeline` (S1): removed `truncate max-w-[…]` on the task **project**
+(`:312`) and **entity** (`:314`) labels and the routine **entity** label (`:279`) →
+`break-words` (project/entity keep a soft `max-w` that now *wraps* instead of
+clipping). The task **title** was already `break-words` (CE-8D).
+
+## 3 · Sweep — every data truncation found + fixed (cited)
+`grep -rnE 'truncate|text-ellipsis|overflow-hidden|whitespace-nowrap|max-w-\[' content/*.tsx`:
+
+| Location | Was | Action |
+|---|---|---|
+| `ContentPipeline.tsx:279` routine entity | `truncate max-w-[90px]` | → `break-words` ✅ |
+| `ContentPipeline.tsx:312` task project | `truncate max-w-[100px]` | → `break-words max-w-[140px]` (wraps) ✅ |
+| `ContentPipeline.tsx:314` task entity | `truncate max-w-[80px]` | → `break-words max-w-[110px]` (wraps) ✅ |
+| `PieceGrid.tsx:321` day-column title | `truncate max-w-[160px]` | → `break-words max-w-[160px]` (wraps) ✅ |
+| S2/S3 task band title/project | cramped/clipped line | → labeled wrapped `TaskBand` ✅ |
+| `headerCellClass whitespace-nowrap` (DailyLog/ScenifyDraft/ScenifyModal) | label chrome | **kept** (labels, not data) |
+| `PieceGrid.tsx:372` "+ day" button `whitespace-nowrap` | chrome | **kept** |
+| `PieceGrid.tsx:387` scene card | already `break-words` | no change |
+| `TaskBand` status/time spans `whitespace-nowrap` | a badge + a clock string (atomic) | intentional (not clipped — no max-w) |
+
+**Legacy, NOT on the content page (left as-is, cited):** `ContentTable.tsx`
+(`truncateScript`, header `whitespace-nowrap`), `SceneHeaderRow.tsx`,
+`ScriptDrawer.tsx`, `SectionG_Content.tsx` — all retired from the page in CE-7
+(`page.tsx` renders only `ContentPipeline`); `ContentTable` survives only for the
+home preview (empty arrays). Not rendered on the content page → out of scope.
+
+---
+
+## Verify
+- **Every task field readable + labeled in S1/S2/S3:** `TaskBand` labels TIME/TASK/
+  PROJECT/STATUS, all `break-words`; S1 project/entity wrap. ✅
+- **No data truncation anywhere on the content page:** active-pipeline files
+  (`ContentPipeline`/`ScenifyDraft`/`DailyLog`/`PieceGrid`/`TaskBand`) have **zero**
+  `truncate`/ellipsis on data text (grep → none but a comment). Remaining hits are
+  legacy files not mounted on the page. ✅
+- **Contrast standard kept:** purple uppercase field labels, body `text-primary`/
+  `text-muted`, no `text-faint`. ✅
+- **0-schema, no payload/route change:** task rows read-only (the inline commit reuses
+  CE-8E's route); no schema/`api/` in the diff. ✅
+- **tsc** exit 0; **eslint** exit 0.
+
+## git diff scope
+New: `content/TaskBand.tsx`. Modified: `content/ScenifyDraft.tsx` +
+`content/DailyLog.tsx` (renderTaskRow → `TaskBand`; import swap),
+`content/ContentPipeline.tsx` (S1 wrap sweep), `content/PieceGrid.tsx` (day-title
+wrap) (+ this report). No schema, no routes.
+
+---
+
+## Result
+Task rows now read as labeled, wrapped fields — **TIME · TASK · PROJECT · STATUS** —
+via one shared `TaskBand` in both the S2 day map and the S3 timeline, with the inline
+time-commit living in the TIME field on planned rows. The S1 task list and the
+day-column title wrap too. No data text truncates anywhere on the content page (legacy
+off-page files noted). Presentation only; 0-schema; tsc + eslint clean.

--- a/src/components/workbench/operations/content/ContentPipeline.tsx
+++ b/src/components/workbench/operations/content/ContentPipeline.tsx
@@ -276,7 +276,7 @@ export default function ContentPipeline() {
                           </span>
                           <span className="text-text-primary font-medium flex-1">{r.name}</span>
                           {entityNameById.get(r.entity_id) && (
-                            <span className="text-text-muted truncate max-w-[90px]">{entityNameById.get(r.entity_id)}</span>
+                            <span className="text-text-muted break-words">{entityNameById.get(r.entity_id)}</span>
                           )}
                           <span className="text-text-muted">
                             {r.steps.length} step{r.steps.length === 1 ? '' : 's'}
@@ -309,9 +309,9 @@ export default function ContentPipeline() {
                         <span className="text-text-primary flex-1 break-words" title={t.title}>
                           {t.title}
                         </span>
-                        {t.project && <span className="text-text-muted truncate max-w-[100px]">{t.project.title}</span>}
+                        {t.project && <span className="text-text-muted break-words max-w-[140px]">{t.project.title}</span>}
                         {t.project && entityNameById.get(t.project.entity_id) && (
-                          <span className="text-text-muted shrink-0 truncate max-w-[80px]">
+                          <span className="text-text-muted break-words max-w-[110px]">
                             {entityNameById.get(t.project.entity_id)}
                           </span>
                         )}

--- a/src/components/workbench/operations/content/DailyLog.tsx
+++ b/src/components/workbench/operations/content/DailyLog.tsx
@@ -23,7 +23,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useOperationsEntity } from '../EntitySelector';
 import { CONTENT_DAY_PLAN_CHANGED_EVENT } from './ScenifyModal';
-import TaskTimeCommit from './TaskTimeCommit';
+import TaskBand from './TaskBand';
 import {
   compareDayOrder,
   minuteOfDayFromInstant,
@@ -407,21 +407,19 @@ export default function DailyLog({ date }: { date: string }) {
     );
   };
 
-  // Read-only execution band — a task block, visually distinct (gold left accent).
+  // Read-only execution band — fully legible, labeled, wrapped (shared TaskBand).
   const renderTaskRow = (b: (typeof taskBlocks)[number]) => (
     <tr key={`task-${b.id}`}>
-      <td colSpan={6} className="border border-border-light border-l-4 border-l-amber-400 bg-amber-50/50 px-3 py-1.5 align-top">
-        <div className="flex flex-wrap items-center gap-x-3 gap-y-0.5">
-          <span className="text-amber-700" aria-hidden="true">▦</span>
-          <span className={b.planned ? 'text-text-muted' : 'text-text-primary font-semibold tabular-nums'}>{b.label}</span>
-          <span className="text-text-primary break-words">{b.title}</span>
-          {b.projectName && <span className="text-text-muted">· {b.projectName}</span>}
-          {/* OPS-CE-8E: set the time inline (first commit) for block-less rows. */}
-          {b.planned && b.itemId && <TaskTimeCommit itemId={b.itemId} date={date} />}
-          <span className="ml-auto px-1.5 py-0.5 rounded border border-amber-300 bg-white text-amber-700 text-[10px] uppercase tracking-wide">
-            {b.status}
-          </span>
-        </div>
+      <td colSpan={6} className="border border-border-light border-l-4 border-l-amber-400 bg-amber-50/50 px-3 py-2 align-top">
+        <TaskBand
+          timeLabel={b.planned ? '' : b.label}
+          planned={b.planned}
+          itemId={b.itemId}
+          date={date}
+          title={b.title}
+          projectName={b.projectName}
+          status={b.status}
+        />
       </td>
     </tr>
   );

--- a/src/components/workbench/operations/content/PieceGrid.tsx
+++ b/src/components/workbench/operations/content/PieceGrid.tsx
@@ -318,7 +318,7 @@ export default function PieceGrid() {
                   >
                     <div>{fmtDate(p.piece_date)}</div>
                     {p.title && (
-                      <div className="font-normal text-text-muted truncate max-w-[160px]">{p.title}</div>
+                      <div className="font-normal text-text-muted break-words max-w-[160px]">{p.title}</div>
                     )}
                     {(p.project_id || p.source_ai_usage_id) && (
                       <div

--- a/src/components/workbench/operations/content/ScenifyDraft.tsx
+++ b/src/components/workbench/operations/content/ScenifyDraft.tsx
@@ -19,7 +19,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { CONTENT_DAY_PLAN_CHANGED_EVENT, CONTENT_SCENES_CHANGED_EVENT } from './ScenifyModal';
-import TaskTimeCommit from './TaskTimeCommit';
+import TaskBand from './TaskBand';
 import {
   compareDayOrder,
   minuteOfDayFromInstant,
@@ -483,21 +483,19 @@ export default function ScenifyDraft({
     );
   };
 
-  // Read-only task band (S3's style), spanning the table; full title WRAPPED.
+  // Read-only task band — fully legible, labeled, wrapped (shared TaskBand).
   const renderTaskRow = (task: TaskView) => (
     <tr key={`task-${task.id}`}>
-      <td colSpan={8} className="border border-border-light border-l-4 border-l-amber-400 bg-amber-50/50 px-3 py-1.5 align-top">
-        <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
-          <span className="text-amber-700" aria-hidden="true">▦</span>
-          <span className={task.planned ? 'text-text-muted' : 'text-text-primary font-semibold tabular-nums'}>{task.label}</span>
-          <span className="text-text-primary break-words">{task.title}</span>
-          {task.projectName && <span className="text-text-muted">· {task.projectName}</span>}
-          {/* OPS-CE-8E: set the time inline (first commit) for block-less rows. */}
-          {task.planned && task.itemId && <TaskTimeCommit itemId={task.itemId} date={date} />}
-          <span className="ml-auto shrink-0 px-1.5 py-0.5 rounded border border-amber-300 bg-white text-amber-700 text-[10px] uppercase tracking-wide">
-            {task.status}
-          </span>
-        </div>
+      <td colSpan={8} className="border border-border-light border-l-4 border-l-amber-400 bg-amber-50/50 px-3 py-2 align-top">
+        <TaskBand
+          timeLabel={task.planned ? '' : task.label}
+          planned={task.planned}
+          itemId={task.itemId}
+          date={date}
+          title={task.title}
+          projectName={task.projectName}
+          status={task.status}
+        />
       </td>
     </tr>
   );

--- a/src/components/workbench/operations/content/TaskBand.tsx
+++ b/src/components/workbench/operations/content/TaskBand.tsx
@@ -1,0 +1,75 @@
+/**
+ * TaskBand — the shared, fully-legible inner content of a task row's amber band
+ * (OPS-CE-8F), used by BOTH the S2 day map (ScenifyDraft) and the S3 timeline
+ * (DailyLog) so the two can't drift. Fields are clearly separated, labeled (small
+ * purple uppercase labels mirroring the scene rows), and WRAPPED — nothing truncates:
+ *
+ *   TIME (actual/scheduled, labeled; or the inline commit form when planned) ·
+ *   TASK (full title, wrapped, primary) · PROJECT (full name, wrapped) · STATUS
+ *
+ * Read-only except the inline TaskTimeCommit on planned (block-less) rows. The amber
+ * band chrome lives on the parent <td>; this renders only the labeled fields.
+ */
+
+'use client';
+
+import TaskTimeCommit from './TaskTimeCommit';
+
+const fieldLabel = 'text-brand-purple uppercase tracking-wide text-[10px] font-medium';
+
+function Field({ label, children, className }: { label: string; children: React.ReactNode; className?: string }) {
+  return (
+    <div className={`flex flex-col gap-0.5 ${className ?? ''}`}>
+      <span className={fieldLabel}>{label}</span>
+      {children}
+    </div>
+  );
+}
+
+export default function TaskBand({
+  timeLabel,
+  planned,
+  itemId,
+  date,
+  title,
+  projectName,
+  status,
+}: {
+  timeLabel: string;
+  planned: boolean;
+  itemId?: string;
+  date: string;
+  title: string;
+  projectName: string | null;
+  status: string;
+}) {
+  return (
+    <div className="flex flex-wrap items-start gap-x-5 gap-y-2">
+      <span className="text-amber-700 mt-4" aria-hidden="true">▦</span>
+
+      <Field label="time">
+        {planned && itemId ? (
+          <TaskTimeCommit itemId={itemId} date={date} />
+        ) : (
+          <span className="text-text-primary font-medium tabular-nums whitespace-nowrap">{timeLabel}</span>
+        )}
+      </Field>
+
+      <Field label="task" className="min-w-[160px] flex-1">
+        <span className="text-text-primary font-medium break-words">{title}</span>
+      </Field>
+
+      {projectName && (
+        <Field label="project" className="min-w-[120px]">
+          <span className="text-text-muted break-words">{projectName}</span>
+        </Field>
+      )}
+
+      <Field label="status">
+        <span className="px-1.5 py-0.5 rounded border border-amber-300 bg-white text-amber-700 text-[10px] uppercase tracking-wide whitespace-nowrap">
+          {status}
+        </span>
+      </Field>
+    </div>
+  );
+}


### PR DESCRIPTION
…truncation anywhere on the content page