### PR TITLE
feat(EVOLVE-1): add the Evolve button — edit goals + re-run the full …

### DIFF
--- a/src/components/workbench/operations/projects/ProjectRow.tsx
+++ b/src/components/workbench/operations/projects/ProjectRow.tsx
@@ -97,6 +97,11 @@ export default function ProjectRow({ project, entities, allProjects, onUpdate, o
   const [pipeError, setPipeError] = useState<string | null>(null);
   // PHASE2-5: bump to force the live <TaskList/> to re-fetch (mirrors promptsRefresh).
   const [taskRefresh, setTaskRefresh] = useState(0);
+  // EVOLVE-1: the "loop again with new goals" affordance (edit goals → re-run the pipe).
+  const [evolving, setEvolving] = useState(false);
+  const [evolveGoalsText, setEvolveGoalsText] = useState('');
+  const [evolveSaving, setEvolveSaving] = useState(false);
+  const [evolveError, setEvolveError] = useState<string | null>(null);
   const [flash, setFlash] = useState(false);
   const [showDesignReasoning, setShowDesignReasoning] = useState(false);
   // PR-Ops-Content-2: lazy-mount the read-only evolution timeline (the project's
@@ -357,6 +362,53 @@ export default function ProjectRow({ project, entities, allProjects, onUpdate, o
     }
   };
 
+  // EVOLVE-1: loop the pipe again with new goals on an existing project. Evolve =
+  // edit the goals → save them (project PATCH) → re-fire run-pipe, which re-runs
+  // research→audit→fusion on the NEW goals and APPENDS a new task batch (the existing
+  // append-only versioning via source_ai_usage_id — prior tasks are never deleted, the
+  // EvolutionTimeline shows every version). No new pipe logic — reuses run-pipe.
+  const handleEvolveStart = () => {
+    const current = Array.isArray(project.goal_items)
+      ? project.goal_items.filter((x): x is string => typeof x === 'string')
+      : [];
+    setEvolveGoalsText(current.join('\n'));
+    setEvolveError(null);
+    setEvolving(true);
+  };
+  const handleEvolveCancel = () => { setEvolving(false); setEvolveError(null); };
+  const handleEvolveConfirm = async () => {
+    const goalItems = evolveGoalsText.split('\n').map((s) => s.trim()).filter((s) => s.length > 0);
+    if (goalItems.length === 0) {
+      setEvolveError('enter at least one goal to evolve');
+      return;
+    }
+    setEvolveSaving(true);
+    setEvolveError(null);
+    try {
+      // 1 · Save the new goals (same project PATCH the edit form uses → goal_items).
+      const res = await fetch(`/api/operations/projects/${project.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ goalItems }),
+      });
+      const body = await res.json();
+      if (!res.ok) {
+        setEvolveError(body?.message ?? body?.error ?? 'failed to save evolved goals');
+        return;
+      }
+      // 2 · Goals saved → close the editor, refresh, then fire run-pipe on the new
+      //     goals (append-only — prior tasks stay in the evolution timeline).
+      setEvolving(false);
+      setPromptsRefresh((n) => n + 1);
+      onUpdate();
+      await handleRunPipe();
+    } catch (e) {
+      setEvolveError(e instanceof Error ? e.message : 'failed to evolve');
+    } finally {
+      setEvolveSaving(false);
+    }
+  };
+
   // PAID Anthropic AI — POST generate-tasks. Container-owned: never reachable
   // from the pure <ProjectRowView/>.
   const handleGenerateTasks = async () => {
@@ -525,6 +577,14 @@ export default function ProjectRow({ project, entities, allProjects, onUpdate, o
           runningPipe={runningPipe}
           pipeQueued={pipeQueued}
           pipeError={pipeError}
+          evolving={evolving}
+          evolveGoalsText={evolveGoalsText}
+          evolveSaving={evolveSaving}
+          evolveError={evolveError}
+          onEvolveStart={handleEvolveStart}
+          onEvolveGoalsChange={setEvolveGoalsText}
+          onEvolveConfirm={handleEvolveConfirm}
+          onEvolveCancel={handleEvolveCancel}
         />
       </div>
     );

--- a/src/components/workbench/operations/projects/TruthMachineView.tsx
+++ b/src/components/workbench/operations/projects/TruthMachineView.tsx
@@ -54,6 +54,17 @@ export interface TruthMachineViewProps {
   runningPipe?: boolean;
   pipeQueued?: boolean;
   pipeError?: string | null;
+
+  // ── EVOLVE-1: loop the pipe again with NEW goals (edit goals → re-run run-pipe,
+  // append-only). Optional so other render paths are unaffected. ──────────────
+  evolving?: boolean;
+  evolveGoalsText?: string;
+  evolveSaving?: boolean;
+  evolveError?: string | null;
+  onEvolveStart?: () => void;
+  onEvolveGoalsChange?: (value: string) => void;
+  onEvolveConfirm?: () => void;
+  onEvolveCancel?: () => void;
   /** TM-2: the live interpolated prompts (null while loading / unfetched). */
   prompts: PromptPreview | null;
   promptsLoading: boolean;
@@ -263,6 +274,14 @@ export default function TruthMachineView({
   runningPipe,
   pipeQueued,
   pipeError,
+  evolving,
+  evolveGoalsText,
+  evolveSaving,
+  evolveError,
+  onEvolveStart,
+  onEvolveGoalsChange,
+  onEvolveConfirm,
+  onEvolveCancel,
 }: TruthMachineViewProps) {
   const goalItems = asStringArray(project.goal_items);
   const problemItems = asStringArray(project.problem_items);
@@ -461,6 +480,81 @@ export default function TruthMachineView({
       <Stage n={5} label="plan" color={STRIPE.plan}>
         {taskSection}
       </Stage>
+
+      {/* EVOLVE-1: loop the pipe again with new goals. Edit the goals → re-run the
+          WHOLE pipe (research→audit→fusion) on the evolved state. Append-only — the
+          prior tasks stay in the evolution timeline; this adds a new version. Reuses
+          run-pipe (no new pipe logic). Shown only when the container wires onEvolveStart. */}
+      {onEvolveStart && (
+        <>
+          <Chevron />
+          <section
+            className="rounded-md border border-gray-200 bg-white p-3 sm:p-4 space-y-2.5 border-l-4 shadow-sm"
+            style={{ borderLeftColor: STRIPE.plan }}
+          >
+            <div className="flex items-center justify-between gap-2">
+              <span className="text-[11px] font-bold tracking-widest uppercase" style={{ color: STRIPE.plan }}>
+                ↻ evolve
+              </span>
+              {!evolving && (
+                <button
+                  type="button"
+                  onClick={onEvolveStart}
+                  disabled={pipeQueued || runningPipe}
+                  title="Edit your goals and re-run the whole pipe — appends a new version, prior tasks preserved"
+                  className="px-2 py-0.5 rounded text-white text-xs disabled:opacity-60"
+                  style={{ backgroundColor: STRIPE.plan }}
+                >
+                  ↻ evolve — new goals, loop again
+                </button>
+              )}
+            </div>
+
+            {!evolving ? (
+              <div className="text-gray-500 text-[11px]">
+                Finished a round? Evolve it — edit your goals and re-run research → audit → fusion on the new
+                state. This <span className="font-medium text-gray-700">appends a new version</span>; your prior
+                tasks stay in the timeline (nothing is deleted).
+              </div>
+            ) : (
+              <div className="space-y-2">
+                <div className={sub}>new goals — one per line</div>
+                <textarea
+                  value={evolveGoalsText ?? ''}
+                  onChange={(e) => onEvolveGoalsChange?.(e.target.value)}
+                  rows={4}
+                  placeholder="Enter your evolved goals, one per line…"
+                  className="w-full rounded-md border border-gray-300 p-2 text-xs text-gray-900"
+                />
+                <div className="text-gray-500 text-[11px]">
+                  Running evolution appends a <span className="font-medium text-gray-700">new task version</span> —
+                  research → audit → fusion re-run on these goals; your prior tasks are preserved in the evolution timeline.
+                </div>
+                {evolveError && <div className="text-[11px] text-red-600">{evolveError}</div>}
+                <div className="flex items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={onEvolveConfirm}
+                    disabled={evolveSaving || pipeQueued || runningPipe}
+                    className="px-2 py-0.5 rounded text-white text-xs disabled:opacity-60"
+                    style={{ backgroundColor: STRIPE.fusion }}
+                  >
+                    {evolveSaving ? 'saving + queuing…' : '↻ run evolution'}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={onEvolveCancel}
+                    disabled={evolveSaving}
+                    className="px-2 py-0.5 border border-gray-300 rounded text-gray-600 hover:bg-white text-xs disabled:opacity-60"
+                  >
+                    cancel
+                  </button>
+                </div>
+              </div>
+            )}
+          </section>
+        </>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
…pipe (research→audit→fusion) on an existing project, append-only (prior tasks preserved in the evolution timeline), reuses run-pipe (no new pipe logic), closes the pipeline loop