### PR TITLE
feat(PD-2): separated project queue cards — clean cards w/ colored st…

### DIFF
--- a/src/app/api/operations/projects/route.ts
+++ b/src/app/api/operations/projects/route.ts
@@ -74,6 +74,8 @@ export async function GET(request: NextRequest) {
 
     const projects = await prisma.operations_projects.findMany({
       where,
+      // PD-2: task_count via Prisma _count on the tasks relation (no migration).
+      include: { _count: { select: { tasks: true } } },
       orderBy: [
         // Prisma can't sort by computed status_order without raw SQL; we sort
         // server-side after fetch. Single-user backlogs are small (<200), so
@@ -84,6 +86,21 @@ export async function GET(request: NextRequest) {
       ],
     });
 
+    // PD-2: run_count = DISTINCT source_ai_usage_id across each project's tasks (the
+    // evolve-run markers). groupBy on (project_id, source_ai_usage_id) → one row per
+    // distinct run; count rows per project. Reads existing data — NO migration.
+    const projectIds = projects.map((p) => p.id);
+    const runGroups = projectIds.length
+      ? await prisma.operations_project_tasks.groupBy({
+          by: ['project_id', 'source_ai_usage_id'],
+          where: { project_id: { in: projectIds }, source_ai_usage_id: { not: null } },
+        })
+      : [];
+    const runCountByProject = new Map<string, number>();
+    for (const g of runGroups) {
+      runCountByProject.set(g.project_id, (runCountByProject.get(g.project_id) ?? 0) + 1);
+    }
+
     // Status-priority sort layered on top of priority_score order.
     const sorted = projects.slice().sort((a, b) => {
       const sa = STATUS_ORDER[a.status];
@@ -93,7 +110,14 @@ export async function GET(request: NextRequest) {
       return 0;
     });
 
-    return NextResponse.json({ projects: sorted });
+    // PD-2: surface the real counts on each row (and drop the internal _count shape).
+    const withCounts = sorted.map(({ _count, ...p }) => ({
+      ...p,
+      task_count: _count.tasks,
+      run_count: runCountByProject.get(p.id) ?? 0,
+    }));
+
+    return NextResponse.json({ projects: withCounts });
   } catch (error) {
     console.error('[Projects GET]', error);
     return NextResponse.json(

--- a/src/components/workbench/operations/SectionD_ProjectBacklog.tsx
+++ b/src/components/workbench/operations/SectionD_ProjectBacklog.tsx
@@ -19,6 +19,7 @@
 import { useEffect, useState } from 'react';
 import { useOperationsEntity } from './EntitySelector';
 import ProjectRow from './projects/ProjectRow';
+import ProjectQueueCard from './projects/ProjectQueueCard';
 import ProjectCreateForm from './projects/ProjectCreateForm';
 import type { Project } from './projects/types';
 
@@ -142,17 +143,27 @@ export default function SectionD_ProjectBacklog() {
       ) : (
         <div className="space-y-2">
           {projects.map((p) => (
-            <ProjectRow
+            // PD-2: the queue is separated clean cards. The card opens the existing
+            // ProjectRow detail (defaultExpanded) — click→detail navigation preserved.
+            <ProjectQueueCard
               key={p.id}
               project={p}
-              entities={entities}
-              allProjects={projects}
-              onUpdate={fetchProjects}
-              onDelete={fetchProjects}
-              isJumpTarget={targetProjectId === p.id}
-              onClearTarget={() => setTargetProjectId(null)}
-              onJumpTo={setTargetProjectId}
-            />
+              taskCount={p.task_count ?? 0}
+              runCount={p.run_count ?? 0}
+              forceOpen={targetProjectId === p.id}
+            >
+              <ProjectRow
+                project={p}
+                entities={entities}
+                allProjects={projects}
+                onUpdate={fetchProjects}
+                onDelete={fetchProjects}
+                isJumpTarget={targetProjectId === p.id}
+                onClearTarget={() => setTargetProjectId(null)}
+                onJumpTo={setTargetProjectId}
+                defaultExpanded
+              />
+            </ProjectQueueCard>
           ))}
         </div>
       )}

--- a/src/components/workbench/operations/projects/ProjectQueueCard.tsx
+++ b/src/components/workbench/operations/projects/ProjectQueueCard.tsx
@@ -1,0 +1,84 @@
+/**
+ * ProjectQueueCard (PD-2) — a single project in the QUEUE, as a clean white card with a
+ * colored left-stripe (matching the merged pipe look). Shows title, real task/request
+ * counts, and status; clicking opens the project's detail (the existing <ProjectRow/>,
+ * passed as children and mounted only when open — lazy, so collapsed cards never fetch).
+ *
+ * Presentation only: it owns NO data/fetch. The counts arrive as props (computed by the
+ * list API's Prisma _count + distinct run-marker groupBy). The detail behavior is entirely
+ * the existing ProjectRow — PD-3 reworks what that detail shows. Mobile-first single column.
+ */
+
+'use client';
+
+import { useEffect, useState } from 'react';
+import type { Project, ProjectStatus } from './types';
+import { STATUS_LABELS, STATUS_PILL_CLASSES } from './types';
+
+// Left-stripe color by status — a quick visual scan of the backlog.
+const STRIPE: Record<ProjectStatus, string> = {
+  not_started: '#9CA3AF', // gray
+  in_progress: '#6B46C1', // purple
+  blocked: '#D97706',     // amber
+  completed: '#059669',   // emerald
+  cancelled: '#9CA3AF',   // gray
+  archived: '#9CA3AF',    // gray
+};
+
+interface Props {
+  project: Project;
+  taskCount: number;
+  runCount: number;
+  /** When this project is a cross-project jump target, open it automatically. */
+  forceOpen?: boolean;
+  /** The live detail (an existing <ProjectRow defaultExpanded/>), mounted only when open. */
+  children: React.ReactNode;
+}
+
+export default function ProjectQueueCard({ project, taskCount, runCount, forceOpen, children }: Props) {
+  const [open, setOpen] = useState(false);
+
+  // A dependency jump → open the target card so the row inside can scroll/flash.
+  useEffect(() => {
+    if (forceOpen) setOpen(true);
+  }, [forceOpen]);
+
+  const stripe = STRIPE[project.status] ?? '#9CA3AF';
+
+  if (open) {
+    return (
+      <div className="space-y-1.5">
+        <button
+          type="button"
+          onClick={() => setOpen(false)}
+          className="text-[11px] text-gray-500 hover:text-gray-800 hover:underline"
+        >
+          ‹ back to projects
+        </button>
+        {children}
+      </div>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={() => setOpen(true)}
+      className="w-full text-left rounded-md border border-gray-200 border-l-4 bg-white p-3 sm:p-4 shadow-sm hover:shadow transition-shadow flex items-center justify-between gap-3"
+      style={{ borderLeftColor: stripe }}
+    >
+      <div className="min-w-0">
+        <div className="text-sm font-semibold text-gray-900 truncate">{project.title}</div>
+        <div className="text-[11px] text-gray-500 mt-0.5 tabular-nums">
+          {taskCount} {taskCount === 1 ? 'task' : 'tasks'} · {runCount} {runCount === 1 ? 'request' : 'requests'}
+        </div>
+      </div>
+      <div className="flex items-center gap-2 shrink-0">
+        <span className={`inline-block px-2 py-0.5 rounded-full text-[10px] font-medium ${STATUS_PILL_CLASSES[project.status]}`}>
+          {STATUS_LABELS[project.status]}
+        </span>
+        <span className="text-gray-300 text-sm" aria-hidden="true">›</span>
+      </div>
+    </button>
+  );
+}

--- a/src/components/workbench/operations/projects/ProjectRow.tsx
+++ b/src/components/workbench/operations/projects/ProjectRow.tsx
@@ -47,6 +47,9 @@ interface Props {
   onClearTarget: () => void;
   /** Called when the user clicks a dependency link inside this row. */
   onJumpTo: (projectId: string) => void;
+  /** PD-2: start expanded (the queue card opens straight into the detail). Default false
+   *  → existing behavior unchanged everywhere else. */
+  defaultExpanded?: boolean;
 }
 
 function projectToForm(p: Project): ProjectForm {
@@ -69,8 +72,8 @@ function projectToForm(p: Project): ProjectForm {
   };
 }
 
-export default function ProjectRow({ project, entities, allProjects, onUpdate, onDelete, isJumpTarget, onClearTarget, onJumpTo }: Props) {
-  const [expanded, setExpanded] = useState(false);
+export default function ProjectRow({ project, entities, allProjects, onUpdate, onDelete, isJumpTarget, onClearTarget, onJumpTo, defaultExpanded = false }: Props) {
+  const [expanded, setExpanded] = useState(defaultExpanded);
   const [editing, setEditing] = useState(false);
   const [form, setForm] = useState<ProjectForm>(() => projectToForm(project));
   const [saving, setSaving] = useState(false);

--- a/src/components/workbench/operations/projects/types.ts
+++ b/src/components/workbench/operations/projects/types.ts
@@ -43,6 +43,10 @@ export interface Project {
   created_at: string;
   updated_at: string;
   created_by: string | null;
+  // PD-2: present on the queue list response (/api/operations/projects GET). Optional
+  // because other fetches of a Project don't compute them.
+  task_count?: number;
+  run_count?: number;
 }
 
 /**


### PR DESCRIPTION
…ripe + real task/request counts (Prisma _count + distinct run markers, no migration), click opens project

Claude-Session: https://claude.ai/code/session_012Z6YwBrX5TEHaZBhQJ7EDg