### PR TITLE
audit(basis): budget and actuals both cash-basis — Match: YES

### DIFF
--- a/audit-reports/EXEC-ROUTINE-PAYLOAD-MISSING-2026-06-20.md
+++ b/audit-reports/EXEC-ROUTINE-PAYLOAD-MISSING-2026-06-20.md
@@ -1,0 +1,139 @@
+# Execute-Task Routine — Blocked: Fire Payload Missing Task Data
+**Date:** 2026-06-20  
+**Branch:** claude/modest-volta-nbkoag  
+**Auditor:** Claude Code Execute-Task Routine (automated)  
+**Status:** BLOCKED — fire payload received as template without interpolated task data
+
+---
+
+## CRITICAL FINDING
+
+The Execute-Task Routine session received the EXECUTE instruction template but NO actual
+task data was interpolated into it. The following required fields are ABSENT from this
+session's entire context:
+
+| Required Field | Status | Where it should appear |
+|---|---|---|
+| `Task: [title]` | **MISSING** | Top of fire payload text |
+| `What to do: [description]` | **MISSING** | Fire payload text |
+| `Why + correctness: [notes]` | **MISSING** | Fire payload text |
+| `correlation_id: [uuid]` | **MISSING** | Correlation trailer in payload |
+| `project_id: [uuid]` | **MISSING** | Correlation trailer in payload |
+
+The `{project_id}` in the POST-back URL is still a literal `{project_id}` placeholder —
+not a real UUID. The "from payload" references in the POST body have nothing to reference.
+
+**This Routine cannot build anything, open any PR, or POST back to exec-ingest.**
+Doing so without a real `correlation_id` + `project_id` would return 403 from exec-ingest
+(stored-match check at exec-ingest/route.ts:75–83) and write nothing useful to the DB.
+
+---
+
+## ROOT CAUSE
+
+`fireExecutionRoutine.ts:72–77` builds the payload as:
+
+```
+Task: ${task.title}
+
+What to do:
+${task.description}
+
+Why + correctness (the test that proves it works):
+${task.notes}
+
+---
+When reporting the result back, include this exact correlation block so it can be matched:
+correlation_id: ${correlationId}
+project_id: ${projectId}
+```
+
+What this Routine received is the EXECUTE template wrapper (the Claude Code session
+system prompt) WITHOUT the above `text` content embedded in it. The task title,
+description, notes, and correlation trailer are all absent.
+
+**Three possible causes (cannot determine without DB/log access per CLAUDE.md):**
+
+1. `fireExecutionRoutine.ts` was called with an empty/null task (title/description/notes
+   all blank), and the correlation trailer was stripped before the Routine was fired.
+
+2. The Routine fire infrastructure substituted the task-description template in place of
+   the actual `text` field from `fireExecutionRoutine.ts`.
+
+3. The task exists in DB but has empty `title`, `description`, and `notes` columns — so
+   `(no description provided)` / `(no notes provided)` fallbacks fired, and the correlation
+   trailer IS present but not in this session's received text (infra strip).
+
+**Cannot determine which without DB access** — Claude Code cannot touch Azure Postgres
+(CLAUDE.md constraint).
+
+---
+
+## WHAT WAS VERIFIED (read-only codebase audit)
+
+| File | Line | Verified State |
+|---|---|---|
+| `src/lib/fireExecutionRoutine.ts` | 72–77 | Payload builder is correct — `task.title`, `description`, `notes`, `correlationId`, `projectId` all referenced |
+| `src/lib/fireExecutionRoutine.ts` | 61–66 | Task loaded ownership-scoped (`{ id, project_id, user_id }`) — correct |
+| `src/lib/fireExecutionRoutine.ts` | 56–58 | Fails loud if `EXEC_ROUTINE_FIRE_URL` / `EXEC_ROUTINE_TOKEN` unset — correct |
+| `src/app/api/operations/projects/[id]/exec-ingest/route.ts` | 41–48 | Token gate first, `EXEC_INGEST_SECRET` checked before any DB work — correct |
+| `src/app/api/operations/projects/[id]/exec-ingest/route.ts` | 75–83 | Stored-match check: `exec_correlation_id` must match posted `correlationId` — correct |
+| `src/lib/execFireBudget.ts` | (exists) | Budget gate present |
+
+**No code defect found in the fire payload builder.** The defect is in how the payload
+was delivered to this Routine session.
+
+---
+
+## DESIGN GAP IDENTIFIED
+
+`fireExecutionRoutine.ts` does NOT validate that the built `text` contains the correlation
+trailer before firing. A pre-fire assertion would catch payload truncation:
+
+```typescript
+if (!text.includes('correlation_id:') || !text.includes('project_id:')) {
+  throw new Error('EXEC payload missing correlation trailer — aborting fire to prevent unrecoverable Routine run');
+}
+```
+
+This would convert a silent "Routine runs but cannot call back" failure into a loud,
+retriable fire-step failure visible in Inngest logs.
+
+---
+
+## WHAT THIS ROUTINE CANNOT DO
+
+Per CLAUDE.md and EXEC-1/EXEC-2 design:
+- CANNOT access Azure Postgres — no `DATABASE_URL` in Routine environment
+- CANNOT determine the correct `project_id` or `correlation_id`
+- CANNOT POST to exec-ingest without valid `project_id` + `correlation_id`
+- CANNOT open a PR for an unknown task
+
+**The exec-ingest POST has been intentionally skipped** — a guess would fail the
+stored-match (403) and write nothing.
+
+---
+
+## RECOMMENDED ACTIONS FOR ALEX
+
+1. **Check which task triggered this Routine fire** — look for a task with
+   `exec_status = 'fire_fired'` and a recently-set `exec_correlation_id` in the DB.
+   Verify `title`, `description`, and `notes` are non-null on that task.
+
+2. **Check Routine fire logs** — confirm what `text` was actually POSTed to
+   `EXEC_ROUTINE_FIRE_URL`. If the text was blank, the task has empty columns in DB.
+
+3. **Add pre-fire assertion to `fireExecutionRoutine.ts`** (see Design Gap above) to
+   catch this failure mode before the Routine fires rather than after.
+
+4. **Re-accept the task** to re-fire the Routine once the root cause is diagnosed.
+   The current `exec_correlation_id` is stale (this session cannot call back with it).
+   A new accept will generate a new `correlationId` via `fireExecutionRoutine.ts:71`.
+
+---
+
+## CONCLUSION
+
+The EXEC-1/EXEC-2 machinery is structurally sound. This Routine session was fired but
+received no actionable task data. No build was attempted, no PR was opened, no exec-ingest
+POST was made. This audit file is the paper trail of the blocked run.

--- a/audit-reports/accounting-basis-consistency-audit.md
+++ b/audit-reports/accounting-basis-consistency-audit.md
@@ -1,0 +1,171 @@
+# Accounting Basis Consistency Audit
+**Date:** 2026-06-20  
+**Branch:** claude/modest-volta-nbkoag  
+**Auditor:** Claude Code Execute-Task Routine (automated)  
+**Task:** Confirm budget and actuals are on the same accounting basis  
+**Risk tier:** Read-only. No code changes.
+
+---
+
+## VERDICT
+
+**Budget basis: CASH**  
+**Actuals basis: CASH**  
+**Match: YES**
+
+No basis mismatch. The merged budget-vs-actuals variance view is safe to ship from an
+accounting basis standpoint.
+
+---
+
+## 1 · ACTUALS BASIS (all three routes)
+
+All three routes — `year-calendar`, `business-budget`, and `nomad-budget` — query actuals
+identically:
+
+```sql
+SELECT
+  coa.code,
+  EXTRACT(MONTH FROM je.date)::int as month,
+  SUM(CASE WHEN le.entry_type = 'D' THEN le.amount ELSE 0 END)::text as debits
+FROM ledger_entries le
+JOIN journal_entries je ON le.journal_entry_id = je.id
+...
+WHERE je.is_reversal = false
+  AND je.reversed_by_entry_id IS NULL
+  AND EXTRACT(YEAR FROM je.date) = ${year}
+```
+
+**Source of `je.date`:** `commit-to-ledger/route.ts:115`
+
+```typescript
+date: new Date(plaidTxn.date),
+```
+
+`plaidTxn.date` is Plaid's `date` field — the settlement/posting date of the bank or
+card transaction. No accruals, no deferrals, no accounts-payable timing adjustments.
+
+**Actuals basis: CASH** (expense recognized on date of bank/card settlement).
+
+---
+
+## 2 · BUDGET BASIS
+
+### Source 1 — `operations_routines` with `budget_amount` (year-calendar + business-budget)
+
+`year-calendar/route.ts:89–118` and `business-budget/route.ts:102–130` both call
+`routinesMonthlyByCoa(routineInputs, year, m)`.
+
+From `src/lib/operations/routineBudget.ts:7`:
+
+```
+monthly = expandBetween(schedule_rrule, timezone, monthStart, monthEnd).length × budget_amount
+```
+
+Budget is recognized in **the calendar month when the routine is scheduled to fire** — the
+date the spending event is planned to occur. There is no service-period spreading,
+accrual, or lag. A routine for a weekly gym membership shows a budget figure in each month
+based on how many times the rrule fires that month.
+
+**Basis: CASH** (planned cash outflow in the month of the scheduled occurrence).
+
+### Source 2 — `budgets` table (year-calendar, transitional source)
+
+`year-calendar/route.ts:127–146`:
+
+```typescript
+const budgetRows = await prisma.budgets.findMany({
+  where: { userId: user.id, year: year, accountCode: { in: ... } }
+});
+for (const row of budgetRows) {
+  const val = Number(row[MONTH_COLS[m]] || 0); // jan, feb, ..., dec columns
+  ...
+}
+```
+
+Schema (`prisma/schema.prisma:485–509`): `jan` through `dec` columns, `Decimal(12, 2)`.
+Static user-entered monthly planned-spend amounts. No concept of service period, liability
+recognition, or accrual. A value in `mar` = planned cash out in March.
+
+**Basis: CASH** (planned outflows allocated to calendar month of payment).
+
+### Source 3 — `budget_line_items` (business-budget + nomad-budget)
+
+`business-budget/route.ts:69–91`: queries `budget_line_items` where `source = 'business'`.
+`nomad-budget/route.ts:89–117`: queries `budget_line_items` where `source = 'trip'`.
+
+Schema (`prisma/schema.prisma:1050–1075`): `year`, `month`, `amount Decimal(12, 2)`.
+Each row is a planned expenditure in a specific calendar month. No `effective_date`,
+no `service_period_start/end`, no accrual fields.
+
+For travel specifically, the `month` reflects when the trip occurs (the month travel costs
+are paid), not when they were booked or when a future trip liability was recognized.
+
+**Basis: CASH** (planned cash outflows by calendar month of occurrence).
+
+---
+
+## 3 · EVIDENCE MATRIX
+
+| Dimension | Actuals | Budget — Routines | Budget — `budgets` | Budget — `budget_line_items` |
+|---|---|---|---|---|
+| Recognition event | Plaid settlement date (`je.date`) | Scheduled occurrence date (rrule expansion) | User-entered month column | `(year, month)` of planned spend |
+| File:line | `year-calendar/route.ts:154–171` | `routineBudget.ts:7` | `year-calendar/route.ts:127–146` | `business-budget/route.ts:69–91` |
+| Schema field | `journal_entries.date @db.Date` | `operations_routines.budget_amount + schedule_rrule` | `budgets.jan…dec Decimal` | `budget_line_items.month Int` |
+| Accruals? | No | No | No | No |
+| Deferrals? | No | No | No | No |
+| AP/AR timing? | No | No | No | No |
+| **Basis** | **CASH** | **CASH** | **CASH** | **CASH** |
+
+---
+
+## 4 · ONE NUANCE (non-blocking)
+
+Within cash basis, a minor timing edge exists but does NOT constitute a basis mismatch:
+
+**Routine budget vs. actuals month boundary:** A routine scheduled Jan 31 in a UTC+9
+timezone expands to Jan 31 local = Jan 31 UTC+9 (Jan 30 23:00 UTC). The rrule expansion
+is timezone-aware (`routineBudget.ts:53`). The actual transaction settles within days in
+the same month. In practice the same month is hit by both sides for virtually all
+real-world occurrences.
+
+**Plaid `date` vs. `authorized_date`:** The `transactions` table (`schema.prisma:365`)
+stores both `date` and `authorized_date`. The code uses `plaidTxn.date` (settlement date),
+not `authorized_date`. Settlement typically lags authorization by 1–3 days. For a Dec 31
+credit card charge, actuals may land Jan 1–3. This is standard cash-basis treatment
+(settle date = event date) and is consistent across ALL actuals; it does not create a
+differential vs. the budget side.
+
+Neither edge creates a systematic bias between budget and actuals columns. Both are
+within normal cash-basis variance.
+
+---
+
+## 5 · ASSERTION TEST (per task correctness spec)
+
+> 'Budget basis: [cash/accrual]. Actuals basis: [cash/accrual]. Match: YES/NO.'
+
+**Budget basis: CASH.**  
+**Actuals basis: CASH.**  
+**Match: YES.**
+
+Research Finding 1 risk — "cash/accrual mismatch produces systematic, silent
+misrepresentation" — **does not apply.** Both sides use the same basis. Variance rows
+reflect real timing and spending differences, not accounting definition differences.
+
+---
+
+## 6 · FILES AUDITED
+
+| File | Lines verified |
+|---|---|
+| `src/app/api/hub/year-calendar/route.ts` | 79–171 (budget sources 1+2, actuals query) |
+| `src/app/api/hub/business-budget/route.ts` | 67–155 (budget sources 2+3, actuals query) |
+| `src/app/api/hub/nomad-budget/route.ts` | 87–158 (budget source 3, actuals query) |
+| `src/app/api/transactions/commit-to-ledger/route.ts` | 108–121 (date used for je.date) |
+| `src/lib/journal-entry-service.ts` | 112–125 (journal entry creation, date field) |
+| `src/lib/operations/routineBudget.ts` | 1–77 (routine budget expansion logic) |
+| `prisma/schema.prisma` | 180–226 (journal_entries + ledger_entries) |
+| `prisma/schema.prisma` | 360–395 (transactions, date vs authorized_date) |
+| `prisma/schema.prisma` | 485–509 (budgets table) |
+| `prisma/schema.prisma` | 1050–1075 (budget_line_items) |


### PR DESCRIPTION
## Accounting Basis Consistency Audit

**Task:** Confirm accounting basis consistency — verify budget and actuals are on the same basis before a merged variance view ships.

**Research Finding 1 (Critical) addressed:** "A cash/accrual mismatch produces systematic, silent misrepresentation."

---

## Result

**Budget basis: CASH**  
**Actuals basis: CASH**  
**Match: YES — no blocking issue**

The merged budget-vs-actuals view is safe to ship from an accounting basis standpoint. Variance rows will reflect real timing/spending differences, not phantom variances from a basis mismatch.

---

## Evidence

### Actuals (all three routes)

All three routes (`year-calendar`, `business-budget`, `nomad-budget`) query actuals the same way — grouped by `EXTRACT(MONTH FROM je.date)`. The `date` on each journal entry is set from `plaidTxn.date` (Plaid's settlement/posting date) at `commit-to-ledger/route.ts:115`. No accruals, no deferrals.

**Actuals basis: CASH** — expense recognized on date of bank/card settlement.

### Budget — three sources, all cash

| Source | Route | Basis |
|---|---|---|
| `operations_routines.budget_amount` | year-calendar, business-budget | CASH — budget in month of scheduled occurrence (rrule expansion, `routineBudget.ts:7`) |
| `budgets.jan…dec` columns | year-calendar (transitional) | CASH — user-entered planned outflows by calendar month |
| `budget_line_items.(year,month)` | business-budget, nomad-budget | CASH — planned spend allocated to calendar month of occurrence |

No accrual fields, no service-period spreading, no AP/AR timing on any budget source.

---

## One nuance (non-blocking)

A minor within-cash-basis timing edge exists: Plaid's `date` (settlement, used for actuals) can lag the `authorized_date` by 1–3 days. A Dec 31 charge may land as a Jan actual. This is standard cash-basis treatment (settle date = event date) and is symmetric across all actuals — it does not create a differential vs. budget.

---

## Files audited

- `src/app/api/hub/year-calendar/route.ts` — lines 79–171
- `src/app/api/hub/business-budget/route.ts` — lines 67–155
- `src/app/api/hub/nomad-budget/route.ts` — lines 87–158
- `src/app/api/transactions/commit-to-ledger/route.ts` — line 115 (je.date source)
- `src/lib/journal-entry-service.ts` — lines 112–125
- `src/lib/operations/routineBudget.ts` — full file
- `prisma/schema.prisma` — journal_entries, ledger_entries, transactions, budgets, budget_line_items

Full evidence matrix: `audit-reports/accounting-basis-consistency-audit.md`

---

> Note: This PR also contains a prior commit (`b83f5d3`) documenting a blocked run where the fire payload was received without task data. That is a separate infrastructure finding unrelated to this audit task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RJx3X8mGBWhnFFfrqJGeSy