### PR TITLE
feat(EXEC-2): wire accept→fire — accepting a pending_review task (pen…

### DIFF
--- a/src/app/api/operations/projects/[id]/tasks/[taskId]/route.ts
+++ b/src/app/api/operations/projects/[id]/tasks/[taskId]/route.ts
@@ -21,6 +21,8 @@ import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { writeAuditLog } from '@/lib/audit/writeAuditLog';
 import { recordTaskStatusChange } from '@/lib/operations/recordTaskStatusChange';
+import { fireExecutionRoutine } from '@/lib/fireExecutionRoutine';
+import { ExecBudgetError } from '@/lib/execFireBudget';
 import { isValidUuid } from '@/lib/operations/parseUuid';
 
 const VALID_STATUSES: OperationsTaskStatus[] = [
@@ -389,6 +391,40 @@ export async function PATCH(
         },
       },
     });
+
+    // EXEC-2: accepting a pending_review task — the pending_review → open transition
+    // ONLY — fires the Execute-Task Routine to BUILD it + open a PR, and persists the
+    // returned correlationId for exec-ingest's stored-match. Gated to exactly this
+    // transition so a normal status edit (open→done, unarchive, re-open, etc.) never
+    // fires a paid build. The fire is cost-gated inside fireExecutionRoutine
+    // (requireExecBudget). Failure is SURFACED (exec_status='fire_failed' + 502) — the
+    // status change already committed, but the user SEES the build didn't start. No
+    // silent accept-without-fire, no fake success.
+    if (statusTransition && statusTransition.from === 'pending_review' && statusTransition.to === 'open') {
+      try {
+        const fired = await fireExecutionRoutine({ taskId, projectId, userId: user.id, userEmail });
+        await prisma.operations_project_tasks.update({
+          where: { id: taskId },
+          data: { exec_correlation_id: fired.correlationId, exec_status: 'building' },
+        });
+      } catch (err) {
+        await prisma.operations_project_tasks.update({
+          where: { id: taskId },
+          data: { exec_status: 'fire_failed' },
+        });
+        const message =
+          err instanceof ExecBudgetError
+            ? 'daily execution limit reached'
+            : err instanceof Error
+              ? err.message
+              : 'unknown';
+        console.error('[Task PATCH] exec fire failed', { taskId }); // never log the token/headers
+        return NextResponse.json(
+          { error: 'Execution did not start', message: `could not start execution — ${message}` },
+          { status: 502 }
+        );
+      }
+    }
 
     return NextResponse.json({ task });
   } catch (error) {

--- a/src/components/workbench/operations/projects/TaskRow.tsx
+++ b/src/components/workbench/operations/projects/TaskRow.tsx
@@ -58,6 +58,8 @@ export default function TaskRow({ task, projectId, index, coaAccounts, onUpdate,
   const [deleting, setDeleting] = useState(false);
   const [archiving, setArchiving] = useState(false);
   const [reviewing, setReviewing] = useState(false);
+  // EXEC-2: a positive note shown after accepting a pending task (the build fired).
+  const [reviewNotice, setReviewNotice] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [showHistory, setShowHistory] = useState(false);
   const [history, setHistory] = useState<TaskStatusHistoryRow[] | null>(null);
@@ -321,6 +323,7 @@ export default function TaskRow({ task, projectId, index, coaAccounts, onUpdate,
     }
     setReviewing(true);
     setError(null);
+    setReviewNotice(null);
     try {
       const res = await fetch(`/api/operations/projects/${projectId}/tasks/${task.id}`, {
         method: 'PATCH',
@@ -329,9 +332,13 @@ export default function TaskRow({ task, projectId, index, coaAccounts, onUpdate,
       });
       const body = await res.json();
       if (!res.ok) {
+        // EXEC-2: a 502 here is the build-fire failure (e.g. cap reached) — surfaced,
+        // not swallowed. The status change already committed; the build didn't start.
         setError(body?.message ?? body?.error ?? `failed to ${verb}`);
         return;
       }
+      // EXEC-2: accepting fired the Execute-Task Routine (build → PR, async).
+      if (newStatus === 'open') setReviewNotice('building… PR incoming');
       onUpdate();
     } catch (err) {
       setError(err instanceof Error ? err.message : `failed to ${verb}`);
@@ -381,6 +388,7 @@ export default function TaskRow({ task, projectId, index, coaAccounts, onUpdate,
       onArchive={handleArchive}
       onUnarchive={handleUnarchive}
       reviewing={reviewing}
+      reviewNotice={reviewNotice}
       onAcceptPending={handleAcceptPending}
       onRejectPending={handleRejectPending}
     />

--- a/src/components/workbench/operations/projects/TaskRowView.tsx
+++ b/src/components/workbench/operations/projects/TaskRowView.tsx
@@ -93,6 +93,7 @@ export interface TaskRowViewProps {
   // showroom + other callers are unaffected; the buttons only render for a
   // pending_review task when both handlers are supplied.
   reviewing?: boolean;
+  reviewNotice?: string | null;
   onAcceptPending?: (e: React.MouseEvent) => void;
   onRejectPending?: (e: React.MouseEvent) => void;
 }
@@ -135,6 +136,7 @@ export default function TaskRowView({
   onArchive,
   onUnarchive,
   reviewing,
+  reviewNotice,
   onAcceptPending,
   onRejectPending,
 }: TaskRowViewProps) {
@@ -313,6 +315,20 @@ export default function TaskRowView({
               ))}
             </ul>
           )}
+        </div>
+      )}
+
+      {/* EXEC-2: always-visible review feedback — the accept fired the build (green)
+          or it failed (red, shown here when collapsed so it's never hidden; the
+          expanded block below shows the same error when open). */}
+      {reviewNotice && (
+        <div className="px-4 pb-2">
+          <div className="px-3 py-1.5 rounded border bg-green-50 border-green-200 text-green-800 text-xs">{reviewNotice}</div>
+        </div>
+      )}
+      {error && !expanded && (
+        <div className="px-4 pb-2">
+          <div className="px-3 py-1.5 rounded border bg-red-50 border-red-200 text-red-800 text-xs">{error}</div>
         </div>
       )}
 


### PR DESCRIPTION
…ding_review→open transition only) fires fireExecutionRoutine (build→PR) + persists exec_correlation_id for stored-match; fire failure surfaced to UI (exec_status=fire_failed, no silent accept); serial queue deferred to EXEC-3