### PR TITLE
fix(calendar): fetch visible view range (from/to) instead of month; b…

### DIFF
--- a/src/app/api/calendar/route.ts
+++ b/src/app/api/calendar/route.ts
@@ -17,10 +17,24 @@ export async function GET(request: Request) {
     const { searchParams } = new URL(request.url);
     const year = parseInt(searchParams.get('year') || new Date().getFullYear().toString());
     const month = searchParams.get('month') ? parseInt(searchParams.get('month')!) : null;
+    // PR-calendar-visible-range: optional explicit visible window (inclusive 'YYYY-MM-DD').
+    // When present it takes precedence over month/year so a week/day spanning a month boundary
+    // loads ALL its events. month + year modes are kept for the other caller (hub/page.tsx).
+    const fromParam = searchParams.get('from');
+    const toParam = searchParams.get('to');
+    const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 
     let events: any[];
-    
-    if (month) {
+
+    if (fromParam && toParam && DATE_RE.test(fromParam) && DATE_RE.test(toParam)) {
+      events = await prisma.$queryRaw`
+        SELECT * FROM calendar_events
+        WHERE user_id = ${user.id}
+        AND start_date >= ${fromParam}::date
+        AND start_date <= ${toParam}::date
+        ORDER BY start_date ASC
+      `;
+    } else if (month) {
       const startOfMonth = `${year}-${String(month).padStart(2, '0')}-01`;
       const endOfMonth = month === 12 
         ? `${year + 1}-01-01` 

--- a/src/components/hub/HubCalendar.tsx
+++ b/src/components/hub/HubCalendar.tsx
@@ -103,6 +103,14 @@ export default function HubCalendar({ demoEvents, onRequireAuth }: HubCalendarPr
   const now = new Date();
   const [selectedYear, setSelectedYear] = useState(now.getFullYear());
   const [selectedMonth, setSelectedMonth] = useState(now.getMonth());
+  // PR-calendar-visible-range: the VISIBLE window (inclusive YYYY-MM-DD) drives ALL three
+  // fetches — replacing the month-only window so a week/day spanning a month boundary loads
+  // every event. Seeded to the current month; the grid's onRangeChange swaps in the on-screen
+  // window (day/week/month). Always a valid range (no fallback).
+  const [range, setRange] = useState<{ from: string; to: string }>(() => {
+    const lastDay = new Date(selectedYear, selectedMonth + 1, 0).getDate();
+    return { from: `${selectedYear}-${pad(selectedMonth + 1)}-01`, to: `${selectedYear}-${pad(selectedMonth + 1)}-${pad(lastDay)}` };
+  });
 
   const [events, setEvents] = useState<CalendarEvent[]>([]);
   const [operationsItems, setOperationsItems] = useState<DailyPlanItem[]>([]);
@@ -114,7 +122,7 @@ export default function HubCalendar({ demoEvents, onRequireAuth }: HubCalendarPr
   // ── The 3 calendar loaders — SAME logic as hub/page.tsx:192-294. ──
   const loadCalendar = async () => {
     try {
-      const res = await fetch(`/api/calendar?year=${selectedYear}&month=${selectedMonth + 1}`);
+      const res = await fetch(`/api/calendar?from=${range.from}&to=${range.to}`);
       if (res.ok) {
         const data = await res.json();
         const raw = (data.events || []) as CalendarEvent[];
@@ -125,9 +133,8 @@ export default function HubCalendar({ demoEvents, onRequireAuth }: HubCalendarPr
 
   const loadOperationsBlocks = async () => {
     try {
-      const from = `${selectedYear}-${pad(selectedMonth + 1)}-01`;
-      const lastDay = new Date(selectedYear, selectedMonth + 1, 0).getDate();
-      const to = `${selectedYear}-${pad(selectedMonth + 1)}-${pad(lastDay)}`;
+      const from = range.from;
+      const to = range.to;
       const res = await fetch(`/api/operations/daily-plan/items?from=${from}&to=${to}`);
       setOperationsItems(res.ok ? ((await res.json()).items || []) : []);
     } catch (err) {
@@ -138,9 +145,8 @@ export default function HubCalendar({ demoEvents, onRequireAuth }: HubCalendarPr
 
   const loadOperationsRoutines = async () => {
     try {
-      const from = `${selectedYear}-${pad(selectedMonth + 1)}-01`;
-      const lastDay = new Date(selectedYear, selectedMonth + 1, 0).getDate();
-      const to = `${selectedYear}-${pad(selectedMonth + 1)}-${pad(lastDay)}`;
+      const from = range.from;
+      const to = range.to;
       const res = await fetch(`/api/hub/operations-routines?from=${from}&to=${to}`);
       if (res.ok) {
         const data: RoutinesWindowResponse = await res.json();
@@ -163,7 +169,7 @@ export default function HubCalendar({ demoEvents, onRequireAuth }: HubCalendarPr
   useEffect(() => {
     if (demoEvents) return;
     loadCalendar(); loadOperationsBlocks(); loadOperationsRoutines();
-  }, [selectedYear, selectedMonth, demoEvents]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [range.from, range.to, demoEvents]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // ── The merge — SAME as hub/page.tsx:379-394. In demo mode, render the static
   //    seed straight through (already in CalendarEvent shape). ──
@@ -239,6 +245,7 @@ export default function HubCalendar({ demoEvents, onRequireAuth }: HubCalendarPr
         onEventClick={handleEventClick}
         phoneDayOnly={true}
         onMonthChange={(year, month) => { setSelectedYear(year); setSelectedMonth(month); }}
+        onRangeChange={(from, to) => setRange({ from, to })}
         flush={true}
       />
 

--- a/src/components/shared/CalendarGrid.tsx
+++ b/src/components/shared/CalendarGrid.tsx
@@ -93,6 +93,13 @@ export interface CalendarGridProps {
    */
   onMonthChange?: (year: number, month: number) => void;
   /**
+   * PR-calendar-visible-range: fires with the VISIBLE window (inclusive 'YYYY-MM-DD')
+   * whenever the view/nav changes — day→[day,day], week→[weekStart,weekStart+6],
+   * month→[month-01,month-lastDay]. Lets the parent fetch exactly what's on screen, so a
+   * week/day spanning a month boundary loads ALL its events. Additive — onMonthChange stays.
+   */
+  onRangeChange?: (from: string, to: string) => void;
+  /**
    * Opt-in (PR-Calendar-Seamless): drop the outer card chrome (rounded corners, border,
    * shadow) so the grid sits FLUSH inside a parent that already provides the frame —
    * one continuous surface under a header band (a flush day-view look). Default false →
@@ -258,6 +265,7 @@ export default function CalendarGrid({
   enableHubChrome = false,
   phoneDayOnly = false,
   onMonthChange,
+  onRangeChange,
   flush = false,
 }: CalendarGridProps) {
   const router = useRouter();
@@ -438,6 +446,28 @@ export default function CalendarGrid({
   useEffect(() => {
     onMonthChange?.(selectedYear, selectedMonth);
   }, [selectedYear, selectedMonth]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // PR-calendar-visible-range: emit the VISIBLE window (inclusive YYYY-MM-DD) so the parent
+  // fetches exactly what's on screen — fixing the boundary-week gap. Day→[day,day],
+  // week→[weekStart,weekStart+6], month→[month-01,month-lastDay]. Always derivable from view
+  // state (no fallback). Keyed on every input that moves the window.
+  useEffect(() => {
+    if (!onRangeChange) return;
+    let from: Date;
+    let to: Date;
+    if (calendarView === 'day') {
+      from = selectedDay;
+      to = selectedDay;
+    } else if (calendarView === 'week') {
+      from = selectedWeekStart;
+      to = new Date(selectedWeekStart);
+      to.setDate(to.getDate() + 6);
+    } else {
+      from = new Date(selectedYear, selectedMonth, 1);
+      to = new Date(selectedYear, selectedMonth + 1, 0); // last day of the month
+    }
+    onRangeChange(dateToKey(from), dateToKey(to));
+  }, [calendarView, selectedWeekStart, selectedDay, selectedYear, selectedMonth]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // PR-Calendar-Native: on phone-day-only, force the Day view (Week/Month are hidden).
   useEffect(() => {


### PR DESCRIPTION
…oundary weeks load all events; month/year modes kept

Claude-Session: https://claude.ai/code/session_012Z6YwBrX5TEHaZBhQJ7EDg