### PR TITLE
style(Content-style-2): script/day-calendar to homepage contract; kee…

### DIFF
--- a/src/components/workbench/operations/content/DayCalendarView.tsx
+++ b/src/components/workbench/operations/content/DayCalendarView.tsx
@@ -24,7 +24,7 @@ import { useMemo, useState, type ReactNode } from 'react';
 import { dayAnchoredMinute, minuteOfDayFromInstant, minuteOfDayFromTime } from '@/lib/content/dayOrder';
 import type { TimelineRow, Entity } from './dayCalendarTypes';
 
-const sectionHeader = 'font-mono text-sm font-medium tracking-wide text-brand-purple';
+const sectionHeader = 'text-sm font-medium tracking-wide text-brand-purple';
 
 // House calendar block colors — adopted from the shared CalendarGrid's filled blocks
 // (CalendarGrid.tsx:516 renders `${calendarColor} text-white`), with the per-source
@@ -44,7 +44,7 @@ const ROW_GRID =
   'grid-cols-[5.5rem_minmax(0,1fr)_5.5rem] ' +
   'lg:grid-cols-[7rem_minmax(0,1fr)_minmax(0,0.6fr)_5rem_5.5rem]';
 
-const chipBase = 'px-2 py-0.5 rounded border text-[11px] font-mono';
+const chipBase = 'px-2 py-0.5 rounded border text-[11px]';
 const chipOn = 'border-brand-purple bg-brand-purple text-white';
 const chipOff = 'border-border-light text-text-muted hover:bg-bg-row';
 const navBtn =
@@ -233,7 +233,7 @@ export default function DayCalendarView({
       project = row.travel.coaCode; // the COA shows in the project column for travel
       fill = TRAVEL_FILL;
       rightPill = (
-        <span className="px-2 py-0.5 rounded border border-transparent bg-white text-cyan-700 text-[11px] font-mono whitespace-nowrap">
+        <span className="px-2 py-0.5 rounded border border-transparent bg-white text-cyan-700 text-[11px] whitespace-nowrap">
           ${Math.round(row.travel.cost).toLocaleString()}
         </span>
       );
@@ -242,7 +242,7 @@ export default function DayCalendarView({
       project = row.block.projectName;
       fill = TASK_FILL;
       rightPill = (
-        <span className="px-2 py-0.5 rounded border border-transparent bg-white text-indigo-700 text-[11px] font-mono uppercase tracking-wide whitespace-nowrap">
+        <span className="px-2 py-0.5 rounded border border-transparent bg-white text-indigo-700 text-[11px] uppercase tracking-wide whitespace-nowrap">
           {row.block.status}
         </span>
       );
@@ -288,7 +288,7 @@ export default function DayCalendarView({
           els.push(
             <li
               key={`gap-${rowKey(r)}`}
-              className="flex items-center gap-2 px-2 py-0.5 text-[10px] font-mono uppercase tracking-wide text-text-muted"
+              className="flex items-center gap-2 px-2 py-0.5 text-[10px] uppercase tracking-wide text-text-muted"
             >
               <span className="flex-1 border-t border-dashed border-border-light" aria-hidden="true" />
               {fmtDuration(gap)} open
@@ -305,7 +305,7 @@ export default function DayCalendarView({
   }, [timed, collidingKeys, entityNameById]);
 
   return (
-    <section className="bg-white rounded border border-border shadow-sm p-5 space-y-3">
+    <section className="bg-white rounded border border-border p-4 space-y-3">
       <div className="flex flex-wrap items-center justify-between gap-2">
         <button
           type="button"
@@ -317,13 +317,13 @@ export default function DayCalendarView({
             · DAY
             <span className="ml-2 font-normal text-text-muted">time blocks</span>
           </h2>
-          <span className="font-mono text-xs text-brand-purple" aria-hidden="true">
+          <span className="text-xs text-brand-purple" aria-hidden="true">
             {open ? '▾ hide' : '▸ show'}
           </span>
         </button>
         {/* Day nav — drives the SHARED date (same setter as section 3). Button
             treatment echoes trips/ItineraryAgenda.tsx:151-155. */}
-        <div className="flex items-center gap-1 font-mono text-xs">
+        <div className="flex items-center gap-1 text-xs">
           <button type="button" onClick={() => onDateChange(shiftDay(date, -1))} className={navBtn} aria-label="Previous day">
             ‹
           </button>
@@ -347,7 +347,7 @@ export default function DayCalendarView({
             <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
               {presentEntityIds.length > 0 && (
                 <div className="flex flex-wrap items-center gap-1.5">
-                  <span className="font-mono text-[10px] uppercase tracking-wide text-text-muted">entity</span>
+                  <span className="text-[10px] uppercase tracking-wide text-text-muted">entity</span>
                   {presentEntityIds.map((id) => (
                     <button
                       key={id}
@@ -362,7 +362,7 @@ export default function DayCalendarView({
               )}
               {(hasScenes || hasTasks || hasTravel) && (
                 <div className="flex flex-wrap items-center gap-1.5">
-                  <span className="font-mono text-[10px] uppercase tracking-wide text-text-muted">source</span>
+                  <span className="text-[10px] uppercase tracking-wide text-text-muted">source</span>
                   {hasScenes && (
                     <button
                       type="button"
@@ -396,21 +396,21 @@ export default function DayCalendarView({
           )}
 
           {error && (
-            <div className="text-xs font-mono px-3 py-2 rounded border bg-red-50 border-red-200 text-red-800">
+            <div className="text-xs px-3 py-2 rounded border bg-red-50 border-red-200 text-red-800">
               {error}
             </div>
           )}
 
           {loading ? (
-            <p className="text-sm font-mono text-text-muted">Loading…</p>
+            <p className="text-sm text-text-muted">Loading…</p>
           ) : visible.length === 0 ? (
-            <p className="text-xs font-mono text-text-muted">No time blocks for {date}.</p>
+            <p className="text-xs text-text-muted">No time blocks for {date}.</p>
           ) : (
-            <ul className="space-y-1 font-mono text-xs">
+            <ul className="space-y-1 text-xs">
               {timedElements}
               {untimed.length > 0 && (
                 <li className="pt-3 mt-2 border-t border-border-light">
-                  <span className="font-mono text-xs font-medium text-brand-purple uppercase tracking-wide">
+                  <span className="text-xs font-medium text-brand-purple uppercase tracking-wide">
                     unscheduled
                   </span>
                   <span className="ml-2 font-normal text-text-muted">no time set · {untimed.length}</span>

--- a/src/components/workbench/operations/content/ScriptGeneratorView.tsx
+++ b/src/components/workbench/operations/content/ScriptGeneratorView.tsx
@@ -75,15 +75,15 @@ export default function ScriptGeneratorView({
   const hasScript = draft !== null;
 
   return (
-    <section className="bg-white rounded border border-border shadow-sm p-5 space-y-3">
+    <section className="bg-white rounded border border-border p-4 space-y-3">
       <div className="flex flex-wrap items-center justify-between gap-3">
-        <h2 className="font-mono text-sm font-medium tracking-wide text-brand-purple">
+        <h2 className="text-sm font-medium tracking-wide text-brand-purple">
           4 · SCRIPT
           <span className="ml-2 font-normal text-text-muted">the day&rsquo;s answers + task record → reel voiceover</span>
         </h2>
         <div className="flex items-center gap-2">
           {hasScript && (
-            <span className="font-mono text-xs text-text-muted">
+            <span className="text-xs text-text-muted">
               {words} words · ~{readTime(words)} read
             </span>
           )}
@@ -92,35 +92,37 @@ export default function ScriptGeneratorView({
             onClick={onGenerate}
             disabled={generating || !!disabledReason}
             title={disabledReason ?? undefined}
-            className="px-3 py-1 font-mono text-xs border border-brand-purple rounded text-brand-purple hover:bg-purple-100/50 disabled:opacity-50"
+            className="px-3 py-1 text-xs border border-brand-purple rounded text-brand-purple hover:bg-purple-100/50 disabled:opacity-50"
           >
             {generating ? 'writing…' : hasScript ? '↻ regenerate' : '✨ generate script'}
           </button>
         </div>
       </div>
 
-      {disabledReason && <p className="font-mono text-xs text-text-muted">{disabledReason}</p>}
+      {disabledReason && <p className="text-xs text-text-muted">{disabledReason}</p>}
       {notice && (
-        <div className="font-mono text-xs px-3 py-2 rounded border bg-purple-50 border-brand-purple/40 text-text-primary">{notice}</div>
+        <div className="text-xs px-3 py-2 rounded border bg-purple-50 border-brand-purple/40 text-text-primary">{notice}</div>
       )}
       {error && (
-        <div className="font-mono text-xs px-3 py-2 rounded border bg-red-50 border-red-200 text-red-800">{error}</div>
+        <div className="text-xs px-3 py-2 rounded border bg-red-50 border-red-200 text-red-800">{error}</div>
       )}
 
       {/* DAY-AUDIT helper — run in Claude Code, paste the output below. Always visible. */}
       <div className="rounded border border-border-light bg-bg-row p-3 space-y-2">
         <div className="flex items-center justify-between gap-2">
-          <span className="font-mono text-xs text-brand-purple font-medium uppercase tracking-wide">
+          <span className="text-xs text-brand-purple font-medium uppercase tracking-wide">
             Day-audit — run this in Claude Code, paste the output below
           </span>
           <button
             type="button"
             onClick={onCopyPrompt}
-            className="px-2 py-0.5 font-mono text-xs border border-brand-purple rounded text-brand-purple hover:bg-purple-100/50"
+            className="px-2 py-0.5 text-xs border border-brand-purple rounded text-brand-purple hover:bg-purple-100/50"
           >
             {copied ? 'copied ✓' : 'copy prompt'}
           </button>
         </div>
+        {/* Content-style-2: the day-audit PROMPT is a code value (pasted into Claude Code) — kept
+            monospace, like the rrule input. The surrounding chrome is sans. */}
         <pre className="font-mono text-[11px] leading-relaxed text-text-muted whitespace-pre-wrap break-words bg-white border border-border-light rounded p-2">
 {dayAuditPrompt}
         </pre>
@@ -128,10 +130,10 @@ export default function ScriptGeneratorView({
 
       {/* EXECUTION NOTES — the authoritative receipts. */}
       <div className="space-y-1">
-        <label className="font-mono text-xs text-brand-purple font-medium uppercase tracking-wide">
+        <label className="text-xs text-brand-purple font-medium uppercase tracking-wide">
           Execution notes (optional)
         </label>
-        <p className="font-mono text-xs text-text-muted">
+        <p className="text-xs text-text-muted">
           what actually got built/done today, in your words — the receipts. The script grounds its work claims in this.
         </p>
         <textarea
@@ -140,13 +142,13 @@ export default function ScriptGeneratorView({
           rows={4}
           disabled={!hasPiece}
           placeholder={hasPiece ? 'paste the day-audit bullets, or jot the receipts…' : 'start the day’s log first (section 3)'}
-          className="w-full resize-y bg-white border border-brand-purple/40 rounded px-3 py-2 font-mono text-xs leading-relaxed text-text-primary focus:outline-none focus:ring-2 focus:ring-brand-purple/20 focus:border-brand-purple disabled:opacity-50"
+          className="w-full resize-y bg-white border border-brand-purple/40 rounded px-3 py-2 text-xs leading-relaxed text-text-primary focus:outline-none focus:ring-2 focus:ring-brand-purple/20 focus:border-brand-purple disabled:opacity-50"
         />
         <button
           type="button"
           onClick={onSaveNotes}
           disabled={execSaving || !hasPiece}
-          className="px-3 py-1 font-mono text-xs border border-brand-purple bg-brand-purple text-white rounded hover:opacity-90 disabled:opacity-50"
+          className="px-3 py-1 text-xs border border-brand-purple bg-brand-purple text-white rounded hover:opacity-90 disabled:opacity-50"
         >
           {execSaving ? 'saving…' : 'save notes'}
         </button>
@@ -154,6 +156,8 @@ export default function ScriptGeneratorView({
 
       {hasScript && (
         <div className="space-y-2">
+          {/* Content-style-2: the scene-tagged reel SCRIPT stays monospace (the raw-script artifact
+              — scene tags align), like the rrule/COA code-value precedent. */}
           <textarea
             value={draft ?? ''}
             onChange={(e) => onDraftChange(e.target.value)}
@@ -166,11 +170,11 @@ export default function ScriptGeneratorView({
               type="button"
               onClick={onSave}
               disabled={saving}
-              className="px-3 py-1 font-mono text-xs border border-brand-purple bg-brand-purple text-white rounded hover:opacity-90 disabled:opacity-50"
+              className="px-3 py-1 text-xs border border-brand-purple bg-brand-purple text-white rounded hover:opacity-90 disabled:opacity-50"
             >
               {saving ? 'saving…' : 'save to the day'}
             </button>
-            <span className="font-mono text-xs text-text-muted">edits are yours — saving overwrites the day&rsquo;s script (every run is logged)</span>
+            <span className="text-xs text-text-muted">edits are yours — saving overwrites the day&rsquo;s script (every run is logged)</span>
           </div>
         </div>
       )}


### PR DESCRIPTION
…p raw-script mono; cleans showroom (shared); completes Content restyle (66 mono/7 files aligned)

Claude-Session: https://claude.ai/code/session_012Z6YwBrX5TEHaZBhQJ7EDg