### PR TITLE
feat(guest): COA + budget fields on routine builder via shared static…

### DIFF
--- a/src/components/home/RoutineCreateForm.tsx
+++ b/src/components/home/RoutineCreateForm.tsx
@@ -17,6 +17,7 @@
 
 import { useState } from 'react';
 import RRULEBuilder from '@/components/workbench/operations/routines/RRULEBuilder';
+import { DEFAULT_COA } from '@/lib/coaDefaults';
 import type { RoutineForm, CadenceMode, CadenceGroup } from '@/components/workbench/operations/routines/types';
 import {
   DEFAULT_ROUTINE_FORM,
@@ -101,6 +102,47 @@ export default function RoutineCreateForm({ onRequireAuth }: Props) {
             <select className={inputClass} value="preview" disabled>
               <option value="preview">Your workspace · set after login</option>
             </select>
+          </div>
+        </div>
+
+        {/* GUEST COA + budget — mirrors the real form's per-occurrence money pair (workbench
+            RoutineCreateForm.tsx:148-172), but the COA list is the STATIC client-safe DEFAULT_COA
+            constant: NO /api/chart-of-accounts fetch, NO CoaSelect, NO real-user COA data. Both
+            optional; write to existing local state (form.budget_amount / form.coa_code, already on
+            RoutineForm). Captured into the in-memory routine on Add via the {...form} spread. */}
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <div className={labelClass}>budget / occurrence (optional)</div>
+            <input
+              type="number"
+              min="0"
+              step="0.01"
+              value={form.budget_amount ?? ''}
+              onChange={(e) => setForm({ ...form, budget_amount: e.target.value })}
+              className={inputClass}
+              placeholder="e.g., 60"
+            />
+          </div>
+          <div>
+            <div className={labelClass}>COA (optional)</div>
+            <select
+              value={form.coa_code ?? ''}
+              onChange={(e) => setForm({ ...form, coa_code: e.target.value })}
+              className={inputClass}
+            >
+              <option value="">— None —</option>
+              {DEFAULT_COA.map((a) => (
+                <option key={a.code} value={a.code}>
+                  {a.code} — {a.name}
+                </option>
+              ))}
+            </select>
+            {/* Truth-in-labeling: these are the shared STARTER categories, not the guest's
+                personalized chart (real COAs are per-user + editable after login) — mirrors the
+                entity field's honest "set after login" placeholder above. */}
+            <div className="text-text-muted text-[10px] font-mono mt-1">
+              starter categories · your own chart after login
+            </div>
           </div>
         </div>
 

--- a/src/lib/coaDefaults.ts
+++ b/src/lib/coaDefaults.ts
@@ -1,0 +1,51 @@
+// Pure-data, client-safe chart-of-accounts defaults — NO prisma, NO server-only deps.
+// Single source of truth for the default chart every new user is seeded with: imported by
+// the server seeder (seedDefaultCOA.ts) AND by client surfaces that need the canonical
+// category list WITHOUT fetching anyone's per-user COA (e.g. the logged-out routine builder
+// shows these starter categories with zero /api/chart-of-accounts call). Rows copied verbatim
+// from the original seedDefaultCOA.ts definition — codes/names/account_types unchanged.
+
+export interface CoaDefault {
+  code: string;
+  name: string;
+  account_type: 'revenue' | 'expense';
+}
+
+export const DEFAULT_COA: CoaDefault[] = [
+  // INCOME
+  { code: '4000', name: 'Wages & Salary', account_type: 'revenue' },
+  { code: '4200', name: 'Other Income', account_type: 'revenue' },
+  { code: '4500', name: 'Side Hustle Income', account_type: 'revenue' },
+  { code: '4600', name: 'Retirement Distribution', account_type: 'revenue' },
+
+  // TAX-SPECIFIC
+  { code: '8950', name: 'Early Withdrawal Penalty', account_type: 'expense' },
+
+  // FIXED EXPENSES
+  { code: '8100', name: 'Rent/Mortgage', account_type: 'expense' },
+  { code: '8110', name: 'Utilities', account_type: 'expense' },
+  { code: '8200', name: 'Phone & Internet', account_type: 'expense' },
+  { code: '8140', name: 'Health Insurance', account_type: 'expense' },
+  { code: '6600', name: 'Auto Insurance', account_type: 'expense' },
+  { code: '8190', name: 'Subscriptions', account_type: 'expense' },
+  { code: '6700', name: 'Student Loan Payment', account_type: 'expense' },
+  { code: '6710', name: 'Credit Card Payment', account_type: 'expense' },
+
+  // VARIABLE EXPENSES
+  { code: '8120', name: 'Groceries', account_type: 'expense' },
+  { code: '6100', name: 'Meals & Dining', account_type: 'expense' },
+  { code: '6400', name: 'Gas & Fuel', account_type: 'expense' },
+  { code: '8130', name: 'Healthcare & Medical', account_type: 'expense' },
+  { code: '8150', name: 'Personal Care', account_type: 'expense' },
+  { code: '8170', name: 'Entertainment', account_type: 'expense' },
+
+  // TRAVEL EXPENSES
+  { code: '7100', name: 'Flights', account_type: 'expense' },
+  { code: '7200', name: 'Lodging', account_type: 'expense' },
+  { code: '7300', name: 'Rental Car', account_type: 'expense' },
+  { code: '7400', name: 'Activities & Tickets', account_type: 'expense' },
+  { code: '7500', name: 'Equipment Rental', account_type: 'expense' },
+  { code: '7600', name: 'Ground Transport', account_type: 'expense' },
+  { code: '7700', name: 'Travel Meals', account_type: 'expense' },
+  { code: '7800', name: 'Tips & Misc', account_type: 'expense' },
+];

--- a/src/lib/seedDefaultCOA.ts
+++ b/src/lib/seedDefaultCOA.ts
@@ -1,43 +1,5 @@
 import { prisma } from './prisma';
-
-const DEFAULT_COA = [
-  // INCOME
-  { code: '4000', name: 'Wages & Salary', account_type: 'revenue' },
-  { code: '4200', name: 'Other Income', account_type: 'revenue' },
-  { code: '4500', name: 'Side Hustle Income', account_type: 'revenue' },
-  { code: '4600', name: 'Retirement Distribution', account_type: 'revenue' },
-
-  // TAX-SPECIFIC
-  { code: '8950', name: 'Early Withdrawal Penalty', account_type: 'expense' },
-
-  // FIXED EXPENSES
-  { code: '8100', name: 'Rent/Mortgage', account_type: 'expense' },
-  { code: '8110', name: 'Utilities', account_type: 'expense' },
-  { code: '8200', name: 'Phone & Internet', account_type: 'expense' },
-  { code: '8140', name: 'Health Insurance', account_type: 'expense' },
-  { code: '6600', name: 'Auto Insurance', account_type: 'expense' },
-  { code: '8190', name: 'Subscriptions', account_type: 'expense' },
-  { code: '6700', name: 'Student Loan Payment', account_type: 'expense' },
-  { code: '6710', name: 'Credit Card Payment', account_type: 'expense' },
-
-  // VARIABLE EXPENSES
-  { code: '8120', name: 'Groceries', account_type: 'expense' },
-  { code: '6100', name: 'Meals & Dining', account_type: 'expense' },
-  { code: '6400', name: 'Gas & Fuel', account_type: 'expense' },
-  { code: '8130', name: 'Healthcare & Medical', account_type: 'expense' },
-  { code: '8150', name: 'Personal Care', account_type: 'expense' },
-  { code: '8170', name: 'Entertainment', account_type: 'expense' },
-
-  // TRAVEL EXPENSES
-  { code: '7100', name: 'Flights', account_type: 'expense' },
-  { code: '7200', name: 'Lodging', account_type: 'expense' },
-  { code: '7300', name: 'Rental Car', account_type: 'expense' },
-  { code: '7400', name: 'Activities & Tickets', account_type: 'expense' },
-  { code: '7500', name: 'Equipment Rental', account_type: 'expense' },
-  { code: '7600', name: 'Ground Transport', account_type: 'expense' },
-  { code: '7700', name: 'Travel Meals', account_type: 'expense' },
-  { code: '7800', name: 'Tips & Misc', account_type: 'expense' },
-];
+import { DEFAULT_COA } from '@/lib/coaDefaults';
 
 export async function seedDefaultCOA(userId: string, entityId: string): Promise<boolean> {
   try {


### PR DESCRIPTION
… DEFAULT_COA (zero fetch, no user data)