### PR TITLE
fix(trading): retire dead claude-sonnet-4-20250514 → claude-sonnet-4-…

### DIFF
--- a/src/app/api/ai/convergence-synthesis/route.ts
+++ b/src/app/api/ai/convergence-synthesis/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { requireTier } from '@/lib/auth-helpers';
 import Anthropic from '@anthropic-ai/sdk';
+import { MODEL_SONNET_4 } from '@/lib/ai/client';
 import type { PipelineResult } from '@/lib/convergence/pipeline';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 
@@ -343,7 +344,7 @@ export async function POST(request: Request) {
     const aiStart = Date.now();
 
     const msg = await callWithRetry(client, {
-      model: 'claude-sonnet-4-20250514',
+      model: MODEL_SONNET_4,
       max_tokens: 4000,
       temperature: 0.2,
       system: SYSTEM_PROMPT,

--- a/src/app/api/ai/market-brief/route.ts
+++ b/src/app/api/ai/market-brief/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { requireTier } from '@/lib/auth-helpers';
 import Anthropic from '@anthropic-ai/sdk';
+import { MODEL_SONNET_4 } from '@/lib/ai/client';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 async function callWithRetry(client: Anthropic, params: any, maxRetries = 3): Promise<any> {
@@ -186,7 +187,7 @@ export async function POST(request: Request) {
     console.log('[Market Brief] Input tokens estimate:', Math.round(JSON.stringify(trimmedBody).length / 4));
 
     const msg = await callWithRetry(client, {
-      model: 'claude-sonnet-4-20250514',
+      model: MODEL_SONNET_4,
       max_tokens: 2500,
       temperature: 0.2,
       system: SYSTEM_PROMPT,

--- a/src/app/api/ai/strategy-analysis/route.ts
+++ b/src/app/api/ai/strategy-analysis/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { requireTier } from '@/lib/auth-helpers';
 import Anthropic from '@anthropic-ai/sdk';
+import { MODEL_SONNET_4 } from '@/lib/ai/client';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 
 async function callWithRetry(client: Anthropic, params: any, maxRetries = 3): Promise<any> {
@@ -124,7 +125,7 @@ export async function POST(request: Request) {
     const client = new Anthropic({ apiKey });
 
     const msg = await callWithRetry(client, {
-      model: 'claude-sonnet-4-20250514',
+      model: MODEL_SONNET_4,
       max_tokens: 1500,
       temperature: 0.2,
       system: SYSTEM_PROMPT,

--- a/src/app/api/ops/ai-plan/route.ts
+++ b/src/app/api/ops/ai-plan/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 import Anthropic from '@anthropic-ai/sdk';
+import { MODEL_SONNET_4 } from '@/lib/ai/client';
 
 interface Answers {
   energy: string;
@@ -107,7 +108,7 @@ export async function POST(request: Request) {
       }
 
       const msg = await client.messages.create({
-        model: 'claude-sonnet-4-20250514',
+        model: MODEL_SONNET_4,
         max_tokens: 2000,
         temperature: 0.3,
         system: buildAdjustPrompt(adjustment, currentPlan),
@@ -127,7 +128,7 @@ export async function POST(request: Request) {
     const systemPrompt = buildSynthesisPrompt(date, dayNumber, answers);
 
     const msg = await client.messages.create({
-      model: 'claude-sonnet-4-20250514',
+      model: MODEL_SONNET_4,
       max_tokens: 2000,
       temperature: 0.5,
       system: systemPrompt,

--- a/src/app/api/ops/brain-dump/route.ts
+++ b/src/app/api/ops/brain-dump/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 import Anthropic from '@anthropic-ai/sdk';
+import { MODEL_SONNET_4 } from '@/lib/ai/client';
 
 function buildPrompt(bullets: string[]): string {
   const numbered = bullets.map((b, i) => `${i + 1}. ${b}`).join('\n');
@@ -60,7 +61,7 @@ export async function POST(request: Request) {
     const client = new Anthropic({ apiKey });
 
     const msg = await client.messages.create({
-      model: 'claude-sonnet-4-20250514',
+      model: MODEL_SONNET_4,
       max_tokens: 2000,
       temperature: 0.4,
       system: buildPrompt(bullets),

--- a/src/lib/ai/client.ts
+++ b/src/lib/ai/client.ts
@@ -5,9 +5,9 @@
  * 5 API routes. All new AI features (PR-Ops-3.5 onward) use this client;
  * existing routes can incrementally migrate without behavior change.
  *
- * Model alias convention: callers pass the dated model ID directly (e.g.,
- * 'claude-sonnet-4-20250514') matching existing codebase usage. Future PR
- * may centralize model selection but v0 keeps the choice with the caller.
+ * Model convention: the Sonnet model ID lives in one place — the MODEL_SONNET_4
+ * constant below. /api/ai/* and /api/ops/* routes import it rather than hardcoding
+ * a dated string (which is how the retired ID lingered across 6 sites).
  */
 
 import Anthropic from '@anthropic-ai/sdk';
@@ -25,22 +25,27 @@ export function getAnthropicClient(): Anthropic {
 }
 
 /**
- * Sonnet 4 (dated 2025-05-14) — current production model in this codebase.
- * Matches the convention used by /api/ai/* and /api/ops/* routes.
+ * Sonnet 4.6 — current production Sonnet in this codebase. The single source of
+ * truth for the Sonnet model ID across /api/ai/* and /api/ops/* routes. (The prior
+ * dated Sonnet 4 ID was retired and started 404ing — see
+ * audit-reports/trade-model-404-audit.md.)
  */
-export const MODEL_SONNET_4 = 'claude-sonnet-4-20250514';
+export const MODEL_SONNET_4 = 'claude-sonnet-4-6';
 
 /**
  * Cost per million tokens for cost tracking. Source: Anthropic pricing page.
+ * Keyed by MODEL_SONNET_4 so computeCostUsd finds the rate (it throws on an
+ * unknown key). Values carried over from the prior Sonnet 4 entry ($3 / $15);
+ * verify against current Sonnet 4.6 pricing.
  * Update when pricing changes; future PR may move this to a per-model
  * config that auto-syncs.
  */
 export const COST_PER_MILLION_INPUT_USD: Record<string, number> = {
-  'claude-sonnet-4-20250514': 3.0,
+  'claude-sonnet-4-6': 3.0,
 };
 
 export const COST_PER_MILLION_OUTPUT_USD: Record<string, number> = {
-  'claude-sonnet-4-20250514': 15.0,
+  'claude-sonnet-4-6': 15.0,
 };
 
 /**


### PR DESCRIPTION
…6 app-wide via MODEL_SONNET_4 constant; fixes scan 404 + 5 other Sonnet features; cost-map key updated

The retired Sonnet 4 dated ID 404'd the convergence scan's synthesis call (and 5 other Sonnet features). Point MODEL_SONNET_4 at the current claude-sonnet-4-6, rename the cost-map keys so computeCostUsd finds the rate, and route all 6 previously-hardcoded call-sites through the constant (single source of truth). Pricing values ($3/$15) carried over from the Sonnet 4 entry — verify vs current.


Claude-Session: https://claude.ai/code/session_012Z6YwBrX5TEHaZBhQJ7EDg