### PR TITLE
feat(COST-GUARD-1): durable daily spend cap on all 5 AI pipe paid-rou…

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1141,6 +1141,22 @@ model travel_search_usage {
   @@unique([searchDate, provider])
 }
 
+// ─── Per-user daily cap counter for the AI pipe paid-calls (COST-GUARD-1) ─────
+// Mirrors travel_search_usage: a durable per-(UTC date + user) counter that
+// pipeBudget.ts increments before each paid pipe call (research / fusion / evolve
+// / design / stateless create-form) and fails LOUD (429) over the cap. This is the
+// prerequisite that stops an auto-firing loop running up the Anthropic bill.
+// Migration: operations_ai_pipe_usage table run by Alex via psql (additive).
+model operations_ai_pipe_usage {
+  id        String   @id @default(cuid())
+  usageDate String // "YYYY-MM-DD" (UTC)
+  userId    String
+  callCount Int      @default(0)
+  updatedAt DateTime @updatedAt
+
+  @@unique([usageDate, userId])
+}
+
 // ─── Per-key request rate-limiter (durable, fixed-window) ────────────────────
 // Net-new: there is no app rate-limiter today. Mirrors the durable usage-counter
 // shape so it survives deploys AND holds across serverless instances (an in-memory

--- a/src/app/api/operations/ai/generate-design/route.ts
+++ b/src/app/api/operations/ai/generate-design/route.ts
@@ -24,6 +24,7 @@ import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { generateProjectDesign } from '@/lib/ai/generateProjectDesign';
 import { toNorthStarContext } from '@/lib/ai/northStarContext';
+import { requirePipeBudget, PipeBudgetError } from '@/lib/pipeBudget';
 
 interface RequestBody {
   title?: string;
@@ -95,6 +96,9 @@ export async function POST(request: NextRequest) {
     const diagnosisResult = validateItems(body.diagnosisItems, 'diagnosisItems', true);
     if (!diagnosisResult.ok) return NextResponse.json({ error: 'Validation', message: diagnosisResult.message }, { status: 400 });
 
+    // COST-GUARD-1: daily spend cap — AFTER auth, BEFORE the paid call. Over cap → 429.
+    await requirePipeBudget(user.id);
+
     const nsRow = await prisma.operations_north_star.findUnique({
       where: { user_id: user.id },
     });
@@ -121,6 +125,9 @@ export async function POST(request: NextRequest) {
       inspection: result.inspection,
     });
   } catch (error) {
+    if (error instanceof PipeBudgetError) {
+      return NextResponse.json({ error: 'Rate limit', message: error.message }, { status: 429 });
+    }
     console.error('[Stateless Generate Design POST]', error);
     return NextResponse.json(
       { error: 'Failed to generate design', message: error instanceof Error ? error.message : 'unknown' },

--- a/src/app/api/operations/ai/generate-tasks/route.ts
+++ b/src/app/api/operations/ai/generate-tasks/route.ts
@@ -23,6 +23,7 @@ import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { generateProjectTasks } from '@/lib/ai/generateProjectTasks';
 import { toNorthStarContext } from '@/lib/ai/northStarContext';
+import { requirePipeBudget, PipeBudgetError } from '@/lib/pipeBudget';
 
 interface RequestBody {
   projectTitle?: unknown;
@@ -119,6 +120,10 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: diagnosisResult.message }, { status: 400 });
     }
 
+    // COST-GUARD-1: daily spend cap — AFTER auth, BEFORE the paid call. Placed in the
+    // outer try so PipeBudgetError reaches the outer catch (→ 429), not the inner 500.
+    await requirePipeBudget(user.id);
+
     try {
       const nsRow = await prisma.operations_north_star.findUnique({
         where: { user_id: user.id },
@@ -153,6 +158,9 @@ export async function POST(request: NextRequest) {
       );
     }
   } catch (error) {
+    if (error instanceof PipeBudgetError) {
+      return NextResponse.json({ error: 'Rate limit', message: error.message }, { status: 429 });
+    }
     console.error('[Stateless Generate Tasks POST]', error);
     return NextResponse.json(
       {

--- a/src/app/api/operations/projects/[id]/generate-design/route.ts
+++ b/src/app/api/operations/projects/[id]/generate-design/route.ts
@@ -21,6 +21,7 @@ import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { generateProjectDesign } from '@/lib/ai/generateProjectDesign';
 import { toNorthStarContext } from '@/lib/ai/northStarContext';
+import { requirePipeBudget, PipeBudgetError } from '@/lib/pipeBudget';
 
 /**
  * Resolve a field's items: prefer the JSONB array, fall back to wrapping
@@ -70,6 +71,9 @@ export async function POST(
       );
     }
 
+    // COST-GUARD-1: daily spend cap — AFTER auth, BEFORE the paid call. Over cap → 429.
+    await requirePipeBudget(user.id);
+
     const nsRow = await prisma.operations_north_star.findUnique({
       where: { user_id: user.id },
     });
@@ -97,6 +101,9 @@ export async function POST(
       inspection: result.inspection,
     });
   } catch (error) {
+    if (error instanceof PipeBudgetError) {
+      return NextResponse.json({ error: 'Rate limit', message: error.message }, { status: 429 });
+    }
     console.error('[Generate Design POST]', error);
     return NextResponse.json(
       { error: 'Failed to generate design', message: error instanceof Error ? error.message : 'unknown' },

--- a/src/app/api/operations/projects/[id]/generate-tasks/route.ts
+++ b/src/app/api/operations/projects/[id]/generate-tasks/route.ts
@@ -22,6 +22,7 @@ import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { generateProjectTasks } from '@/lib/ai/generateProjectTasks';
 import { toNorthStarContext } from '@/lib/ai/northStarContext';
+import { requirePipeBudget, PipeBudgetError } from '@/lib/pipeBudget';
 
 /**
  * Resolve a field's items: prefer the JSONB array, fall back to wrapping
@@ -73,6 +74,9 @@ export async function POST(
       );
     }
 
+    // COST-GUARD-1: daily spend cap — AFTER auth, BEFORE the paid call. Over cap → 429.
+    await requirePipeBudget(user.id);
+
     const nsRow = await prisma.operations_north_star.findUnique({
       where: { user_id: user.id },
     });
@@ -100,6 +104,9 @@ export async function POST(
       inspection: result.inspection,
     });
   } catch (error) {
+    if (error instanceof PipeBudgetError) {
+      return NextResponse.json({ error: 'Rate limit', message: error.message }, { status: 429 });
+    }
     console.error('[Generate Tasks POST]', error);
     return NextResponse.json(
       {

--- a/src/app/api/operations/projects/[id]/research/route.ts
+++ b/src/app/api/operations/projects/[id]/research/route.ts
@@ -26,6 +26,7 @@ import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { generateDeepResearch } from '@/lib/ai/generateDeepResearch';
 import { toNorthStarContext } from '@/lib/ai/northStarContext';
+import { requirePipeBudget, PipeBudgetError } from '@/lib/pipeBudget';
 
 /**
  * Resolve a field's items: prefer the JSONB array, fall back to wrapping the legacy
@@ -78,6 +79,9 @@ export async function POST(
       );
     }
 
+    // COST-GUARD-1: daily spend cap — AFTER auth, BEFORE the paid call. Over cap → 429.
+    await requirePipeBudget(user.id);
+
     const nsRow = await prisma.operations_north_star.findUnique({
       where: { user_id: user.id },
     });
@@ -108,6 +112,9 @@ export async function POST(
       inspection: result.inspection,
     });
   } catch (error) {
+    if (error instanceof PipeBudgetError) {
+      return NextResponse.json({ error: 'Rate limit', message: error.message }, { status: 429 });
+    }
     console.error('[Project Research POST]', error);
     return NextResponse.json(
       {

--- a/src/lib/pipeBudget.ts
+++ b/src/lib/pipeBudget.ts
@@ -1,0 +1,70 @@
+import { prisma } from '@/lib/prisma';
+
+// ─── AI pipe daily spend-cap kill-switch (COST-GUARD-1) ──────────────────────
+// Mirrors the production-proven travelSearchQuota.ts (the durable daily-cap guard).
+// Every PAID pipe call (research / fusion / evolve / design / stateless create-form)
+// must go through requirePipeBudget(userId) AFTER auth, BEFORE the paid call. It
+// increments a durable per-(UTC date + user) counter and fails LOUD — PipeBudgetError
+// — when the daily cap is crossed. No silent fallback: over cap = throw → the route
+// returns 429 and NO paid token is spent. This is the prerequisite that stops an
+// auto-firing loop running up the Anthropic bill past the cap.
+//
+// Cap: AI_PIPE_DAILY_CAP env (a positive integer) wins, else DEFAULT_PIPE_DAILY_CAP.
+// Tune AI_PIPE_DAILY_CAP before enabling any unwatched/auto-firing loop.
+
+const DEFAULT_PIPE_DAILY_CAP = 20;
+const WARN_RATIO = 0.8;
+
+export class PipeBudgetError extends Error {
+  constructor(
+    public userId: string,
+    public callCount: number,
+    public cap: number,
+  ) {
+    super(`AI pipe daily limit reached — ${callCount}/${cap} calls used today`);
+    this.name = 'PipeBudgetError';
+  }
+}
+
+function currentDate(): string {
+  const d = new Date();
+  return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}-${String(d.getUTCDate()).padStart(2, '0')}`;
+}
+
+/** The per-user daily cap. AI_PIPE_DAILY_CAP env (positive int) → DEFAULT_PIPE_DAILY_CAP. */
+export function dailyCap(): number {
+  const env = parseInt(process.env.AI_PIPE_DAILY_CAP || '', 10);
+  return Number.isFinite(env) && env > 0 ? env : DEFAULT_PIPE_DAILY_CAP;
+}
+
+/** Today's pipe usage for a user — for an admin/usage view. */
+export async function getPipeUsage(userId: string): Promise<{
+  usageDate: string; userId: string; callCount: number; cap: number; pct: number;
+}> {
+  const usageDate = currentDate();
+  const row = await prisma.operations_ai_pipe_usage.findUnique({
+    where: { usageDate_userId: { usageDate, userId } },
+  });
+  const callCount = row?.callCount ?? 0;
+  const cap = dailyCap();
+  return { usageDate, userId, callCount, cap, pct: cap > 0 ? Math.round((callCount / cap) * 100) : 0 };
+}
+
+/** Atomically reserve one pipe paid-call against today's per-user cap. Throws
+ *  PipeBudgetError when the cap is crossed. Warns once at the 80% mark. Call this
+ *  immediately AFTER auth and BEFORE each real paid pipe call. */
+export async function requirePipeBudget(userId: string): Promise<void> {
+  const usageDate = currentDate();
+  const cap = dailyCap();
+  const row = await prisma.operations_ai_pipe_usage.upsert({
+    where: { usageDate_userId: { usageDate, userId } },
+    update: { callCount: { increment: 1 } },
+    create: { usageDate, userId, callCount: 1 },
+  });
+  if (row.callCount > cap) {
+    throw new PipeBudgetError(userId, row.callCount, cap);
+  }
+  if (row.callCount === Math.floor(cap * WARN_RATIO)) {
+    console.warn(`[PipeBudget] user ${userId} at ${Math.round(WARN_RATIO * 100)}% of daily cap (${row.callCount}/${cap})`);
+  }
+}


### PR DESCRIPTION
…tes (research/fusion/evolve/design/stateless) — mirror travelSearchQuota, fail-loud 429 over cap=20 (AI_PIPE_DAILY_CAP env), the prerequisite for any auto-firing loop