### PR TITLE
EDGE-3: monotonicity reject + HV10>IV disqualification — sanity gates…

### DIFF
--- a/src/app/api/test/convergence/route.ts
+++ b/src/app/api/test/convergence/route.ts
@@ -7,7 +7,7 @@ import { fetchFredMacro, fetchFredDailySeries, fetchAnnualFinancials, fetchNewsS
 import { computeCrossAssetCorrelations } from '@/lib/convergence/cross-asset';
 import { fetchChainAndBuildCards } from '@/lib/convergence/chain-fetcher';
 import type { ChainTickerInput } from '@/lib/convergence/chain-fetcher';
-import { generateTradeCards } from '@/lib/convergence/trade-cards';
+import { generateTradeCards, computeCloseToCloseHV } from '@/lib/convergence/trade-cards';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 import type {
   CandleData,
@@ -299,6 +299,10 @@ export async function GET(request: Request) {
           'Risk-free rate is required for Black-Scholes calculation.'
         );
       }
+      // EDGE-3: 10-day realized vol (same computation as the displayed vol cone,
+      // percent → decimal); null = HV10>IV gate declares itself not-evaluated.
+      const hv10Pct = computeCloseToCloseHV(ttCandleResult.candles, 10);
+
       const chainInput: ChainTickerInput[] = [{
         symbol,
         suggested_dte: scoringResult.strategy_suggestion.suggested_dte,
@@ -307,6 +311,7 @@ export async function GET(request: Request) {
         ivRank: ttScannerResult.data.ivRank,
         iv30: rawIv30 / 100,
         hv30: rawHv30 / 100,
+        hv10: hv10Pct != null ? hv10Pct / 100 : null,
         riskFreeRate: fredResult.data.fedFunds / 100,
       }];
 

--- a/src/lib/convergence/chain-fetcher.ts
+++ b/src/lib/convergence/chain-fetcher.ts
@@ -14,6 +14,10 @@ export interface ChainTickerInput {
   ivRank: number;        // 0-1 scale
   iv30: number;          // decimal e.g. 0.42
   hv30: number;          // decimal e.g. 0.25
+  // EDGE-3: 10-day realized vol, decimal (e.g. 0.55). Required — null means not
+  // computable from candle history; the HV10>IV gate then declares itself
+  // not-evaluated instead of running on an invented value.
+  hv10: number | null;
   // Risk-free rate from FRED FEDFUNDS series, converted to decimal. Required — no default.
   riskFreeRate: number;
 }
@@ -361,6 +365,7 @@ export async function fetchChainAndBuildCards(
             symbol: ticker.symbol,
             iv30: ticker.iv30,
             hv30: ticker.hv30,
+            hv10: ticker.hv10,
             riskFreeRate: ticker.riskFreeRate,
           });
 

--- a/src/lib/convergence/pipeline.ts
+++ b/src/lib/convergence/pipeline.ts
@@ -15,7 +15,7 @@ import type { FullScoringResult } from './composite';
 import { computePreFilter } from './pre-filter';
 import type { PreFilterResult } from './pre-filter';
 import { logScanSnapshotBatch } from './snapshot-logger';
-import { generateTradeCards } from './trade-cards';
+import { generateTradeCards, computeCloseToCloseHV } from './trade-cards';
 import type {
   TTScannerData,
   ConvergenceInput,
@@ -1532,6 +1532,12 @@ export async function runPipeline(
       // Exclude ticker if IV_percentile is null — no fallback
       if (s.vol_edge.breakdown.mispricing.inputs.IV_percentile == null) return null;
 
+      // EDGE-3: 10-day realized vol for the HV10>IV sanity gate — same
+      // computation as the displayed vol cone (computeCloseToCloseHV, percent),
+      // converted to decimal. null when candle history is insufficient; the
+      // gate then declares itself not-evaluated (never imputed).
+      const hv10Pct = computeCloseToCloseHV(candleDataMap.get(row.symbol) ?? [], 10);
+
       return {
         symbol: row.symbol,
         suggested_dte: s.strategy_suggestion.suggested_dte,
@@ -1540,6 +1546,7 @@ export async function runPipeline(
         ivRank: (s.vol_edge.breakdown.mispricing.inputs.IV_percentile as number) / 100,
         iv30: (tt.iv30 ?? 30) / 100,
         hv30: (tt.hv30 ?? 25) / 100,
+        hv10: hv10Pct != null ? hv10Pct / 100 : null,
         riskFreeRate: fedFundsRate,
       };
     }).filter((input): input is NonNullable<typeof input> => input !== null);

--- a/src/lib/convergence/trade-cards.ts
+++ b/src/lib/convergence/trade-cards.ts
@@ -291,6 +291,25 @@ function computeForwardVol(termStructure: { date: string; iv: number }[]): Forwa
 
 // ===== REALIZED VOLATILITY CONE =====
 
+/**
+ * Close-to-close log-return HV, annualized ×√252, in PERCENT (e.g. 42.3).
+ * EDGE-3: exported so the strategy-builder's HV10>IV gate and the displayed
+ * vol cone use the SAME computation — what the UI shows == what fires.
+ */
+export function computeCloseToCloseHV(candles: CandleData[], windowDays: number): number | null {
+  if (!candles || candles.length < windowDays + 1) return null;
+  const slice = candles.slice(candles.length - windowDays - 1);
+  const logReturns: number[] = [];
+  for (let i = 1; i < slice.length; i++) {
+    if (slice[i - 1].close <= 0 || slice[i].close <= 0) continue;
+    logReturns.push(Math.log(slice[i].close / slice[i - 1].close));
+  }
+  if (logReturns.length < windowDays * 0.8) return null;
+  const mean = logReturns.reduce((a, b) => a + b, 0) / logReturns.length;
+  const variance = logReturns.reduce((s, r) => s + Math.pow(r - mean, 2), 0) / (logReturns.length - 1);
+  return Math.round(Math.sqrt(variance) * Math.sqrt(252) * 100 * 10) / 10;
+}
+
 function computeVolCone(candles: CandleData[], currentIv: number | null, ttHv60?: number | null, ttHv90?: number | null): RealizedVolCone {
   if (!candles || candles.length < 11) {
     return {
@@ -302,19 +321,7 @@ function computeVolCone(candles: CandleData[], currentIv: number | null, ttHv60?
     };
   }
 
-  function computeHV(windowDays: number): number | null {
-    if (candles.length < windowDays + 1) return null;
-    const slice = candles.slice(candles.length - windowDays - 1);
-    const logReturns: number[] = [];
-    for (let i = 1; i < slice.length; i++) {
-      if (slice[i - 1].close <= 0 || slice[i].close <= 0) continue;
-      logReturns.push(Math.log(slice[i].close / slice[i - 1].close));
-    }
-    if (logReturns.length < windowDays * 0.8) return null;
-    const mean = logReturns.reduce((a, b) => a + b, 0) / logReturns.length;
-    const variance = logReturns.reduce((s, r) => s + Math.pow(r - mean, 2), 0) / (logReturns.length - 1);
-    return Math.round(Math.sqrt(variance) * Math.sqrt(252) * 100 * 10) / 10;
-  }
+  const computeHV = (windowDays: number): number | null => computeCloseToCloseHV(candles, windowDays);
 
   return {
     hv10: computeHV(10),

--- a/src/lib/strategy-builder.ts
+++ b/src/lib/strategy-builder.ts
@@ -180,6 +180,12 @@ export interface StrategyLeg {
   theta: number;
   vega: number;
   wideSpread: boolean;
+  // Chain IV of this leg (dxfeed, decimal e.g. 0.42). EDGE-3: the HV10>IV gate
+  // compares realized vol against the IV actually being SOLD (short legs).
+  // null = feed provided no IV for this contract; the gate declares itself
+  // not-evaluated rather than inventing a value. Optional so the custom-card
+  // path (buildCustomCard) is unaffected.
+  iv?: number | null;
 }
 
 export interface StrategyCard {
@@ -219,6 +225,10 @@ export interface GenerateParams {
   symbol?: string;        // for debug logging
   iv30?: number;          // implied volatility decimal (e.g. 0.42 for 42%)
   hv30?: number;          // 30-day HV decimal (e.g. 0.25 for 25%)
+  // EDGE-3: 10-day realized vol, decimal (e.g. 0.55 for 55%). Required — the caller
+  // must decide; null = not computable from candle history, in which case the
+  // HV10>IV gate declares itself not-evaluated (never imputed, never silent).
+  hv10: number | null;
   // Risk-free rate from FRED FEDFUNDS series, converted to decimal. Required — no default.
   riskFreeRate: number;
 }
@@ -428,6 +438,7 @@ function makeLeg(
     theta: side === 'sell' ? -theta : theta,
     vega: side === 'sell' ? -vega : vega,
     wideSpread: type === 'call' ? strike.callWideSpread : strike.putWideSpread,
+    iv: (type === 'call' ? strike.callIv : strike.putIv) ?? null,
   };
 }
 
@@ -883,7 +894,72 @@ export function generateStrategies(params: GenerateParams): GenerateResult {
     'Long Straddle': 0.25, 'Long Strangle': 0.25,
   };
 
+  // EDGE-3: track whether the HV10>IV gate ever passed a premium-selling card
+  // without being evaluable — the non-evaluation is DECLARED below, never silent.
+  let hv10GateSkippedNoHv10 = 0;
+  const hv10GateSkippedNoLegIv: string[] = [];
+
   const filtered = cards.filter(card => {
+    // ─── EDGE-3 Sanity Gate 1: strike-price monotonicity ─────────────
+    // No-arbitrage ordering at the prices this card actually transacts at
+    // (sell legs @ bid, buy legs @ ask — see makeLeg): a put at a lower strike
+    // must not cost more than a put at a higher strike; a call at a higher
+    // strike must not cost more than a call at a lower strike. A violating
+    // chain is broken — the candidate is REJECTED and declared, never repaired.
+    for (const legType of ['put', 'call'] as const) {
+      const sameType = card.legs
+        .filter(l => l.type === legType)
+        .sort((a, b) => a.strike - b.strike);
+      for (let i = 0; i < sameType.length; i++) {
+        for (let j = i + 1; j < sameType.length; j++) {
+          const lo = sameType[i];
+          const hi = sameType[j];
+          if (lo.strike === hi.strike) continue;
+          const violated = legType === 'put' ? lo.price > hi.price : hi.price > lo.price;
+          if (violated) {
+            const detail = `${legType} ${lo.strike} @ $${lo.price.toFixed(2)} (${lo.side}) vs ${legType} ${hi.strike} @ $${hi.price.toFixed(2)} (${hi.side})`;
+            console.log(`[StrategyBuilder] ${sym}: MONOTONICITY GATE rejected "${card.name}" — ${detail}`);
+            rejections.push({
+              strategy: card.name,
+              reason: `monotonicity_violation: ${detail}`,
+              gate: 'construction',
+            });
+            return false;
+          }
+        }
+      }
+    }
+
+    // ─── EDGE-3 Sanity Gate 2: HV10 > sold IV disqualification ───────
+    // Premium-selling only: if 10-day realized vol exceeds the IV of the legs
+    // being SOLD, the premium is underpriced for current movement — REJECT.
+    // Unevaluable (hv10 null or no short-leg IV from the feed) → the candidate
+    // proceeds and the non-evaluation is DECLARED after the filter (no silent
+    // gap, no invented value, no waiver logic).
+    if (CREDIT_STRATEGIES.includes(card.name)) {
+      const shortIvs = card.legs
+        .filter(l => l.side === 'sell' && l.iv != null && l.iv > 0)
+        .map(l => l.iv as number);
+      if (params.hv10 == null) {
+        hv10GateSkippedNoHv10++;
+      } else if (shortIvs.length === 0) {
+        hv10GateSkippedNoLegIv.push(card.name);
+      } else {
+        const soldIv = shortIvs.reduce((a, b) => a + b, 0) / shortIvs.length;
+        if (params.hv10 > soldIv) {
+          const detail = `hv10=${(params.hv10 * 100).toFixed(1)}% iv=${(soldIv * 100).toFixed(1)}%`;
+          console.log(`[StrategyBuilder] ${sym}: HV10>IV GATE rejected "${card.name}" — ${detail} (short-leg IVs: [${shortIvs.map(v => (v * 100).toFixed(1)).join(', ')}])`);
+          rejections.push({
+            strategy: card.name,
+            reason: `hv10_exceeds_iv: ${detail}`,
+            gate: 'construction',
+            details: { value: params.hv10, threshold: soldIv },
+          });
+          return false;
+        }
+      }
+    }
+
     // Gate A: EV must be positive (uses hvPoP for credit, deltaPoP for debit)
     if (card.ev <= 0) {
       const effectiveML = card.isUnlimited ? hvProxyML : (card.maxLoss ?? 0);
@@ -926,6 +1002,27 @@ export function generateStrategies(params: GenerateParams): GenerateResult {
 
     return true;
   });
+
+  // EDGE-3: declare, don't silently pass. If the HV10>IV gate could not be
+  // evaluated for premium-selling candidates, say so on the same surface as
+  // missing_live_quote (EDGE-1 precedent) — these are declarations, not
+  // rejections; the candidates proceeded UNCHECKED.
+  if (hv10GateSkippedNoHv10 > 0) {
+    console.log(`[StrategyBuilder] ${sym}: HV10>IV gate NOT EVALUATED for ${hv10GateSkippedNoHv10} premium-selling candidate(s) — hv10 unavailable (insufficient candle history)`);
+    rejections.push({
+      strategy: 'all',
+      reason: `hv10 unavailable — HV10>IV gate not evaluated (${hv10GateSkippedNoHv10} premium-selling candidate(s) proceeded unchecked)`,
+      gate: 'construction',
+    });
+  }
+  if (hv10GateSkippedNoLegIv.length > 0) {
+    console.log(`[StrategyBuilder] ${sym}: HV10>IV gate NOT EVALUATED for [${hv10GateSkippedNoLegIv.join(', ')}] — no short-leg IV from the chain feed`);
+    rejections.push({
+      strategy: 'all',
+      reason: `no short-leg IV from chain feed — HV10>IV gate not evaluated (${hv10GateSkippedNoLegIv.join(', ')} proceeded unchecked)`,
+      gate: 'construction',
+    });
+  }
 
   // ─── Edge-Aware Composite Scoring ───────────────────────────────
   const edgeRatio = iv > 0 ? Math.max(0, (iv - hv)) / iv : 0;


### PR DESCRIPTION
… implemented

Completes PIPELINE-EDGE-AUDIT: the two missing sanity gates now run at the top of the strategy filter in generateStrategies. Both REJECT and DECLARE via the existing RejectionReason taxonomy (gate: 'construction', same surface as EDGE-1's missing_live_quote → chain-fetcher rejections map → pipeline rejection_reasons → scanner UI). Neither gate repairs, substitutes, or waives.

Gate 1 — strike-price monotonicity (all strategy types): for every same-type leg pair in a candidate, checked at the prices the card actually transacts at (sell @ bid, buy @ ask — makeLeg): a lower-strike put must not cost more than a higher-strike put; a higher-strike call must not cost more than a lower-strike call. Violation → 'monotonicity_violation: <type> <strike> @ <price> (side) vs ...' with strikes and prices (auditable). Catches broken chains that the netCredit>0 checks miss: Iron Condor wings netted together, and Bull Call/Debit Spreads which previously had no price-sanity at all.

Gate 2 — HV10 > sold IV (premium-selling types only, CREDIT_STRATEGIES): if 10-day realized vol exceeds the mean chain IV of the legs being SOLD, the premium is underpriced for current movement → 'hv10_exceeds_iv: hv10=X% iv=Y%'. IV compared is the short legs' per-contract dxfeed IV (decimal, threaded onto StrategyLeg.iv via makeLeg) — NOT params.iv30, which carries an imputed 30 upstream. hv10 comes from the same computation as the displayed vol cone (computeCloseToCloseHV, extracted and exported from trade-cards.ts — what the UI shows == what fires), computed in the pipeline from candleDataMap and passed as a required nullable field through ChainTickerInput/GenerateParams.

Unevaluable gate is DECLARED, never silent: hv10 null (insufficient candles) or no short-leg IV from the feed → the candidate proceeds and a declaration ('hv10 unavailable — HV10>IV gate not evaluated (N candidates proceeded unchecked)') is pushed on the same rejection-reasons surface. Rejecting on a missing meta-input would fabricate a failure from absence of evidence.

No scoring math changed — the gates only reject candidates. No route changes, nothing in PUBLIC_PATHS, no new fetches.