### PR TITLE
feat(PHASE2-1): sync pending_review enum + render 'pending review' ba…

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2699,6 +2699,7 @@ enum OperationsTaskStatus {
   cancelled
   superseded
   archived
+  pending_review
 }
 
 enum CalendarBlockStatus {

--- a/src/app/api/operations/projects/[id]/evolution/route.ts
+++ b/src/app/api/operations/projects/[id]/evolution/route.ts
@@ -26,6 +26,8 @@ import { getVerifiedEmail } from '@/lib/cookie-auth';
 // Same status-priority ordering used by the tasks GET route, so a
 // version's task list reads in the same order the user sees elsewhere.
 const STATUS_ORDER: Record<OperationsTaskStatus, number> = {
+  // PHASE2-1: auto-fired tasks awaiting the user's accept sort FIRST (need attention).
+  pending_review: -1,
   open: 0,
   in_progress: 1,
   blocked: 2,

--- a/src/app/api/operations/projects/[id]/tasks/route.ts
+++ b/src/app/api/operations/projects/[id]/tasks/route.ts
@@ -23,6 +23,8 @@ import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { writeAuditLog } from '@/lib/audit/writeAuditLog';
 
 const STATUS_ORDER: Record<OperationsTaskStatus, number> = {
+  // PHASE2-1: auto-fired tasks awaiting the user's accept sort FIRST (need attention).
+  pending_review: -1,
   open: 0,
   in_progress: 1,
   blocked: 2,

--- a/src/components/workbench/operations/projects/types.ts
+++ b/src/components/workbench/operations/projects/types.ts
@@ -121,7 +121,8 @@ export type TaskStatus =
   | 'blocked'
   | 'completed'
   | 'cancelled'
-  | 'archived';
+  | 'archived'
+  | 'pending_review';
 
 export interface Task {
   id: string;
@@ -204,6 +205,8 @@ export const TASK_STATUS_LABELS: Record<TaskStatus, string> = {
   completed: 'done',
   cancelled: 'cancelled',
   archived: 'archived',
+  // PHASE2-1: auto-fired tasks land here awaiting the user's accept (→ open).
+  pending_review: 'pending review',
 };
 
 export const TASK_STATUS_PILL_CLASSES: Record<TaskStatus, string> = {
@@ -213,6 +216,8 @@ export const TASK_STATUS_PILL_CLASSES: Record<TaskStatus, string> = {
   completed: 'bg-green-50 text-green-800',
   cancelled: 'bg-gray-50 text-gray-500',
   archived: 'bg-gray-50 text-gray-500',
+  // PHASE2-1: amber-on-purple "awaiting your review" — distinct from open/in-process.
+  pending_review: 'bg-purple-50 text-purple-800',
 };
 
 /**


### PR DESCRIPTION
…dge — the auto-fire checkpoint value, app union + label/pill maps (manual flow unchanged, enum ALTER run by Alex)