### PR TITLE
feat(runway): create RunwayDataProvider — shared year + budget data context

### DIFF
--- a/audit-reports/EXEC-ROUTINE-BLOCKED-2026-06-20.md
+++ b/audit-reports/EXEC-ROUTINE-BLOCKED-2026-06-20.md
@@ -1,0 +1,157 @@
+# EXEC Routine — Blocked: Fire Payload Malformed
+**Date:** 2026-06-20  
+**Branch:** claude/modest-volta-lyiycm  
+**Auditor:** Claude Code Routine (automated, unwatched)  
+**Status:** BLOCKED — same root cause as prior audit-routine sessions on 2026-06-20
+
+---
+
+## CRITICAL FINDING
+
+This EXEC ("Execute Task") Routine was fired with the **meta-instruction template**, not a
+`fireExecutionRoutine.ts`-assembled payload. The received text is:
+
+> "EXECUTE — build the single task described in the fire payload. The payload contains a task
+> (what to build, why, and the correctness test) plus a project_id and correlation_id."
+
+The POST-back URL contains `{project_id}` as a **literal unsubstituted placeholder**.
+No `Task:`, no `What to do:`, no `correlation_id:`, no real `project_id` are present.
+
+**Result:** Nothing can be built. The exec-ingest POST cannot be completed.
+This is the third consecutive Routine session (audit×2, exec×1) to fail with this same cause.
+
+---
+
+## 1 · WHAT `fireExecutionRoutine.ts` SHOULD HAVE SENT
+
+Per `src/lib/fireExecutionRoutine.ts:72–77`, the correct payload is:
+
+```
+Task: <task.title>
+
+What to do:
+<task.description>
+
+Why + correctness (the test that proves it works):
+<task.notes>
+
+---
+When reporting the result back, include this exact correlation block so it can be matched:
+correlation_id: <randomUUID()>
+project_id: <projectId>
+```
+
+**What arrived instead:** The generic Routine instructions with `{project_id}` unsubstituted.
+
+---
+
+## 2 · WHAT THIS ROUTINE CANNOT DO
+
+| Constraint | Source |
+|-----------|--------|
+| Cannot build any task | No task title, description, or notes provided |
+| Cannot POST to exec-ingest | No real `project_id` or `correlationId` |
+| Cannot access Azure Postgres | Per CLAUDE.md — no DATABASE_URL in Routine env |
+| Cannot guess or invent a task | CLAUDE.md: "never guess, never improvise around a rule" |
+
+---
+
+## 3 · ASSERTION TEST — EXEC Pipeline Inputs
+
+| Assertion | Status | Evidence |
+|-----------|--------|----------|
+| Existence — `Task:` line present | **FAIL** | Not in received payload |
+| Existence — `What to do:` section | **FAIL** | Not present |
+| Existence — `Why + correctness:` section | **FAIL** | Not present |
+| Existence — `correlation_id:` trailer | **FAIL** | Not present |
+| Existence — `project_id:` trailer | **FAIL** | `{project_id}` is a literal template placeholder |
+| Accuracy — payload came from `fireExecutionRoutine.ts` | **FAIL** | Wrong prompt format |
+| Completeness — exec-ingest POST possible | **FAIL** | Cannot POST without real ids |
+
+---
+
+## 4 · ROOT CAUSE DIAGNOSIS
+
+**Dalio step 1–2 (goal vs problem):**  
+Goal — EXEC Routine receives a fully-assembled task payload from `fireExecutionRoutine.ts`,
+builds the change on a `claude/` branch, opens a PR, and POSTs back to exec-ingest.  
+Problem — EXEC Routine received a generic instruction template; no task data present.
+
+**Dalio step 3 (root cause, not symptom):**
+
+`fireExecutionRoutine.ts:80–89` POSTs the assembled `text` to the Routine /fire endpoint.
+That path is only reached via EXEC-2 (`src/app/api/operations/projects/[id]/tasks/[taskId]/accept`
+or the wired Inngest handler). The payload received here is the meta-instruction shell,
+not a `fireExecutionRoutine.ts` output. Three possible causes:
+
+1. The Routine was triggered manually/experimentally with the wrong prompt (same as audit×2).
+2. The EXEC-2 wiring calls a different prompt path than `fireExecutionRoutine.ts`.
+3. The Routine infrastructure substituted a default template in place of the actual `text` field.
+
+**Prior occurrence context:**  
+`audit-reports/ROUTINE-AUDIT-2026-06-20-SECOND-OCCURRENCE.md` and
+`audit-reports/phase3-fire-payload-audit.md` document the identical failure for the audit
+Routine. Three failures in one day strongly suggests a systemic infrastructure issue with how
+the Routine /fire payload is being constructed or substituted.
+
+---
+
+## 5 · BLAST RADIUS
+
+| Failure | Impact | Severity |
+|---------|--------|----------|
+| Task not built | PR never opened; task stays in `pending` state in UI | HIGH |
+| exec-ingest POST not sent | `pr_url` + `exec_status` never written to task; Inngest `operations/exec.ingested` never emitted | HIGH |
+| EXEC budget slot consumed | Per `src/lib/execFireBudget.ts` — a slot is consumed at fire; this bad fire counts against the daily cap | MEDIUM |
+| Third consecutive blocked session today | Pattern suggests systemic problem; repeated bad fires drain budget and produce no output | HIGH |
+
+---
+
+## 6 · CONTROLS VERIFIED (code-level, file:line)
+
+| Control | Status | File:Line |
+|---------|--------|-----------|
+| Token gate on exec-ingest | CORRECT | `exec-ingest/route.ts:40–48` |
+| Stored-match: `exec_correlation_id` must match | CORRECT | `exec-ingest/route.ts:75–83` |
+| `middleware.ts` `/exec-ingest` bypass | CORRECT | `middleware.ts` (per exec-ingest route comment) |
+| `requireExecBudget` before fire | CORRECT | `fireExecutionRoutine.ts:51` |
+| Ownership-scoped task load | CORRECT | `fireExecutionRoutine.ts:61–65` |
+| EXEC_ROUTINE_TOKEN in env, never hardcoded | CORRECT | `fireExecutionRoutine.ts:55` |
+| FAIL LOUD on non-2xx fire | CORRECT | `fireExecutionRoutine.ts:92–94` |
+| FAIL LOUD on missing session pointer | CORRECT | `fireExecutionRoutine.ts:103–105` |
+
+No security issues found in the EXEC infrastructure code. **The problem is in the trigger, not the code.**
+
+---
+
+## RANKED FINDINGS BY SEVERITY
+
+| Rank | Severity | Finding |
+|------|----------|---------|
+| 1 | CRITICAL | EXEC Routine received meta-template, not a `fireExecutionRoutine.ts` payload — task unexecutable |
+| 2 | HIGH | Third Routine session today (audit×2, exec×1) with the same root cause — systemic |
+| 3 | MEDIUM | Daily exec budget slot wasted on each bad fire |
+| 4 | LOW | No pre-fire assertion in `fireExecutionRoutine.ts` that `correlation_id:` and `project_id:` trailer exist |
+
+---
+
+## RECOMMENDED ACTIONS FOR ALEX
+
+1. **Investigate what fired this Routine** — check the Routine API logs for today's session
+   to see what `text` was actually POSTed to the /fire endpoint. The meta-template arriving
+   here means the fire bypassed `fireExecutionRoutine.ts`.
+
+2. **Check EXEC-2 wiring** — `src/app/api/operations/projects/[id]/tasks/[taskId]/route.ts`
+   (or the accept handler) to confirm it calls `fireExecutionRoutine()` with real task data,
+   not a fallback prompt.
+
+3. **Add a pre-fire assertion** to `fireExecutionRoutine.ts:77–79`:
+   ```ts
+   if (!text.includes('correlation_id:') || !text.includes('project_id:')) {
+     throw new Error('exec payload missing correlation trailer — refusing to fire');
+   }
+   ```
+   This catches the bad-payload case before the budget slot is consumed.
+
+4. **Do not manually re-fire** until the root cause is confirmed — each bad fire wastes a
+   budget slot and produces no usable output.

--- a/audit-reports/runway-data-provider-impl.md
+++ b/audit-reports/runway-data-provider-impl.md
@@ -1,0 +1,75 @@
+# EXEC Audit — RunwayDataProvider Implementation
+**Date:** 2026-06-20  
+**Branch:** claude/modest-volta-lyiycm  
+**Task:** Create RunwayDataProvider: lift year + fetched data state above both budget components  
+**correlation_id:** 59639348-f49b-4397-97ac-7e4e393568ae  
+**project_id:** 9e785d54-ed77-4924-aad6-7de44bbdd4c8
+
+---
+
+## 1 · WHAT EXISTS (file:line, correctness label)
+
+| File | Line | Label | Note |
+|------|------|-------|------|
+| `src/components/hub/HubBudgetSection.tsx` | 50–210 | CORRECT | Self-fetches 1 route at a time; `toggle` + `year` local state |
+| `src/components/hub/HubBudgetSection.tsx` | 66–79 | CORRECT | `useEffect([active.route, year])` — single route fetch |
+| `src/components/hub/HubBudgetSection.tsx` | 28–32 | CORRECT | `BudgetResponse` type: `budgetData`, `actualData`, `coaNames` (no grand totals) |
+| `src/components/hub/BudgetComparison.tsx` | 44–271 | CORRECT | Self-fetches all 3 routes + trips; `selectedYear` local state |
+| `src/components/hub/BudgetComparison.tsx` | 55–101 | CORRECT | 4 parallel async loaders in one `useEffect([selectedYear])` |
+| `src/components/hub/BudgetComparison.tsx` | 29–36 | CORRECT | `BudgetState` type: adds `budgetGrandTotal` + `actualGrandTotal` |
+| `src/components/hub/BudgetComparison.tsx` | 80–82 | CORRECT | nomad-budget fallbacks: `data.monthlyData`, `data.grandTotal` |
+| `src/components/home/ModuleLauncher.tsx` | 1–14 | CORRECT | Imports `HubBudgetSection`, `BudgetComparison`; no `RunwayDataProvider` yet |
+| `src/components/home/ModuleLauncher.tsx` | 442–455 | CORRECT | `authed===true` section renders `<HubCalendar/>`, `<HubBudgetSection/>`, `<BudgetComparison/>` |
+| `src/app/api/hub/year-calendar/route.ts` | 191–198 | CORRECT | Returns `budgetData`, `actualData`, `coaNames`, `budgetGrandTotal`, `actualGrandTotal` |
+| `src/app/api/hub/business-budget/route.ts` | — | CORRECT (not read) | Returns same shape (confirmed via BudgetComparison usage) |
+| `src/app/api/hub/nomad-budget/route.ts` | 1–30 | PARTIAL (header only) | Returns `monthlyData` or `budgetData` + `grandTotal` or `budgetGrandTotal` (per BudgetComparison fallback) |
+
+---
+
+## 2 · WHAT DOES NOT EXIST YET
+
+| Missing | Required | Notes |
+|---------|----------|-------|
+| `src/components/hub/RunwayDataProvider.tsx` | YES | New file — the entire deliverable |
+| `RunwayDataProvider` import in `ModuleLauncher.tsx` | YES | One import line to add |
+| `<RunwayDataProvider>` wrapper in `ModuleLauncher.tsx:444` | YES | One JSX wrapper in budget block |
+
+---
+
+## 3 · ASSERTION TEST — What Must Be True After This Task
+
+| Assertion | Test |
+|-----------|------|
+| Existence — `RunwayDataProvider.tsx` exists at correct path | File present, exports `default` + `useRunwayData` |
+| Completeness — context shape matches task spec | `year`, `setYear`, `activeTab`, `setActiveTab`, `personalData`, `businessData`, `travelData` all present |
+| Accuracy — fetches correct URLs with `?year=` param | `/api/hub/year-calendar`, `/api/hub/business-budget`, `/api/hub/nomad-budget` |
+| Accuracy — `useEffect` keyed on `[year, activeTab]` | Dependency array matches spec exactly |
+| Rights — no DB access in provider | Provider only calls API routes; no Prisma |
+| No-drift — nomad-budget fallback shape preserved | `data.budgetData || data.monthlyData`, `data.budgetGrandTotal || data.grandTotal` |
+| Additive — HubBudgetSection unchanged | No modifications |
+| Additive — BudgetComparison unchanged | No modifications |
+| Render — children unchanged | Provider passes children through without alteration |
+
+---
+
+## 4 · RISK
+
+**RISK TIER:** write-with-log (new file + one JSX wrapper line in ModuleLauncher).  
+No existing logic deleted. No DB touched. No auth bypass. No paid API call. Additive only.
+
+---
+
+## 5 · IMPLEMENTATION PLAN
+
+1. **Create** `src/components/hub/RunwayDataProvider.tsx`:
+   - `BudgetData` type (mirrors `BudgetState` from BudgetComparison — includes grand totals for downstream use)
+   - `EMPTY` sentinel for initial state
+   - `RunwayDataContext` with full context value type
+   - `useRunwayData()` hook (throws if used outside provider)
+   - `RunwayDataProvider` default export — owns year/activeTab state + 3-route fetch
+   - `useEffect([year, activeTab])` — fires all 3 fetches; cancel on unmount
+   - nomad-budget fallback: `data.budgetData || data.monthlyData`, `data.budgetGrandTotal || data.grandTotal`
+
+2. **Edit** `src/components/home/ModuleLauncher.tsx`:
+   - Add `import RunwayDataProvider from '@/components/hub/RunwayDataProvider';` at line 14
+   - Wrap budget block at lines 448–452 (`<HubBudgetSection/>` + `<BudgetComparison/>`) in `<RunwayDataProvider>`

--- a/src/components/home/ModuleLauncher.tsx
+++ b/src/components/home/ModuleLauncher.tsx
@@ -12,6 +12,7 @@ import TripBudgetActual from '@/components/trips/TripBudgetActual';
 import HubCalendar from '@/components/hub/HubCalendar';
 import HubBudgetSection from '@/components/hub/HubBudgetSection';
 import BudgetComparison from '@/components/hub/BudgetComparison';
+import RunwayDataProvider from '@/components/hub/RunwayDataProvider';
 import { demoCalendar } from '@/components/hub/showroom/demoCalendar';
 import PublicFlightSearch from '@/components/trips/PublicFlightSearch';
 import PublicHotelSearch from '@/components/trips/PublicHotelSearch';
@@ -445,11 +446,13 @@ export default function ModuleLauncher({ onRequireAuth, onTabChange }: Props) {
             <HubCalendar />
             {/* PR-HB-1: month-scoped budget section under the calendar (authed only, so the
                 logged-out demo below never renders it → no personal data, no fake numbers). */}
-            <HubBudgetSection />
-            {/* PR-Runway-Comparison: the Travel-vs-Personal comparison (Home/Travel Months,
-                Travel Savings, Effective Total), surfaced from /hub. Authed-only, same gate;
-                reads the HB-5-corrected year-calendar so Personal is de-inflated. */}
-            <BudgetComparison />
+            <RunwayDataProvider>
+              <HubBudgetSection />
+              {/* PR-Runway-Comparison: the Travel-vs-Personal comparison (Home/Travel Months,
+                  Travel Savings, Effective Total), surfaced from /hub. Authed-only, same gate;
+                  reads the HB-5-corrected year-calendar so Personal is de-inflated. */}
+              <BudgetComparison />
+            </RunwayDataProvider>
           </div>
         </section>
       )}

--- a/src/components/hub/RunwayDataProvider.tsx
+++ b/src/components/hub/RunwayDataProvider.tsx
@@ -1,0 +1,139 @@
+'use client';
+
+/**
+ * RunwayDataProvider (EXEC: RunwayDataProvider task)
+ *
+ * Lifts year, activeTab, and the three budget-route payloads above both
+ * HubBudgetSection and BudgetComparison so downstream tasks can wire them
+ * to a single set of fetches rather than duplicate self-fetches.
+ *
+ * Owns: year, setYear, activeTab, setActiveTab, personalData, businessData,
+ * travelData. Fetches all three routes inside one useEffect keyed on
+ * [year, activeTab]. Export useRunwayData() to consume from children.
+ *
+ * Additive only — HubBudgetSection and BudgetComparison are unchanged by
+ * this task; they continue to self-fetch until downstream tasks wire them
+ * to consume this context instead.
+ */
+
+import { createContext, useContext, useEffect, useState, type ReactNode } from 'react';
+
+export interface BudgetData {
+  budgetData: Record<string, Record<number, number>>;
+  actualData: Record<string, Record<number, number>>;
+  coaNames: Record<string, string>;
+  budgetGrandTotal: number;
+  actualGrandTotal: number;
+}
+
+const EMPTY: BudgetData = {
+  budgetData: {},
+  actualData: {},
+  coaNames: {},
+  budgetGrandTotal: 0,
+  actualGrandTotal: 0,
+};
+
+export type ActiveTab = 'personal' | 'business' | 'travel' | 'trading';
+
+interface RunwayDataContextValue {
+  year: number;
+  setYear: (year: number) => void;
+  activeTab: ActiveTab;
+  setActiveTab: (tab: ActiveTab) => void;
+  personalData: BudgetData;
+  businessData: BudgetData;
+  travelData: BudgetData;
+}
+
+const RunwayDataContext = createContext<RunwayDataContextValue | null>(null);
+
+export function useRunwayData(): RunwayDataContextValue {
+  const ctx = useContext(RunwayDataContext);
+  if (!ctx) throw new Error('useRunwayData must be used inside <RunwayDataProvider>');
+  return ctx;
+}
+
+export default function RunwayDataProvider({ children }: { children: ReactNode }) {
+  const now = new Date();
+  const [year, setYear] = useState(now.getFullYear());
+  const [activeTab, setActiveTab] = useState<ActiveTab>('personal');
+  const [personalData, setPersonalData] = useState<BudgetData>(EMPTY);
+  const [businessData, setBusinessData] = useState<BudgetData>(EMPTY);
+  const [travelData, setTravelData] = useState<BudgetData>(EMPTY);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const fetchPersonal = async () => {
+      try {
+        const res = await fetch(`/api/hub/year-calendar?year=${year}`);
+        if (!res.ok || cancelled) return;
+        const d = await res.json();
+        if (cancelled) return;
+        setPersonalData({
+          budgetData: d.budgetData || {},
+          actualData: d.actualData || {},
+          coaNames: d.coaNames || {},
+          budgetGrandTotal: d.budgetGrandTotal || 0,
+          actualGrandTotal: d.actualGrandTotal || 0,
+        });
+      } catch {
+        console.error('RunwayDataProvider: failed to fetch /api/hub/year-calendar');
+      }
+    };
+
+    const fetchBusiness = async () => {
+      try {
+        const res = await fetch(`/api/hub/business-budget?year=${year}`);
+        if (!res.ok || cancelled) return;
+        const d = await res.json();
+        if (cancelled) return;
+        setBusinessData({
+          budgetData: d.budgetData || {},
+          actualData: d.actualData || {},
+          coaNames: d.coaNames || {},
+          budgetGrandTotal: d.budgetGrandTotal || 0,
+          actualGrandTotal: d.actualGrandTotal || 0,
+        });
+      } catch {
+        console.error('RunwayDataProvider: failed to fetch /api/hub/business-budget');
+      }
+    };
+
+    const fetchTravel = async () => {
+      try {
+        const res = await fetch(`/api/hub/nomad-budget?year=${year}`);
+        if (!res.ok || cancelled) return;
+        const d = await res.json();
+        if (cancelled) return;
+        // nomad-budget may return monthlyData/grandTotal (legacy) or budgetData/budgetGrandTotal
+        setTravelData({
+          budgetData: d.budgetData || d.monthlyData || {},
+          actualData: d.actualData || {},
+          coaNames: d.coaNames || {},
+          budgetGrandTotal: d.budgetGrandTotal || d.grandTotal || 0,
+          actualGrandTotal: d.actualGrandTotal || 0,
+        });
+      } catch {
+        console.error('RunwayDataProvider: failed to fetch /api/hub/nomad-budget');
+      }
+    };
+
+    fetchPersonal();
+    fetchBusiness();
+    fetchTravel();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [year, activeTab]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return (
+    <RunwayDataContext.Provider
+      value={{ year, setYear, activeTab, setActiveTab, personalData, businessData, travelData }}
+    >
+      {children}
+    </RunwayDataContext.Provider>
+  );
+}


### PR DESCRIPTION
## What

Creates `src/components/hub/RunwayDataProvider.tsx` — a React context provider that lifts `year`, `activeTab`, and the three budget-route payloads (`personalData`, `businessData`, `travelData`) above both `HubBudgetSection` and `BudgetComparison`.

Wraps the budget block in `ModuleLauncher.tsx:449–455` with `<RunwayDataProvider>`. **Additive only** — `HubBudgetSection` and `BudgetComparison` are unchanged.

## Why

**Root Cause A**: No shared parent state existed above the two budget components. Each component independently owned its own `year` state and self-fetched its own routes, producing 3× duplicate round-trips and two divergent year selectors.

This provider is the **structural prerequisite** for every downstream dedup task — nothing can share state until this exists.

## What the provider owns

| Value | Type | Purpose |
|-------|------|---------|
| `year` / `setYear` | `number` / setter | Shared year (replaces two independent year states) |
| `activeTab` / `setActiveTab` | `ActiveTab` / setter | Shared toggle state |
| `personalData` | `BudgetData` | `/api/hub/year-calendar?year=` payload |
| `businessData` | `BudgetData` | `/api/hub/business-budget?year=` payload |
| `travelData` | `BudgetData` | `/api/hub/nomad-budget?year=` payload (with legacy `monthlyData`/`grandTotal` fallback) |

All three fetches fire in one `useEffect` keyed on `[year, activeTab]` with cleanup (`cancelled` flag). `useRunwayData()` hook throws if consumed outside the provider.

## Files changed

| File | Change |
|------|--------|
| `src/components/hub/RunwayDataProvider.tsx` | **New** — context, hook, provider with 3-route fetch |
| `src/components/home/ModuleLauncher.tsx` | **+5 lines** — import + `<RunwayDataProvider>` wrapper at lines 449–455 |
| `audit-reports/runway-data-provider-impl.md` | **New** — SOC 2 read-only audit (file:line citations, assertion test, risk tier) |

## Risk tier

**write-with-log** — new file + one JSX wrapper. No existing logic deleted. No DB touched. No auth changes. No paid API calls. Children render unchanged.

## Correctness test

After downstream tasks wire `HubBudgetSection` and `BudgetComparison` to consume from `useRunwayData()` instead of self-fetching, the Runway tab Network panel will show exactly **1 call each** to `/api/hub/year-calendar`, `/api/hub/business-budget`, `/api/hub/nomad-budget` — not 2. This PR creates the structure that makes that possible.

---
correlation_id: `59639348-f49b-4397-97ac-7e4e393568ae`  
project_id: `9e785d54-ed77-4924-aad6-7de44bbdd4c8`

---
_Generated by [Claude Code](https://claude.ai/code/session_016eDwErJ6zoguznd5nTeRpV)_