### PR TITLE
PR-Calendar-Flush: Calendar tab — remove redundant purple band + capt…

### DIFF
--- a/src/components/home/ModuleLauncher.tsx
+++ b/src/components/home/ModuleLauncher.tsx
@@ -349,36 +349,20 @@ export default function ModuleLauncher({ onRequireAuth }: Props) {
           data). Logged out → a LIVING DEMO fed a static fictional seed, which
           fetches NOTHING (zero personal-route calls — fake by construction). Auth
           still resolving (authed === null) → nothing. /hub is untouched. */}
+      {/* PR-Calendar-Flush: Calendar tab is flush — no purple band, no card chrome (the
+          highlighted Calendar tab already says you're here). The grid toolbar sits right
+          under the tab row, one continuous surface. Other modules keep their bands. */}
       {authed === true && (
-        <section className={`w-full py-10 bg-white border-b border-border ${activeModule === 'calendar' ? 'block' : 'hidden'}`}>
+        <section className={`w-full bg-white border-b border-border ${activeModule === 'calendar' ? 'block' : 'hidden'}`}>
           <div className="max-w-7xl mx-auto px-4 lg:px-8">
-            <div className="rounded-lg overflow-hidden border border-gray-200/50 shadow-sm">
-              <div className="bg-brand-purple/80 text-white px-4 py-2.5 text-sm font-semibold flex items-center justify-between">
-                <span>Calendar</span>
-                <span className="text-[10px] uppercase tracking-wider font-normal text-white/80">Your data</span>
-              </div>
-              {/* PR-Calendar-Seamless: no body padding — the calendar flows flush under
-                  the purple band (one continuous surface, Apple/Outlook style). */}
-              <div className="bg-white">
-                <HubCalendar />
-              </div>
-            </div>
+            <HubCalendar />
           </div>
         </section>
       )}
       {authed === false && (
-        <section className={`w-full py-10 bg-white border-b border-border ${activeModule === 'calendar' ? 'block' : 'hidden'}`}>
+        <section className={`w-full bg-white border-b border-border ${activeModule === 'calendar' ? 'block' : 'hidden'}`}>
           <div className="max-w-7xl mx-auto px-4 lg:px-8">
-            <div className="rounded-lg overflow-hidden border border-gray-200/50 shadow-sm">
-              <div className="bg-brand-purple/80 text-white px-4 py-2.5 text-sm font-semibold flex items-center justify-between">
-                <span>Calendar</span>
-                <span className="text-[10px] uppercase tracking-wider font-normal text-white/80">Live demo · log in to use</span>
-              </div>
-              {/* PR-Calendar-Seamless: no body padding — flush under the purple band. */}
-              <div className="bg-white">
-                <HubCalendar demoEvents={demoCalendar} onRequireAuth={onRequireAuth} />
-              </div>
-            </div>
+            <HubCalendar demoEvents={demoCalendar} onRequireAuth={onRequireAuth} />
           </div>
         </section>
       )}

--- a/src/components/hub/HubCalendar.tsx
+++ b/src/components/hub/HubCalendar.tsx
@@ -185,16 +185,17 @@ export default function HubCalendar({ demoEvents, onRequireAuth }: HubCalendarPr
     setDetailEvent(event);
   };
 
-  // PR-Calendar-Seamless: no root gap — the caption + grid flow FLUSH under the parent's
-  // purple band (one continuous surface). The redundant month-nav is gone
-  // (PR-Calendar-Native); the grid's own toolbar is the single date nav.
+  // PR-Calendar-Flush: the descriptive caption + the parent purple band are gone — the
+  // grid's toolbar flows flush under the tab row. The only thing kept up top is a tiny
+  // logged-out "live demo" tag (the signal that used to live in the band), so a guest
+  // still knows the data is made up.
   return (
     <div>
-      <p className="px-4 pt-2 pb-1.5 text-[11px] leading-snug text-text-muted">
-        {isDemo
-          ? 'This is the real app — these events are made up, and nothing here gets saved.'
-          : 'Trips, routines, and your daily plan — all in one place.'}
-      </p>
+      {isDemo && (
+        <p className="px-4 pt-2 text-[10px] font-semibold uppercase tracking-wider text-brand-purple">
+          Live demo · log in to use
+        </p>
+      )}
 
       {/* PR-Calendar-Apple: edge-to-edge grid (Apple day-view). PR-Calendar-Native:
           phone = day-only + a week strip; the grid's nav drives this component's fetch


### PR DESCRIPTION
…ion, toolbar flush under the tabs (Apple/Outlook continuous surface); other modules unchanged