### PR TITLE
PR-Mobile-Calendar-Declutter: remove LIVE DEMO bar everywhere + hide …

### DIFF
--- a/src/components/hub/HubCalendar.tsx
+++ b/src/components/hub/HubCalendar.tsx
@@ -204,17 +204,12 @@ export default function HubCalendar({ demoEvents, onRequireAuth }: HubCalendarPr
   };
 
   // PR-Calendar-Flush: the descriptive caption + the parent purple band are gone — the
-  // grid's toolbar flows flush under the tab row. The only thing kept up top is a tiny
-  // logged-out "live demo" tag (the signal that used to live in the band), so a guest
-  // still knows the data is made up.
+  // grid's toolbar flows flush under the tab row.
+  // PR-Mobile-Calendar-Declutter: the small "live demo" tag that used to sit up top is
+  // removed too (clutter, worst on phone's tight space); the logged-out sign-up CTA below
+  // still tells a guest the data is a demo.
   return (
     <div>
-      {isDemo && (
-        <p className="px-4 pt-2 text-[10px] font-semibold uppercase tracking-wider text-brand-purple">
-          Live demo · log in to use
-        </p>
-      )}
-
       {/* Edge-to-edge day-view grid. On phone it's day-only with a week strip; the grid's
           nav drives this component's fetch month via onMonthChange. */}
       <CalendarGrid

--- a/src/components/shared/CalendarGrid.tsx
+++ b/src/components/shared/CalendarGrid.tsx
@@ -382,18 +382,18 @@ export default function CalendarGrid({
       {/* Header bar */}
       <div className={toolbarBarClass}>
         <div className={toolbarLeftClass}>
-          <div className={`${viewTrackExtra}flex bg-border/70 rounded p-0.5`}>
-            {enableDayView && (
-              <button onClick={() => selectView('day')} className={`${viewBtnExtra}px-3 py-1.5 text-sm font-medium rounded-md transition-colors ${calendarView === 'day' ? viewBtnActive : viewBtnInactive}`}>Day</button>
-            )}
-            {/* PR-Calendar-Native: Week/Month hidden on phone-day-only (phone = day-only). */}
-            {!phoneOnlyActive && (
-              <>
-                <button onClick={() => selectView('week')} className={`${viewBtnExtra}px-3 py-1.5 text-sm font-medium rounded-md transition-colors ${calendarView === 'week' ? viewBtnActive : viewBtnInactive}`}>Week</button>
-                <button onClick={() => selectView('month')} className={`${viewBtnExtra}px-3 py-1.5 text-sm font-medium rounded-md transition-colors ${calendarView === 'month' ? viewBtnActive : viewBtnInactive}`}>Month</button>
-              </>
-            )}
-          </div>
+          {/* PR-Mobile-Calendar-Declutter: on phone-day-only the view is locked to Day, so
+              hide the WHOLE Day/Week/Month track — the lone "Day" button was dead UI eating
+              a row. Desktop (a real Day/Week/Month choice) keeps it. */}
+          {!phoneOnlyActive && (
+            <div className={`${viewTrackExtra}flex bg-border/70 rounded p-0.5`}>
+              {enableDayView && (
+                <button onClick={() => selectView('day')} className={`${viewBtnExtra}px-3 py-1.5 text-sm font-medium rounded-md transition-colors ${calendarView === 'day' ? viewBtnActive : viewBtnInactive}`}>Day</button>
+              )}
+              <button onClick={() => selectView('week')} className={`${viewBtnExtra}px-3 py-1.5 text-sm font-medium rounded-md transition-colors ${calendarView === 'week' ? viewBtnActive : viewBtnInactive}`}>Week</button>
+              <button onClick={() => selectView('month')} className={`${viewBtnExtra}px-3 py-1.5 text-sm font-medium rounded-md transition-colors ${calendarView === 'month' ? viewBtnActive : viewBtnInactive}`}>Month</button>
+            </div>
+          )}
           {/* Timezone toggle */}
           {calendarView !== 'month' && (
             <select


### PR DESCRIPTION
…redundant Day toggle on mobile (desktop keeps Day/Week/Month)