### PR TITLE
Ops-CE-8G: task lifecycle — edit/uncommit time, mark done with actual…

### DIFF
--- a/audit-reports/ops-ce-8g-impl.md
+++ b/audit-reports/ops-ce-8g-impl.md
@@ -1,0 +1,91 @@
+# OPS-CE-8G — Task lifecycle on the Content page (edit / uncommit / mark done)
+
+**Branch:** `claude/ops-ce-8g` (off `main`; CE-8F merged)
+**Date:** 2026-06-03
+**One concept:** edit a committed time, uncommit a mistaken block, and mark done
+(actuals + block completed + task completed) — inline, on the shared `TaskBand`.
+**All reuse existing routes; 0-schema; auth unchanged; flat law (inline confirms).**
+
+> ✅ `git diff` = `TaskBand.tsx` (the lifecycle, shared — no S2/S3 drift), the two
+> row-data builders (`ScenifyDraft`, `DailyLog`), and a ContentPipeline S1-refresh
+> listener. No `prisma/schema.prisma`, no `api/`. tsc exit 0; eslint exit 0.
+
+---
+
+## Audit — routes (all exist, cited; no STOP)
+
+| Action | Route (existing) | Notes |
+|---|---|---|
+| **Edit time** | `PATCH /api/operations/daily-plan/blocks/[blockId]` (`blocks/[blockId]/route.ts:38`) | `{ scheduled_start, scheduled_end }`; re-checks overlap (excl. self) → **409** unless `allow_conflicts` (`:99-106`). |
+| **Uncommit** | `DELETE /api/operations/daily-plan/blocks/[blockId]` (`:191`) | hard-deletes the block → item returns to block-less ("planned"). |
+| **Mark done — block** | `PATCH /api/operations/daily-plan/blocks/[blockId]` | accepts `actual_start`/`actual_end` (`:111-139`) + `status:'completed'` (`:141-149`). |
+| **Mark done — task** | `PATCH /api/operations/projects/[id]/tasks/[taskId]` (`tasks/[taskId]/route.ts:79`) | `{ status:'completed' }` → in a `$transaction` writes `operations_task_status_history` (`recordTaskStatusChange`, `:335-345`) + `completed_at = NOW()` (`:299-300`) + `operations_project_task_completed` audit (`:356-358`). |
+
+**Done-flow mirroring (truth-first):** Daily Plan's `DailyPlanItemRow` does **not**
+itself complete the *task* from a block (its only PATCH targets the *item*'s
+notes/order; block status is the calendar side). The canonical **task** completion is
+the project-task PATCH above (the Projects-tab flow: status history + completed_at +
+audit). CE-8G **mirrors that exactly** — `{ status:'completed' }` — never reimplements
+it. **commit ≠ completion:** committing a time only creates a `scheduled` block; DONE
+is a separate explicit action that sets actuals + completes both block and task.
+
+## Build (shared `TaskBand`, S2 + S3)
+The lifecycle lives entirely in `TaskBand` (one component → no drift). Modes:
+- **planned (no block)** → the CE-8E inline commit form (`TaskTimeCommit`).
+- **committed, not done** → TIME label + **[edit time] · [uncommit] · [✓ mark done]**:
+  - *edit time* — inline start/end (prefilled from scheduled) → block PATCH
+    `scheduled_*`; **409 → "schedule anyway"** (allow_conflicts), mirroring commit.
+  - *uncommit* — inline confirm ("Remove the time? Returns to planned.") → block
+    DELETE (no modal — flat law).
+  - *mark done* — inline **actuals** (prefilled from scheduled, editable) → block
+    PATCH `{ actual_*, status:'completed' }` **then** (if the row has a task) task
+    PATCH `{ status:'completed' }`.
+- **done (block completed)** → permanent **"✓ DONE · {actual times}"** + a purple
+  status pill; **no actions** (the provable completed record stays in the day map +
+  the record forever).
+
+Ad-hoc items (no `task`) complete only the block (no task PATCH). Every mutation
+dispatches **`CONTENT_DAY_PLAN_CHANGED_EVENT`**. The two callers only **extend the
+row data** they pass to `TaskBand` (blockId, taskId, projectId, scheduled ISO,
+status, planned) — no logic duplicated.
+
+## To-do pool (S1) — verdict: already excludes completed (cited)
+`GET /api/operations/tasks/unscheduled` (`tasks/unscheduled/route.ts`) filters
+`status: { in: ['open','in_progress','blocked'] }` **and**
+`daily_plan_items: { none: { calendar_blocks: { some: {} } } }`. So a task **drops
+out of S1 automatically** once it is **completed** (status filter) *or* has a
+committed block (the unscheduled predicate). **No read-fix needed.** To make it
+instant, `ContentPipeline` now listens to `CONTENT_DAY_PLAN_CHANGED_EVENT` and
+re-runs `load` (the `/unscheduled` fetch) + day pre-marks + counts — so a done/
+committed task leaves the to-do list in one click. S2/S3 already listen (CE-8D) and
+re-read → the row flips to ✓ / re-sorts immediately.
+
+## Verify
+- **Edit** → block PATCH `scheduled_*` (409 → schedule-anyway) → event → re-sort. ✅
+- **Uncommit** → block DELETE → event → row returns to planned (commit form). ✅
+- **Mark done** → actuals + block `completed`, then task `completed` via the existing
+  status flow (history + completed_at + audit) → event → row shows ✓ DONE; task
+  leaves S1; stays in the map/record. ✅
+- **commit ≠ completion** — committing never sets status completed (CE-8E unchanged). ✅
+- **Reuse-only / no STOP** — every route pre-existing; auth unchanged. **0-schema.** ✅
+- **Flat law** — inline confirms, no modal. **Contrast standard** — purple labels,
+  white inputs `border-brand-purple/40` + focus ring `brand-purple/20`. ✅
+- **tsc** exit 0; **eslint** exit 0.
+
+## git diff scope
+`content/TaskBand.tsx` (lifecycle), `content/ScenifyDraft.tsx` +
+`content/DailyLog.tsx` (row-data: blockId/taskId/projectId/scheduled ISO),
+`content/ContentPipeline.tsx` (S1 refresh on the day-plan event) (+ this report). No
+schema, no routes.
+
+---
+
+## Result
+Task rows in the S2 map and S3 timeline now carry the full lifecycle inline:
+**edit** a committed time (409→schedule-anyway), **uncommit** a mistaken block back to
+planned, and **mark done** — which logs actuals, completes the block, and completes
+the task through the **existing** status flow (status history + `completed_at` +
+audit). A done task drops from the S1 to-do pool (`/unscheduled` already excludes
+completed) and remains in the day map/record as the permanent ✓ — all in one click via
+`CONTENT_DAY_PLAN_CHANGED_EVENT`. Reuse-only, 0-schema, flat, contrast-clean; tsc +
+eslint pass.

--- a/src/components/workbench/operations/content/ContentPipeline.tsx
+++ b/src/components/workbench/operations/content/ContentPipeline.tsx
@@ -149,6 +149,18 @@ export default function ContentPipeline() {
     return () => window.removeEventListener(CONTENT_SCENES_CHANGED_EVENT, refresh);
   }, [loadCounts]);
 
+  // A day-plan change (add / commit / uncommit / done) → refresh the S1 to-do pool
+  // (/tasks/unscheduled drops committed + completed tasks) + the day pre-marks + counts.
+  useEffect(() => {
+    const refresh = () => {
+      void load();
+      void loadDayItems();
+      void loadCounts();
+    };
+    window.addEventListener(CONTENT_DAY_PLAN_CHANGED_EVENT, refresh);
+    return () => window.removeEventListener(CONTENT_DAY_PLAN_CHANGED_EVENT, refresh);
+  }, [load, loadDayItems, loadCounts]);
+
   const entityNameById = useMemo(
     () => new Map(entities.map((e) => [e.id, e.name])),
     [entities]

--- a/src/components/workbench/operations/content/DailyLog.tsx
+++ b/src/components/workbench/operations/content/DailyLog.tsx
@@ -204,10 +204,15 @@ export default function DailyLog({ date }: { date: string }) {
   const taskBlocks = useMemo(() => {
     const rows: {
       id: string;
-      itemId?: string;
+      itemId: string;
+      blockId: string | null;
+      taskId: string | null;
+      projectId: string | null;
       title: string;
       projectName: string | null;
       status: string;
+      scheduledStart: string | null;
+      scheduledEnd: string | null;
       label: string;
       minute: number | null;
       order: number;
@@ -218,15 +223,22 @@ export default function DailyLog({ date }: { date: string }) {
       // CROSS-ENTITY: all items for the date (personal + business).
       const title = item.task?.title ?? item.ad_hoc_title ?? 'Untitled';
       const projectName = item.task?.project_id ? projectNameById[item.task.project_id] ?? null : null;
+      const taskId = item.task?.id ?? null;
+      const projectId = item.task?.project_id ?? null;
       if (item.calendar_blocks.length === 0) {
         // Assigned to the day but no time committed yet — visible immediately.
         rows.push({
           id: `item-${item.id}`,
           itemId: item.id,
+          blockId: null,
+          taskId,
+          projectId,
           title,
           projectName,
           status: 'planned',
-          label: 'planned · no time yet',
+          scheduledStart: null,
+          scheduledEnd: null,
+          label: '',
           minute: null,
           order: UNTIMED_TASK_ORDER_BASE + plannedIndex++,
           planned: true,
@@ -241,9 +253,15 @@ export default function DailyLog({ date }: { date: string }) {
         const minute = minuteOfDayFromInstant(start);
         rows.push({
           id: b.id,
+          itemId: item.id,
+          blockId: b.id,
+          taskId,
+          projectId,
           title,
           projectName,
           status: b.status,
+          scheduledStart: b.scheduled_start,
+          scheduledEnd: b.scheduled_end,
           label,
           minute,
           order: minute,
@@ -412,13 +430,18 @@ export default function DailyLog({ date }: { date: string }) {
     <tr key={`task-${b.id}`}>
       <td colSpan={6} className="border border-border-light border-l-4 border-l-amber-400 bg-amber-50/50 px-3 py-2 align-top">
         <TaskBand
-          timeLabel={b.planned ? '' : b.label}
+          date={date}
           planned={b.planned}
           itemId={b.itemId}
-          date={date}
+          blockId={b.blockId}
+          taskId={b.taskId}
+          projectId={b.projectId}
           title={b.title}
           projectName={b.projectName}
           status={b.status}
+          scheduledStart={b.scheduledStart}
+          scheduledEnd={b.scheduledEnd}
+          timeLabel={b.label}
         />
       </td>
     </tr>

--- a/src/components/workbench/operations/content/ScenifyDraft.tsx
+++ b/src/components/workbench/operations/content/ScenifyDraft.tsx
@@ -84,11 +84,16 @@ interface PlanItem {
 // A read-only task band in the day map.
 interface TaskView {
   id: string;
-  itemId?: string; // the daily_plan_item id — present on planned (block-less) rows
+  itemId: string; // the daily_plan_item id (for planned commit)
+  blockId: string | null; // the calendar_block id (committed rows)
+  taskId: string | null; // for completing the task on "mark done"
+  projectId: string | null;
   title: string;
   projectName: string | null;
   status: string;
-  label: string;
+  scheduledStart: string | null;
+  scheduledEnd: string | null;
+  label: string; // time label for committed rows
   planned: boolean;
 }
 
@@ -363,10 +368,15 @@ export default function ScenifyDraft({
           task: {
             id: `item-${item.id}`,
             itemId: item.id,
+            blockId: null,
+            taskId: item.task?.id ?? null,
+            projectId: item.task?.project_id ?? null,
             title,
             projectName,
             status: 'planned',
-            label: 'planned · no time yet',
+            scheduledStart: null,
+            scheduledEnd: null,
+            label: '',
             planned: true,
           },
         });
@@ -383,9 +393,15 @@ export default function ScenifyDraft({
           order: minute,
           task: {
             id: b.id,
+            itemId: item.id,
+            blockId: b.id,
+            taskId: item.task?.id ?? null,
+            projectId: item.task?.project_id ?? null,
             title,
             projectName,
             status: b.status,
+            scheduledStart: b.scheduled_start,
+            scheduledEnd: b.scheduled_end,
             label: `${fmtClock(start)}–${end ? fmtClock(end) : '…'} ${useActual ? '(actual)' : '(scheduled)'}`,
             planned: false,
           },
@@ -488,13 +504,18 @@ export default function ScenifyDraft({
     <tr key={`task-${task.id}`}>
       <td colSpan={8} className="border border-border-light border-l-4 border-l-amber-400 bg-amber-50/50 px-3 py-2 align-top">
         <TaskBand
-          timeLabel={task.planned ? '' : task.label}
+          date={date}
           planned={task.planned}
           itemId={task.itemId}
-          date={date}
+          blockId={task.blockId}
+          taskId={task.taskId}
+          projectId={task.projectId}
           title={task.title}
           projectName={task.projectName}
           status={task.status}
+          scheduledStart={task.scheduledStart}
+          scheduledEnd={task.scheduledEnd}
+          timeLabel={task.label}
         />
       </td>
     </tr>

--- a/src/components/workbench/operations/content/TaskBand.tsx
+++ b/src/components/workbench/operations/content/TaskBand.tsx
@@ -1,21 +1,32 @@
 /**
- * TaskBand — the shared, fully-legible inner content of a task row's amber band
- * (OPS-CE-8F), used by BOTH the S2 day map (ScenifyDraft) and the S3 timeline
- * (DailyLog) so the two can't drift. Fields are clearly separated, labeled (small
- * purple uppercase labels mirroring the scene rows), and WRAPPED — nothing truncates:
+ * TaskBand — the shared task-row band (S2 day map + S3 timeline), fully legible
+ * (CE-8F) and now the task LIFECYCLE surface (OPS-CE-8G), inline / flat-law:
  *
- *   TIME (actual/scheduled, labeled; or the inline commit form when planned) ·
- *   TASK (full title, wrapped, primary) · PROJECT (full name, wrapped) · STATUS
+ *   • PLANNED (no block)     → inline commit form (TaskTimeCommit, CE-8E).
+ *   • COMMITTED (block, not done) → TIME label + [edit time] · [uncommit] · [✓ mark done].
+ *       - edit time  → PATCH /daily-plan/blocks/[blockId] { scheduled_* } (409→allow_conflicts).
+ *       - uncommit   → DELETE /daily-plan/blocks/[blockId] (inline confirm) → back to planned.
+ *       - mark done  → actuals (prefilled scheduled, editable) → PATCH block
+ *                      { actual_*, status:'completed' } THEN PATCH the task
+ *                      { status:'completed' } (the EXISTING task-status flow: status
+ *                      history + completed_at + audit). commit ≠ completion — DONE is explicit.
+ *   • DONE (block completed) → permanent "✓ DONE · {actual times}" record; no actions.
  *
- * Read-only except the inline TaskTimeCommit on planned (block-less) rows. The amber
- * band chrome lives on the parent <td>; this renders only the labeled fields.
+ * Every mutation dispatches CONTENT_DAY_PLAN_CHANGED_EVENT so S1/S2/S3 refresh: the
+ * done task leaves the to-do pool and flips to ✓ in the map in one click. All routes
+ * are EXISTING Daily Plan / project-task routes; auth unchanged; 0-schema.
  */
 
 'use client';
 
+import { useState } from 'react';
+import { CONTENT_DAY_PLAN_CHANGED_EVENT } from './ScenifyModal';
 import TaskTimeCommit from './TaskTimeCommit';
 
 const fieldLabel = 'text-brand-purple uppercase tracking-wide text-[10px] font-medium';
+const timeInput =
+  'px-1.5 py-0.5 bg-white border border-brand-purple/40 rounded text-text-primary focus:outline-none focus:ring-2 focus:ring-brand-purple/20 focus:border-brand-purple';
+const btn = 'px-2 py-0.5 border rounded disabled:opacity-50';
 
 function Field({ label, children, className }: { label: string; children: React.ReactNode; className?: string }) {
   return (
@@ -26,33 +37,229 @@ function Field({ label, children, className }: { label: string; children: React.
   );
 }
 
+// ISO instant → local "HH:MM" for prefilling time inputs.
+const isoToTime = (iso: string | null): string => {
+  if (!iso) return '';
+  const d = new Date(iso);
+  return `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`;
+};
+
+type Mode = 'view' | 'edit' | 'uncommit' | 'done';
+
 export default function TaskBand({
-  timeLabel,
+  date,
   planned,
   itemId,
-  date,
+  blockId,
+  taskId,
+  projectId,
   title,
   projectName,
   status,
+  scheduledStart,
+  scheduledEnd,
+  timeLabel,
 }: {
-  timeLabel: string;
-  planned: boolean;
-  itemId?: string;
   date: string;
+  planned: boolean;
+  itemId: string;
+  blockId: string | null;
+  taskId: string | null;
+  projectId: string | null;
   title: string;
   projectName: string | null;
   status: string;
+  scheduledStart: string | null;
+  scheduledEnd: string | null;
+  actualStart?: string | null;
+  actualEnd?: string | null;
+  timeLabel: string;
 }) {
+  const done = status === 'completed';
+  const [mode, setMode] = useState<Mode>('view');
+  const [start, setStart] = useState('');
+  const [end, setEnd] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [conflict, setConflict] = useState(false);
+
+  const open = (m: Mode) => {
+    setStart(isoToTime(scheduledStart) || '09:00');
+    setEnd(isoToTime(scheduledEnd) || '10:00');
+    setError(null);
+    setConflict(false);
+    setMode(m);
+  };
+
+  const fail = (e: unknown, fallback: string) => setError(e instanceof Error ? e.message : fallback);
+  const done2 = () => {
+    window.dispatchEvent(new Event(CONTENT_DAY_PLAN_CHANGED_EVENT));
+  };
+
+  // Validate the two time inputs against the day; returns ISO strings or null.
+  const toIso = (): { startIso: string; endIso: string } | null => {
+    const s = new Date(`${date}T${start}`);
+    const e = new Date(`${date}T${end}`);
+    if (Number.isNaN(s.getTime()) || Number.isNaN(e.getTime())) {
+      setError('Invalid time');
+      return null;
+    }
+    if (e.getTime() <= s.getTime()) {
+      setError('End must be after start');
+      return null;
+    }
+    return { startIso: s.toISOString(), endIso: e.toISOString() };
+  };
+
+  const saveEdit = async (allowConflicts: boolean) => {
+    if (busy || !blockId) return;
+    const iso = toIso();
+    if (!iso) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const body: Record<string, unknown> = { scheduled_start: iso.startIso, scheduled_end: iso.endIso };
+      if (allowConflicts) body.allow_conflicts = true;
+      const res = await fetch(`/api/operations/daily-plan/blocks/${blockId}`, {
+        method: 'PATCH',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      if (res.status === 409) {
+        setConflict(true);
+        setError('Overlaps another block.');
+        setBusy(false);
+        return;
+      }
+      if (!res.ok) throw new Error((await res.json().catch(() => ({})))?.message ?? `failed (${res.status})`);
+      setMode('view');
+      done2();
+    } catch (e) {
+      fail(e, 'failed to update time');
+      setBusy(false);
+    }
+  };
+
+  const uncommit = async () => {
+    if (busy || !blockId) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/operations/daily-plan/blocks/${blockId}`, {
+        method: 'DELETE',
+        credentials: 'include',
+      });
+      if (!res.ok) throw new Error((await res.json().catch(() => ({})))?.message ?? `failed (${res.status})`);
+      done2(); // the row becomes planned again (re-read)
+    } catch (e) {
+      fail(e, 'failed to uncommit');
+      setBusy(false);
+    }
+  };
+
+  const markDone = async () => {
+    if (busy || !blockId) return;
+    const iso = toIso();
+    if (!iso) return;
+    setBusy(true);
+    setError(null);
+    try {
+      // 1) the block: actuals + completed.
+      const blockRes = await fetch(`/api/operations/daily-plan/blocks/${blockId}`, {
+        method: 'PATCH',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ actual_start: iso.startIso, actual_end: iso.endIso, status: 'completed' }),
+      });
+      if (!blockRes.ok) throw new Error((await blockRes.json().catch(() => ({})))?.message ?? `block failed (${blockRes.status})`);
+      // 2) the task: completed via the EXISTING task-status flow (status history +
+      //    completed_at + audit). Skipped for ad-hoc items (no task).
+      if (taskId && projectId) {
+        const taskRes = await fetch(`/api/operations/projects/${projectId}/tasks/${taskId}`, {
+          method: 'PATCH',
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ status: 'completed' }),
+        });
+        if (!taskRes.ok) throw new Error((await taskRes.json().catch(() => ({})))?.message ?? `task failed (${taskRes.status})`);
+      }
+      setMode('view');
+      done2();
+    } catch (e) {
+      fail(e, 'failed to mark done');
+      setBusy(false);
+    }
+  };
+
   return (
     <div className="flex flex-wrap items-start gap-x-5 gap-y-2">
-      <span className="text-amber-700 mt-4" aria-hidden="true">▦</span>
+      <span className={done ? 'text-brand-purple mt-4' : 'text-amber-700 mt-4'} aria-hidden="true">
+        {done ? '✓' : '▦'}
+      </span>
 
       <Field label="time">
-        {planned && itemId ? (
+        {planned && !blockId ? (
           <TaskTimeCommit itemId={itemId} date={date} />
+        ) : done ? (
+          <span className="text-text-primary font-medium tabular-nums whitespace-nowrap">✓ DONE · {timeLabel}</span>
+        ) : mode === 'edit' || mode === 'done' ? (
+          <span className="flex flex-wrap items-center gap-1.5">
+            <label className="flex items-center gap-1 text-brand-purple font-medium">
+              {mode === 'done' ? 'actual start' : 'start'}
+              <input type="time" value={start} onChange={(e) => setStart(e.target.value)} className={timeInput} />
+            </label>
+            <label className="flex items-center gap-1 text-brand-purple font-medium">
+              {mode === 'done' ? 'actual end' : 'end'}
+              <input type="time" value={end} onChange={(e) => setEnd(e.target.value)} className={timeInput} />
+            </label>
+            <button
+              type="button"
+              onClick={() => (mode === 'done' ? markDone() : saveEdit(false))}
+              disabled={busy}
+              className={`${btn} border-brand-purple bg-brand-purple text-white hover:opacity-90`}
+            >
+              {busy ? 'saving…' : mode === 'done' ? 'confirm done' : 'save time'}
+            </button>
+            {conflict && mode === 'edit' && (
+              <button
+                type="button"
+                onClick={() => saveEdit(true)}
+                disabled={busy}
+                className={`${btn} border-amber-400 text-amber-700 hover:bg-amber-50`}
+              >
+                schedule anyway
+              </button>
+            )}
+            <button type="button" onClick={() => setMode('view')} disabled={busy} className={`${btn} border-border text-text-muted hover:bg-bg-row`}>
+              cancel
+            </button>
+          </span>
+        ) : mode === 'uncommit' ? (
+          <span className="flex flex-wrap items-center gap-1.5">
+            <span className="text-text-muted">Remove the time? Returns to planned.</span>
+            <button type="button" onClick={uncommit} disabled={busy} className={`${btn} border-red-300 text-red-700 hover:bg-red-50`}>
+              {busy ? 'removing…' : 'remove'}
+            </button>
+            <button type="button" onClick={() => setMode('view')} disabled={busy} className={`${btn} border-border text-text-muted hover:bg-bg-row`}>
+              cancel
+            </button>
+          </span>
         ) : (
-          <span className="text-text-primary font-medium tabular-nums whitespace-nowrap">{timeLabel}</span>
+          <span className="flex flex-wrap items-center gap-2">
+            <span className="text-text-primary font-medium tabular-nums whitespace-nowrap">{timeLabel}</span>
+            <button type="button" onClick={() => open('edit')} className={`${btn} border-brand-purple text-brand-purple hover:bg-purple-100/50`}>
+              edit time
+            </button>
+            <button type="button" onClick={() => setMode('uncommit')} className={`${btn} border-border text-text-muted hover:bg-bg-row`}>
+              uncommit
+            </button>
+            <button type="button" onClick={() => open('done')} className={`${btn} border-brand-purple bg-brand-purple text-white hover:opacity-90`}>
+              ✓ mark done
+            </button>
+          </span>
         )}
+        {error && <span className="text-red-700 mt-0.5">{error}</span>}
       </Field>
 
       <Field label="task" className="min-w-[160px] flex-1">
@@ -66,7 +273,11 @@ export default function TaskBand({
       )}
 
       <Field label="status">
-        <span className="px-1.5 py-0.5 rounded border border-amber-300 bg-white text-amber-700 text-[10px] uppercase tracking-wide whitespace-nowrap">
+        <span
+          className={`px-1.5 py-0.5 rounded border text-[10px] uppercase tracking-wide whitespace-nowrap ${
+            done ? 'border-brand-purple bg-purple-50 text-brand-purple' : 'border-amber-300 bg-white text-amber-700'
+          }`}
+        >
           {status}
         </span>
       </Field>


### PR DESCRIPTION
…s, done leaves the to-do pool and stays in the day record