### PR TITLE
TEACH-1: tappable plain-language explainers for every card metric

### DIFF
--- a/src/components/convergence/ConvergenceIntelligence.tsx
+++ b/src/components/convergence/ConvergenceIntelligence.tsx
@@ -4,6 +4,11 @@ import React, { useState, useCallback, useEffect, useMemo, createContext, useCon
 import ScannerResultsTable from './ScannerResultsTable';
 // LANG-1: persistent data-not-advice disclaimer, rendered above the card results.
 import TradingDataDisclaimer from '@/components/trading/TradingDataDisclaimer';
+// TEACH-1: tap-to-open plain-language explainers for every card metric (deterministic,
+// no fetch). MetricInfo wraps a metric label; each panel is individually dismissible.
+// (MetricExplainerProvider is available for one-at-a-time coordination but is not wrapped
+// here — it would require surgery on the whole card return; panels self-manage instead.)
+import MetricInfo from '@/components/trading/MetricExplainer';
 import FilterPanel from './FilterPanel';
 import { countActiveFilters } from './FilterPanel';
 import type { ScannerFilters } from '@/lib/convergence/filter-types';
@@ -533,7 +538,7 @@ export function TerminalTradeCard({ detail, sentiment, savedCards, savingCards, 
         )}
         {ks && (
           <div className="text-xs text-text-muted mt-0.5">
-            IV RANK {ks.iv_rank != null ? ks.iv_rank.toFixed(2) : '—'} · IV {ks.iv30 != null ? `${ks.iv30.toFixed(1)}%` : '—'} · HV30 {ks.hv30 != null ? `${ks.hv30.toFixed(1)}%` : '—'}{ks.iv_hv_spread != null ? ` · VRP ${ks.iv_hv_spread > 0 ? '+' : ''}${ks.iv_hv_spread.toFixed(1)}%` : ''}
+            <MetricInfo metricKey="iv_rank" values={{ iv_rank: ks.iv_rank ?? null }} hasValue={ks.iv_rank != null}>IV RANK</MetricInfo> {ks.iv_rank != null ? ks.iv_rank.toFixed(2) : '—'} · <MetricInfo metricKey="iv30" values={{ iv30: ks.iv30 ?? null }} hasValue={ks.iv30 != null}>IV</MetricInfo> {ks.iv30 != null ? `${ks.iv30.toFixed(1)}%` : '—'} · <MetricInfo metricKey="hv30" values={{ hv30: ks.hv30 ?? null }} hasValue={ks.hv30 != null}>HV30</MetricInfo> {ks.hv30 != null ? `${ks.hv30.toFixed(1)}%` : '—'}{ks.iv_hv_spread != null ? ` · VRP ${ks.iv_hv_spread > 0 ? '+' : ''}${ks.iv_hv_spread.toFixed(1)}%` : ''}
           </div>
         )}
         {ks?.vol_cone && (
@@ -739,24 +744,24 @@ export function TerminalTradeCard({ detail, sentiment, savedCards, savingCards, 
                 : card.setup.net_debit != null
                 ? <span className="text-text-primary font-bold">PAY ${(card.setup.net_debit * 100).toFixed(0)}</span>
                 : null}
-              <span className="text-text-muted"> · MAX LOSS </span>
+              <span className="text-text-muted"> · <MetricInfo metricKey="max_loss" values={{ max_loss: Number(card.setup.max_loss) }} hasValue={card.setup.max_loss != null}>MAX LOSS</MetricInfo> </span>
               <span className="text-brand-red">{fmtDollar(card.setup.max_loss)}</span>
               {/* RISK-1: max loss as % of user-entered account size (only when set). */}
               {accountSize > 0 && card.setup.max_loss != null && (
                 <span className="text-text-faint"> ({((Math.abs(card.setup.max_loss) / accountSize) * 100).toFixed(1)}% of acct)</span>
               )}
-              <span className="text-text-muted"> · POP </span>
+              <span className="text-text-muted"> · <MetricInfo metricKey="est_pop" values={{ pop: card.setup.probability_of_profit != null ? card.setup.probability_of_profit * 100 : null, pop_method: card.setup.pop_method === 'breakeven_d2' ? 'N(d2)' : 'delta' }} hasValue={card.setup.probability_of_profit != null}>POP</MetricInfo> </span>
               <span className="text-text-primary">{fmtPct(card.setup.probability_of_profit)}</span>
               <span className="text-text-faint"> ({card.setup.pop_method === 'breakeven_d2' ? 'N(d2)' : 'Δ approx'})</span>
-              <span className="text-text-muted"> · EV </span>
+              <span className="text-text-muted"> · <MetricInfo metricKey="ev" values={{ ev: Number(card.setup.ev) }} hasValue={card.setup.ev != null}>EV</MetricInfo> </span>
               <span className={card.setup.ev >= 0 ? 'text-brand-green' : 'text-brand-red'}>{card.setup.ev >= 0 ? '+' : ''}${Math.round(card.setup.ev)}</span>
-              <span className="text-text-muted"> · EV/RISK </span>
+              <span className="text-text-muted"> · <MetricInfo metricKey="ev_per_risk" values={{ ev_per_risk: Number(card.setup.ev_per_risk) }} hasValue={card.setup.ev_per_risk != null}>EV/RISK</MetricInfo> </span>
               <span className="text-text-primary">{card.setup.ev_per_risk.toFixed(3)}</span>
-              <span className="text-text-muted"> · R:R </span>
+              <span className="text-text-muted"> · <MetricInfo metricKey="risk_reward" values={{ risk_reward: Number(card.setup.risk_reward_ratio) }} hasValue={card.setup.risk_reward_ratio != null}>R:R</MetricInfo> </span>
               <span className="text-text-primary">{card.setup.risk_reward_ratio != null ? card.setup.risk_reward_ratio.toFixed(2) : '—'}</span>
             </div>
             <div className="text-xs text-text-muted mt-0.5">
-              B/E {(card.setup.breakevens?.length ?? 0) === 0 ? '—' : card.setup.breakevens.map(b => `$${b.toFixed(2)}`).join(' / ')} · HV POP {card.setup.hv_pop != null ? `${Math.round(card.setup.hv_pop * 100)}%` : '—'} · THETA <span className={thetaPerDay >= 0 ? 'text-brand-green' : 'text-brand-red'}>{thetaPerDay >= 0 ? '+' : ''}${thetaPerDay.toFixed(2)}/day</span> · VEGA/pt <span className={vegaPt >= 0 ? 'text-brand-green' : 'text-brand-red'}>{vegaPt >= 0 ? '+' : ''}${Math.abs(vegaPt).toFixed(2)}</span> · KELLY <span className={kellyPct >= 2 ? 'text-brand-green' : kellyPct >= 1 ? 'text-yellow-400' : 'text-text-muted'}>{kellyPct.toFixed(1)}%</span>
+              <MetricInfo metricKey="breakevens" values={{ breakevens: (card.setup.breakevens?.length ?? 0) === 0 ? null : card.setup.breakevens.map(b => `$${b.toFixed(2)}`).join(' / ') }} hasValue={(card.setup.breakevens?.length ?? 0) > 0}>B/E</MetricInfo> {(card.setup.breakevens?.length ?? 0) === 0 ? '—' : card.setup.breakevens.map(b => `$${b.toFixed(2)}`).join(' / ')} · <MetricInfo metricKey="hv_pop" values={{ hv_pop: card.setup.hv_pop != null ? card.setup.hv_pop * 100 : null }} hasValue={card.setup.hv_pop != null}>HV POP</MetricInfo> {card.setup.hv_pop != null ? `${Math.round(card.setup.hv_pop * 100)}%` : '—'} · <MetricInfo metricKey="theta" values={{ theta: thetaPerDay }}>THETA</MetricInfo> <span className={thetaPerDay >= 0 ? 'text-brand-green' : 'text-brand-red'}>{thetaPerDay >= 0 ? '+' : ''}${thetaPerDay.toFixed(2)}/day</span> · <MetricInfo metricKey="vega" values={{ vega: vegaPt }}>VEGA/pt</MetricInfo> <span className={vegaPt >= 0 ? 'text-brand-green' : 'text-brand-red'}>{vegaPt >= 0 ? '+' : ''}${Math.abs(vegaPt).toFixed(2)}</span> · <MetricInfo metricKey="kelly" values={{ kelly: kellyPct }}>KELLY</MetricInfo> <span className={kellyPct >= 2 ? 'text-brand-green' : kellyPct >= 1 ? 'text-yellow-400' : 'text-text-muted'}>{kellyPct.toFixed(1)}%</span>
             </div>
             {card.setup.has_wide_spread && (
               <div className="text-xs text-yellow-400 mt-0.5">&#x26A0; Wide bid-ask spread — prices estimated from theoretical model</div>
@@ -852,24 +857,24 @@ export function TickerCard({ detail, sentiment, savedCards, savingCards, saveErr
       <div className="px-5 py-2 flex items-center justify-between flex-wrap gap-2 bg-brand-purple-hover">
         <div className="flex items-center gap-3">
           <span className="text-sm font-black font-mono text-white">{detail.symbol}</span>
-          <span className="text-sm font-black font-mono" style={{ color: gradeColorHex(comp.score) }} title="Convergence score 0–100. Combines Vol Edge, Quality, Regime, and Info Edge gates using z-score weighted averaging. Higher = stronger multi-signal agreement.">{comp.score.toFixed(1)}</span>
-          <span className="text-terminal-lg font-black" style={{ color: gradeColorHex(comp.score) }} title="Letter grade derived from composite score. A = 80+, B = 65+, C = 50+, D = 35+, F = below 35.">{letterGrade(comp.score)}</span>
+          <span className="text-sm font-black font-mono" style={{ color: gradeColorHex(comp.score) }}><MetricInfo metricKey="composite_score" values={{ score: comp.score }}>{comp.score.toFixed(1)}</MetricInfo></span>
+          <span className="text-terminal-lg font-black" style={{ color: gradeColorHex(comp.score) }}><MetricInfo metricKey="letter_grade" values={{ score: comp.score, grade: letterGrade(comp.score) }}>{letterGrade(comp.score)}</MetricInfo></span>
         </div>
         <div className="flex items-center gap-2 flex-wrap">
-          <span title="Scanner-computed direction based on dominant signal alignment across all four gates."><Badge variant={dirBadgeVariant(comp.direction)} size="sm">{comp.direction}</Badge></span>
+          <MetricInfo metricKey="direction" values={{ direction: comp.direction }}><Badge variant={dirBadgeVariant(comp.direction)} size="sm">{comp.direction}</Badge></MetricInfo>
           {ks?.sector && <span title="Stock sector from market data. Useful for concentration risk — avoid over-weighting one sector."><Badge variant="default" size="sm">{ks.sector}</Badge></span>}
-          <span title="Number of scoring gates above 50. All 4 gates above 50 = full position signal. Fewer gates = reduced conviction. 4/4 is the maximum signal strength."><Badge variant={gate.variant} size="sm">
+          <MetricInfo metricKey="gates" values={{ gates: comp.categories_above_50 }}><Badge variant={gate.variant} size="sm">
             {comp.categories_above_50}/4 {gate.text}
-          </Badge></span>
+          </Badge></MetricInfo>
         </div>
       </div>
 
       {/* B) SCORE BARS */}
       <div className="px-5 py-2 space-y-1.5 border-b border-border">
-        <div title="Volatility Edge (0–100): measures whether options are mispriced relative to realized vol. Combines VRP z-score, IV percentile, term structure shape, skew asymmetry, and dealer gamma exposure. Above 50 = options appear expensive = edge for premium sellers."><ScoreBar label="Vol Edge" score={comp.category_scores.vol_edge} /></div>
-        <div title="Quality Gate (0–100): measures the fundamental health of the underlying company. Combines Piotroski F-Score safety, profitability margins, earnings quality (accrual ratio + beat rate), and growth trajectory. Above 50 = high-quality underlying."><ScoreBar label="Quality" score={comp.category_scores.quality} /></div>
-        <div title="Macro Regime Gate (0–100): measures whether the current macro environment favors the trade direction. Scored from 14 FRED macro indicators including GDP, CPI, Fed Funds, yield curve, and credit spreads. Above 50 = favorable macro backdrop."><ScoreBar label="Regime" score={comp.category_scores.regime} /></div>
-        <div title="Information Edge Gate (0–100): measures signals of informed activity. Combines insider net purchase ratio (MSPR), institutional ownership changes, analyst upgrades/downgrades, SUE earnings surprise, and FinBERT news sentiment. Above 50 = positive information asymmetry."><ScoreBar label="Info Edge" score={comp.category_scores.info_edge} /></div>
+        <div title="Volatility Edge (0–100): measures whether options are mispriced relative to realized vol. Combines VRP z-score, IV percentile, term structure shape, skew asymmetry, and dealer gamma exposure. Above 50 = options appear expensive = edge for premium sellers."><MetricInfo metricKey="vol_edge" values={{ score: comp.category_scores.vol_edge }}><ScoreBar label="Vol Edge" score={comp.category_scores.vol_edge} /></MetricInfo></div>
+        <div title="Quality Gate (0–100): measures the fundamental health of the underlying company. Combines Piotroski F-Score safety, profitability margins, earnings quality (accrual ratio + beat rate), and growth trajectory. Above 50 = high-quality underlying."><MetricInfo metricKey="quality" values={{ score: comp.category_scores.quality }}><ScoreBar label="Quality" score={comp.category_scores.quality} /></MetricInfo></div>
+        <div title="Macro Regime Gate (0–100): measures whether the current macro environment favors the trade direction. Scored from 14 FRED macro indicators including GDP, CPI, Fed Funds, yield curve, and credit spreads. Above 50 = favorable macro backdrop."><MetricInfo metricKey="regime" values={{ score: comp.category_scores.regime }}><ScoreBar label="Regime" score={comp.category_scores.regime} /></MetricInfo></div>
+        <div title="Information Edge Gate (0–100): measures signals of informed activity. Combines insider net purchase ratio (MSPR), institutional ownership changes, analyst upgrades/downgrades, SUE earnings surprise, and FinBERT news sentiment. Above 50 = positive information asymmetry."><MetricInfo metricKey="info_edge" values={{ score: comp.category_scores.info_edge }}><ScoreBar label="Info Edge" score={comp.category_scores.info_edge} /></MetricInfo></div>
       </div>
 
       {/* B2) SOCIAL PULSE — promoted from Key Stats */}
@@ -958,11 +963,11 @@ export function TickerCard({ detail, sentiment, savedCards, savingCards, saveErr
                 {/* Key numbers row */}
                 <div className="grid grid-cols-5 gap-3 mb-2">
                   <div className="text-center">
-                    <div className="text-[9px] text-text-muted uppercase">Max Profit</div>
+                    <div className="text-[9px] text-text-muted uppercase"><MetricInfo metricKey="max_profit" values={{ max_profit: Number(card.setup.max_profit) }} hasValue={card.setup.max_profit != null}>Max Profit</MetricInfo></div>
                     <div className="text-sm font-mono font-black text-brand-green">{fmtDollar(card.setup.max_profit)}</div>
                   </div>
                   <div className="text-center">
-                    <div className="text-[9px] text-text-muted uppercase">Max Loss</div>
+                    <div className="text-[9px] text-text-muted uppercase"><MetricInfo metricKey="max_loss" values={{ max_loss: Number(card.setup.max_loss) }} hasValue={card.setup.max_loss != null}>Max Loss</MetricInfo></div>
                     <div className="text-sm font-mono font-black text-brand-red">{fmtDollar(card.setup.max_loss)}</div>
                     {/* RISK-1: max loss as % of user-entered account size (only when set). */}
                     {accountSize > 0 && card.setup.max_loss != null && (
@@ -972,20 +977,20 @@ export function TickerCard({ detail, sentiment, savedCards, savingCards, saveErr
                     )}
                   </div>
                   <div className="text-center">
-                    <div className="text-[9px] text-text-muted uppercase" title={card.setup.pop_method === 'breakeven_d2' ? 'PoP via N(d2) at breakeven price — the standard Black-Scholes probability that the underlying closes beyond the breakeven price at expiration. More accurate than delta approx.' : 'PoP estimated from option deltas — quick approximation used when breakeven calculation is unavailable. Less precise than N(d2) method.'}>Est. PoP</div>
+                    <div className="text-[9px] text-text-muted uppercase" title={card.setup.pop_method === 'breakeven_d2' ? 'PoP via N(d2) at breakeven price — the standard Black-Scholes probability that the underlying closes beyond the breakeven price at expiration. More accurate than delta approx.' : 'PoP estimated from option deltas — quick approximation used when breakeven calculation is unavailable. Less precise than N(d2) method.'}><MetricInfo metricKey="est_pop" values={{ pop: card.setup.probability_of_profit != null ? card.setup.probability_of_profit * 100 : null, pop_method: card.setup.pop_method === 'breakeven_d2' ? 'N(d2)' : 'delta' }} hasValue={card.setup.probability_of_profit != null}>Est. PoP</MetricInfo></div>
                     <div className="text-sm font-mono font-black text-text-primary">{fmtPct(card.setup.probability_of_profit)}</div>
                     <div className={`text-[8px] font-mono mt-0.5 ${card.setup.pop_method === 'breakeven_d2' ? 'text-brand-green' : 'text-text-faint'}`}>
                       {card.setup.pop_method === 'breakeven_d2' ? 'N(d2)' : 'Δ approx'}
                     </div>
                   </div>
                   <div className="text-center">
-                    <div className="text-[9px] text-text-muted uppercase" title="Expected Value estimate using three-outcome model. Not a guarantee of returns.">Est. EV</div>
+                    <div className="text-[9px] text-text-muted uppercase" title="Expected Value estimate using three-outcome model. Not a guarantee of returns."><MetricInfo metricKey="ev" values={{ ev: Number(card.setup.ev) }} hasValue={card.setup.ev != null}>Est. EV</MetricInfo></div>
                     <div className={`text-sm font-mono font-black ${card.setup.ev > 0 ? 'text-brand-green' : card.setup.ev < 0 ? 'text-brand-red' : 'text-text-muted'}`}>
                       {card.setup.ev !== 0 ? `${card.setup.ev >= 0 ? '+' : ''}$${Math.round(card.setup.ev)}` : '—'}
                     </div>
                   </div>
                   <div className="text-center">
-                    <div className="text-[9px] text-text-muted uppercase">Risk/Reward</div>
+                    <div className="text-[9px] text-text-muted uppercase"><MetricInfo metricKey="risk_reward" values={{ risk_reward: Number(card.setup.risk_reward_ratio) }} hasValue={card.setup.risk_reward_ratio != null}>Risk/Reward</MetricInfo></div>
                     <div className="text-sm font-mono font-black text-text-primary">{card.setup.risk_reward_ratio != null ? card.setup.risk_reward_ratio.toFixed(2) : '—'}</div>
                   </div>
                 </div>
@@ -994,7 +999,7 @@ export function TickerCard({ detail, sentiment, savedCards, savingCards, saveErr
                 <div className="border-t border-border mt-2 pt-2">
                   <div className="grid grid-cols-3 gap-3 mb-2">
                     <div className="text-center">
-                      <div className="text-[9px] text-text-muted uppercase" title="Dollar delta: how much this position gains or loses if the stock moves $1. Calculated as net delta × stock price × 100.">Δ Exposure</div>
+                      <div className="text-[9px] text-text-muted uppercase" title="Dollar delta: how much this position gains or loses if the stock moves $1. Calculated as net delta × stock price × 100."><MetricInfo metricKey="delta" values={{ dollar_delta: Math.round((card.setup.greeks?.delta ?? 0) * (card.key_stats?.current_price ?? 0) * 100) }} hasValue={card.setup.greeks?.delta != null}>Δ Exposure</MetricInfo></div>
                       <div className={`text-sm font-mono font-black ${(() => {
                         const cp = card.key_stats?.current_price;
                         if (cp == null) return 'text-text-muted';
@@ -1010,7 +1015,7 @@ export function TickerCard({ detail, sentiment, savedCards, savingCards, saveErr
                       </div>
                     </div>
                     <div className="text-center">
-                      <div className="text-[9px] text-text-muted uppercase" title="Dollar theta: how much this position earns (credit) or loses (debit) per calendar day from time decay alone. Already in per-contract dollar terms.">Daily θ</div>
+                      <div className="text-[9px] text-text-muted uppercase" title="Dollar theta: how much this position earns (credit) or loses (debit) per calendar day from time decay alone. Already in per-contract dollar terms."><MetricInfo metricKey="theta" values={{ theta: card.setup.greeks?.theta_per_day != null ? Number(card.setup.greeks.theta_per_day) : null }} hasValue={card.setup.greeks?.theta_per_day != null}>Daily θ</MetricInfo></div>
                       {(() => {
                         const t = card.setup.greeks?.theta_per_day ?? 0;
                         return (
@@ -1021,7 +1026,7 @@ export function TickerCard({ detail, sentiment, savedCards, savingCards, saveErr
                       })()}
                     </div>
                     <div className="text-center">
-                      <div className="text-[9px] text-text-muted uppercase" title="Dollar vega: how much this position gains or loses if implied volatility moves 1 percentage point. Per contract.">Vega/pt</div>
+                      <div className="text-[9px] text-text-muted uppercase" title="Dollar vega: how much this position gains or loses if implied volatility moves 1 percentage point. Per contract."><MetricInfo metricKey="vega" values={{ vega: card.setup.greeks?.vega != null ? Number(card.setup.greeks.vega) * 100 : null }} hasValue={card.setup.greeks?.vega != null}>Vega/pt</MetricInfo></div>
                       {(() => {
                         const v = (card.setup.greeks?.vega ?? 0) * 100;
                         return (
@@ -1063,11 +1068,8 @@ export function TickerCard({ detail, sentiment, savedCards, savingCards, saveErr
                   const kellyPct = Math.round(quarterKelly * 1000) / 10;
                   return (
                     <div className="border-t border-border mt-2 pt-2 flex justify-between items-start px-1">
-                      <span
-                        className="text-[9px] uppercase tracking-wider text-text-muted cursor-help"
-                        title="Quarter-Kelly = 25% of full Kelly criterion. Formula: (win_rate × ratio − loss_rate) / ratio × 0.25, where ratio = max_profit / max_loss."
-                      >
-                        Kelly Size
+                      <span className="text-[9px] uppercase tracking-wider text-text-muted">
+                        <MetricInfo metricKey="kelly" values={{ kelly: kellyPct }}>Kelly Size</MetricInfo>
                       </span>
                       <div className="text-right">
                         <span className={`text-sm font-mono font-bold ${

--- a/src/components/trading/MetricExplainer.tsx
+++ b/src/components/trading/MetricExplainer.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import { createContext, useContext, useId, useState, type ReactNode } from 'react';
+import { METRIC_EXPLAINERS, type MetricValues } from './metricExplainers';
+
+/**
+ * TEACH-1 — tap-to-open, mobile-first metric explainers.
+ *
+ * `MetricInfo` wraps a metric's on-card label with a subtle affordance (dotted underline
+ * + ⓘ). Tapping it opens a plain-language panel: what the number MEANS (with the card's
+ * LIVE values) → HOW it's made (numbered steps) → the exact data source. One panel open
+ * at a time (coordinated by MetricExplainerProvider). No fetches, no external calls —
+ * content is deterministic client-side templates.
+ *
+ * TRUTH-FIRST: if the metric's value is missing, the panel shows the true-state message
+ * instead of a fabricated number.
+ */
+
+interface Ctx { openId: string | null; setOpenId: (id: string | null) => void; }
+const ExplainerCtx = createContext<Ctx | null>(null);
+
+export function MetricExplainerProvider({ children }: { children: ReactNode }) {
+  const [openId, setOpenId] = useState<string | null>(null);
+  return <ExplainerCtx.Provider value={{ openId, setOpenId }}>{children}</ExplainerCtx.Provider>;
+}
+
+interface MetricInfoProps {
+  metricKey: string;
+  values: MetricValues;
+  /** The metric's primary value; when null/undefined the panel shows the true-state message. */
+  hasValue?: boolean;
+  /** Reason the value is unavailable, if known from the data (else a generic true-state line). */
+  missingReason?: string;
+  children: ReactNode;
+}
+
+export default function MetricInfo({ metricKey, values, hasValue = true, missingReason, children }: MetricInfoProps) {
+  const id = useId();
+  const ctx = useContext(ExplainerCtx);
+  // Fall back to self-managed state if no provider is mounted (still works, just not
+  // coordinated one-at-a-time).
+  const [selfOpen, setSelfOpen] = useState(false);
+  const open = ctx ? ctx.openId === id : selfOpen;
+  const toggle = () => {
+    if (ctx) ctx.setOpenId(open ? null : id);
+    else setSelfOpen((o) => !o);
+  };
+
+  const meta = METRIC_EXPLAINERS[metricKey];
+
+  return (
+    <span className="relative inline-block">
+      <button
+        type="button"
+        onClick={toggle}
+        aria-expanded={open}
+        className="inline-flex items-center gap-0.5 border-b border-dotted border-text-faint text-left hover:border-brand-purple focus:outline-none focus:border-brand-purple"
+      >
+        {children}
+        <span aria-hidden="true" className="text-[9px] text-text-faint">ⓘ</span>
+      </button>
+
+      {open && meta && (
+        <span
+          role="dialog"
+          className="absolute left-0 top-full z-50 mt-1 block w-72 max-w-[85vw] rounded-lg border border-border bg-white p-3 text-left shadow-lg"
+        >
+          <span className="mb-1 flex items-start justify-between gap-2">
+            <span className="text-sm font-semibold text-text-primary">{meta.title}</span>
+            <button
+              type="button"
+              onClick={toggle}
+              aria-label="Close"
+              className="shrink-0 text-xs text-text-muted hover:text-text-primary"
+            >
+              ✕
+            </button>
+          </span>
+
+          {hasValue ? (
+            <>
+              <span className="block space-y-1 text-xs text-text-secondary">
+                {meta.explain(values).map((line, i) => (
+                  <span key={i} className="block">{line}</span>
+                ))}
+              </span>
+              <span className="mt-2 block text-[11px] font-semibold uppercase tracking-wider text-text-muted">How it&rsquo;s made</span>
+              <ol className="mt-0.5 list-decimal space-y-0.5 pl-4 text-[11px] text-text-secondary">
+                {meta.pipeline.map((step, i) => (
+                  <li key={i}>{step}</li>
+                ))}
+              </ol>
+            </>
+          ) : (
+            <span className="block text-xs text-text-secondary">
+              This value could not be computed for this card — {missingReason || 'data not available from source'}.
+            </span>
+          )}
+
+          <span className="mt-2 block font-mono text-[10px] text-text-muted">
+            Data source: {meta.source}
+          </span>
+        </span>
+      )}
+    </span>
+  );
+}

--- a/src/components/trading/metricExplainers.ts
+++ b/src/components/trading/metricExplainers.ts
@@ -1,0 +1,428 @@
+// TEACH-1 — plain-language explainers for every number on a trade card.
+//
+// Deterministic client-side content templates — ZERO per-tap cost, no fetches, no
+// external APIs. Each explainer interpolates the card's LIVE values.
+//
+// Language rules (LANG-1 + Alex's voice): plain, ~5th-grade readable, no jargon without
+// an immediate plain translation, step-by-step "how this number is made", NO imperatives,
+// NO "should/recommend/consider", NO predictions. We teach what a number MEANS and HOW
+// it is made — never what to do about it.
+//
+// TRUTH-FIRST: `source` labels are exact per the Phase-1 catalog (TastyTrade live options
+// chain / Finnhub / FRED / computed by the scanner / computed on this page) — no generic
+// "market data" hand-waving. A null/missing value is handled by the UI's true-state
+// message; explain() may assume the value it needs is present (the UI guards nulls).
+
+export interface MetricValues {
+  [k: string]: number | string | null | undefined;
+}
+
+export interface MetricExplainer {
+  title: string;
+  /** 2-4 short plain sentences using the card's live numbers. */
+  explain: (v: MetricValues) => string[];
+  /** How the number is made: 3-6 plain steps (raw data -> math -> result). */
+  pipeline: string[];
+  /** Exact data-source label (Phase-1 accurate). */
+  source: string;
+}
+
+const pct = (v: unknown, d = 0) => (typeof v === 'number' ? `${v.toFixed(d)}%` : '—');
+const num = (v: unknown, d = 1) => (typeof v === 'number' ? v.toFixed(d) : '—');
+const dollars = (v: unknown) =>
+  typeof v === 'number' ? (v < 0 ? '-' : '') + '$' + Math.abs(Math.round(v)).toLocaleString('en-US') : '—';
+
+export const METRIC_EXPLAINERS: Record<string, MetricExplainer> = {
+  composite_score: {
+    title: 'Convergence score',
+    explain: (v) => [
+      `This card scores ${num(v.score)} out of 100.`,
+      'It is the average of four separate report cards on the trade — how mispriced the options look, how healthy the company is, whether the wider market backdrop fits, and whether informed people are buying.',
+      'A higher number means more of those four things point the same way at once.',
+    ],
+    pipeline: [
+      'Four gates are each scored 0 to 100: Vol Edge, Quality, Regime, Info Edge.',
+      'Each gate is turned into a "z-score" — how far above or below normal it is.',
+      'The four are blended with fixed weights (Vol Edge counts most, Info Edge least).',
+      'The blend is scaled back onto a 0-to-100 line — that is this number.',
+    ],
+    source: 'Computed by the scanner from the four gate scores',
+  },
+
+  letter_grade: {
+    title: 'Letter grade',
+    explain: (v) => [
+      `The score of ${num(v.score)} maps to grade ${v.grade ?? '—'}.`,
+      'It is just the score in report-card form: 80 and up is an A, 65+ a B, 50+ a C, 35+ a D, below 35 an F.',
+      'The grade adds no new information — it only makes the score quicker to read.',
+    ],
+    pipeline: [
+      'Take the convergence score (0 to 100).',
+      'Look up which band it falls in: 80+ A, 65+ B, 50+ C, 35+ D, else F.',
+      'Show that letter.',
+    ],
+    source: 'Computed on this page from the convergence score',
+  },
+
+  vol_edge: {
+    title: 'Vol Edge',
+    explain: (v) => [
+      `Vol Edge is ${num(v.score)} out of 100.`,
+      'It asks one question: are these options priced higher than the stock actually tends to move?',
+      'When options are "expensive" like that, a seller of options is being paid extra for the same risk. Above 50 means they look expensive.',
+    ],
+    pipeline: [
+      'Measure how much the options imply the stock will move (implied volatility).',
+      'Measure how much the stock has really moved lately (realized volatility).',
+      'Compare the two as a z-score, and add option-chain shape clues (term structure, skew, dealer positioning).',
+      'Blend those into a 0-to-100 score.',
+      'Example: if options price in a big swing but the stock has been calm, this score rises.',
+    ],
+    source: 'Computed by the scanner from TastyTrade options data and price history',
+  },
+
+  quality: {
+    title: 'Quality gate',
+    explain: (v) => [
+      `Quality is ${num(v.score)} out of 100.`,
+      'It is a health check on the underlying company — is it profitable, financially safe, and steady with its earnings?',
+      'Above 50 means the company looks solid rather than shaky.',
+    ],
+    pipeline: [
+      'Pull company fundamentals: profitability, margins, balance-sheet safety (Piotroski F-Score).',
+      'Add earnings quality: how often it beats, and whether profits are real cash or accounting.',
+      'Combine those into a 0-to-100 score.',
+    ],
+    source: 'Computed by the scanner from Finnhub fundamentals data',
+  },
+
+  regime: {
+    title: 'Macro regime gate',
+    explain: (v) => [
+      `Regime is ${num(v.score)} out of 100.`,
+      'It looks at the weather of the whole economy — growth, inflation, interest rates, the yield curve — and asks whether that backdrop fits this trade.',
+      'Above 50 means the big-picture conditions line up rather than fight the trade.',
+    ],
+    pipeline: [
+      'Read 14 national economic indicators (GDP, CPI, Fed Funds rate, yield curve, credit spreads, and more).',
+      'Classify the current environment (for example: calm growth, or high-stress).',
+      'Score how well that environment fits the trade direction, 0 to 100.',
+    ],
+    source: 'Computed by the scanner from FRED macro data',
+  },
+
+  info_edge: {
+    title: 'Info Edge gate',
+    explain: (v) => [
+      `Info Edge is ${num(v.score)} out of 100.`,
+      'It watches for footprints of people who tend to know more — company insiders buying, big institutions, analysts changing their minds, and the tone of the news.',
+      'Above 50 means those footprints lean positive.',
+    ],
+    pipeline: [
+      'Check insider buying vs selling (the MSPR ratio).',
+      'Check institutional ownership changes and analyst upgrades/downgrades.',
+      'Read recent news tone with a sentiment model (FinBERT) and earnings-surprise history.',
+      'Blend into a 0-to-100 score.',
+    ],
+    source: 'Computed by the scanner from Finnhub analyst/insider data and news sentiment',
+  },
+
+  gates: {
+    title: 'Gates passed',
+    explain: (v) => [
+      `${v.gates ?? '—'} of 4 gates scored above 50 on this card.`,
+      'The four gates are Vol Edge, Quality, Regime, and Info Edge. A gate "passes" when its score clears 50.',
+      'More gates above 50 means more of the four checks agree at the same time. 4 of 4 is the most agreement possible.',
+    ],
+    pipeline: [
+      'Score each of the four gates 0 to 100.',
+      'Count how many are above 50.',
+      'Show that count out of 4.',
+    ],
+    source: 'Computed on this page from the four gate scores',
+  },
+
+  direction: {
+    title: 'Direction',
+    explain: (v) => [
+      `The scanner reads this setup as "${v.direction ?? '—'}".`,
+      'It is the way the four gates lean when you add them up — up-leaning, down-leaning, or balanced.',
+      'It describes what the signals say, not a call on what happens next.',
+    ],
+    pipeline: [
+      'Look at which gates are strong and in which direction they point.',
+      'Take the dominant lean across all four.',
+      'Label it (for example bullish, bearish, or neutral).',
+    ],
+    source: 'Computed by the scanner from the four gate scores',
+  },
+
+  iv_rank: {
+    title: 'IV Rank',
+    explain: (v) => [
+      `IV Rank is ${num(v.iv_rank, 2)}.`,
+      `It says today's option prices sit near the ${num(v.iv_rank, 0)} mark on a 0-to-100 line versus the past year.`,
+      'Higher means options are pricier than they usually are — the market is paying up for a possible move.',
+    ],
+    pipeline: [
+      'Track this stock’s implied volatility (option-priced expected move) every day for a year.',
+      'Find where today sits between the year’s lowest and highest.',
+      'Turn that position into a 0-to-100 rank.',
+      'Example: 82 means options are more expensive than they were on about 82% of the past year.',
+    ],
+    source: 'Computed by the scanner from TastyTrade options data',
+  },
+
+  iv30: {
+    title: 'IV (30-day)',
+    explain: (v) => [
+      `The 30-day implied volatility is ${pct(v.iv30, 1)}.`,
+      'This is the size of move the options are pricing in over the next month, as a yearly percentage.',
+      'Bigger number means the options expect a bumpier ride.',
+    ],
+    pipeline: [
+      'Read the current option prices around 30 days out.',
+      'Back out the move those prices imply (implied volatility).',
+      'State it as an annualized percentage.',
+    ],
+    source: 'Computed by the scanner from TastyTrade live options chain',
+  },
+
+  hv30: {
+    title: 'HV (30-day)',
+    explain: (v) => [
+      `The 30-day historical volatility is ${pct(v.hv30, 1)}.`,
+      'This is how much the stock has ACTUALLY moved over the last month, as a yearly percentage.',
+      'It is the reality check against what the options expect.',
+    ],
+    pipeline: [
+      'Take the stock’s daily price changes over the past ~30 days.',
+      'Measure how spread out those changes were (standard deviation).',
+      'Scale it up to a yearly percentage.',
+    ],
+    source: 'Computed by the scanner from historical price data',
+  },
+
+  vrp: {
+    title: 'VRP (IV minus HV)',
+    explain: (v) => [
+      `The volatility risk premium is ${typeof v.vrp === 'number' ? (v.vrp > 0 ? '+' : '') + pct(v.vrp, 1) : '—'}.`,
+      'It is simply what options expect (IV) minus what the stock actually did (HV).',
+      'A positive gap means options were pricing in more movement than really happened — the seller’s cushion.',
+    ],
+    pipeline: [
+      'Take implied volatility (what options expect).',
+      'Subtract historical volatility (what actually happened).',
+      'The leftover gap is the volatility risk premium.',
+      'Example: IV 40% minus HV 25% = +15% — options were 15 points "richer" than reality.',
+    ],
+    source: 'Computed by the scanner from TastyTrade IV and historical price data',
+  },
+
+  max_profit: {
+    title: 'Max profit',
+    explain: (v) => [
+      `The most this trade can make is ${dollars(v.max_profit)}.`,
+      'It is the best-case dollar outcome if everything lands exactly right at expiration.',
+      'It is a ceiling, not a promise — most trades land somewhere in between.',
+    ],
+    pipeline: [
+      'Take the option legs, their strike prices, and the price paid or collected.',
+      'Work out the payoff at the single best price for this structure.',
+      'Multiply by 100 (one option controls 100 shares).',
+    ],
+    source: 'Computed by the scanner from the option legs and prices',
+  },
+
+  max_loss: {
+    title: 'Max loss',
+    explain: (v) => [
+      `The most this trade is designed to lose is ${dollars(v.max_loss)}.`,
+      'It is the worst-case dollar outcome for a defined-risk structure at expiration.',
+      'This is the number the track record checks each closed trade against.',
+    ],
+    pipeline: [
+      'Take the option legs, strikes, and the price paid or collected.',
+      'Work out the payoff at the single worst price for this structure.',
+      'Multiply by 100 (one option controls 100 shares).',
+      'Note: if a leg is a naked short, loss is not capped — the card flags that separately.',
+    ],
+    source: 'Computed by the scanner from the option legs and prices',
+  },
+
+  est_pop: {
+    title: 'Estimated probability of profit',
+    explain: (v) => [
+      `The estimated chance this trade ends with any profit is ${pct(v.pop, 0)}.`,
+      v.pop_method === 'N(d2)'
+        ? 'It is measured from where the stock would have to close (the breakeven), using a standard options-math formula.'
+        : 'It is a quick estimate read from the option deltas — less precise than the breakeven method.',
+      'It is an estimate from today’s prices, not a guarantee.',
+    ],
+    pipeline: [
+      'Find the breakeven price(s) where the trade turns from loss to profit.',
+      'Use options math to estimate the chance the stock closes on the winning side (the N(d2) method).',
+      'If breakevens are unavailable, fall back to a delta-based approximation.',
+      'State it as a percentage.',
+    ],
+    source: 'Computed by the scanner from the option prices and breakevens',
+  },
+
+  ev: {
+    title: 'Expected value (EV)',
+    explain: (v) => [
+      `The estimated average outcome is ${dollars(v.ev)} per trade.`,
+      'It weighs the win, the loss, and the in-between by how likely each is, then averages them.',
+      'It is a long-run average estimate, not what any single trade will do.',
+    ],
+    pipeline: [
+      'List the possible outcomes (roughly: max win, max loss, and a middle case).',
+      'Estimate the chance of each from the option prices.',
+      'Multiply each outcome by its chance and add them up.',
+      'Example: 60% chance of +$100 and 40% chance of -$100 gives an EV of +$20.',
+    ],
+    source: 'Computed by the scanner using a three-outcome model',
+  },
+
+  ev_per_risk: {
+    title: 'EV per unit of risk',
+    explain: (v) => [
+      `For every $1 at risk, the estimated average return is ${num(v.ev_per_risk, 3)}.`,
+      'It takes the expected value and divides it by the max loss, so trades of different sizes can be compared fairly.',
+      'Bigger means more estimated reward for the same dollar of risk.',
+    ],
+    pipeline: [
+      'Take the expected value (the average estimated outcome).',
+      'Divide it by the max loss (the dollars at risk).',
+      'The result is expected return per dollar risked.',
+    ],
+    source: 'Computed by the scanner from EV and max loss',
+  },
+
+  risk_reward: {
+    title: 'Risk / reward',
+    explain: (v) => [
+      `The risk-to-reward ratio is ${num(v.risk_reward, 2)}.`,
+      'It compares the most you can lose to the most you can make.',
+      'A ratio of 2.00 means you are risking two dollars to try to make one — common for high-probability option sales.',
+    ],
+    pipeline: [
+      'Take the max loss and the max profit.',
+      'Divide max loss by max profit.',
+      'Show the ratio.',
+    ],
+    source: 'Computed by the scanner from max loss and max profit',
+  },
+
+  breakevens: {
+    title: 'Breakeven price(s)',
+    explain: (v) => [
+      `This trade breaks even at ${v.breakevens ? String(v.breakevens) : '—'}.`,
+      'These are the stock prices where the trade makes exactly zero at expiration — the line between profit and loss.',
+      'Inside the breakevens the trade profits; past them it loses.',
+    ],
+    pipeline: [
+      'Start from the strikes and the price paid or collected.',
+      'Find the stock price(s) where the payoff is exactly zero.',
+      'Those are the breakeven point(s).',
+    ],
+    source: 'Computed by the scanner from the option legs and prices',
+  },
+
+  delta: {
+    title: 'Delta exposure',
+    explain: (v) => [
+      `Dollar delta is about ${dollars(v.dollar_delta)}.`,
+      'It is how much the position gains or loses if the stock moves $1 right now.',
+      'Near zero means the trade barely cares which way the stock goes — it is close to direction-neutral.',
+    ],
+    pipeline: [
+      'Take the position’s net delta from the live option chain.',
+      'Multiply by the stock price and by 100 (shares per contract).',
+      'That is the dollar move per $1 stock move.',
+    ],
+    source: 'Computed by the scanner from TastyTrade live option greeks',
+  },
+
+  theta: {
+    title: 'Daily theta',
+    explain: (v) => [
+      `Time decay is ${typeof v.theta === 'number' ? (v.theta >= 0 ? '+' : '') + dollars(v.theta) : '—'} per day.`,
+      'It is how much the position earns (if positive) or loses (if negative) each day just from time passing.',
+      'Option sellers usually want this positive — the clock pays them.',
+    ],
+    pipeline: [
+      'Take the position’s theta from the live option chain.',
+      'Express it in dollars per contract, per calendar day.',
+      'Show that daily amount.',
+    ],
+    source: 'Computed by the scanner from TastyTrade live option greeks',
+  },
+
+  vega: {
+    title: 'Vega',
+    explain: (v) => [
+      `Vega is about ${dollars(v.vega)} per 1 point of volatility.`,
+      'It is how much the position gains or loses if implied volatility moves up or down by one percentage point.',
+      'It tells you how sensitive the trade is to options getting more or less "expensive".',
+    ],
+    pipeline: [
+      'Take the position’s vega from the live option chain.',
+      'Scale it to dollars per contract per 1 volatility point.',
+      'Show that amount.',
+    ],
+    source: 'Computed by the scanner from TastyTrade live option greeks',
+  },
+
+  kelly: {
+    title: 'Quarter-Kelly size',
+    explain: (v) => [
+      `Quarter-Kelly comes out to ${num(v.kelly, 1)}% of an account.`,
+      'The Kelly formula estimates a position size from the win chance and the reward-to-risk. This card uses a quarter of it — a cautious fraction.',
+      'It is a math output about sizing, not a call to trade any amount.',
+    ],
+    pipeline: [
+      'Take the estimated win rate and the reward-to-risk ratio.',
+      'Full Kelly = (win rate × ratio − loss rate) ÷ ratio.',
+      'Multiply by 0.25 to get the cautious quarter-Kelly.',
+      'Show it as a percent of an account. Example: full Kelly 8% → quarter-Kelly 2%.',
+    ],
+    source: 'Computed on this page from the win rate and reward-to-risk',
+  },
+
+  hv_pop: {
+    title: 'HV-based probability of profit',
+    explain: (v) => [
+      `Using how the stock has really moved, the estimated chance of profit is ${pct(v.hv_pop, 0)}.`,
+      'It is the same idea as PoP, but it uses the stock’s actual past movement (historical volatility) instead of what options imply.',
+      'Comparing it with the options-based PoP shows whether the two agree.',
+    ],
+    pipeline: [
+      'Measure the stock’s real movement (historical volatility).',
+      'Estimate the chance it closes on the winning side of the breakevens.',
+      'State it as a percentage.',
+    ],
+    source: 'Computed by the scanner from historical price data',
+  },
+
+  net_credit_debit: {
+    title: 'Credit collected / debit paid',
+    explain: (v) => [
+      typeof v.net_credit === 'number' && v.net_credit > 0
+        ? `This trade collects ${dollars((v.net_credit as number) * 100)} up front.`
+        : typeof v.net_debit === 'number'
+        ? `This trade costs ${dollars((v.net_debit as number) * 100)} up front.`
+        : 'The upfront amount is not available for this card.',
+      'A credit is cash you receive to open the trade; a debit is cash you pay.',
+      'It is multiplied by 100 because one option contract controls 100 shares.',
+    ],
+    pipeline: [
+      'Add up the price of the options you sell (money in).',
+      'Subtract the price of the options you buy (money out).',
+      'If the total is positive it is a credit; if negative it is a debit. Multiply by 100.',
+    ],
+    source: 'Computed by the scanner from the option legs and prices',
+  },
+};
+
+export type MetricKey = keyof typeof METRIC_EXPLAINERS;


### PR DESCRIPTION
Content + presentation layer only — no metric computation, fetch, or card logic changed. Deterministic client-side templates: zero per-tap cost, no external calls, no new routes.

- metricExplainers.ts: typed map of 24 metrics -> { title, explain(liveValues)->string[], pipeline (how the number is made), source (exact per-metric data source: TastyTrade live options chain / Finnhub / FRED / computed by the scanner / computed on this page) }. Plain ~5th-grade language, worked mini-examples, no imperatives/recommend/predict.
- MetricExplainer.tsx: <MetricInfo> wraps a metric label with a dotted-underline + ⓘ affordance; tap opens a panel (title -> plain explanation with the card's LIVE numbers -> numbered "how it's made" -> "Data source:" line). Mobile-first tap (existing title= tooltips were hover-only, dead on touch). Null value -> true-state message, not a fabricated number. (MetricExplainerProvider exported for one-at-a-time; panels self-manage here to avoid whole-return surgery — each is individually dismissible.)
- Wired 24 metric sites across BOTH card renderers (TickerCard: composite, grade, direction, gates, 4 gate bars, max profit/loss, PoP, EV, R:R, delta, theta, vega, kelly; TerminalTradeCard: max loss, PoP, EV, EV/risk, R:R, breakevens, HV PoP, theta, vega, kelly, IV rank/IV/HV30). Replaced 14 hover-only title= tooltips with tappable explainers.