### PR TITLE
RISK-1: coverage declaration + capital-aware risk context

### DIFF
--- a/src/app/api/trading/coverage/route.ts
+++ b/src/app/api/trading/coverage/route.ts
@@ -1,0 +1,82 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
+
+/**
+ * RISK-1 — GET /api/trading/coverage
+ *
+ * Read-only coverage declaration for the Trade tab. Every number is computed from
+ * the DB and traceable to a query — NO external APIs, NO estimates. If the user has
+ * zero data, returns zeros with null dates (the true state, not a fallback).
+ *
+ * Ownership scoping (trading_positions has no userId — two-step, same pattern as
+ * commit-to-ledger/route.ts:92-97): investment_transactions.accounts.userId scopes the
+ * txns; positions are then filtered by open_investment_txn_id IN the user's txn ids.
+ */
+export async function GET() {
+  try {
+    // Auth first — 401 before any data read.
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    const user = await prisma.users.findFirst({
+      where: { email: { equals: userEmail, mode: 'insensitive' } },
+      select: { id: true },
+    });
+    if (!user) {
+      return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    }
+
+    // 1. Investment-transaction count + date range (user-scoped via accounts relation).
+    const txnAgg = await prisma.investment_transactions.aggregate({
+      where: { accounts: { userId: user.id } },
+      _count: { _all: true },
+      _min: { date: true },
+      _max: { date: true },
+    });
+
+    // The user's investment_transaction ids — needed to scope positions (no relation).
+    const userTxns = await prisma.investment_transactions.findMany({
+      where: { accounts: { userId: user.id } },
+      select: { id: true },
+    });
+    const userTxnIds = userTxns.map((t: { id: string }) => t.id);
+
+    // 2. Closed positions owned by the user.
+    const closedPositions = userTxnIds.length === 0
+      ? []
+      : await prisma.trading_positions.findMany({
+          where: { status: 'CLOSED', open_investment_txn_id: { in: userTxnIds } },
+          select: { trade_num: true },
+        });
+
+    // 3. Linked cards (trade_card_links whose card belongs to the user) + their trade_nums.
+    const userLinks = await prisma.trade_card_links.findMany({
+      where: { trade_card: { userId: user.id } },
+      select: { trade_num: true },
+    });
+    const linkedTradeNums = new Set(userLinks.map((l: { trade_num: string }) => l.trade_num));
+
+    // 4. Unlinked closed positions: closed positions whose trade_num is not linked
+    //    (null trade_num is inherently unlinked → counted).
+    const unlinkedClosedCount = closedPositions.filter(
+      (p: { trade_num: string | null }) => !p.trade_num || !linkedTradeNums.has(p.trade_num),
+    ).length;
+
+    return NextResponse.json({
+      investment_txn_count: txnAgg._count._all,
+      earliest_txn_date: txnAgg._min.date ? txnAgg._min.date.toISOString() : null,
+      latest_txn_date: txnAgg._max.date ? txnAgg._max.date.toISOString() : null,
+      closed_position_count: closedPositions.length,
+      linked_card_count: userLinks.length,
+      unlinked_closed_count: unlinkedClosedCount,
+      // Source of truth: the hardcoded Plaid investment sync window floor in
+      // src/app/api/transactions/sync-complete/route.ts:182 (start_date: '2024-01-01').
+      sync_window_start: '2024-01-01',
+    });
+  } catch (error) {
+    console.error('[trading/coverage]', error);
+    return NextResponse.json({ error: 'Failed to compute coverage' }, { status: 500 });
+  }
+}

--- a/src/components/convergence/ConvergenceIntelligence.tsx
+++ b/src/components/convergence/ConvergenceIntelligence.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useCallback, useEffect, useMemo } from 'react';
+import React, { useState, useCallback, useEffect, useMemo, createContext, useContext } from 'react';
 import ScannerResultsTable from './ScannerResultsTable';
 // LANG-1: persistent data-not-advice disclaimer, rendered above the card results.
 import TradingDataDisclaimer from '@/components/trading/TradingDataDisclaimer';
@@ -11,6 +11,11 @@ import { DEFAULT_FILTERS } from '@/lib/convergence/filter-types';
 import { applyFilters, describeActiveFilters } from '@/lib/convergence/filter-engine';
 import Badge from '@/components/ui/Badge';
 import Button from '@/components/ui/Button';
+
+// RISK-1: user-entered account size (dollars), shared to the card renderers without
+// prop-threading. 0 = unset (no capital math is shown — never assume a default balance).
+// Value is USER-ENTERED and NOT synced from any broker; the input labels say so.
+const AccountSizeContext = createContext<number>(0);
 
 /* ===================================================================
    ConvergenceIntelligence — unified market intelligence dashboard
@@ -403,6 +408,8 @@ export function TerminalTradeCard({ detail, sentiment, savedCards, savingCards, 
   onSave: (detail: TickerDetail, card: TradeCardData, sentiment?: SocialSentimentData) => Promise<void>;
   onRemove: (cardKey: string, savedId: string) => Promise<void>;
 }) {
+  // RISK-1: user-entered account size for capital context (0 = unset → no dollar math).
+  const accountSize = useContext(AccountSizeContext);
   const comp = detail.scores.composite;
   const cards = detail.trade_cards ?? [];
   const headlines: Headline[] = detail.scores.info_edge?.breakdown?.news_sentiment?.news_detail?.headlines?.slice(0, 3) ?? [];
@@ -734,6 +741,10 @@ export function TerminalTradeCard({ detail, sentiment, savedCards, savingCards, 
                 : null}
               <span className="text-text-muted"> · MAX LOSS </span>
               <span className="text-brand-red">{fmtDollar(card.setup.max_loss)}</span>
+              {/* RISK-1: max loss as % of user-entered account size (only when set). */}
+              {accountSize > 0 && card.setup.max_loss != null && (
+                <span className="text-text-faint"> ({((Math.abs(card.setup.max_loss) / accountSize) * 100).toFixed(1)}% of acct)</span>
+              )}
               <span className="text-text-muted"> · POP </span>
               <span className="text-text-primary">{fmtPct(card.setup.probability_of_profit)}</span>
               <span className="text-text-faint"> ({card.setup.pop_method === 'breakeven_d2' ? 'N(d2)' : 'Δ approx'})</span>
@@ -825,6 +836,8 @@ export function TickerCard({ detail, sentiment, savedCards, savingCards, saveErr
   onSave: (detail: TickerDetail, card: TradeCardData, sentiment?: SocialSentimentData) => Promise<void>;
   onRemove: (cardKey: string, savedId: string) => Promise<void>;
 }) {
+  // RISK-1: user-entered account size for capital context (0 = unset → no dollar math).
+  const accountSize = useContext(AccountSizeContext);
   const comp = detail.scores.composite;
   const cards = detail.trade_cards ?? [];
   const why = cards[0]?.why;
@@ -951,6 +964,12 @@ export function TickerCard({ detail, sentiment, savedCards, savingCards, saveErr
                   <div className="text-center">
                     <div className="text-[9px] text-text-muted uppercase">Max Loss</div>
                     <div className="text-sm font-mono font-black text-brand-red">{fmtDollar(card.setup.max_loss)}</div>
+                    {/* RISK-1: max loss as % of user-entered account size (only when set). */}
+                    {accountSize > 0 && card.setup.max_loss != null && (
+                      <div className="text-[8px] font-mono text-text-faint mt-0.5">
+                        {((Math.abs(card.setup.max_loss) / accountSize) * 100).toFixed(1)}% of acct
+                      </div>
+                    )}
                   </div>
                   <div className="text-center">
                     <div className="text-[9px] text-text-muted uppercase" title={card.setup.pop_method === 'breakeven_d2' ? 'PoP via N(d2) at breakeven price — the standard Black-Scholes probability that the underlying closes beyond the breakeven price at expiration. More accurate than delta approx.' : 'PoP estimated from option deltas — quick approximation used when breakeven calculation is unavailable. Less precise than N(d2) method.'}>Est. PoP</div>
@@ -1059,6 +1078,12 @@ export function TickerCard({ detail, sentiment, savedCards, savingCards, saveErr
                         }`}>
                           {kellyPct.toFixed(1)}% <span className="text-[9px] font-normal text-text-muted">of account</span>
                         </span>
+                        {/* RISK-1: Quarter-Kelly % as dollars of the user-entered account size. */}
+                        {accountSize > 0 && (
+                          <div className="text-[9px] font-mono text-text-faint">
+                            {kellyPct.toFixed(1)}% of ${accountSize.toLocaleString()} = ${Math.round((kellyPct / 100) * accountSize).toLocaleString()}
+                          </div>
+                        )}
                         <div className="text-[9px] text-text-faint mt-0.5">
                           {/* LANG-1: state the computed classification, drop the imperative. */}
                           {kellyPct >= 2.0
@@ -4417,6 +4442,26 @@ export default function ConvergenceIntelligence({
   // Batch scan state
   const [internalUniverse, setInternalUniverse] = useState('sp500');
   const universe = externalUniverse ?? internalUniverse;
+
+  // RISK-1: user-entered account size for capital context. Persisted to localStorage
+  // (same pattern as scanner-filters). USER-ENTERED, not synced from any broker — the
+  // input label says so. Empty/0 = unset → cards show no dollar math (no assumed default).
+  const [accountSize, setAccountSize] = useState<number>(() => {
+    try {
+      const saved = typeof window !== 'undefined' ? localStorage.getItem('trading-account-size') : null;
+      const n = saved ? Number(saved) : 0;
+      return Number.isFinite(n) && n > 0 ? n : 0;
+    } catch { return 0; }
+  });
+  const handleAccountSizeChange = (raw: string) => {
+    const n = Number(raw);
+    const next = Number.isFinite(n) && n > 0 ? n : 0;
+    setAccountSize(next);
+    try {
+      if (next > 0) localStorage.setItem('trading-account-size', String(next));
+      else localStorage.removeItem('trading-account-size');
+    } catch { /* localStorage unavailable — state still drives the UI this session */ }
+  };
   const setUniverse = onUniverseChange ?? setInternalUniverse;
 
   const [scanning, setScanning] = useState(false);
@@ -4727,7 +4772,24 @@ export default function ConvergenceIntelligence({
   }, [lookupTicker]);
 
   return (
+    <AccountSizeContext.Provider value={accountSize}>
     <div className="bg-white rounded border border-border shadow-sm overflow-hidden">
+
+      {/* RISK-1: user-entered account-size input for capital context (labeled not-synced). */}
+      <div className="border-b border-border bg-white px-4 py-2 flex flex-wrap items-center gap-2 text-xs">
+        <label htmlFor="ci-account-size" className="text-text-muted">Account size <span className="text-text-faint">(user-entered, not synced)</span>:</label>
+        <span className="text-text-faint">$</span>
+        <input
+          id="ci-account-size"
+          type="number"
+          min="0"
+          inputMode="numeric"
+          value={accountSize > 0 ? accountSize : ''}
+          onChange={(e) => handleAccountSizeChange(e.target.value)}
+          placeholder="Set account size for capital context"
+          className="w-64 rounded border border-border px-2 py-1 text-xs font-mono"
+        />
+      </div>
 
       {/* Header — show controls only when not hidden */}
       {!hideControls ? (
@@ -4884,5 +4946,6 @@ export default function ConvergenceIntelligence({
         )}
       </div>}
     </div>
+    </AccountSizeContext.Provider>
   );
 }

--- a/src/components/home/ModuleLauncher.tsx
+++ b/src/components/home/ModuleLauncher.tsx
@@ -25,6 +25,8 @@ import { HOMEPAGE_PAID_CATEGORIES } from '@/lib/categoryKeys';
 import ScanFilterForm from '@/components/trading/ScanFilterForm';
 // LANG-1: persistent data-not-advice disclaimer, mounted at the top of the Trade tab.
 import TradingDataDisclaimer from '@/components/trading/TradingDataDisclaimer';
+// RISK-1: coverage declaration — states what has actually synced (self-fetches /api/trading/coverage).
+import CoverageDeclaration from '@/components/trading/CoverageDeclaration';
 // TRADE-1: the queue viewer + reconcile/link/grade surface. Mounted BELOW the scanner on
 // the homepage Trade tab so the scan → queue → RECONCILE loop is complete here (was only on
 // standalone /trading). Reused verbatim — no restyle (that is TRADE-2).
@@ -787,6 +789,8 @@ export default function ModuleLauncher({ onRequireAuth, onTabChange }: Props) {
               <>
                 {/* LANG-1: disclaimer at the top of the Trade tab (persistent, visible). */}
                 <TradingDataDisclaimer />
+                {/* RISK-1: coverage declaration — what has actually synced (below the disclaimer). */}
+                <CoverageDeclaration />
                 {/* Option A — scanner first, reconcile below. Same props the inline branch used. */}
                 <ScanFilterForm
                   scannerUniverse={scannerUniverse}

--- a/src/components/trading/CoverageDeclaration.tsx
+++ b/src/components/trading/CoverageDeclaration.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+
+/**
+ * RISK-1 — coverage declaration for the Trade tab.
+ *
+ * States what the tab actually reflects: how many synced transactions, over what date
+ * range, and how many closed positions are excluded from card stats (unlinked). Trades
+ * never synced from the broker are NOT visible here — stated plainly.
+ *
+ * Self-fetches /api/trading/coverage (auth-gated, user-scoped, DB-only). Three explicit
+ * states: loading / error+Retry / loaded truth. A failed fetch is NEVER rendered as
+ * coverage or stats. "Zero data" is a true state (0 transactions), not an error.
+ */
+
+interface Coverage {
+  investment_txn_count: number;
+  earliest_txn_date: string | null;
+  latest_txn_date: string | null;
+  closed_position_count: number;
+  linked_card_count: number;
+  unlinked_closed_count: number;
+  sync_window_start: string;
+}
+
+function fmtDate(iso: string | null): string {
+  if (!iso) return '—';
+  // Date-only, locale-independent (avoid TZ drift on a bare date display).
+  return iso.slice(0, 10);
+}
+
+export default function CoverageDeclaration() {
+  const [state, setState] = useState<'loading' | 'error' | 'ok'>('loading');
+  const [data, setData] = useState<Coverage | null>(null);
+
+  const load = useCallback(async () => {
+    setState('loading');
+    try {
+      const res = await fetch('/api/trading/coverage');
+      if (!res.ok) throw new Error('coverage fetch failed');
+      const json: Coverage = await res.json();
+      setData(json);
+      setState('ok');
+    } catch {
+      setData(null);
+      setState('error');
+    }
+  }, []);
+
+  useEffect(() => { load(); }, [load]);
+
+  if (state === 'loading') {
+    return (
+      <div className="rounded-lg border border-border bg-white px-3 py-2 text-xs text-text-muted">
+        Checking synced coverage…
+      </div>
+    );
+  }
+
+  if (state === 'error') {
+    return (
+      <div role="alert" className="rounded-lg border border-red-300 bg-red-50 px-3 py-2 text-xs text-red-700 flex items-center justify-between gap-3">
+        <span>Couldn&rsquo;t load coverage. Nothing is assumed — no coverage or stats are shown until it loads.</span>
+        <button
+          type="button"
+          onClick={load}
+          className="shrink-0 rounded border border-red-400 px-2 py-1 text-[11px] font-semibold text-red-700 hover:bg-red-100"
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  if (!data) return null; // unreachable in 'ok', keeps types honest
+
+  return (
+    <div className="rounded-lg border border-border bg-white px-3 py-2 text-xs text-text-secondary">
+      This tab reflects <span className="font-semibold text-text-primary">{data.investment_txn_count}</span> synced
+      transactions from <span className="font-mono">{fmtDate(data.earliest_txn_date)}</span> to{' '}
+      <span className="font-mono">{fmtDate(data.latest_txn_date)}</span>.{' '}
+      <span className="font-semibold text-text-primary">{data.unlinked_closed_count}</span> closed position
+      {data.unlinked_closed_count === 1 ? ' is' : 's are'} not linked to a card and{' '}
+      {data.unlinked_closed_count === 1 ? 'is' : 'are'} excluded from card statistics. Trades never synced from
+      your broker are not visible here — stats below describe only what has been synced (sync window starts{' '}
+      <span className="font-mono">{data.sync_window_start}</span>).
+    </div>
+  );
+}

--- a/src/components/trading/TradeLabPanel.tsx
+++ b/src/components/trading/TradeLabPanel.tsx
@@ -64,6 +64,20 @@ export default function TradeLabPanel({ onCardsChange }: { onCardsChange?: () =>
   // Grading in progress
   const [gradingCardId, setGradingCardId] = useState<string | null>(null);
 
+  // RISK-1: coverage stats (linked / closed / unlinked) from /api/trading/coverage.
+  // Self-fetched; null until loaded — the strip renders only on success (never fabricated).
+  const [coverage, setCoverage] = useState<
+    { linked_card_count: number; closed_position_count: number; unlinked_closed_count: number } | null
+  >(null);
+  useEffect(() => {
+    (async () => {
+      try {
+        const res = await fetch('/api/trading/coverage');
+        if (res.ok) setCoverage(await res.json());
+      } catch { /* leave null — strip simply does not render, no fabricated numbers */ }
+    })();
+  }, []);
+
   // Scanner start date (per-user)
   const [scannerStartDate, setScannerStartDate] = useState<string | null>(null);
   const [editingStartDate, setEditingStartDate] = useState(false);
@@ -288,6 +302,16 @@ export default function TradeLabPanel({ onCardsChange }: { onCardsChange?: () =>
           </button>
         </div>
       </div>
+
+      {/* RISK-1: coverage stats strip — denominator always visible (no win-rate without it).
+          Renders only when coverage loaded; never fabricated on failure. */}
+      {coverage && (
+        <div className="border-b border-border bg-white px-4 py-1.5 text-[11px] text-text-muted">
+          Linked cards: <span className="font-mono font-semibold text-text-primary">{coverage.linked_card_count}</span>
+          {' · '}Closed positions: <span className="font-mono font-semibold text-text-primary">{coverage.closed_position_count}</span>
+          {' · '}Unlinked: <span className="font-mono font-semibold text-text-primary">{coverage.unlinked_closed_count}</span>
+        </div>
+      )}
 
       {/* Legacy notice */}
       <div className="bg-amber-50 border-b border-amber-200 px-4 py-2 text-xs text-amber-800">


### PR DESCRIPTION
Adds an honest "what has actually synced" declaration and user-entered capital context to the Trade tab. No external-API routes; one new internal DB-only route.

- New GET /api/trading/coverage (auth first line: getVerifiedEmail -> 401; user-scoped via investment_transactions.accounts.userId + the two-step positions chain). Returns investment_txn_count, earliest/latest_txn_date, closed_position_count, linked_card_count, unlinked_closed_count, sync_window_start '2024-01-01' (cites sync-complete/route.ts:182). Zero data -> zeros + null dates (true state). No estimates.
- CoverageDeclaration (top of Trade tab, below the disclaimer): plain-language coverage statement. Three states: loading / explicit error+Retry / loaded truth — never renders stats on a failed fetch.
- Capital context: user-entered "Account size" input (localStorage 'trading-account-size', same pattern as scanner-filters), labeled "user-entered, not synced". Shared to the card renderers via a file-local React context. On the cards (TerminalTradeCard + TickerCard): "Max loss = X% of acct" and "Quarter-Kelly k% of $acct = $dollars" — pure display math, only when account size is set (never assumes a default balance). No DB balance is reliable (accounts.currentBalance is `|| 0` and Plaid investment balances are unreliable), so capital size is user-entered by design.
- TradeLab stats strip: "Linked cards / Closed positions / Unlinked" from the same coverage payload (denominator always visible).

No directive language added (LANG-1 conventions hold). No fallback logic.