### PR TITLE
TAX-1: Tax tab flush migration + closed-books handoff gate (tax begin…

### DIFF
--- a/src/app/dashboard/tax-filing/page.tsx
+++ b/src/app/dashboard/tax-filing/page.tsx
@@ -1,3 +1,4 @@
+import { AppLayout } from '@/components/ui';
 import TaxFilingWizard from '@/components/tax-filing/TaxFilingWizard';
 
 export const metadata = {
@@ -6,6 +7,13 @@ export const metadata = {
 
 // Server-rendered shell. The wizard itself is a client component so it can
 // manage step state and fetch auto-detection data on mount.
+// TAX-1: AppLayout chrome now lives HERE (moved out of TaxFilingWizard so the wizard is
+// bare and reusable on the homepage Tax tab). Render is identical to before — the same
+// <AppLayout> wraps the same wizard content.
 export default function TaxFilingPage() {
-  return <TaxFilingWizard />;
+  return (
+    <AppLayout>
+      <TaxFilingWizard />
+    </AppLayout>
+  );
 }

--- a/src/components/home/ModuleLauncher.tsx
+++ b/src/components/home/ModuleLauncher.tsx
@@ -36,6 +36,9 @@ import BookkeepingCockpitBar from '@/components/bookkeeping/BookkeepingCockpitBa
 // dashboard's canonical order. It owns its own data layer; the 5 BOOKS-1 drop-ins now render
 // inside it at their dashboard positions (no longer standalone here).
 import BooksPipeline from '@/components/home/BooksPipeline';
+// TAX-1: the closed-books handoff gate — shows the tax wizard only once a period is
+// closed, otherwise a "close your books first" screen that jumps to the Books tab.
+import TaxHandoffGate from '@/components/home/TaxHandoffGate';
 import OperationsPipelineShowroom from '@/components/workbench/operations/showroom/OperationsPipelineShowroom';
 // HB-4e-mount: the real routine builder (workbench CRUD) + its self-fetching entity provider, plus
 // the fetch-free logged-out teaser. Mounted verbatim on the homepage Routines tab — no restyle yet.
@@ -520,6 +523,9 @@ export default function ModuleLauncher({ onRequireAuth, onTabChange }: Props) {
   // BOOKS-1: Books gets its own flush block (below). Non-admins render the shared paid
   // stub via renderBody(bookkeepingModule) — the SAME stub Trade/Tax/Compliance use.
   const bookkeepingModule = MODULES.find((m) => m.key === 'bookkeeping')!;
+  // TAX-1: Tax gets its own flush block (below). Non-admins render the shared paid stub
+  // via renderBody(taxModule) — the SAME stub Trade/Books/Compliance use.
+  const taxModule = MODULES.find((m) => m.key === 'tax')!;
 
   return (
     <>
@@ -859,6 +865,23 @@ export default function ModuleLauncher({ onRequireAuth, onTabChange }: Props) {
           </div>
         </div>
       </section>
+      {/* TAX-1: Tax renders in its own FLUSH block (mirrors Books/Trade). Active-module check
+          uses the TAB key 'tax' (TABS :103; MODULE_TO_TAB tax→'tax' :115 — module key and tab
+          key both 'tax'; selectTab sets activeModule to the tab key). Gated exactly like
+          Books/Trade: isAdmin sees the closed-books handoff gate (wizard once a period is
+          closed, else a "close your books first" screen that jumps to the Books tab);
+          everyone else falls through to renderBody(taxModule) → the shared paid stub. */}
+      <section className={`w-full bg-white border-b border-border ${activeModule === 'tax' ? 'block' : 'hidden'}`}>
+        <div className="max-w-7xl mx-auto">
+          <div className="px-4 py-4 space-y-6">
+            {isAdmin ? (
+              <TaxHandoffGate onGoToBooks={() => selectTab('books')} />
+            ) : (
+              renderBody(taxModule)
+            )}
+          </div>
+        </div>
+      </section>
       {MODULES.map((m, i) => {
         // PR-TG1: Travel now renders in its own flush, edge-to-edge block above (out of
         // this map, no purple band). Skip it here so it never double-renders. Returning
@@ -871,7 +894,10 @@ export default function ModuleLauncher({ onRequireAuth, onTabChange }: Props) {
         // BOOKS-1: 'bookkeeping' now renders in its own flush block above → skip here (module
         // key 'bookkeeping', not tab key 'books'). Index `i` stays stable, so the
         // bg-bg-row/bg-white parity of tax(i=5)/compliance(i=6)/content(i=7) is unchanged.
-        if (m.key === 'travel' || m.key === 'routines' || m.key === 'projects' || m.key === 'content' || m.key === 'trading' || m.key === 'bookkeeping') return null;
+        // TAX-1: 'tax' now renders in its own flush block above → skip here. Index `i` stays
+        // stable, so the only remaining band-rendered module (compliance, i=6 → bg-white) is
+        // unchanged.
+        if (m.key === 'travel' || m.key === 'routines' || m.key === 'projects' || m.key === 'content' || m.key === 'trading' || m.key === 'bookkeeping' || m.key === 'tax') return null;
         return (
         <section key={m.key} className={`w-full py-10 ${i % 2 === 1 ? 'bg-bg-row' : 'bg-white'} border-b border-border ${activeModule === (MODULE_TO_TAB[m.key] ?? m.key) ? 'block' : 'hidden'}`}>
           <div className="max-w-7xl mx-auto px-4 lg:px-8 space-y-6">

--- a/src/components/home/TaxHandoffGate.tsx
+++ b/src/components/home/TaxHandoffGate.tsx
@@ -1,0 +1,124 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { BookOpen, Lock } from 'lucide-react';
+import TaxFilingWizard from '@/components/tax-filing/TaxFilingWizard';
+
+/**
+ * TAX-1 — the closed-books handoff gate for the homepage Tax tab.
+ *
+ * "Tax begins at completed books": the wizard only opens once the user has actually
+ * CLOSED at least one accounting period (closing_periods.status === 'closed'). This
+ * mirrors the constitution — tax figures derive from the ledger, so they are only
+ * trustworthy once a period is closed.
+ *
+ * Handoff rule (documented, intentionally simple for TAX-1): if ANY closed period
+ * exists for the user's default entity, the handoff is satisfied and the wizard renders.
+ * Refining this to per-tax-year granularity (filing year N needs year-N closes) is a
+ * later PR.
+ *
+ * TRUTH-FIRST — three explicit states, no guessing:
+ *   loading → neutral placeholder
+ *   error   → explicit error + Retry (a FAILED closing-periods/entities fetch is neither
+ *             open nor closed — we never guess a state)
+ *   loaded  → NO closed period → the handoff gate screen (with a jump-to-Books button)
+ *             ≥1 closed period → the bare <TaxFilingWizard />
+ * "No entity / no closed period" is the TRUE not-yet-closed state, not a fallback.
+ *
+ * All fetches hit existing, auth-gated, user-scoped routes (/api/entities,
+ * /api/closing-periods) — no new routes.
+ */
+
+interface Props {
+  /** Switches the homepage to the Books tab (ModuleLauncher selectTab('books')). */
+  onGoToBooks: () => void;
+}
+
+type GateState = 'loading' | 'error' | 'gate' | 'wizard';
+
+export default function TaxHandoffGate({ onGoToBooks }: Props) {
+  const [state, setState] = useState<GateState>('loading');
+  const [periodCount, setPeriodCount] = useState(0);
+
+  const load = useCallback(async () => {
+    setState('loading');
+    try {
+      // Resolve the default entity — same rule BooksPipeline uses (is_default || [0]).
+      const entRes = await fetch('/api/entities');
+      if (!entRes.ok) throw new Error('entities fetch failed');
+      const entData = await entRes.json();
+      const entities = entData.entities || [];
+      const def = entities.find((e: { is_default?: boolean }) => e.is_default) || entities[0];
+      // No entity at all → the user cannot have closed a period → TRUE gate state
+      // (not an error, not a guess).
+      if (!def) {
+        setPeriodCount(0);
+        setState('gate');
+        return;
+      }
+      const cpRes = await fetch(`/api/closing-periods?entityId=${encodeURIComponent(def.id)}`);
+      if (!cpRes.ok) throw new Error('closing-periods fetch failed');
+      const cpData = await cpRes.json();
+      const periods: Array<{ status?: string }> = cpData.periods || [];
+      // Closed contract: status === 'closed'. 'reopened' and absent do NOT count.
+      const closed = periods.filter((p) => p.status === 'closed').length;
+      setPeriodCount(periods.length);
+      setState(closed > 0 ? 'wizard' : 'gate');
+    } catch {
+      setState('error');
+    }
+  }, []);
+
+  useEffect(() => { load(); }, [load]);
+
+  if (state === 'loading') {
+    return (
+      <div className="rounded-xl border-2 border-border bg-white px-4 py-3 text-sm text-text-muted">
+        Checking your books…
+      </div>
+    );
+  }
+
+  if (state === 'error') {
+    return (
+      <div role="alert" className="rounded-xl border-2 border-red-300 bg-red-50 px-4 py-3 text-sm text-red-700 flex items-center justify-between gap-3">
+        <span>Couldn&rsquo;t check whether your books are closed. Nothing is assumed — the tax wizard stays locked until we can confirm.</span>
+        <button
+          type="button"
+          onClick={load}
+          className="shrink-0 rounded-lg border border-red-400 px-3 py-1.5 text-xs font-semibold text-red-700 hover:bg-red-100"
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  if (state === 'gate') {
+    return (
+      <div className="rounded-xl border-2 border-brand-gold/50 bg-brand-gold/5 px-6 py-8 text-center">
+        <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-brand-gold/15 text-brand-gold">
+          <Lock className="h-6 w-6" aria-hidden="true" />
+        </div>
+        <h3 className="text-lg font-semibold text-text-primary">Tax begins at completed books</h3>
+        <p className="mx-auto mt-2 max-w-md text-sm text-text-secondary">
+          Your tax figures come straight from your ledger, so the filing wizard opens once you&rsquo;ve
+          closed at least one accounting period. {periodCount > 0
+            ? `You have ${periodCount} period${periodCount === 1 ? '' : 's'} on record, but none are closed yet.`
+            : 'No periods are closed yet.'}
+        </p>
+        <button
+          type="button"
+          onClick={onGoToBooks}
+          className="mx-auto mt-5 inline-flex items-center gap-2 rounded-lg bg-brand-purple px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-brand-purple/90"
+        >
+          <BookOpen className="h-4 w-4" aria-hidden="true" />
+          Go to Books &amp; close a period
+        </button>
+      </div>
+    );
+  }
+
+  // state === 'wizard' — handoff satisfied (at least one closed period); render the bare wizard.
+  return <TaxFilingWizard />;
+}

--- a/src/components/tax-filing/TaxFilingWizard.tsx
+++ b/src/components/tax-filing/TaxFilingWizard.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useState, useEffect, useCallback } from 'react';
-import { AppLayout } from '@/components/ui';
+// TAX-1: AppLayout chrome moved OUT to the /dashboard/tax-filing page so this wizard is
+// bare and can also mount inside the homepage Tax tab (which supplies its own chrome).
 import LifeEventsStep from './steps/LifeEventsStep';
 import DocumentsStep from './steps/DocumentsStep';
 import IncomeReviewStep from './steps/IncomeReviewStep';
@@ -291,8 +292,7 @@ export default function TaxFilingWizard() {
   const StepComponent = step.Component;
 
   return (
-    <AppLayout>
-      <div className="px-4 py-6 max-w-5xl mx-auto">
+    <div className="px-4 py-6 max-w-5xl mx-auto">
         {/* Header */}
         <div className="mb-6 flex items-start justify-between gap-4">
           <div>
@@ -452,6 +452,5 @@ export default function TaxFilingWizard() {
           </div>
         </div>
       </div>
-    </AppLayout>
   );
 }


### PR DESCRIPTION
…s at completed books)

Migrate Tax into its own homepage flush tab, gated on the books-close handoff.

- Decouple chrome: move <AppLayout> out of TaxFilingWizard and into /dashboard/tax-filing/page.tsx. The standalone page renders identically (same AppLayout wraps the same wizard content); the wizard is now bare and reusable.
- New src/components/home/TaxHandoffGate.tsx: resolves the default entity (/api/entities, is_default||[0]), reads /api/closing-periods for that entity, and gates on the closed contract (status==='closed'; 'reopened'/absent do NOT count). Three explicit states — loading / error+Retry (a failed fetch is never guessed open or closed) / loaded. Loaded: >=1 closed period -> <TaxFilingWizard/>; else a "Tax begins at completed books" screen with a button that jumps to the Books tab (selectTab('books')). Handoff rule (documented): ANY closed period satisfies it; per-tax-year granularity is a later PR. "No entity/no closed period" is the true not-yet-closed state, not a fallback.
- Flush Tax <section> gated activeModule === 'tax', admin-gated like Books/Trade; non-admins fall through to renderBody(taxModule) -> the shared paid stub.
- Add module key 'tax' to the MODULES.map skip-list; index i unchanged so the only remaining band-rendered module (compliance, i=6 -> bg-white) does not flip.

All fetches hit existing auth-gated, user-scoped routes. No new routes; nothing added to PUBLIC_PATHS.