### PR TITLE
PR-Calendar-Seamless: calendar content flush under the purple header …

### DIFF
--- a/src/components/home/ModuleLauncher.tsx
+++ b/src/components/home/ModuleLauncher.tsx
@@ -357,7 +357,9 @@ export default function ModuleLauncher({ onRequireAuth }: Props) {
                 <span>Calendar</span>
                 <span className="text-[10px] uppercase tracking-wider font-normal text-white/80">Your data</span>
               </div>
-              <div className="bg-white p-4">
+              {/* PR-Calendar-Seamless: no body padding — the calendar flows flush under
+                  the purple band (one continuous surface, Apple/Outlook style). */}
+              <div className="bg-white">
                 <HubCalendar />
               </div>
             </div>
@@ -372,7 +374,8 @@ export default function ModuleLauncher({ onRequireAuth }: Props) {
                 <span>Calendar</span>
                 <span className="text-[10px] uppercase tracking-wider font-normal text-white/80">Live demo · log in to use</span>
               </div>
-              <div className="bg-white p-4">
+              {/* PR-Calendar-Seamless: no body padding — flush under the purple band. */}
+              <div className="bg-white">
                 <HubCalendar demoEvents={demoCalendar} onRequireAuth={onRequireAuth} />
               </div>
             </div>

--- a/src/components/hub/HubCalendar.tsx
+++ b/src/components/hub/HubCalendar.tsx
@@ -185,13 +185,12 @@ export default function HubCalendar({ demoEvents, onRequireAuth }: HubCalendarPr
     setDetailEvent(event);
   };
 
+  // PR-Calendar-Seamless: no root gap — the caption + grid flow FLUSH under the parent's
+  // purple band (one continuous surface). The redundant month-nav is gone
+  // (PR-Calendar-Native); the grid's own toolbar is the single date nav.
   return (
-    <div className="space-y-3">
-      {/* PR-Calendar-Apple: the caption is its OWN full-width line (out of the nav row).
-          PR-Calendar-Native: the redundant month-nav is gone — the grid's own toolbar is
-          the single date nav; onMonthChange keeps this component's fetch window in sync
-          with the grid's displayed month. */}
-      <p className="text-xs text-text-muted">
+    <div>
+      <p className="px-4 pt-2 pb-1.5 text-[11px] leading-snug text-text-muted">
         {isDemo
           ? 'This is the real app — these events are made up, and nothing here gets saved.'
           : 'Trips, routines, and your daily plan — all in one place.'}
@@ -211,10 +210,11 @@ export default function HubCalendar({ demoEvents, onRequireAuth }: HubCalendarPr
         onEventClick={handleEventClick}
         phoneDayOnly={true}
         onMonthChange={(year, month) => { setSelectedYear(year); setSelectedMonth(month); }}
+        flush={true}
       />
 
       {isDemo && (
-        <div className="flex flex-col items-start gap-2 rounded-lg border border-border bg-bg-row p-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="m-4 flex flex-col items-start gap-2 rounded-lg border border-border bg-bg-row p-4 sm:flex-row sm:items-center sm:justify-between">
           <p className="text-sm text-text-secondary">
             Like what you see? Make a free account and fill it with your own trips, routines, and plans.
           </p>

--- a/src/components/shared/CalendarGrid.tsx
+++ b/src/components/shared/CalendarGrid.tsx
@@ -79,6 +79,13 @@ export interface CalendarGridProps {
    * undefined → no-op for the other callers.
    */
   onMonthChange?: (year: number, month: number) => void;
+  /**
+   * Opt-in (PR-Calendar-Seamless): drop the outer card chrome (rounded corners, border,
+   * shadow) so the grid sits FLUSH inside a parent that already provides the frame —
+   * one continuous surface under a header band, Apple/Outlook style. Default false →
+   * the other callers keep their floating card.
+   */
+  flush?: boolean;
 }
 
 // ═══════════════════════════════════════════════════════════════
@@ -180,6 +187,7 @@ export default function CalendarGrid({
   enableHubChrome = false,
   phoneDayOnly = false,
   onMonthChange,
+  flush = false,
 }: CalendarGridProps) {
   const router = useRouter();
   const now = new Date();
@@ -359,7 +367,7 @@ export default function CalendarGrid({
   // ═══════════════════════════════════════════════════════════════
 
   return (
-    <div className={`bg-white ${hubMobileToolbar ? 'rounded-lg' : 'rounded'} border border-border overflow-hidden shadow-sm`}>
+    <div className={flush ? 'bg-white overflow-hidden' : `bg-white ${hubMobileToolbar ? 'rounded-lg' : 'rounded'} border border-border overflow-hidden shadow-sm`}>
       {/* Mobile auto-default to Day view (PR-Ops-Cal-4) — opt-in only.
           Mounting the controller only when enableDayView keeps the responsive
           hook/listener off the prop-off path entirely. */}


### PR DESCRIPTION
…(kill the wasted space; Apple/Outlook continuous-surface feel)