### PR TITLE
refactor(hub): wire HubBudgetSection to RunwayDataProvider — eliminate duplicate fetches + year desync

### DIFF
--- a/audit-reports/HUB-RUNWAY-PROVIDER-AUDIT.md
+++ b/audit-reports/HUB-RUNWAY-PROVIDER-AUDIT.md
@@ -1,0 +1,76 @@
+# Audit: Wire HubBudgetSection to RunwayDataProvider
+**Date:** 2026-06-20  
+**Branch:** `claude/modest-volta-rj98sb`  
+**Correlation:** `19a48b08-5d98-4cc7-9734-1327f77b3ed6`  
+**Risk tier:** write-with-log — data-fetching layer only, zero rendering changes
+
+---
+
+## Files read (file:line citations)
+
+| File | Lines inspected | Purpose |
+|------|----------------|---------|
+| `src/components/hub/HubBudgetSection.tsx` | 1–210 | Target component — full read |
+| `src/components/hub/BudgetComparison.tsx` | 1–271 | Sibling consumer — full read |
+| `src/components/home/ModuleLauncher.tsx` | 1–528+ | Provider mount point — full read |
+
+---
+
+## Root cause confirmed
+
+**Root Cause A (Diagnosis §5 FM2 + FM3):** `HubBudgetSection` owns independent `year` and `toggle` state and self-fetches `active.route?year=${year}` inside a `useEffect` (`HubBudgetSection.tsx:53,66–79`). `BudgetComparison` owns independent `selectedYear` state and self-fetches the same three routes (`BudgetComparison.tsx:55–101`). Year state changes in either component are invisible to the other, producing desync. Both components hitting the same three routes constitutes the "3× duplicate fetches" (PI1.3 completeness violation).
+
+---
+
+## Structural observations
+
+- `HubBudgetSection.tsx:22` — imports `{ useEffect, useState }`. After refactor only `useState` remains.
+- `HubBudgetSection.tsx:34` — `ToggleKey` defined locally. Moves to provider; imported back here.
+- `HubBudgetSection.tsx:28–32` — `BudgetResponse` interface defined locally. Moves to provider; imported back here.
+- `HubBudgetSection.tsx:50–79` — state that moves to provider: `year` (line 53), `toggle` (line 52), `data` (line 55), `loading` (line 56). The `useEffect` fetch block (lines 66–79) is removed entirely.
+- `HubBudgetSection.tsx:54,58–60` — state that stays LOCAL: `monthIdx` (line 54), `drillDown` (lines 58–60).
+- `HubBudgetSection.tsx:82–99` — row derivation (`allRows`, `rows`, totals): **zero changes** — still reads `data.coaNames`, `data.budgetData`, `data.actualData`. The local `data` binding is set to the provider slice for the active toggle.
+- `HubBudgetSection.tsx:121–123` — year stepper buttons call `setYear(y => y - 1/+1)`. After refactor these write to provider context, satisfying the correctness test (BudgetComparison re-renders to the same year in the next task).
+- `ModuleLauncher.tsx:448–452` — `<HubBudgetSection />` and `<BudgetComparison />` are sibling children of the same `<div className="max-w-7xl mx-auto">`. The `RunwayDataProvider` wraps both.
+
+---
+
+## No security / auth / migration / schema gate
+
+- No API route changes.
+- No DB writes.
+- No auth flow changes.
+- No Prisma schema changes.
+- Provider only orchestrates existing authenticated `fetch()` calls that were already happening in HubBudgetSection — no new routes, no new cost, no new surface area.
+
+---
+
+## Implementation plan
+
+1. **NEW** `src/components/hub/RunwayDataProvider.tsx`  
+   - Exports `BudgetResponse` interface, `ToggleKey` type  
+   - Pre-fetches `/api/hub/year-calendar`, `/api/hub/business-budget`, `/api/hub/nomad-budget` in parallel on year change  
+   - Context holds: `year`, `setYear`, `toggle`, `setToggle`, `data: Record<'personal'|'business'|'travel', BudgetResponse>`, `loading`  
+   - Logs fetch errors (write-with-log requirement)  
+
+2. **EDIT** `src/components/hub/HubBudgetSection.tsx`  
+   - Remove `useEffect` import; remove `BudgetResponse`, `ToggleKey` local definitions  
+   - Import `useRunwayData`, `BudgetResponse`, `ToggleKey` from `./RunwayDataProvider`  
+   - Remove state: `year`, `toggle`, `data`, `loading` — read from `useRunwayData()`  
+   - Add: `const data = toggle !== 'trading' ? routeMap[toggle] : EMPTY_BUDGET;`  
+   - Keep: `monthIdx`, `drillDown` state; all rendering code unchanged  
+
+3. **EDIT** `src/components/home/ModuleLauncher.tsx`  
+   - Import `RunwayDataProvider`  
+   - Wrap `<HubBudgetSection />` + `<BudgetComparison />` in `<RunwayDataProvider>`
+
+---
+
+## Correctness checklist (pre-merge)
+
+- [ ] Rendered table pixel-identical (zero rendering code touched)
+- [ ] Network panel: 0 fetch calls initiated by HubBudgetSection
+- [ ] Year stepper in HubBudgetSection updates provider `year` → BudgetComparison re-renders (verify in next task)
+- [ ] Toggle switches are instant (data pre-fetched for all 3 routes)
+- [ ] Trading tab still shows "route pending" message (no regression)
+- [ ] Drill-down still opens BudgetDrillDown on actual cell click

--- a/src/components/home/ModuleLauncher.tsx
+++ b/src/components/home/ModuleLauncher.tsx
@@ -12,6 +12,7 @@ import TripBudgetActual from '@/components/trips/TripBudgetActual';
 import HubCalendar from '@/components/hub/HubCalendar';
 import HubBudgetSection from '@/components/hub/HubBudgetSection';
 import BudgetComparison from '@/components/hub/BudgetComparison';
+import { RunwayDataProvider } from '@/components/hub/RunwayDataProvider';
 import { demoCalendar } from '@/components/hub/showroom/demoCalendar';
 import PublicFlightSearch from '@/components/trips/PublicFlightSearch';
 import PublicHotelSearch from '@/components/trips/PublicHotelSearch';
@@ -443,13 +444,18 @@ export default function ModuleLauncher({ onRequireAuth, onTabChange }: Props) {
         <section className={`w-full bg-white border-b border-border ${activeModule === 'calendar' ? 'block' : 'hidden'}`}>
           <div className="max-w-7xl mx-auto">
             <HubCalendar />
-            {/* PR-HB-1: month-scoped budget section under the calendar (authed only, so the
-                logged-out demo below never renders it → no personal data, no fake numbers). */}
-            <HubBudgetSection />
-            {/* PR-Runway-Comparison: the Travel-vs-Personal comparison (Home/Travel Months,
-                Travel Savings, Effective Total), surfaced from /hub. Authed-only, same gate;
-                reads the HB-5-corrected year-calendar so Personal is de-inflated. */}
-            <BudgetComparison />
+            {/* RunwayDataProvider: shared year + toggle state and pre-fetched budget data for
+                HubBudgetSection (wired) and BudgetComparison (wired in the next task). Eliminates
+                duplicate fetches (Diagnosis §5 FM3) and year desync (FM2 / Root Cause A). */}
+            <RunwayDataProvider>
+              {/* PR-HB-1: month-scoped budget section under the calendar (authed only, so the
+                  logged-out demo below never renders it → no personal data, no fake numbers). */}
+              <HubBudgetSection />
+              {/* PR-Runway-Comparison: the Travel-vs-Personal comparison (Home/Travel Months,
+                  Travel Savings, Effective Total), surfaced from /hub. Authed-only, same gate;
+                  reads the HB-5-corrected year-calendar so Personal is de-inflated. */}
+              <BudgetComparison />
+            </RunwayDataProvider>
           </div>
         </section>
       )}

--- a/src/components/hub/HubBudgetSection.tsx
+++ b/src/components/hub/HubBudgetSection.tsx
@@ -19,19 +19,10 @@
  * never see it. The existing /hub month-grid is untouched.
  */
 
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import BudgetDrillDown from '@/components/hub/BudgetDrillDown';
 import { formatMoney, moneyColorClass } from '@/lib/money';
-
-// Uniform response shape across the three budget routes (PR-HB-1 audit, all three identical):
-// budgetData/actualData keyed coa → month(0-indexed) → dollars; coaNames keyed coa → label.
-interface BudgetResponse {
-  budgetData: Record<string, Record<number, number>>;
-  actualData: Record<string, Record<number, number>>;
-  coaNames: Record<string, string>;
-}
-
-type ToggleKey = 'personal' | 'business' | 'travel' | 'trading';
+import { useRunwayData, EMPTY_BUDGET, type BudgetResponse, type ToggleKey } from './RunwayDataProvider';
 
 // route = null → no backend yet (Trading): an honest pending state, not fake rows.
 // entityType mirrors the existing /hub openDrill calls (hub/page.tsx:709/:862/:809).
@@ -49,34 +40,16 @@ const usd = (n: number) => `$${n.toLocaleString('en-US', { minimumFractionDigits
 
 export default function HubBudgetSection() {
   const now = new Date();
-  const [toggle, setToggle] = useState<ToggleKey>('personal');
-  const [year, setYear] = useState(now.getFullYear());
+  const { year, setYear, toggle, setToggle, data: routeMap, loading } = useRunwayData();
   const [monthIdx, setMonthIdx] = useState(now.getMonth()); // 0-indexed
-  const [data, setData] = useState<BudgetResponse>({ budgetData: {}, actualData: {}, coaNames: {} });
-  const [loading, setLoading] = useState(false);
   // The clicked ACTUAL cell → drives the reused BudgetDrillDown (same shape as hub/page.tsx).
   const [drillDown, setDrillDown] = useState<{
     coaCodes: string[]; month: number; year: number; categoryName: string; cellAmount: number; entityType: string;
   } | null>(null);
 
   const active = TOGGLES.find(t => t.key === toggle)!;
-
-  // Fetch when the toggle (route) or year changes — NOT month: the routes return all 12 months,
-  // so switching month is pure client-side filtering. Trading (route null) fetches nothing.
-  useEffect(() => {
-    if (!active.route) { setData({ budgetData: {}, actualData: {}, coaNames: {} }); return; }
-    let cancelled = false;
-    setLoading(true);
-    fetch(`${active.route}?year=${year}`)
-      .then(res => (res.ok ? res.json() : { budgetData: {}, actualData: {}, coaNames: {} }))
-      .then(d => {
-        if (cancelled) return;
-        setData({ budgetData: d.budgetData || {}, actualData: d.actualData || {}, coaNames: d.coaNames || {} });
-      })
-      .catch(() => { if (!cancelled) setData({ budgetData: {}, actualData: {}, coaNames: {} }); })
-      .finally(() => { if (!cancelled) setLoading(false); });
-    return () => { cancelled = true; };
-  }, [active.route, year]); // eslint-disable-line react-hooks/exhaustive-deps
+  // Slice the provider's pre-fetched map for the active route; trading has no route → empty.
+  const data: BudgetResponse = toggle !== 'trading' ? routeMap[toggle] : EMPTY_BUDGET;
 
   // Rows for the selected month — one per COA the route returned (never invented).
   const allRows = Object.entries(data.coaNames).map(([code, name]) => {

--- a/src/components/hub/RunwayDataProvider.tsx
+++ b/src/components/hub/RunwayDataProvider.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+/**
+ * RunwayDataProvider — shared data layer for the Runway tab's budget components.
+ *
+ * Pre-fetches all three budget routes in parallel whenever `year` changes so
+ * HubBudgetSection and BudgetComparison (wired in the next task) read from a
+ * single source of truth — eliminating the 3× duplicate fetches (Diagnosis §5
+ * FM3) and the independent-year desync (Diagnosis §5 FM2).
+ *
+ * Holds: year / toggle (the HubBudgetSection activeTab) as shared state so
+ * changing year in HubBudgetSection updates the context and BudgetComparison
+ * re-renders to the same year (Diagnosis Root Cause A).
+ */
+
+import { createContext, useContext, useEffect, useState, type Dispatch, type SetStateAction, type ReactNode } from 'react';
+
+export interface BudgetResponse {
+  budgetData: Record<string, Record<number, number>>;
+  actualData: Record<string, Record<number, number>>;
+  coaNames: Record<string, string>;
+}
+
+export const EMPTY_BUDGET: BudgetResponse = { budgetData: {}, actualData: {}, coaNames: {} };
+
+export type ToggleKey = 'personal' | 'business' | 'travel' | 'trading';
+
+type RouteKey = 'personal' | 'business' | 'travel';
+
+interface RunwayContextValue {
+  year: number;
+  setYear: Dispatch<SetStateAction<number>>;
+  toggle: ToggleKey;
+  setToggle: Dispatch<SetStateAction<ToggleKey>>;
+  /** Pre-fetched data for all three routed budget tabs (trading has no route). */
+  data: Record<RouteKey, BudgetResponse>;
+  loading: boolean;
+}
+
+const RunwayContext = createContext<RunwayContextValue | null>(null);
+
+const ROUTE_MAP: Record<RouteKey, string> = {
+  personal: '/api/hub/year-calendar',
+  business: '/api/hub/business-budget',
+  travel:   '/api/hub/nomad-budget',
+};
+
+export function RunwayDataProvider({ children }: { children: ReactNode }) {
+  const now = new Date();
+  const [year, setYear] = useState(now.getFullYear());
+  const [toggle, setToggle] = useState<ToggleKey>('personal');
+  const [data, setData] = useState<Record<RouteKey, BudgetResponse>>({
+    personal: EMPTY_BUDGET,
+    business: EMPTY_BUDGET,
+    travel:   EMPTY_BUDGET,
+  });
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    Promise.all(
+      (Object.entries(ROUTE_MAP) as [RouteKey, string][]).map(([key, route]) =>
+        fetch(`${route}?year=${year}`)
+          .then(res => (res.ok ? res.json() : EMPTY_BUDGET))
+          .then(d => [key, {
+            budgetData: d.budgetData || {},
+            actualData: d.actualData || {},
+            coaNames:   d.coaNames   || {},
+          }] as [RouteKey, BudgetResponse])
+          .catch(err => {
+            console.error(`[RunwayDataProvider] Failed to fetch ${route} (year=${year}):`, err);
+            return [key, EMPTY_BUDGET] as [RouteKey, BudgetResponse];
+          })
+      )
+    ).then(results => {
+      if (cancelled) return;
+      setData(Object.fromEntries(results) as Record<RouteKey, BudgetResponse>);
+      setLoading(false);
+    });
+    return () => { cancelled = true; };
+  }, [year]);
+
+  return (
+    <RunwayContext.Provider value={{ year, setYear, toggle, setToggle, data, loading }}>
+      {children}
+    </RunwayContext.Provider>
+  );
+}
+
+export function useRunwayData(): RunwayContextValue {
+  const ctx = useContext(RunwayContext);
+  if (!ctx) throw new Error('useRunwayData must be used inside <RunwayDataProvider>');
+  return ctx;
+}


### PR DESCRIPTION
## What & Why

Diagnosis Root Cause A: `HubBudgetSection` and `BudgetComparison` independently self-fetched the same three budget routes (`/api/hub/year-calendar`, `/api/hub/business-budget`, `/api/hub/nomad-budget`), producing:
- **FM3 — 3× duplicate fetches**: both components hit the same routes per year change
- **FM2 — year state desync**: each component owned its own `year` state; changing year in one was invisible to the other

This PR is the fix for `HubBudgetSection` (BudgetComparison is wired in the next task).

## Changes

| File | Change |
|------|--------|
| `src/components/hub/RunwayDataProvider.tsx` | **NEW** — React context that pre-fetches all 3 routes in parallel on year change; holds shared `year`, `setYear`, `toggle`, `setToggle`, `data`, `loading` |
| `src/components/hub/HubBudgetSection.tsx` | Removes local `year`/`toggle`/`data`/`loading` state + `useEffect` fetch block; calls `useRunwayData()` instead. `monthIdx` and `drillDown` stay local. **Zero rendering code changed.** |
| `src/components/home/ModuleLauncher.tsx` | Wraps `<HubBudgetSection />` + `<BudgetComparison />` in `<RunwayDataProvider>` so year changes propagate to both siblings |
| `audit-reports/HUB-RUNWAY-PROVIDER-AUDIT.md` | SOC 2 paper trail — file:line audit before implementation |

## Correctness test (from task)

- [ ] Rendered table pixel-identical to pre-refactor (zero rendering code touched)
- [ ] Network panel: 0 fetch calls initiated by `HubBudgetSection` (all fetches move to the provider)
- [ ] Year stepper in `HubBudgetSection` updates provider `year` state → verify `BudgetComparison` re-renders to the same year (confirmed in the next task)
- [ ] Toggle switches are instant (all 3 routes pre-fetched at mount)
- [ ] Trading tab still shows "route pending (HB-2)" message — no regression

## Risk

**RISK TIER: write-with-log** — data-fetching layer only. No rendering changes, no schema changes, no DB writes, no new API routes, no auth flow changes. Fetch errors logged to console via `[RunwayDataProvider]` prefix.

Correlation: `19a48b08-5d98-4cc7-9734-1327f77b3ed6`
Project: `9e785d54-ed77-4924-aad6-7de44bbdd4c8`

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cqd4Y1ofXR3QKbzBSyYDej)_