### PR TITLE
KILL-1: never fabricate ledger dates — skip + declare missing close_d…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,4 +77,5 @@ discover-schema.sh
 # Internal audit artifacts — NOT for the public repo (internal reasoning + file:line
 # codebase map + entity UUIDs). Untracked PR-2; local copies kept on disk.
 audits/
-audit-reports/
+# audit-reports/ is TRACKED: CLAUDE.md mandates committing read-only audits there
+# as the SOC 2 paper trail (unignored in KILL-1; was silently blocking the audits).

--- a/src/app/api/trading/commit-to-ledger/route.ts
+++ b/src/app/api/trading/commit-to-ledger/route.ts
@@ -66,6 +66,9 @@ export async function POST(request: NextRequest) {
     let committed = 0;
     let skipped = 0;
     const errors: string[] = [];
+    // KILL-1: trades skipped because a CLOSED leg has no close_date — declared,
+    // never committed on a substitute date.
+    const skippedMissingCloseDate: { trade_num: number; symbol: string }[] = [];
 
     for (const tradeNum of tradeNums) {
       try {
@@ -109,12 +112,28 @@ export async function POST(request: NextRequest) {
           continue;
         }
 
-        // Get close date (latest across legs)
-        const closeDate = positions.reduce<Date | null>((latest, p) => {
-          if (!p.close_date) return latest;
-          if (!latest || p.close_date > latest) return p.close_date;
-          return latest;
-        }, null) || new Date();
+        // KILL-1: the journal entry date is the trade's REAL close date (latest
+        // close_date across legs) — the same convention as every other ledger
+        // writer (stock-lots/commit dates JEs with the real sale date). If any
+        // CLOSED leg has no close_date, the trade's close date is unknowable:
+        // SKIP and DECLARE. Never date a ledger entry with "now", the open
+        // date, or any other substitute — a fabricated date also corrupts the
+        // assertPeriodOpen check below.
+        const legsMissingCloseDate = positions.filter(p => p.close_date == null);
+        if (legsMissingCloseDate.length > 0) {
+          skipped++;
+          skippedMissingCloseDate.push({ trade_num: tradeNum, symbol: positions[0].symbol });
+          errors.push(
+            `Trade #${tradeNum} (${positions[0].symbol}): skipped — ${legsMissingCloseDate.length} CLOSED leg(s) missing close_date; not committed (no date is fabricated)`,
+          );
+          continue;
+        }
+
+        // Latest real close_date across legs (all non-null past the guard,
+        // and positions.length > 0 is guaranteed above)
+        const closeDate = positions
+          .map(p => p.close_date as Date)
+          .reduce((latest, d) => (d > latest ? d : latest));
 
         // Build description from first position
         const symbol = positions[0].symbol;
@@ -206,7 +225,7 @@ export async function POST(request: NextRequest) {
       }
     }
 
-    return NextResponse.json({ committed, skipped, errors });
+    return NextResponse.json({ committed, skipped, skipped_missing_close_date: skippedMissingCloseDate, errors });
   } catch (error) {
     console.error('Trade commit API error:', error);
     const message = error instanceof Error ? error.message : 'Internal server error';


### PR DESCRIPTION
…ate; unignore audit-reports

commit-to-ledger dated a trade's journal entry with new Date() ('now') whenever every CLOSED leg had a null close_date — a fabricated date that was both persisted into journal_entries.date and used to evaluate the assertPeriodOpen guard. Now: if ANY closed leg lacks close_date the trade is SKIPPED and declared — skipped_missing_close_date: [{trade_num, symbol}] in the response plus a human-readable line in errors[] (renders in the existing UI). Committed trades use only the real latest close_date across legs, the same convention as every other ledger writer (stock-lots commit dates JEs with the real sale date). No substitute date of any kind.

Governance one-liner per the constitution: remove audit-reports/ from .gitignore (line 80) so the SOC 2 audit paper trail commits without -f; audits/ stays ignored.

No route/auth changes, nothing in PUBLIC_PATHS.