### PR TITLE
feat(one-budget-toggle): add Month/Year toggle to the budget panel — …

### DIFF
--- a/src/components/home/ModuleLauncher.tsx
+++ b/src/components/home/ModuleLauncher.tsx
@@ -10,9 +10,8 @@ import AllTripsList, { type TripRow } from '@/components/trips/AllTripsList';
 import TripFormModal from '@/components/trips/TripFormModal';
 import TripBudgetActual from '@/components/trips/TripBudgetActual';
 import HubCalendar from '@/components/hub/HubCalendar';
-import HubBudgetSection from '@/components/hub/HubBudgetSection';
-import BudgetComparison from '@/components/hub/BudgetComparison';
 import RunwayDataProvider from '@/components/hub/RunwayDataProvider';
+import RunwayBudgetPanel from '@/components/hub/RunwayBudgetPanel';
 import { demoCalendar } from '@/components/hub/showroom/demoCalendar';
 import PublicFlightSearch from '@/components/trips/PublicFlightSearch';
 import PublicHotelSearch from '@/components/trips/PublicHotelSearch';
@@ -447,23 +446,10 @@ export default function ModuleLauncher({ onRequireAuth, onTabChange }: Props) {
             {/* PR-HB-1: month-scoped budget section under the calendar (authed only, so the
                 logged-out demo below never renders it → no personal data, no fake numbers). */}
             <RunwayDataProvider>
-              {/* CONSOLIDATE-1: visually group the two budget panels under one shared
-                  header so they read as ONE "Runway Budget" section — the month-scoped
-                  budget-vs-actual view above, the full-year comparison below. Presentation
-                  only: neither component's logic / data / fetches / math is touched. */}
-              <div className="border-t border-border bg-white rounded-lg overflow-hidden">
-                <div className="px-4 py-3 lg:px-8 border-b border-border">
-                  <h2 className="text-base font-bold text-text-primary tracking-tight">Runway Budget</h2>
-                  <p className="text-xs text-text-muted mt-0.5">
-                    Month-by-month budget vs actual, and the full-year travel-vs-home comparison.
-                  </p>
-                </div>
-                <HubBudgetSection />
-                {/* PR-Runway-Comparison: the Travel-vs-Personal comparison (Home/Travel Months,
-                    Travel Savings, Effective Total), surfaced from /hub. Authed-only, same gate;
-                    reads the HB-5-corrected year-calendar so Personal is de-inflated. */}
-                <BudgetComparison />
-              </div>
+              {/* ONE-BUDGET-TOGGLE: one panel with a Month/Year toggle — shows
+                  HubBudgetSection (month) OR BudgetComparison (year) one at a time
+                  (RunwayBudgetPanel owns the toggle; neither component is modified). */}
+              <RunwayBudgetPanel />
             </RunwayDataProvider>
           </div>
         </section>

--- a/src/components/hub/RunwayBudgetPanel.tsx
+++ b/src/components/hub/RunwayBudgetPanel.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+/**
+ * RunwayBudgetPanel (ONE-BUDGET-TOGGLE) — one budget panel with a Month/Year toggle.
+ *
+ * Shows ONE of the two budget views at a time instead of stacking both:
+ *   • Month → <HubBudgetSection/>   (the month-scoped Budget-vs-Actual table)
+ *   • Year  → <BudgetComparison/>   (the full-year travel-vs-home comparison grid)
+ *
+ * Presentation + selection only — neither child component is modified; their data,
+ * fetches, math, toggle, and drill-down stay byte-identical. This wrapper just holds
+ * the view toggle and conditionally renders one. Rendered inside RunwayDataProvider
+ * by ModuleLauncher, so the children remain in the provider's context scope.
+ */
+
+import { useState } from 'react';
+import HubBudgetSection from './HubBudgetSection';
+import BudgetComparison from './BudgetComparison';
+
+export default function RunwayBudgetPanel() {
+  const [view, setView] = useState<'month' | 'year'>('month');
+
+  return (
+    <div className="border-t border-border bg-white rounded-lg overflow-hidden">
+      <div className="px-4 py-3 lg:px-8 border-b border-border">
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+          <div>
+            <h2 className="text-base font-bold text-text-primary tracking-tight">Runway Budget</h2>
+            <p className="text-xs text-text-muted mt-0.5">
+              {view === 'month'
+                ? 'Month-by-month budget vs actual.'
+                : 'Full-year travel-vs-home comparison.'}
+            </p>
+          </div>
+          {/* Month / Year toggle — mirrors HubBudgetSection's Personal/Business/Travel
+              toggle styling (same tokens, no new hex). */}
+          <div className="flex gap-1.5">
+            {([['month', 'Month'], ['year', 'Year']] as const).map(([key, label]) => (
+              <button
+                key={key}
+                type="button"
+                onClick={() => setView(key)}
+                className={`text-xs px-3 py-1 rounded border transition-colors font-medium ${
+                  view === key
+                    ? 'bg-brand-purple text-white border-brand-purple'
+                    : 'text-text-secondary border-border hover:bg-bg-row'
+                }`}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+      {view === 'month' ? <HubBudgetSection /> : <BudgetComparison />}
+    </div>
+  );
+}


### PR DESCRIPTION
…shows HubBudgetSection (month) or BudgetComparison (year) one at a time instead of stacking both; no logic change to either component