### PR TITLE
fix: guard fireExecutionRoutine against malformed/empty payload

### DIFF
--- a/src/lib/fireExecutionRoutine.ts
+++ b/src/lib/fireExecutionRoutine.ts
@@ -47,17 +47,14 @@ export interface FireExecutionRoutineResult {
 export async function fireExecutionRoutine(input: FireExecutionRoutineInput): Promise<FireExecutionRoutineResult> {
   const { taskId, projectId, userId, userEmail } = input;
 
-  // 1 · COST GATE FIRST — over the daily exec cap → ExecBudgetError, no fire.
-  await requireExecBudget(userId);
-
-  // 2 · Config — fail loud if the Routine endpoint/token aren't set (server-only env).
+  // 1 · Config — fail loud if the Routine endpoint/token aren't set (server-only env).
   const fireUrl = process.env.EXEC_ROUTINE_FIRE_URL;
   const token = process.env.EXEC_ROUTINE_TOKEN;
   if (!fireUrl || !token) {
     throw new Error('EXEC_ROUTINE_FIRE_URL / EXEC_ROUTINE_TOKEN not set — cannot fire the execution Routine');
   }
 
-  // 3 · Load the task ownership-scoped (defensive — never another user's task).
+  // 2 · Load the task ownership-scoped (defensive — never another user's task).
   const task = await prisma.operations_project_tasks.findFirst({
     where: { id: taskId, project_id: projectId, user_id: userId },
   });
@@ -65,7 +62,32 @@ export async function fireExecutionRoutine(input: FireExecutionRoutineInput): Pr
     throw new Error(`task ${taskId} not found for project ${projectId} / user ${userId} — cannot fire execution Routine`);
   }
 
-  // 4 · Build the exec payload from the task's what / how / why-and-test. A
+  // 3 · PAYLOAD-INTEGRITY GUARD — refuse to fire a malformed/empty payload.
+  //       A blank task (no title, or no actionable instruction in description/notes)
+  //       produces a template-looking fire the exec-ingest callback can never match,
+  //       burning a Routine run. This runs BEFORE the budget gate so a malformed task
+  //       never consumes a daily exec slot. Fail loud rather than POST garbage (per the
+  //       file's no-silent-fallback contract). The error carries the task id but
+  //       NEVER the token or any header.
+  const hasTitle = typeof task.title === 'string' && task.title.trim().length > 0;
+  if (!hasTitle) {
+    throw new Error(`cannot fire execution Routine: task ${taskId} has no title — refusing to send a malformed payload`);
+  }
+  const hasInstruction =
+    (typeof task.description === 'string' && task.description.trim().length > 0) ||
+    (typeof task.notes === 'string' && task.notes.trim().length > 0);
+  if (!hasInstruction) {
+    throw new Error(`cannot fire execution Routine: task ${taskId} has no description/notes (no actionable instruction) — refusing to send a malformed payload`);
+  }
+  if (!projectId.trim()) {
+    throw new Error(`cannot fire execution Routine: task ${taskId} has a blank project_id — the exec-ingest callback could never be matched`);
+  }
+
+  // 4 · COST GATE — over the daily exec cap → ExecBudgetError, no fire. Runs after the
+  //     integrity guard so a malformed task is rejected without reserving a paid slot.
+  await requireExecBudget(userId);
+
+  // 5 · Build the exec payload from the task's what / how / why-and-test. A
   //     correlation trailer carries the task + run id so the exec-ingest callback
   //     can match the returned PR to this fire.
   const correlationId = randomUUID();
@@ -76,7 +98,7 @@ export async function fireExecutionRoutine(input: FireExecutionRoutineInput): Pr
     `---\nWhen reporting the result back, include this exact correlation block so it can be matched:\n` +
     `correlation_id: ${correlationId}\nproject_id: ${projectId}`;
 
-  // 5 · POST to the Routines /fire endpoint (the verified shape).
+  // 6 · POST to the Routines /fire endpoint (the verified shape).
   const res = await fetch(fireUrl, {
     method: 'POST',
     headers: {
@@ -88,13 +110,13 @@ export async function fireExecutionRoutine(input: FireExecutionRoutineInput): Pr
     body: JSON.stringify({ text }),
   });
 
-  // 6 · FAIL LOUD on non-2xx — surface status + body, NEVER the token/headers.
+  // 7 · FAIL LOUD on non-2xx — surface status + body, NEVER the token/headers.
   if (!res.ok) {
     const body = await res.text().catch(() => '<unreadable body>');
     throw new Error(`execution Routine fire failed (${res.status}): ${body.slice(0, 500)}`);
   }
 
-  // 7 · Parse the session pointer — fail loud if the expected fields are absent.
+  // 8 · Parse the session pointer — fail loud if the expected fields are absent.
   const json = (await res.json().catch(() => null)) as
     | { type?: string; claude_code_session_id?: string; claude_code_session_url?: string }
     | null;


### PR DESCRIPTION
## Summary

Adds a pre-fire payload-integrity guard to `fireExecutionRoutine` so a blank or malformed task can never be POSTed to the Execute-Task Routine. The guard refuses to fire when:

- `task.title` is empty/whitespace,
- both `task.description` and `task.notes` are empty/whitespace (no actionable instruction), or
- `project_id` is blank (the value the exec-ingest callback matches on).

On any of these it throws a clear, token-free Error consistent with the module's existing FAIL-LOUD contract. The success path is unchanged.

The guard also runs **before** the `requireExecBudget()` cost gate, so a structurally-invalid task is rejected without reserving a daily exec slot (no paid call attempted, no quota burned).

## Why this matters

The EXEC-1 Routine was fired with a malformed payload: no real `Task:` data and `project_id` / `correlationId` arriving as unsubstituted placeholders. Because `exec-ingest/route.ts` requires both `project_id` and `correlationId` to match a callback, the returned PR could never be reconciled — the run was silently wasted. Root cause (issue candidate #2): `task.title` / `task.description` / `task.notes` were all null/empty while the correlation/project values were blank, so the assembled `text` looked like the template. Today the builder substitutes `(no description provided)` / `(no notes provided)` and fires anyway.

This converts a silent malformed fire into a loud, diagnosable refusal that never reaches the Routine API. The same class of malformed payload recurred three times in one day (#1066, #1075, #1076), so the guard lives at the single fire site that all of those share.

## Scope note

A code review surfaced a related architectural gap: when an accepted `pending_review` task is malformed, the failure still surfaces after the `pending_review -> open` state transition that the PATCH route commits, and there is no UI retry path once the user fixes the task. That is a cross-file change to the accept/PATCH flow that is out of scope for this single-concept fix (and is one of the recurrences the issue tracks). Flagging it here so it can be addressed in a follow-up if you'd like.

## Testing

This repo has no test runner configured (no jest/vitest, `package.json` has no `test` script), so verification is by manual reasoning against the documented occurrences plus the existing fail-loud invariants:

- Happy path: task with non-empty `title` and at least one of `description`/`notes`, valid `project_id` — guard passes, payload assembled and POSTed exactly as before (no behavior change).
- `title` empty/whitespace — guard throws before the budget gate and before any fetch; no exec slot consumed, no Routine run.
- `title` present but `description` AND `notes` both empty/whitespace — guard throws (the malformed-template case reported).
- Blank `project_id` — guard throws, preventing an exec-ingest callback that could never be matched.
- Token safety: thrown errors include only the task id, never the `Authorization` header, `EXEC_ROUTINE_TOKEN`, or `EXEC_INGEST_SECRET`.

The change is confined to `src/lib/fireExecutionRoutine.ts`.

Fixes #1075
