### PR TITLE
TRADE-2: restyle the dark TerminalTradeCard to the light app aesthetic

### DIFF
--- a/src/components/convergence/ConvergenceIntelligence.tsx
+++ b/src/components/convergence/ConvergenceIntelligence.tsx
@@ -385,7 +385,7 @@ function termBar(score: number, width = 10): string {
 }
 
 function termGateColor(score: number): string {
-  return score >= 50 ? 'text-green-400' : 'text-red-400';
+  return score >= 50 ? 'text-brand-green' : 'text-brand-red';
 }
 
 function termTruncate(s: string, max: number): string {
@@ -407,7 +407,7 @@ export function TerminalTradeCard({ detail, sentiment, savedCards, savingCards, 
   const ks = cards[0]?.key_stats;
   const why = cards[0]?.why;
 
-  const divider = <div className="border-t border-gray-700 my-1" />;
+  const divider = <div className="border-t border-border my-1" />;
 
   // ── Shared sections (rendered for both trade and no-trade cases) ──
 
@@ -448,22 +448,22 @@ export function TerminalTradeCard({ detail, sentiment, savedCards, savingCards, 
 
     return (
       <div>
-        <div className="text-[10px] text-gray-400 uppercase tracking-wider font-bold mb-1">For vs Against</div>
+        <div className="text-[10px] text-text-muted uppercase tracking-wider font-bold mb-1">For vs Against</div>
         <div className="grid grid-cols-2 gap-2">
           <div>
-            <div className="text-[10px] text-green-400 font-bold mb-0.5">FOR THE TRADE</div>
+            <div className="text-[10px] text-brand-green font-bold mb-0.5">FOR THE TRADE</div>
             {forItems.length > 0 ? forItems.map((s, i) => (
-              <div key={i} className="text-xs text-green-400 leading-relaxed">&#10003; {s}</div>
+              <div key={i} className="text-xs text-brand-green leading-relaxed">&#10003; {s}</div>
             )) : (
-              <div className="text-xs text-gray-500">No bullish signals found</div>
+              <div className="text-xs text-text-faint">No bullish signals found</div>
             )}
           </div>
           <div>
-            <div className="text-[10px] text-red-400 font-bold mb-0.5">AGAINST THE TRADE</div>
+            <div className="text-[10px] text-brand-red font-bold mb-0.5">AGAINST THE TRADE</div>
             {againstItems.length > 0 ? againstItems.map((s, i) => (
-              <div key={i} className="text-xs text-red-400 leading-relaxed">&#10007; {s}</div>
+              <div key={i} className="text-xs text-brand-red leading-relaxed">&#10007; {s}</div>
             )) : (
-              <div className="text-xs text-green-400">No risk flags</div>
+              <div className="text-xs text-brand-green">No risk flags</div>
             )}
           </div>
         </div>
@@ -480,11 +480,11 @@ export function TerminalTradeCard({ detail, sentiment, savedCards, savingCards, 
     ];
     return (
       <div>
-        <div className="text-[10px] text-gray-400 uppercase tracking-wider font-bold mb-1">Gate Scores</div>
+        <div className="text-[10px] text-text-muted uppercase tracking-wider font-bold mb-1">Gate Scores</div>
         <div className="grid grid-cols-2 gap-x-4 gap-y-0.5">
           {gates.map(([label, score]) => (
             <div key={label} className="flex items-center gap-1">
-              <span className="w-16 text-xs text-gray-400 shrink-0">{label}</span>
+              <span className="w-16 text-xs text-text-muted shrink-0">{label}</span>
               <span className={`text-xs font-bold w-8 text-right ${termGateColor(score)}`}>{score.toFixed(1)}</span>
               <span className={`text-xs font-mono ${termGateColor(score)}`}>{termBar(score)}</span>
             </div>
@@ -507,28 +507,28 @@ export function TerminalTradeCard({ detail, sentiment, savedCards, savingCards, 
     const vrpZ = bd.mispricing?.z_scores?.vrp_z;
     return (
       <div>
-        <div className="text-[10px] text-gray-400 uppercase tracking-wider font-bold mb-1">Vol Detail</div>
+        <div className="text-[10px] text-text-muted uppercase tracking-wider font-bold mb-1">Vol Detail</div>
         <div className="grid grid-cols-3 gap-x-3 gap-y-0.5">
           {subs.map(([label, score, extra]) => (
             <div key={label} className="flex items-center gap-1">
-              <span className="text-xs text-gray-400">{label}</span>
-              <span className={`text-xs font-bold ${score >= 50 ? 'text-green-400' : 'text-red-400'}`}>{Math.round(score)}</span>
-              {extra && <span className="text-xs text-gray-500">{extra}</span>}
+              <span className="text-xs text-text-muted">{label}</span>
+              <span className={`text-xs font-bold ${score >= 50 ? 'text-brand-green' : 'text-brand-red'}`}>{Math.round(score)}</span>
+              {extra && <span className="text-xs text-text-faint">{extra}</span>}
             </div>
           ))}
         </div>
         {vrpZ != null && (
-          <div className="text-xs text-gray-400 mt-0.5">
-            VRP z: <span className={vrpZ > 0.5 ? 'text-green-400' : vrpZ < -0.5 ? 'text-red-400' : 'text-gray-400'}>{vrpZ >= 0 ? '+' : ''}{vrpZ.toFixed(1)}</span>
+          <div className="text-xs text-text-muted mt-0.5">
+            VRP z: <span className={vrpZ > 0.5 ? 'text-brand-green' : vrpZ < -0.5 ? 'text-brand-red' : 'text-text-muted'}>{vrpZ >= 0 ? '+' : ''}{vrpZ.toFixed(1)}</span>
           </div>
         )}
         {ks && (
-          <div className="text-xs text-gray-400 mt-0.5">
+          <div className="text-xs text-text-muted mt-0.5">
             IV RANK {ks.iv_rank != null ? ks.iv_rank.toFixed(2) : '—'} · IV {ks.iv30 != null ? `${ks.iv30.toFixed(1)}%` : '—'} · HV30 {ks.hv30 != null ? `${ks.hv30.toFixed(1)}%` : '—'}{ks.iv_hv_spread != null ? ` · VRP ${ks.iv_hv_spread > 0 ? '+' : ''}${ks.iv_hv_spread.toFixed(1)}%` : ''}
           </div>
         )}
         {ks?.vol_cone && (
-          <div className="text-xs text-gray-500 mt-0.5">
+          <div className="text-xs text-text-faint mt-0.5">
             VOL CONE: {[
               ks.vol_cone.hv10 != null && `HV10 ${ks.vol_cone.hv10}%`,
               ks.vol_cone.hv20 != null && `HV20 ${ks.vol_cone.hv20}%`,
@@ -539,7 +539,7 @@ export function TerminalTradeCard({ detail, sentiment, savedCards, savingCards, 
           </div>
         )}
         {ks?.forward_vol && (
-          <div className="text-xs text-gray-500 mt-0.5">
+          <div className="text-xs text-text-faint mt-0.5">
             FWD VOL {ks.forward_vol.forward_iv}% ({ks.forward_vol.from_dte}→{ks.forward_vol.to_dte}d){ks.vol_cone?.current_iv != null ? ` vs spot IV ${ks.vol_cone.current_iv}%` : ''}
           </div>
         )}
@@ -552,27 +552,27 @@ export function TerminalTradeCard({ detail, sentiment, savedCards, savingCards, 
     const dom = detail.scores?.regime?.breakdown?.dominant_regime;
     return (
       <div>
-        <div className="text-[10px] text-gray-400 uppercase tracking-wider font-bold mb-1">Company &amp; Macro</div>
+        <div className="text-[10px] text-text-muted uppercase tracking-wider font-bold mb-1">Company &amp; Macro</div>
         {ks && (
           <>
-            <div className="text-xs text-gray-400">
+            <div className="text-xs text-text-muted">
               P/E {ks.pe_ratio != null ? ks.pe_ratio.toFixed(1) : '—'} · CAP {fmtMcap(ks.market_cap)} · BETA {ks.beta != null ? ks.beta.toFixed(2) : '—'} · SPY CORR {ks.spy_correlation != null ? ks.spy_correlation.toFixed(2) : '—'} · LIQ {ks.liquidity_rating != null ? `${ks.liquidity_rating}/5` : '—'} · BORROW {ks.borrow_rate != null ? `${ks.borrow_rate.toFixed(1)}%` : '—'} {ks.lendability ?? ''}
             </div>
-            <div className="text-xs text-gray-400 mt-0.5">
+            <div className="text-xs text-text-muted mt-0.5">
               EARNINGS {ks.earnings_date ?? '—'}{ks.days_to_earnings != null && ks.days_to_earnings > 0 ? ` (${ks.days_to_earnings}d away)` : ''}{ks.earnings_pattern ? ` · BEAT ${ks.earnings_pattern.beat_rate ?? '—'}% (${ks.earnings_pattern.total_quarters}Q)${ks.earnings_pattern.sue_score != null ? ` · SUE ${ks.earnings_pattern.sue_score}` : ''}${ks.earnings_pattern.streak ? ` · ${ks.earnings_pattern.streak}` : ''}` : ''}
             </div>
-            <div className="text-xs text-gray-400 mt-0.5">
+            <div className="text-xs text-text-muted mt-0.5">
               DIV YIELD {ks.dividend_yield != null ? `${ks.dividend_yield.toFixed(2)}%` : '—'} · IV %ILE {ks.iv_percentile != null ? ks.iv_percentile.toFixed(1) : '—'}
             </div>
           </>
         )}
         {rs && (
-          <div className="text-xs text-gray-400 mt-0.5">
+          <div className="text-xs text-text-muted mt-0.5">
             REGIME: <span className="text-yellow-400 font-bold">{dom?.toUpperCase()}</span> Goldilocks {Math.round(rs.goldilocks * 100)}% Reflation {Math.round(rs.reflation * 100)}% Stagflation {Math.round(rs.stagflation * 100)}% Deflation {Math.round(rs.deflation * 100)}%
           </div>
         )}
         {why?.regime_context && (
-          <div className="text-xs text-gray-500 mt-0.5">{why.regime_context}</div>
+          <div className="text-xs text-text-faint mt-0.5">{why.regime_context}</div>
         )}
       </div>
     );
@@ -586,43 +586,43 @@ export function TerminalTradeCard({ detail, sentiment, savedCards, savingCards, 
     const instOwners = bd?.institutional_ownership?.indicators?.total_holders;
     return (
       <div>
-        <div className="text-[10px] text-gray-400 uppercase tracking-wider font-bold mb-1">Info Signals</div>
-        <div className="text-xs text-gray-400">
+        <div className="text-[10px] text-text-muted uppercase tracking-wider font-bold mb-1">Info Signals</div>
+        <div className="text-xs text-text-muted">
           ANALYSTS: {ks?.analyst_consensus ?? '—'} · INSIDER MSPR: {mspr != null ? mspr.toFixed(2) : '—'} · NEWS SENTIMENT: {newsScore != null ? newsScore.toFixed(1) : '—'} · INST OWNERS: {instOwners ?? '—'} · BUZZ: {ks?.buzz_ratio != null ? `${ks.buzz_ratio.toFixed(1)}x` : '—'} · TREND: {ks?.sentiment_momentum != null ? ks.sentiment_momentum.toFixed(0) : '—'}
         </div>
         {sentiment && !sentiment.error && sentiment.postCount > 0 && (
           <>
             <div className="text-xs mt-0.5">
-              <span className="text-gray-400">SOCIAL: </span>
-              <span className={sentiment.score > 0.2 ? 'text-green-400 font-bold' : sentiment.score < -0.2 ? 'text-red-400 font-bold' : 'text-gray-400 font-bold'}>
+              <span className="text-text-muted">SOCIAL: </span>
+              <span className={sentiment.score > 0.2 ? 'text-brand-green font-bold' : sentiment.score < -0.2 ? 'text-brand-red font-bold' : 'text-text-muted font-bold'}>
                 {sentiment.score > 0 ? '+' : ''}{sentiment.score.toFixed(2)}
               </span>
-              <span className="text-gray-500"> · {sentiment.postCount} posts · {sentiment.bullishCount}B/{sentiment.bearishCount}Be/{sentiment.neutralCount}N · AGE: {sentiment.dataAge}</span>
+              <span className="text-text-faint"> · {sentiment.postCount} posts · {sentiment.bullishCount}B/{sentiment.bearishCount}Be/{sentiment.neutralCount}N · AGE: {sentiment.dataAge}</span>
             </div>
             {sentiment.themes.length > 0 && (
-              <div className="text-xs text-gray-500 mt-0.5">THEMES: {sentiment.themes.join(' · ')}</div>
+              <div className="text-xs text-text-faint mt-0.5">THEMES: {sentiment.themes.join(' · ')}</div>
             )}
             {sentiment.samplePosts && sentiment.samplePosts.length > 0 && (
               <div className="mt-0.5">
                 {sentiment.samplePosts.slice(0, 2).map((post, i) => (
-                  <div key={i} className="text-xs text-gray-500 truncate">&ldquo;{termTruncate(post.text, 80)}&rdquo; — {post.sentiment}</div>
+                  <div key={i} className="text-xs text-text-faint truncate">&ldquo;{termTruncate(post.text, 80)}&rdquo; — {post.sentiment}</div>
                 ))}
               </div>
             )}
           </>
         )}
         {sentiment?.error && (
-          <div className="text-xs text-gray-500 mt-0.5">SOCIAL: unavailable — {sentiment.error}</div>
+          <div className="text-xs text-text-faint mt-0.5">SOCIAL: unavailable — {sentiment.error}</div>
         )}
         {!sentiment && (
-          <div className="text-xs text-gray-500 mt-0.5">SOCIAL: xAI data not loaded</div>
+          <div className="text-xs text-text-faint mt-0.5">SOCIAL: xAI data not loaded</div>
         )}
         {sentiment && !sentiment.error && sentiment.postCount === 0 && (
-          <div className="text-xs text-gray-500 mt-0.5">SOCIAL: 0 posts found</div>
+          <div className="text-xs text-text-faint mt-0.5">SOCIAL: 0 posts found</div>
         )}
         {/* Magnitude + data age always shown if available */}
         {sentiment && !sentiment.error && sentiment.postCount > 0 && (
-          <div className="text-xs text-gray-500 mt-0.5">MAGNITUDE: {sentiment.magnitude.toFixed(2)}</div>
+          <div className="text-xs text-text-faint mt-0.5">MAGNITUDE: {sentiment.magnitude.toFixed(2)}</div>
         )}
       </div>
     );
@@ -632,12 +632,12 @@ export function TerminalTradeCard({ detail, sentiment, savedCards, savingCards, 
     if (headlines.length === 0) return null;
     return (
       <div>
-        <div className="text-[10px] text-gray-400 uppercase tracking-wider font-bold mb-1">Headlines</div>
+        <div className="text-[10px] text-text-muted uppercase tracking-wider font-bold mb-1">Headlines</div>
         {headlines.map((h, i) => {
-          const color = h.sentiment === 'bullish' ? 'text-green-400' : h.sentiment === 'bearish' ? 'text-red-400' : 'text-gray-400';
+          const color = h.sentiment === 'bullish' ? 'text-brand-green' : h.sentiment === 'bearish' ? 'text-brand-red' : 'text-text-muted';
           return (
-            <div key={i} className="text-xs text-gray-400">
-              <span className={`font-bold ${color}`}>[{h.sentiment.toUpperCase()}]</span> &ldquo;{termTruncate(h.headline, 70)}&rdquo; <span className="text-gray-500">{h.source}</span>
+            <div key={i} className="text-xs text-text-muted">
+              <span className={`font-bold ${color}`}>[{h.sentiment.toUpperCase()}]</span> &ldquo;{termTruncate(h.headline, 70)}&rdquo; <span className="text-text-faint">{h.source}</span>
             </div>
           );
         })}
@@ -649,17 +649,17 @@ export function TerminalTradeCard({ detail, sentiment, savedCards, savingCards, 
 
   if (cards.length === 0) {
     return (
-      <div className="bg-[#1a1a2e] rounded border border-gray-700 font-mono text-xs p-4">
+      <div className="bg-bg-terminal rounded border border-border font-mono text-xs p-4">
         {/* Header */}
-        <div className="text-gray-100">
+        <div className="text-text-primary">
           <span className="font-bold">{detail.symbol}</span>
-          <span className="text-gray-400"> · Score </span>
+          <span className="text-text-muted"> · Score </span>
           <span className={termGateColor(comp.score)}>{comp.score.toFixed(1)} {letterGrade(comp.score)}</span>
-          <span className="text-gray-400"> · {comp.categories_above_50}/4 gates · {comp.direction}</span>
+          <span className="text-text-muted"> · {comp.categories_above_50}/4 gates · {comp.direction}</span>
         </div>
-        <div className="text-red-400 mt-1">No strategies passed quality gates</div>
+        <div className="text-brand-red mt-1">No strategies passed quality gates</div>
         {detail._fetch_errors?.chain_fetch && (
-          <div className="text-gray-500 mt-0.5">{detail._fetch_errors.chain_fetch}</div>
+          <div className="text-text-faint mt-0.5">{detail._fetch_errors.chain_fetch}</div>
         )}
         {divider}
         {renderForAgainst(undefined)}
@@ -697,59 +697,59 @@ export function TerminalTradeCard({ detail, sentiment, savedCards, savingCards, 
         const vegaPt = (card.setup.greeks?.vega ?? 0) * 100;
 
         return (
-          <div key={ci} className="bg-[#1a1a2e] rounded border border-gray-700 font-mono text-xs p-4">
+          <div key={ci} className="bg-bg-terminal rounded border border-border font-mono text-xs p-4">
 
             {/* SECTION 1 — HEADER */}
-            <div className="text-gray-100">
+            <div className="text-text-primary">
               <span className="font-bold">{detail.symbol}</span>
-              <span className="text-gray-400"> · </span>
-              <span className="text-gray-100 font-bold">{card.setup.strategy_name}</span>
-              <span className="text-gray-400"> · {card.setup.expiration_date} · {card.setup.dte}DTE</span>
+              <span className="text-text-muted"> · </span>
+              <span className="text-text-primary font-bold">{card.setup.strategy_name}</span>
+              <span className="text-text-muted"> · {card.setup.expiration_date} · {card.setup.dte}DTE</span>
             </div>
-            <div className="text-gray-400">
+            <div className="text-text-muted">
               Score <span className={termGateColor(comp.score)}>{comp.score.toFixed(1)} {letterGrade(comp.score)}</span> · {comp.categories_above_50}/4 gates · {comp.direction}{ks?.sector ? ` · ${ks.sector}` : ''}
             </div>
 
             {divider}
 
             {/* SECTION 2 — TRADE SETUP */}
-            <div className="text-[10px] text-gray-400 uppercase tracking-wider font-bold mb-1">Trade Setup</div>
+            <div className="text-[10px] text-text-muted uppercase tracking-wider font-bold mb-1">Trade Setup</div>
             {card.setup.legs.map((leg, j) => (
               <div key={j} className="text-xs">
-                <span className={leg.side === 'sell' ? 'text-red-400 font-bold' : 'text-green-400 font-bold'}>
+                <span className={leg.side === 'sell' ? 'text-brand-red font-bold' : 'text-brand-green font-bold'}>
                   {leg.side.toUpperCase().padEnd(4)}
                 </span>
-                <span className="text-gray-400"> {leg.type.toUpperCase().padEnd(4)} </span>
-                <span className="text-gray-100">${leg.strike}</span>
-                <span className="text-gray-500">  ${leg.price.toFixed(2)}</span>
+                <span className="text-text-muted"> {leg.type.toUpperCase().padEnd(4)} </span>
+                <span className="text-text-primary">${leg.strike}</span>
+                <span className="text-text-faint">  ${leg.price.toFixed(2)}</span>
               </div>
             ))}
-            <div className="text-xs text-gray-100 mt-1">
+            <div className="text-xs text-text-primary mt-1">
               {card.setup.net_credit != null && card.setup.net_credit > 0
-                ? <span className="text-green-400 font-bold">COLLECT ${(card.setup.net_credit * 100).toFixed(0)}</span>
+                ? <span className="text-brand-green font-bold">COLLECT ${(card.setup.net_credit * 100).toFixed(0)}</span>
                 : card.setup.net_debit != null
-                ? <span className="text-gray-100 font-bold">PAY ${(card.setup.net_debit * 100).toFixed(0)}</span>
+                ? <span className="text-text-primary font-bold">PAY ${(card.setup.net_debit * 100).toFixed(0)}</span>
                 : null}
-              <span className="text-gray-400"> · MAX LOSS </span>
-              <span className="text-red-400">{fmtDollar(card.setup.max_loss)}</span>
-              <span className="text-gray-400"> · POP </span>
-              <span className="text-gray-100">{fmtPct(card.setup.probability_of_profit)}</span>
-              <span className="text-gray-500"> ({card.setup.pop_method === 'breakeven_d2' ? 'N(d2)' : 'Δ approx'})</span>
-              <span className="text-gray-400"> · EV </span>
-              <span className={card.setup.ev >= 0 ? 'text-green-400' : 'text-red-400'}>{card.setup.ev >= 0 ? '+' : ''}${Math.round(card.setup.ev)}</span>
-              <span className="text-gray-400"> · EV/RISK </span>
-              <span className="text-gray-100">{card.setup.ev_per_risk.toFixed(3)}</span>
-              <span className="text-gray-400"> · R:R </span>
-              <span className="text-gray-100">{card.setup.risk_reward_ratio != null ? card.setup.risk_reward_ratio.toFixed(2) : '—'}</span>
+              <span className="text-text-muted"> · MAX LOSS </span>
+              <span className="text-brand-red">{fmtDollar(card.setup.max_loss)}</span>
+              <span className="text-text-muted"> · POP </span>
+              <span className="text-text-primary">{fmtPct(card.setup.probability_of_profit)}</span>
+              <span className="text-text-faint"> ({card.setup.pop_method === 'breakeven_d2' ? 'N(d2)' : 'Δ approx'})</span>
+              <span className="text-text-muted"> · EV </span>
+              <span className={card.setup.ev >= 0 ? 'text-brand-green' : 'text-brand-red'}>{card.setup.ev >= 0 ? '+' : ''}${Math.round(card.setup.ev)}</span>
+              <span className="text-text-muted"> · EV/RISK </span>
+              <span className="text-text-primary">{card.setup.ev_per_risk.toFixed(3)}</span>
+              <span className="text-text-muted"> · R:R </span>
+              <span className="text-text-primary">{card.setup.risk_reward_ratio != null ? card.setup.risk_reward_ratio.toFixed(2) : '—'}</span>
             </div>
-            <div className="text-xs text-gray-400 mt-0.5">
-              B/E {(card.setup.breakevens?.length ?? 0) === 0 ? '—' : card.setup.breakevens.map(b => `$${b.toFixed(2)}`).join(' / ')} · HV POP {card.setup.hv_pop != null ? `${Math.round(card.setup.hv_pop * 100)}%` : '—'} · THETA <span className={thetaPerDay >= 0 ? 'text-green-400' : 'text-red-400'}>{thetaPerDay >= 0 ? '+' : ''}${thetaPerDay.toFixed(2)}/day</span> · VEGA/pt <span className={vegaPt >= 0 ? 'text-green-400' : 'text-red-400'}>{vegaPt >= 0 ? '+' : ''}${Math.abs(vegaPt).toFixed(2)}</span> · KELLY <span className={kellyPct >= 2 ? 'text-green-400' : kellyPct >= 1 ? 'text-yellow-400' : 'text-gray-400'}>{kellyPct.toFixed(1)}%</span>
+            <div className="text-xs text-text-muted mt-0.5">
+              B/E {(card.setup.breakevens?.length ?? 0) === 0 ? '—' : card.setup.breakevens.map(b => `$${b.toFixed(2)}`).join(' / ')} · HV POP {card.setup.hv_pop != null ? `${Math.round(card.setup.hv_pop * 100)}%` : '—'} · THETA <span className={thetaPerDay >= 0 ? 'text-brand-green' : 'text-brand-red'}>{thetaPerDay >= 0 ? '+' : ''}${thetaPerDay.toFixed(2)}/day</span> · VEGA/pt <span className={vegaPt >= 0 ? 'text-brand-green' : 'text-brand-red'}>{vegaPt >= 0 ? '+' : ''}${Math.abs(vegaPt).toFixed(2)}</span> · KELLY <span className={kellyPct >= 2 ? 'text-brand-green' : kellyPct >= 1 ? 'text-yellow-400' : 'text-text-muted'}>{kellyPct.toFixed(1)}%</span>
             </div>
             {card.setup.has_wide_spread && (
               <div className="text-xs text-yellow-400 mt-0.5">&#x26A0; Wide bid-ask spread — prices estimated from theoretical model</div>
             )}
             {card.setup.is_unlimited_risk && (
-              <div className="text-xs text-red-400 mt-0.5">&#x26A0; UNLIMITED RISK — naked short position</div>
+              <div className="text-xs text-brand-red mt-0.5">&#x26A0; UNLIMITED RISK — naked short position</div>
             )}
 
             {divider}
@@ -788,7 +788,7 @@ export function TerminalTradeCard({ detail, sentiment, savedCards, savingCards, 
                 <Badge variant="success" size="md">Queued &#10003;</Badge>
                 <button
                   onClick={() => onRemove(cardKey, savedId)}
-                  className="text-[10px] text-gray-500 hover:text-red-400 transition-colors"
+                  className="text-[10px] text-text-faint hover:text-brand-red transition-colors"
                 >
                   &#10005; Remove
                 </button>
@@ -800,7 +800,7 @@ export function TerminalTradeCard({ detail, sentiment, savedCards, savingCards, 
             ) : (
               <div>
                 <Button variant="primary" size="md" onClick={() => onSave(detail, card, sentiment)} className="w-full mt-1">Enter Trade</Button>
-                {error && <div className="mt-1 px-2 py-1 rounded text-[10px] bg-red-900/50 text-red-400">Failed: {error}</div>}
+                {error && <div className="mt-1 px-2 py-1 rounded text-[10px] bg-red-900/50 text-brand-red">Failed: {error}</div>}
               </div>
             )}
           </div>


### PR DESCRIPTION
Style-only. The one genuinely dark-terminal surface in the trading UI is ConvergenceIntelligence's TerminalTradeCard (rendered on the Trade tab via TickerChapter). Flip it to the app's light token palette; keep font-mono (the app's data-tab convention, same as the Books cockpit/tables) and preserve semantic P&L colors.

Token mapping (className-only, 77/77 line swaps, no logic touched):
  bg-[#1a1a2e]    -> bg-bg-terminal   (app light surface #f7f6f3)
  border-gray-700 -> border-border
  text-gray-100   -> text-text-primary
  text-gray-400   -> text-text-muted
  text-gray-500   -> text-text-faint
  text-red-400    -> text-brand-red     (semantic loss/error preserved)
  text-green-400  -> text-brand-green   (semantic profit/pass preserved)
termGateColor now returns the brand semantic tokens.

Note: bg-bg-terminal was already the app's LIGHT background (not dark), and the trading font-mono matches the Books/dashboard data surfaces — so neither was changed (confirmed with Alex). ScanFilterForm/TradeLabPanel have no dark card and were left as-is. No route/state/prop/JSX-structure changes.