### PR TITLE
COMP-1: migrate Compliance A-J workbench into flush homepage tab + su…

### DIFF
--- a/src/components/home/ComplianceWorkbench.tsx
+++ b/src/components/home/ComplianceWorkbench.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import Link from 'next/link';
+import { SectionA_IdentityBar } from '@/components/workbench/SectionA_IdentityBar';
+import { SectionB_FounderProfile } from '@/components/workbench/SectionB_FounderProfile';
+import { SectionC_CorpusContext } from '@/components/workbench/SectionC_CorpusContext';
+import { SectionD_DiscoveryLauncher } from '@/components/workbench/SectionD_DiscoveryLauncher';
+import { SectionE_LiveStream } from '@/components/workbench/SectionE_LiveStream';
+import { SectionF_Roadmap } from '@/components/workbench/SectionF_Roadmap';
+import { SectionG_CitationVerification } from '@/components/workbench/SectionG_CitationVerification';
+import { SectionH_CorpusInspector } from '@/components/workbench/SectionH_CorpusInspector';
+import { SectionI_AuditTail } from '@/components/workbench/SectionI_AuditTail';
+import { SectionJ_CostLedger } from '@/components/workbench/SectionJ_CostLedger';
+
+/**
+ * COMP-1 — the Compliance A–J institutional workbench for the homepage Compliance tab.
+ *
+ * Renders the standalone /compliance page's exact section order (SectionA_IdentityBar →
+ * Sections B…J), MINUS its AppLayout chrome (the homepage tab supplies the shell). Each
+ * section is a zero-prop, self-fetching component that manages its own loading/error —
+ * this component adds no fetch logic and no fallback state of its own.
+ *
+ * The standalone page's OpsSubNav is deliberately NOT mounted here: it carries
+ * standalone-app assumptions (usePathname-based active state that is inert on '/',
+ * font-mono terminal styling, and disabled cross-nav placeholders that duplicate the
+ * homepage tabs). Instead we render a homepage-styled link row to the six sub-pages,
+ * which keep their own routes + AppLayout chrome (unchanged).
+ */
+
+const SUBPAGES: { name: string; href: string }[] = [
+  { name: 'Profile', href: '/compliance/profile' },
+  { name: 'Discovery', href: '/compliance/discovery' },
+  { name: 'Registry', href: '/compliance/registry' },
+  { name: 'Citations', href: '/compliance/citations' },
+  { name: 'Audit Log', href: '/compliance/audit-log' },
+  { name: 'Missions', href: '/compliance/missions' },
+];
+
+export default function ComplianceWorkbench() {
+  return (
+    <div className="space-y-4">
+      <SectionA_IdentityBar />
+
+      {/* Sub-page link row — replaces OpsSubNav's role, homepage-styled. Each link opens
+          the existing sub-page route (which keeps its own AppLayout chrome). */}
+      <nav aria-label="Compliance sub-pages" className="flex flex-wrap gap-2">
+        {SUBPAGES.map((p) => (
+          <Link
+            key={p.href}
+            href={p.href}
+            className="rounded-lg border border-brand-purple/20 bg-brand-purple/5 px-3 py-1.5 text-sm font-medium text-brand-purple transition-colors hover:bg-brand-purple/10"
+          >
+            {p.name}
+          </Link>
+        ))}
+      </nav>
+
+      {/* Sections B…J in the standalone page's order (compliance/page.tsx:39-47). */}
+      <SectionB_FounderProfile />
+      <SectionC_CorpusContext />
+      <SectionD_DiscoveryLauncher />
+      <SectionE_LiveStream />
+      <SectionF_Roadmap />
+      <SectionG_CitationVerification />
+      <SectionH_CorpusInspector />
+      <SectionI_AuditTail />
+      <SectionJ_CostLedger />
+    </div>
+  );
+}

--- a/src/components/home/ModuleLauncher.tsx
+++ b/src/components/home/ModuleLauncher.tsx
@@ -39,6 +39,9 @@ import BooksPipeline from '@/components/home/BooksPipeline';
 // TAX-1: the closed-books handoff gate — shows the tax wizard only once a period is
 // closed, otherwise a "close your books first" screen that jumps to the Books tab.
 import TaxHandoffGate from '@/components/home/TaxHandoffGate';
+// COMP-1: the Compliance A–J institutional workbench (Section A → sub-page link row →
+// Sections B…J), bare (no AppLayout — the homepage tab supplies the shell).
+import ComplianceWorkbench from '@/components/home/ComplianceWorkbench';
 import OperationsPipelineShowroom from '@/components/workbench/operations/showroom/OperationsPipelineShowroom';
 // HB-4e-mount: the real routine builder (workbench CRUD) + its self-fetching entity provider, plus
 // the fetch-free logged-out teaser. Mounted verbatim on the homepage Routines tab — no restyle yet.
@@ -526,6 +529,9 @@ export default function ModuleLauncher({ onRequireAuth, onTabChange }: Props) {
   // TAX-1: Tax gets its own flush block (below). Non-admins render the shared paid stub
   // via renderBody(taxModule) — the SAME stub Trade/Books/Compliance use.
   const taxModule = MODULES.find((m) => m.key === 'tax')!;
+  // COMP-1: Compliance gets its own flush block (below). Non-admins render the shared
+  // paid stub via renderBody(complianceModule) — the SAME stub Trade/Books/Tax use.
+  const complianceModule = MODULES.find((m) => m.key === 'compliance')!;
 
   return (
     <>
@@ -882,6 +888,23 @@ export default function ModuleLauncher({ onRequireAuth, onTabChange }: Props) {
           </div>
         </div>
       </section>
+      {/* COMP-1: Compliance renders in its own FLUSH block (mirrors Books/Tax). Active-module
+          check uses the TAB key 'compliance' (TABS :107; MODULE_TO_TAB compliance→'compliance'
+          :119 — module key and tab key both 'compliance'; selectTab sets activeModule to the tab
+          key). Gated exactly like Tax: isAdmin sees the A–J workbench (Section A → sub-page link
+          row → Sections B…J, bare — no AppLayout chrome inside the tab); everyone else falls
+          through to renderBody(complianceModule) → the shared paid stub. */}
+      <section className={`w-full bg-white border-b border-border ${activeModule === 'compliance' ? 'block' : 'hidden'}`}>
+        <div className="max-w-7xl mx-auto">
+          <div className="px-4 py-4 space-y-6">
+            {isAdmin ? (
+              <ComplianceWorkbench />
+            ) : (
+              renderBody(complianceModule)
+            )}
+          </div>
+        </div>
+      </section>
       {MODULES.map((m, i) => {
         // PR-TG1: Travel now renders in its own flush, edge-to-edge block above (out of
         // this map, no purple band). Skip it here so it never double-renders. Returning
@@ -897,7 +920,11 @@ export default function ModuleLauncher({ onRequireAuth, onTabChange }: Props) {
         // TAX-1: 'tax' now renders in its own flush block above → skip here. Index `i` stays
         // stable, so the only remaining band-rendered module (compliance, i=6 → bg-white) is
         // unchanged.
-        if (m.key === 'travel' || m.key === 'routines' || m.key === 'projects' || m.key === 'content' || m.key === 'trading' || m.key === 'bookkeeping' || m.key === 'tax') return null;
+        // COMP-1: 'compliance' now renders in its own flush block above → skip here. With this,
+        // every module renders in its own flush block and the band map below renders NOTHING
+        // (no module remains → nothing to flip). The map code is left in place intentionally;
+        // removing it is a separate cleanup PR.
+        if (m.key === 'travel' || m.key === 'routines' || m.key === 'projects' || m.key === 'content' || m.key === 'trading' || m.key === 'bookkeeping' || m.key === 'tax' || m.key === 'compliance') return null;
         return (
         <section key={m.key} className={`w-full py-10 ${i % 2 === 1 ? 'bg-bg-row' : 'bg-white'} border-b border-border ${activeModule === (MODULE_TO_TAB[m.key] ?? m.key) ? 'block' : 'hidden'}`}>
           <div className="max-w-7xl mx-auto px-4 lg:px-8 space-y-6">


### PR DESCRIPTION
…b-page links

Add src/components/home/ComplianceWorkbench.tsx — the institutional A–J workbench (SectionA_IdentityBar → sub-page link row → Sections B…J) in the standalone page's exact order, MINUS AppLayout (the homepage tab supplies the shell). Sections are zero-prop, self-fetching, no context — mounted bare.

- OpsSubNav is NOT mounted: it carries standalone-app assumptions (usePathname active state inert on '/', font-mono terminal styling, disabled cross-nav placeholders that duplicate homepage tabs). Replaced with a homepage-styled link row to the six sub-pages (Profile, Discovery, Registry, Citations, Audit Log, Missions), which keep their own routes + AppLayout chrome (unchanged).
- Flush Compliance <section> gated activeModule === 'compliance', admin-gated like Books/Tax; non-admins fall through to renderBody(complianceModule) → shared paid stub; guests/non-admins fire zero compliance fetches (workbench only mounts under isAdmin).
- Add module key 'compliance' to the MODULES.map skip-list. Every module now renders in its own flush block, so the band map renders nothing (no module to flip parity). Map code left in place — removing it is a separate cleanup PR.

Standalone /compliance page untouched. No new routes; nothing added to PUBLIC_PATHS.