### PR TITLE
KILL-3: gate-level imputation kill — regime + quality missing signals…

### DIFF
--- a/audit-reports/KILL-3-gate-imputation-audit.md
+++ b/audit-reports/KILL-3-gate-imputation-audit.md
@@ -1,0 +1,40 @@
+# KILL-3 Audit — gate-level imputation kill (pre-implementation classification)
+
+**Date:** 2026-07-06 · **Branch:** `claude/kill-3-gate-imputation-kill` · **Base:** main @ `5fc6becc` (KILL-2 `13bbba34` verified present)
+
+All 34 census violation rows verified on base; pre-change citations below. Classification per the EDGE-2b distinction: assigned-because-missing DIES; computed-from-present-data STAYS.
+
+## DIES (34 sites — all verified verbatim on base)
+
+**regime.ts (11):** `if (v === null) return 50;` in all 11 normalize functions (`:63, :70, :77, :84, :92, :100, :107, :114, :121, :128, :136`) — imputed neutral 50s entered the growth composite (fixed weights `:159-162`) and inflation composite (`:188-191`), tracked as imputed (`:631-641`) but never excluded.
+
+**quality-gate.ts (22):** `let x = 40/50/60;` assigned before the null-guard in every component — safety `:42` liq / `:50` mktcap / `:74` **lendability 60 (favorable AND untracked)** / `:84` beta / `:96` D/E; profitability `:509` margin / `:520` ROE / `:532` ROA / `:567` ROIC(50) / `:579` PE / `:595` PS(50) / `:611` EV-EBITDA(50) / `:638` FCF / `:649` surpriseConsistency / `:650` dteScore / `:651` **beatRate = 0 (worst-case fabrication, untracked)**; growth `:841/:852/:863` (div-growth systematically penalized non-payers 40); fundamentalRisk `:908/:984/:1003`. All entered fixed-weight composites (`:374-390, :768-772, :871-874, :1012-1015`).
+
+**info-edge.ts (1):** `:1304` `totalHits ?? 0` — unparseable EDGAR hit count imputed as "0 material events" → score 65, the most bullish tier, undeclared.
+
+## STAYS (legitimate, each verified)
+
+- regime `baselineScore` sigmoid (50 at the series median) — computed from a PRESENT value.
+- regime ancillary signals (`:492-535`) — already null-honest, audit-only.
+- regime VIX overlay / corrSpy modifier null handling — census GRAYs, awaiting Alex's ruling, untouched.
+- quality volume `= 40` old default — dead code (the exclusion branch `:380-390` always renormalized volume out; generalized by this PR).
+- lendability `= 55` for a present-but-unrecognized string (`:79`) — real data, middle band.
+- dteScore/beat-rate/tier bands assigned inside `if (value !== null)` — real-data tiers.
+- Piotroski null-signal handling (computable-only ratio, modifier 0 = not-applied) and EQ ensemble `unavailable` no-op — modifiers that self-disable, declared in their traces.
+- Altman-Z metric proxies — census GRAY, untouched pending ruling.
+- borrow-rate penalty `(borrowRate ?? 0)*0.8` — penalty-not-applied on missing (modifier no-op), unchanged (censused GRAY-adjacent, not in the kill list).
+
+## Combiner conversion
+
+- **Precedent:** info-edge's EDGE-2 array combiner (`info-edge.ts:1313-1334`) and vol-edge's EDGE-4 component array. Extracted as shared `src/lib/convergence/weighted-combiner.ts` (`combineWeighted`).
+- **regime:** normalize fns → `number | null`; growth/inflation are combiner composites (excluded series renormalize); ALL-series-missing on either side → **fail-loud throw** (declared via the pipeline's per-ticker catch into `errors[]`) because `scan_snapshots.regimeScore` is a non-nullable Float — gate-level exclusion is a migration, flagged for Alex.
+- **quality:** every component nullable; each section is a combiner composite; a zero-component section is EXCLUDED with weight 0 + EXCLUDED formula (vol-edge precedent) and the gate renormalizes 0.40/0.30/0.15/0.15 over active sections; all four empty → fail-loud throw (same `qualityScore` migration note). Modifiers (Altman cap, borrow penalty, HHI, F-Score, EQ ensemble) apply only to computed scores.
+- **N/M declarations:** both gates' DataConfidence now carry `excluded_fields` (derived from the combiners — no drift) + `active_signal_count` (regime 14 total; quality 23 total — was 21 with lendability and beat_rate untracked); pipeline `quality_detail`/`regime_detail` expose them; the UI drill Conf lines render "computed from N/M signals" (same surface as info-edge/vol-edge).
+
+## Consumers (blast radius)
+
+Trace sub_scores → `number | null` in types; consumers verified: UI beat_rate displays all null-guard (`?? '—'`, `!= null`); trade-cards computes beat_rate from `beats/total_quarters` behind a `totalQuarters < 2 → null` guard; pipeline detail rows read section `score`/`weight` (numbers — excluded sections show 0 / weight 0 with EXCLUDED formula); snapshots store the trace JSON with nulls preserved; `borrow_rate_adjustment.score_before_penalty` → nullable. No consumer coerces null back into a number (tripwire grep on the diff: the only `?? 0` added is a presence check that can only exclude, never impute).
+
+## Verification
+
+Executed traces: many-missing ticker → quality gate scored 75 from safety-only (weight renormalized to 1.0, sections 0-weight EXCLUDED, N/M 2/23, lendability null not 60, beat_rate null not 0); regime scored from 4/14 present series (excluded list exact); all-macro-missing → throws the KILL-3 message; `totalHits: null` → material_event_flag null + auto-declared in excluded_fields. Remaining `= 50/= 60/...` literals in both files are all inside `if (value !== null)` real-data tiers. `tsc` exit 0; `next build` compiled successfully (standing sandbox Plaid-env page-data failure unrelated).

--- a/src/components/convergence/ConvergenceIntelligence.tsx
+++ b/src/components/convergence/ConvergenceIntelligence.tsx
@@ -3221,7 +3221,7 @@ function PipelineFlowPanel({ result, progress, universe }: { result: any; progre
                                     </tbody>
                                   </table>
                                 )}
-                                <p className="text-text-muted mt-1">Conf: {r.quality_detail ? (r.quality_detail.data_confidence * 100).toFixed(0) + '%' : '—'}</p>
+                                <p className="text-text-muted mt-1">Conf: {r.quality_detail ? (r.quality_detail.data_confidence * 100).toFixed(0) + '%' : '—'}{r.quality_detail?.active_signal_count != null ? ` · computed from ${r.quality_detail.active_signal_count}/${r.quality_detail.total_signal_count} signals` : ''}</p>
                               </div>
                               {/* REGIME */}
                               <div>
@@ -3248,7 +3248,7 @@ function PipelineFlowPanel({ result, progress, universe }: { result: any; progre
                                     </tbody>
                                   </table>
                                 )}
-                                <p className="text-text-muted mt-1">Conf: {r.regime_detail ? (r.regime_detail.data_confidence * 100).toFixed(0) + '%' : '—'}</p>
+                                <p className="text-text-muted mt-1">Conf: {r.regime_detail ? (r.regime_detail.data_confidence * 100).toFixed(0) + '%' : '—'}{r.regime_detail?.active_signal_count != null ? ` · computed from ${r.regime_detail.active_signal_count}/${r.regime_detail.total_signal_count} signals` : ''}</p>
                               </div>
                               {/* INFO EDGE */}
                               <div>

--- a/src/lib/convergence/info-edge.ts
+++ b/src/lib/convergence/info-edge.ts
@@ -1301,7 +1301,13 @@ export function scoreInfoEdge(input: ConvergenceInput): InfoEdgeResult {
     if (!input.edgar8kScan) {
       return null; // no 8-K data — excluded, weights re-normalize
     }
-    const count = input.edgar8kScan.totalHits ?? 0;
+    // KILL-3: an unparseable hit count (fetcher sets totalHits null) is NOT
+    // "0 material events" — that imputation scored the MOST bullish tier (65).
+    // Missing → excluded + renormalized like the absent-scan case above.
+    const count = input.edgar8kScan.totalHits;
+    if (count == null) {
+      return null; // hit count unparseable — excluded, weights re-normalize
+    }
     let s: number;
     if (count === 0) s = 65;
     else if (count <= 2) s = 50;

--- a/src/lib/convergence/pipeline.ts
+++ b/src/lib/convergence/pipeline.ts
@@ -1368,6 +1368,10 @@ export async function runPipeline(
           },
           mspr_adjustment: scoring.quality.mspr_adjustment,
           data_confidence: scoring.quality.data_confidence.confidence,
+          // KILL-3: how many quality sub-scores were computed from real data
+          // (the rest were excluded and the weights re-normalized).
+          active_signal_count: scoring.quality.data_confidence.active_signal_count ?? null,
+          total_signal_count: scoring.quality.data_confidence.total_sub_scores,
         } : null,
         regime_detail: scoring ? {
           dominant_regime: scoring.regime.breakdown.dominant_regime,
@@ -1386,6 +1390,10 @@ export async function runPipeline(
             vix: scoring.regime.breakdown.vix_overlay.vix,
           },
           data_confidence: scoring.regime.data_confidence.confidence,
+          // KILL-3: how many regime signals were computed from real data
+          // (the rest were excluded and the weights re-normalized).
+          active_signal_count: scoring.regime.data_confidence.active_signal_count ?? null,
+          total_signal_count: scoring.regime.data_confidence.total_sub_scores,
           yield_curve_spread: scoring.regime.breakdown.regime_signals.yield_curve_spread ?? null,
           hy_spread: scoring.regime.breakdown.regime_signals.hy_spread ?? null,
           cross_asset_available: scoring.regime.breakdown.cross_asset_correlations != null,

--- a/src/lib/convergence/quality-gate.ts
+++ b/src/lib/convergence/quality-gate.ts
@@ -1,3 +1,4 @@
+import { combineWeighted } from './weighted-combiner';
 import type {
   ConvergenceInput,
   QualityGateResult,
@@ -39,7 +40,7 @@ function scoreSafety(input: ConvergenceInput): SafetyTrace {
 
   // --- Liquidity rating (15%) ---
   const liqRating = tt?.liquidityRating ?? null;
-  let liquidityRatingScore = 40; // penalty default — missing data
+  let liquidityRatingScore: number | null = null; // KILL-3: missing → excluded + renormalized
   if (liqRating !== null) {
     // TT uses ~1-5 scale. Map: 5->95, 4->80, 3->60, 2->40, 1->20
     liquidityRatingScore = clamp(liqRating * 20 - 5, 0, 100);
@@ -47,7 +48,7 @@ function scoreSafety(input: ConvergenceInput): SafetyTrace {
 
   // --- Market cap (15%) ---
   const marketCap = tt?.marketCap ?? null;
-  let marketCapScore = 40; // penalty default — missing data
+  let marketCapScore: number | null = null; // KILL-3: missing → excluded + renormalized
   if (marketCap !== null) {
     if (marketCap > 200_000_000_000) marketCapScore = 90;
     else if (marketCap > 10_000_000_000) marketCapScore = 75;
@@ -57,7 +58,7 @@ function scoreSafety(input: ConvergenceInput): SafetyTrace {
   }
 
   // --- Volume (15%) ---
-  let volumeScore = 40; // penalty default — missing data
+  let volumeScore: number | null = null; // KILL-3: missing → excluded + renormalized
   let avgVol20d: number | null = null;
   if (candles.length >= 20) {
     const vols = candles.slice(-20).map(c => c.volume);
@@ -71,7 +72,11 @@ function scoreSafety(input: ConvergenceInput): SafetyTrace {
 
   // --- Lendability (10%) ---
   const lendability = tt?.lendability ?? null;
-  let lendabilityScore = 60; // Default: assume easy to borrow
+  // KILL-3: missing lendability is EXCLUDED — it was silently imputed as a
+  // FAVORABLE 60 ("assume easy to borrow") and never tracked. The 55 for a
+  // present-but-unrecognized lendability string is a legitimate middle band
+  // computed from present data and stays.
+  let lendabilityScore: number | null = null;
   if (lendability !== null) {
     const lend = lendability.toLowerCase();
     if (lend === 'easy to borrow' || lend === 'easy') lendabilityScore = 80;
@@ -81,7 +86,7 @@ function scoreSafety(input: ConvergenceInput): SafetyTrace {
 
   // --- Beta (20%) ---
   const beta = tt?.beta ?? (typeof metric['beta'] === 'number' ? metric['beta'] as number : null);
-  let betaScore = 40; // penalty default — missing data
+  let betaScore: number | null = null; // KILL-3: missing → excluded + renormalized
   if (beta !== null) {
     if (beta < 0.8) betaScore = 90;
     else if (beta <= 1.0) betaScore = 80;
@@ -93,7 +98,7 @@ function scoreSafety(input: ConvergenceInput): SafetyTrace {
   // --- Debt-to-Equity (25%) ---
   const debtToEquity = typeof metric['totalDebt/totalEquityQuarterly'] === 'number'
     ? metric['totalDebt/totalEquityQuarterly'] as number : null;
-  let debtToEquityScore = 40; // penalty default — missing data
+  let debtToEquityScore: number | null = null; // KILL-3: missing → excluded + renormalized
   if (debtToEquity !== null) {
     if (debtToEquity < 0.3) debtToEquityScore = 95;
     else if (debtToEquity <= 0.5) debtToEquityScore = 80;
@@ -361,37 +366,28 @@ function scoreSafety(input: ConvergenceInput): SafetyTrace {
     altmanScore = round(z, 2);
   }
 
-  // --- Weighted sum ---
-  const hasCandles = candles.length >= 20;
-  let score: number;
-  let formula: string;
-
+  // --- Weighted sum (KILL-3 / EDGE-2 combiner) ---
   // Christoffersen, Goyenko, Jacobs & Karoui (2018, RFS): options illiquidity
   // premium is ~3.4%/day for ATM calls — liquidity dominates beta for spread traders.
   // Cao & Han (2013, JFE): idiosyncratic vol, not beta, predicts option returns.
   // Weights: 0.25 liq + 0.15 mktcap + 0.15 vol + 0.10 lend + 0.10 beta + 0.25 D/E = 1.0
-  if (hasCandles) {
-    score = round(
-      0.25 * liquidityRatingScore + 0.15 * marketCapScore + 0.15 * volumeScore +
-      0.10 * lendabilityScore + 0.10 * betaScore + 0.25 * debtToEquityScore,
-      1,
-    );
-    formula = `0.25*LiqRating(${round(liquidityRatingScore)}) + 0.15*MktCap(${round(marketCapScore)}) + 0.15*Vol(${round(volumeScore)}) + 0.10*Lend(${round(lendabilityScore)}) + 0.10*Beta(${round(betaScore)}) + 0.25*D/E(${round(debtToEquityScore)}) = ${score}`;
-  } else {
-    // No candle data: exclude volume (15%), renormalize remaining 85% to 100%
-    volumeScore = 0;
-    avgVol20d = null;
-    const w = 0.85;
-    score = round(
-      (0.25 / w) * liquidityRatingScore + (0.15 / w) * marketCapScore +
-      (0.10 / w) * lendabilityScore + (0.10 / w) * betaScore + (0.25 / w) * debtToEquityScore,
-      1,
-    );
-    formula = `Volume EXCLUDED (no candles). Renorm: LiqRating(${round(liquidityRatingScore)}) + MktCap(${round(marketCapScore)}) + Lend(${round(lendabilityScore)}) + Beta(${round(betaScore)}) + D/E(${round(debtToEquityScore)}) = ${score}`;
-  }
+  // A missing component is EXCLUDED and the remaining weights renormalize —
+  // never imputed. (The old volume-exclusion branch generalized to all six.)
+  const safetyComponents = [
+    { key: 'liquidity_rating', weight: 0.25, score: liquidityRatingScore },
+    { key: 'market_cap', weight: 0.15, score: marketCapScore },
+    { key: 'volume', weight: 0.15, score: volumeScore },
+    { key: 'lendability', weight: 0.10, score: lendabilityScore },
+    { key: 'beta', weight: 0.10, score: betaScore },
+    { key: 'debt_to_equity', weight: 0.25, score: debtToEquityScore },
+  ];
+  const safetyCombined = combineWeighted(safetyComponents);
+  let score = safetyCombined.score; // null = NO safety component had data
+  const fmtC = (v: number | null) => (v !== null ? String(round(v)) : 'EXCLUDED');
+  let formula = `0.25*LiqRating(${fmtC(liquidityRatingScore)}) + 0.15*MktCap(${fmtC(marketCapScore)}) + 0.15*Vol(${fmtC(volumeScore)}) + 0.10*Lend(${fmtC(lendabilityScore)}) + 0.10*Beta(${fmtC(betaScore)}) + 0.25*D/E(${fmtC(debtToEquityScore)})${safetyCombined.excludedKeys.length > 0 && score !== null ? ` [missing excluded, weights renormalized ÷${round(safetyCombined.activeWeight, 2)}]` : ''} = ${score ?? 'EXCLUDED (no component data)'}`;
 
   // Altman Z hard gate: if computable and Z < 1.8, cap safety at 40
-  if (altmanScore !== null && altmanScore < 1.8) {
+  if (score !== null && altmanScore !== null && altmanScore < 1.8) {
     score = Math.min(score, 40);
     altmanCapped = true;
   }
@@ -402,7 +398,7 @@ function scoreSafety(input: ConvergenceInput): SafetyTrace {
   const borrowRate = tt?.borrowRate ?? null;
   const borrowRatePenalty = round(Math.min(20, (borrowRate ?? 0) * 0.8), 1);
   const safetyScorePreBorrowPenalty = score;
-  if (borrowRatePenalty > 0) {
+  if (score !== null && borrowRatePenalty > 0) {
     score = Math.max(0, round(score - borrowRatePenalty, 1));
     formula += ` → -${borrowRatePenalty} borrow rate penalty (${borrowRate}% × 0.8) = ${score}`;
   }
@@ -430,15 +426,21 @@ function scoreSafety(input: ConvergenceInput): SafetyTrace {
     else if (hhi < 0.30) concentrationModifier = 0.01;    // Moderately diversified
     // 0.30-0.70: no modifier
 
-    if (concentrationModifier !== 0) {
+    if (score !== null && concentrationModifier !== 0) {
       score = clamp(round(score * (1 + concentrationModifier), 1), 0, 100);
       formula += ` → ×${round(1 + concentrationModifier, 2)} HHI(${hhi}) = ${score}`;
     }
   }
 
+  const rOrNull = (v: number | null) => (v !== null ? round(v) : null);
   return {
-    score: round(score),
+    // KILL-3: score 0 + weight set to 0 by scoreQualityGate when EXCLUDED
+    // (no component data) — vol-edge exclusion precedent; never an imputed value.
+    score: score !== null ? round(score) : 0,
     weight: 0.40,
+    active_signal_count: safetyCombined.activeCount,
+    total_signal_count: safetyCombined.totalCount,
+    excluded_components: safetyCombined.excludedKeys.map(k => `safety.${k}`),
     inputs: {
       liquidity_rating: liqRating,
       market_cap: marketCap,
@@ -449,14 +451,14 @@ function scoreSafety(input: ConvergenceInput): SafetyTrace {
       debt_to_equity: debtToEquity,
     },
     formula,
-    notes: `Liquidity: ${liqRating ?? 'N/A'}, MktCap: ${marketCap ? '$' + (marketCap / 1e9).toFixed(1) + 'B' : 'N/A'}, Beta: ${beta ?? 'N/A'}, D/E: ${debtToEquity ?? 'N/A'}${altmanCapped ? '. ALTMAN Z CAPPED: Z=' + altmanScore + ' < 1.8' : ''}${!hasCandles ? '. Volume excluded (no candle data)' : ''}${revBreakdown ? `. HHI=${hhi}, ${segmentCount} segments, largest=${largestSegmentPct}%` : ''}`,
+    notes: `Liquidity: ${liqRating ?? 'N/A'}, MktCap: ${marketCap ? '$' + (marketCap / 1e9).toFixed(1) + 'B' : 'N/A'}, Beta: ${beta ?? 'N/A'}, D/E: ${debtToEquity ?? 'N/A'}${altmanCapped ? '. ALTMAN Z CAPPED: Z=' + altmanScore + ' < 1.8' : ''}. Computed from ${safetyCombined.activeCount}/${safetyCombined.totalCount} signals${safetyCombined.excludedKeys.length > 0 ? ` (excluded: ${safetyCombined.excludedKeys.join(', ')})` : ''}${revBreakdown ? `. HHI=${hhi}, ${segmentCount} segments, largest=${largestSegmentPct}%` : ''}`,
     sub_scores: {
-      liquidity_rating_score: round(liquidityRatingScore),
-      market_cap_score: round(marketCapScore),
-      volume_score: round(volumeScore),
-      lendability_score: round(lendabilityScore),
-      beta_score: round(betaScore),
-      debt_to_equity_score: round(debtToEquityScore),
+      liquidity_rating_score: rOrNull(liquidityRatingScore),
+      market_cap_score: rOrNull(marketCapScore),
+      volume_score: rOrNull(volumeScore),
+      lendability_score: rOrNull(lendabilityScore),
+      beta_score: rOrNull(betaScore),
+      debt_to_equity_score: rOrNull(debtToEquityScore),
     },
     piotroski_source: piotroskiSource,
     piotroski: {
@@ -506,7 +508,7 @@ function scoreProfitability(input: ConvergenceInput): ProfitabilityTrace {
 
   // --- Gross margin (15%) ---
   const grossMargin = typeof metric['grossMarginTTM'] === 'number' ? metric['grossMarginTTM'] as number : null;
-  let grossMarginScore = 40; // penalty default — missing data
+  let grossMarginScore: number | null = null; // KILL-3: missing → excluded + renormalized
   if (grossMargin !== null) {
     if (grossMargin > 60) grossMarginScore = 85;
     else if (grossMargin > 40) grossMarginScore = 70;
@@ -517,7 +519,7 @@ function scoreProfitability(input: ConvergenceInput): ProfitabilityTrace {
 
   // --- ROE (15%) ---
   const roe = typeof metric['roeTTM'] === 'number' ? metric['roeTTM'] as number : null;
-  let roeScore = 40; // penalty default — missing data
+  let roeScore: number | null = null; // KILL-3: missing → excluded + renormalized
   if (roe !== null) {
     if (roe > 25) roeScore = 90;
     else if (roe > 15) roeScore = 75;
@@ -529,7 +531,7 @@ function scoreProfitability(input: ConvergenceInput): ProfitabilityTrace {
 
   // --- ROA (10%) ---
   const roa = typeof metric['roaTTM'] === 'number' ? metric['roaTTM'] as number : null;
-  let roaScore = 40; // penalty default — missing data
+  let roaScore: number | null = null; // KILL-3: missing → excluded + renormalized
   if (roa !== null) {
     if (roa > 15) roaScore = 90;
     else if (roa > 10) roaScore = 75;
@@ -564,7 +566,7 @@ function scoreProfitability(input: ConvergenceInput): ProfitabilityTrace {
       }
     }
   }
-  let roicScore = 50; // neutral default — missing data
+  let roicScore: number | null = null; // KILL-3: missing → excluded + renormalized (was imputed neutral 50)
   if (roic !== null) {
     if (roic > 25) roicScore = 90;
     else if (roic > 15) roicScore = 80;
@@ -576,7 +578,7 @@ function scoreProfitability(input: ConvergenceInput): ProfitabilityTrace {
 
   // --- P/E ratio (10%) ---
   const pe = tt?.peRatio ?? (typeof metric['peNormalizedAnnual'] === 'number' ? metric['peNormalizedAnnual'] : null);
-  let peScore = 40; // penalty default — missing data
+  let peScore: number | null = null; // KILL-3: missing → excluded + renormalized
   if (pe !== null && typeof pe === 'number') {
     if (pe < 0) peScore = 20;           // Negative earnings
     else if (pe < 5) peScore = 35;      // Suspiciously cheap
@@ -592,7 +594,7 @@ function scoreProfitability(input: ConvergenceInput): ProfitabilityTrace {
   const psAnnual = typeof metric['psAnnual'] === 'number' ? metric['psAnnual'] as number : null;
   const ps = psTTM ?? psAnnual;
   const psSource = psTTM !== null ? 'TTM' : psAnnual !== null ? 'Annual' : 'N/A';
-  let psScore = 50; // neutral default — missing data
+  let psScore: number | null = null; // KILL-3: missing → excluded + renormalized (was imputed neutral 50)
   if (ps !== null) {
     if (ps < 0) psScore = 20;           // Negative revenue
     else if (ps < 1) psScore = 70;       // Very low — possible distress, don't reward maximally
@@ -608,7 +610,7 @@ function scoreProfitability(input: ConvergenceInput): ProfitabilityTrace {
   const evEbitdaAnnual = typeof metric['evEbitdaAnnual'] === 'number' ? metric['evEbitdaAnnual'] as number : null;
   const evEbitda = evEbitdaTTM ?? evEbitdaAnnual;
   const evEbitdaSource = evEbitdaTTM !== null ? 'TTM' : evEbitdaAnnual !== null ? 'Annual' : 'N/A';
-  let evEbitdaScore = 50; // neutral default — missing data
+  let evEbitdaScore: number | null = null; // KILL-3: missing → excluded + renormalized (was imputed neutral 50)
   if (evEbitda !== null) {
     if (evEbitda < 0) evEbitdaScore = 20;       // Negative EBITDA
     else if (evEbitda < 4) evEbitdaScore = 50;   // Suspiciously cheap — possible distress
@@ -635,7 +637,7 @@ function scoreProfitability(input: ConvergenceInput): ProfitabilityTrace {
   const currentPrice = typeof metric['marketCapitalization'] === 'number' && typeof metric['shareOutstanding'] === 'number' && (metric['shareOutstanding'] as number) > 0
     ? (metric['marketCapitalization'] as number) * 1e6 / ((metric['shareOutstanding'] as number) * 1e6)
     : null;
-  let fcfScore = 40; // penalty default — missing data
+  let fcfScore: number | null = null; // KILL-3: missing → excluded + renormalized
   if (fcfShareTTM !== null && currentPrice !== null && currentPrice > 0) {
     const fcfYield = (fcfShareTTM / currentPrice) * 100;
     if (fcfYield > 8) fcfScore = 85;
@@ -646,9 +648,12 @@ function scoreProfitability(input: ConvergenceInput): ProfitabilityTrace {
   }
 
   // --- Earnings quality (25%) — full scoreEarningsQuality logic inlined ---
-  let surpriseConsistency = 40; // penalty default — missing earnings data
-  let dteScore = 40; // penalty default — missing earnings date
-  let beatRate = 0;
+  // KILL-3: EQ internals are null when their source is missing — excluded and
+  // renormalized inside the EQ composite (beatRate was fabricated as worst-case
+  // 0 on absent history; surpriseConsistency/dteScore were penalty 40s).
+  let surpriseConsistency: number | null = null;
+  let dteScore: number | null = null;
+  let beatRate: number | null = null;
   let totalQ = 0;
   let beats = 0;
   let misses = 0;
@@ -715,11 +720,15 @@ function scoreProfitability(input: ConvergenceInput): ProfitabilityTrace {
   }
 
   // Earnings quality composite: consistency 50%, DTE 30%, beat_rate 20%
-  const beatRateScore = clamp(beatRate, 0, 100);
-  let earningsQualityScore = round(
-    0.50 * surpriseConsistency + 0.30 * dteScore + 0.20 * beatRateScore,
-    1,
-  );
+  // KILL-3 / EDGE-2 combiner: missing internals excluded + renormalized;
+  // EQ itself is null (excluded from profitability) when all three are missing.
+  const beatRateScore = beatRate !== null ? clamp(beatRate, 0, 100) : null;
+  const eqCombined = combineWeighted([
+    { key: 'earnings_consistency', weight: 0.50, score: surpriseConsistency },
+    { key: 'earnings_dte', weight: 0.30, score: dteScore },
+    { key: 'beat_rate', weight: 0.20, score: beatRateScore },
+  ]);
+  let earningsQualityScore = eqCombined.score;
 
   // --- SUE + Finnhub ML Ensemble ---
   // Cross-validate our SUE-based score against Finnhub's ML earnings quality score.
@@ -730,15 +739,15 @@ function scoreProfitability(input: ConvergenceInput): ProfitabilityTrace {
   let finnhubEqScore: number | null = null;
   let finnhubEqLetter: string | null = null;
 
-  if (finnhubEQ) {
+  if (finnhubEQ && earningsQualityScore !== null) {
     finnhubEqScore = finnhubEQ.score;
     finnhubEqLetter = finnhubEQ.letterScore;
 
     // Both scores on 0-100 scale. Determine if they agree on quality level.
     // SUE score is earningsQualityScore (0-100), Finnhub score is 0-100.
     // "High quality" = both > 60, "Low quality" = both < 40
-    const sueHigh = earningsQualityScore > 60;
-    const sueLow = earningsQualityScore < 40;
+    const sueHigh = earningsQualityScore! > 60;
+    const sueLow = earningsQualityScore! < 40;
     const mlHigh = finnhubEqScore > 60;
     const mlLow = finnhubEqScore < 40;
 
@@ -758,28 +767,49 @@ function scoreProfitability(input: ConvergenceInput): ProfitabilityTrace {
 
     // Apply modifier: scale distance from neutral (50)
     if (eqConfidenceModifier !== 0) {
-      const distFromNeutral = earningsQualityScore - 50;
+      const distFromNeutral = earningsQualityScore! - 50;
       earningsQualityScore = round(clamp(50 + distFromNeutral * (1 + eqConfidenceModifier), 0, 100), 1);
     }
   }
 
-  // --- Weighted sum (9 components, sum=1.00) ---
+  // --- Weighted sum (9 components, sum=1.00) — KILL-3 / EDGE-2 combiner ---
   // 0.10+0.10+0.07+0.08+0.10+0.07+0.07+0.18+0.23 = 1.00
-  const score = round(
-    0.10 * grossMarginScore + 0.10 * roeScore + 0.07 * roaScore +
-    0.08 * roicScore + 0.10 * peScore + 0.07 * psScore +
-    0.07 * evEbitdaScore + 0.18 * fcfScore + 0.23 * earningsQualityScore,
-    1,
-  );
+  // Missing components are EXCLUDED and the remaining weights renormalize.
+  const profitabilityComponents = [
+    { key: 'gross_margin', weight: 0.10, score: grossMarginScore },
+    { key: 'roe', weight: 0.10, score: roeScore },
+    { key: 'roa', weight: 0.07, score: roaScore },
+    { key: 'roic', weight: 0.08, score: roicScore },
+    { key: 'pe_ratio', weight: 0.10, score: peScore },
+    { key: 'ps', weight: 0.07, score: psScore },
+    { key: 'ev_ebitda', weight: 0.07, score: evEbitdaScore },
+    { key: 'fcf', weight: 0.18, score: fcfScore },
+    { key: 'earnings_quality', weight: 0.23, score: earningsQualityScore },
+  ];
+  const profCombined = combineWeighted(profitabilityComponents);
+  const score = profCombined.score; // null = NO component had data
+  // EQ internals count toward the N/M declaration individually (3), replacing
+  // the aggregate earnings_quality entry.
+  const profExcluded = [
+    ...profCombined.excludedKeys.filter(k => k !== 'earnings_quality'),
+    ...eqCombined.excludedKeys,
+  ].map(k => `profitability.${k}`);
+  const profActiveCount = profCombined.activeCount - (earningsQualityScore !== null ? 1 : 0) + eqCombined.activeCount;
+  const profTotalCount = profCombined.totalCount - 1 + eqCombined.totalCount; // 8 + 3 = 11
 
-  const ensembleTag = finnhubEQ
+  const ensembleTag = finnhubEQ && earningsQualityScore !== null
     ? ` [EQ_ensemble=${eqEnsembleAgreement}, mod=${eqConfidenceModifier > 0 ? '+' : ''}${round(eqConfidenceModifier * 100)}%]`
     : '';
-  const formula = `0.10*Margin(${round(grossMarginScore)}) + 0.10*ROE(${round(roeScore)}) + 0.07*ROA(${round(roaScore)}) + 0.08*ROIC(${round(roicScore)}) + 0.10*PE(${round(peScore)}) + 0.07*PS(${round(psScore)}) + 0.07*EV/EBITDA(${round(evEbitdaScore)}) + 0.18*FCF(${round(fcfScore)}) + 0.23*EQ(${round(earningsQualityScore)})${ensembleTag} = ${score}`;
+  const fmtP = (v: number | null) => (v !== null ? String(round(v)) : 'EXCLUDED');
+  const formula = `0.10*Margin(${fmtP(grossMarginScore)}) + 0.10*ROE(${fmtP(roeScore)}) + 0.07*ROA(${fmtP(roaScore)}) + 0.08*ROIC(${fmtP(roicScore)}) + 0.10*PE(${fmtP(peScore)}) + 0.07*PS(${fmtP(psScore)}) + 0.07*EV/EBITDA(${fmtP(evEbitdaScore)}) + 0.18*FCF(${fmtP(fcfScore)}) + 0.23*EQ(${fmtP(earningsQualityScore)})${ensembleTag}${profCombined.excludedKeys.length > 0 && score !== null ? ` [missing excluded, weights renormalized ÷${round(profCombined.activeWeight, 2)}]` : ''} = ${score ?? 'EXCLUDED (no component data)'}`;
 
+  const rOrNullP = (v: number | null) => (v !== null ? round(v) : null);
   return {
-    score: round(score),
+    score: score !== null ? round(score) : 0,
     weight: 0.30,
+    active_signal_count: profActiveCount,
+    total_signal_count: profTotalCount,
+    excluded_components: profExcluded,
     inputs: {
       gross_margin_ttm: grossMargin,
       roe_ttm: roe,
@@ -799,18 +829,18 @@ function scoreProfitability(input: ConvergenceInput): ProfitabilityTrace {
     formula,
     notes: `Margin=${grossMargin ?? 'N/A'}%, ROE=${roe ?? 'N/A'}%, ROA=${roa ?? 'N/A'}%, ROIC=${roic ?? 'N/A'}%(${roicSource}), PE=${pe ?? 'N/A'}, P/S=${ps ?? 'N/A'}(${psSource}), EV/EBITDA=${evEbitda ?? 'N/A'}(${evEbitdaSource}), FCF/sh=${fcfShareTTM ?? 'N/A'}(${fcfSource}). ${beats} beats, ${misses} misses, ${inLine} in-line out of ${totalQ}Q${finnhubEQ ? `. EQ_ML=${finnhubEqLetter}(${finnhubEqScore}), ensemble=${eqEnsembleAgreement}` : ''}`,
     sub_scores: {
-      gross_margin_score: round(grossMarginScore),
-      roe_score: round(roeScore),
-      roa_score: round(roaScore),
-      roic_score: round(roicScore),
-      pe_score: round(peScore),
-      ps_score: round(psScore),
-      ev_ebitda_score: round(evEbitdaScore),
-      fcf_score: round(fcfScore),
+      gross_margin_score: rOrNullP(grossMarginScore),
+      roe_score: rOrNullP(roeScore),
+      roa_score: rOrNullP(roaScore),
+      roic_score: rOrNullP(roicScore),
+      pe_score: rOrNullP(peScore),
+      ps_score: rOrNullP(psScore),
+      ev_ebitda_score: rOrNullP(evEbitdaScore),
+      fcf_score: rOrNullP(fcfScore),
     },
     earnings_quality: {
-      surprise_consistency: round(surpriseConsistency),
-      dte_score: round(dteScore),
+      surprise_consistency: rOrNullP(surpriseConsistency),
+      dte_score: rOrNullP(dteScore),
       beat_rate: beatRate,
       earnings_detail: {
         total_quarters: totalQ,
@@ -823,7 +853,7 @@ function scoreProfitability(input: ConvergenceInput): ProfitabilityTrace {
       earnings_quality_ensemble: {
         finnhub_eq_score: finnhubEqScore,
         finnhub_eq_letter: finnhubEqLetter,
-        sue_score: round(0.50 * round(surpriseConsistency) + 0.30 * round(dteScore) + 0.20 * beatRateScore, 1), // pre-ensemble SUE score
+        sue_score: eqCombined.score, // pre-ensemble SUE composite (null = EQ not computable)
         ensemble_agreement: eqEnsembleAgreement,
         confidence_modifier: eqConfidenceModifier,
       },
@@ -838,7 +868,7 @@ function scoreGrowth(input: ConvergenceInput): GrowthTrace {
 
   // --- Revenue growth (40%) ---
   const revGrowth = typeof metric['revenueGrowthTTMYoy'] === 'number' ? metric['revenueGrowthTTMYoy'] as number : null;
-  let revenueGrowthScore = 40; // penalty default — missing data
+  let revenueGrowthScore: number | null = null; // KILL-3: missing → excluded + renormalized
   if (revGrowth !== null) {
     if (revGrowth > 20) revenueGrowthScore = 90;
     else if (revGrowth > 10) revenueGrowthScore = 75;
@@ -849,7 +879,7 @@ function scoreGrowth(input: ConvergenceInput): GrowthTrace {
 
   // --- EPS growth (40%) ---
   const epsGrowth = typeof metric['epsGrowthTTMYoy'] === 'number' ? metric['epsGrowthTTMYoy'] as number : null;
-  let epsGrowthScore = 40; // penalty default — missing data
+  let epsGrowthScore: number | null = null; // KILL-3: missing → excluded + renormalized
   if (epsGrowth !== null) {
     if (epsGrowth > 25) epsGrowthScore = 90;
     else if (epsGrowth > 15) epsGrowthScore = 75;
@@ -860,7 +890,10 @@ function scoreGrowth(input: ConvergenceInput): GrowthTrace {
 
   // --- Dividend growth (20%) ---
   const divGrowth = typeof metric['dividendGrowthRate5Y'] === 'number' ? metric['dividendGrowthRate5Y'] as number : null;
-  let dividendGrowthScore = 40; // penalty default — missing data
+  // KILL-3: missing → excluded + renormalized. Note: non-dividend payers
+  // structurally lack dividendGrowthRate5Y and were systematically penalized
+  // 40 — now the growth score simply renormalizes over rev+EPS growth.
+  let dividendGrowthScore: number | null = null;
   if (divGrowth !== null) {
     if (divGrowth > 10) dividendGrowthScore = 85;
     else if (divGrowth > 5) dividendGrowthScore = 70;
@@ -868,16 +901,23 @@ function scoreGrowth(input: ConvergenceInput): GrowthTrace {
     else dividendGrowthScore = 35;
   }
 
-  const score = round(
-    0.40 * revenueGrowthScore + 0.40 * epsGrowthScore + 0.20 * dividendGrowthScore,
-    1,
-  );
+  // KILL-3 / EDGE-2 combiner: missing components excluded + renormalized
+  const growthCombined = combineWeighted([
+    { key: 'revenue', weight: 0.40, score: revenueGrowthScore },
+    { key: 'eps', weight: 0.40, score: epsGrowthScore },
+    { key: 'dividend', weight: 0.20, score: dividendGrowthScore },
+  ]);
+  const score = growthCombined.score;
 
-  const formula = `0.40*RevGrowth(${round(revenueGrowthScore)}) + 0.40*EPSGrowth(${round(epsGrowthScore)}) + 0.20*DivGrowth(${round(dividendGrowthScore)}) = ${score}`;
+  const fmtG = (v: number | null) => (v !== null ? String(round(v)) : 'EXCLUDED');
+  const formula = `0.40*RevGrowth(${fmtG(revenueGrowthScore)}) + 0.40*EPSGrowth(${fmtG(epsGrowthScore)}) + 0.20*DivGrowth(${fmtG(dividendGrowthScore)})${growthCombined.excludedKeys.length > 0 && score !== null ? ` [missing excluded, weights renormalized ÷${round(growthCombined.activeWeight, 2)}]` : ''} = ${score ?? 'EXCLUDED (no component data)'}`;
 
   return {
-    score: round(score),
+    score: score !== null ? round(score) : 0,
     weight: 0.15,
+    active_signal_count: growthCombined.activeCount,
+    total_signal_count: growthCombined.totalCount,
+    excluded_components: growthCombined.excludedKeys.map(k => `growth.${k}`),
     inputs: {
       revenue_growth_yoy: revGrowth,
       eps_growth_yoy: epsGrowth,
@@ -886,9 +926,9 @@ function scoreGrowth(input: ConvergenceInput): GrowthTrace {
     formula,
     notes: `RevGrowth=${revGrowth ?? 'N/A'}%, EPSGrowth=${epsGrowth ?? 'N/A'}%, DivGrowth=${divGrowth ?? 'N/A'}%`,
     sub_scores: {
-      revenue_growth_score: round(revenueGrowthScore),
-      eps_growth_score: round(epsGrowthScore),
-      dividend_growth_score: round(dividendGrowthScore),
+      revenue_growth_score: revenueGrowthScore !== null ? round(revenueGrowthScore) : null,
+      eps_growth_score: epsGrowthScore !== null ? round(epsGrowthScore) : null,
+      dividend_growth_score: dividendGrowthScore !== null ? round(dividendGrowthScore) : null,
     },
   };
 }
@@ -905,7 +945,7 @@ function scoreFundamentalRisk(input: ConvergenceInput): FundamentalRiskTrace {
 
   // --- Cash flow stability (40%) ---
   // Prefer quarterly financials (up to 40 quarters), then annual, then TTM sign check
-  let cashFlowStabilityScore = 40; // penalty default — missing data
+  let cashFlowStabilityScore: number | null = null; // KILL-3: missing → excluded + renormalized
   let cfSource = 'missing';
   let cfQuartersUsed = 0;
   let cfCoV: number | null = null;
@@ -981,7 +1021,7 @@ function scoreFundamentalRisk(input: ConvergenceInput): FundamentalRiskTrace {
 
   // --- Earnings predictability (35%) ---
   // StdDev of surprise percentages — same computation as computeSurpriseThreshold
-  let earningsPredictabilityScore = 40; // penalty default — missing or insufficient data
+  let earningsPredictabilityScore: number | null = null; // KILL-3: missing/insufficient → excluded + renormalized
   let epSource = 'missing';
 
   if (earnings.length >= 2) {
@@ -1000,7 +1040,7 @@ function scoreFundamentalRisk(input: ConvergenceInput): FundamentalRiskTrace {
 
   // --- Asset turnover (25%) — retained from original efficiency score ---
   const assetTurnover = typeof metric['assetTurnoverTTM'] === 'number' ? metric['assetTurnoverTTM'] as number : null;
-  let assetTurnoverScore = 40; // penalty default — missing data
+  let assetTurnoverScore: number | null = null; // KILL-3: missing → excluded + renormalized
   if (assetTurnover !== null) {
     if (assetTurnover > 1.5) assetTurnoverScore = 90;
     else if (assetTurnover > 1.0) assetTurnoverScore = 75;
@@ -1009,16 +1049,23 @@ function scoreFundamentalRisk(input: ConvergenceInput): FundamentalRiskTrace {
     else assetTurnoverScore = 30;
   }
 
-  const score = round(
-    0.40 * cashFlowStabilityScore + 0.35 * earningsPredictabilityScore + 0.25 * assetTurnoverScore,
-    1,
-  );
+  // KILL-3 / EDGE-2 combiner: missing components excluded + renormalized
+  const frCombined = combineWeighted([
+    { key: 'cash_flow_stability', weight: 0.40, score: cashFlowStabilityScore },
+    { key: 'earnings_predictability', weight: 0.35, score: earningsPredictabilityScore },
+    { key: 'asset_turnover', weight: 0.25, score: assetTurnoverScore },
+  ]);
+  const score = frCombined.score;
 
-  const formula = `0.40*CFStability(${round(cashFlowStabilityScore)}) + 0.35*EarnPredict(${round(earningsPredictabilityScore)}) + 0.25*AssetTurn(${round(assetTurnoverScore)}) = ${score}`;
+  const fmtF = (v: number | null) => (v !== null ? String(round(v)) : 'EXCLUDED');
+  const formula = `0.40*CFStability(${fmtF(cashFlowStabilityScore)}) + 0.35*EarnPredict(${fmtF(earningsPredictabilityScore)}) + 0.25*AssetTurn(${fmtF(assetTurnoverScore)})${frCombined.excludedKeys.length > 0 && score !== null ? ` [missing excluded, weights renormalized ÷${round(frCombined.activeWeight, 2)}]` : ''} = ${score ?? 'EXCLUDED (no component data)'}`;
 
   return {
-    score: round(score),
+    score: score !== null ? round(score) : 0,
     weight: 0.15,
+    active_signal_count: frCombined.activeCount,
+    total_signal_count: frCombined.totalCount,
+    excluded_components: frCombined.excludedKeys.map(k => `fundamentalRisk.${k}`),
     inputs: {
       cash_flow_stability: cfSource,
       earnings_predictability: epSource,
@@ -1027,9 +1074,9 @@ function scoreFundamentalRisk(input: ConvergenceInput): FundamentalRiskTrace {
     formula,
     notes: `CF: ${cfSource}, Earnings: ${epSource}, AssetTurn=${assetTurnover ?? 'N/A'}`,
     sub_scores: {
-      cash_flow_stability_score: round(cashFlowStabilityScore),
-      earnings_predictability_score: round(earningsPredictabilityScore),
-      asset_turnover_score: round(assetTurnoverScore),
+      cash_flow_stability_score: cashFlowStabilityScore !== null ? round(cashFlowStabilityScore) : null,
+      earnings_predictability_score: earningsPredictabilityScore !== null ? round(earningsPredictabilityScore) : null,
+      asset_turnover_score: assetTurnoverScore !== null ? round(assetTurnoverScore) : null,
     },
     cash_flow_detail: {
       cf_stability_source: cfSource.split(' ')[0], // "quarterly_financials" | "annual_financials" | "proxy_imputed" | "missing"
@@ -1048,21 +1095,47 @@ export function scoreQualityGate(input: ConvergenceInput): QualityGateResult {
   const growth = scoreGrowth(input);
   const fundamentalRisk = scoreFundamentalRisk(input);
 
+  // KILL-3: a section with ZERO computable components is EXCLUDED from the
+  // gate (weight → 0) and the remaining section weights renormalize —
+  // vol-edge exclusion precedent, never an imputed section score.
+  const sectionActive = (t: { active_signal_count?: number }) => (t.active_signal_count ?? 0) > 0;
+
   // Piotroski change-signal modifier on profitability (Schwartz & Hanauer 2024)
   // Level signals (1-4) already captured by ROE/ROA/FCF; change signals (5-9) are unique.
+  // Applied only when profitability actually computed from real data.
   const fScoreModifier = safety.piotroski.change_signals.modifier;
-  profitability.score = clamp(round(profitability.score + fScoreModifier, 1), 0, 100);
-  if (fScoreModifier !== 0) {
-    profitability.formula += ` → ${fScoreModifier > 0 ? '+' : ''}${fScoreModifier} (F-Score change signals) = ${profitability.score}`;
+  if (sectionActive(profitability)) {
+    profitability.score = clamp(round(profitability.score + fScoreModifier, 1), 0, 100);
+    if (fScoreModifier !== 0) {
+      profitability.formula += ` → ${fScoreModifier > 0 ? '+' : ''}${fScoreModifier} (F-Score change signals) = ${profitability.score}`;
+    }
   }
 
-  let score = round(
-    safety.weight * safety.score +
-    profitability.weight * profitability.score +
-    growth.weight * growth.score +
-    fundamentalRisk.weight * fundamentalRisk.score,
-    1,
-  );
+  const gateCombined = combineWeighted([
+    { key: 'safety', weight: 0.40, score: sectionActive(safety) ? safety.score : null },
+    { key: 'profitability', weight: 0.30, score: sectionActive(profitability) ? profitability.score : null },
+    { key: 'growth', weight: 0.15, score: sectionActive(growth) ? growth.score : null },
+    { key: 'fundamentalRisk', weight: 0.15, score: sectionActive(fundamentalRisk) ? fundamentalRisk.score : null },
+  ]);
+
+  // KILL-3 fail-loud: with zero real data across all four sections there is
+  // nothing honest to score. No imputation — throw; the pipeline's per-ticker
+  // catch declares the failure in errors[]. (Excluding the whole gate from the
+  // composite would need scan_snapshots.qualityScore nullable — a migration,
+  // flagged for Alex.)
+  if (gateCombined.score == null) {
+    throw new Error('Quality gate cannot compute: all four sections lack source data — no imputation (KILL-3)');
+  }
+
+  // Renormalized section weights written back onto the traces (vol-edge
+  // precedent): excluded sections show weight 0 + an EXCLUDED formula.
+  const renorm = (w: number, active: boolean) => (active ? round(w / gateCombined.activeWeight, 4) : 0);
+  safety.weight = renorm(0.40, sectionActive(safety));
+  profitability.weight = renorm(0.30, sectionActive(profitability));
+  growth.weight = renorm(0.15, sectionActive(growth));
+  fundamentalRisk.weight = renorm(0.15, sectionActive(fundamentalRisk));
+
+  let score = gateCombined.score;
 
   // MSPR bonus: latest insider sentiment month
   let msprAdjustment = 0;
@@ -1080,46 +1153,29 @@ export function scoreQualityGate(input: ConvergenceInput): QualityGateResult {
   }
   score = clamp(round(score + msprAdjustment, 1), 0, 100);
 
-  // Build DataConfidence
-  const tt = input.ttScanner;
-  const metric = input.finnhubFundamentals?.metric ?? {};
-  const imputedFields: string[] = [];
-  // Safety sub-scores
-  if (tt?.liquidityRating == null) imputedFields.push('safety.liquidity_rating');
-  if (tt?.marketCap == null) imputedFields.push('safety.market_cap');
-  if (input.candles.length < 20) imputedFields.push('safety.volume');
-  if (tt?.beta == null && typeof metric['beta'] !== 'number') imputedFields.push('safety.beta');
-  if (typeof metric['totalDebt/totalEquityQuarterly'] !== 'number') imputedFields.push('safety.debt_to_equity');
-  // Profitability sub-scores
-  if (typeof metric['grossMarginTTM'] !== 'number') imputedFields.push('profitability.gross_margin');
-  if (typeof metric['roeTTM'] !== 'number') imputedFields.push('profitability.roe');
-  if (typeof metric['roaTTM'] !== 'number') imputedFields.push('profitability.roa');
-  if (tt?.peRatio == null && typeof metric['peNormalizedAnnual'] !== 'number') imputedFields.push('profitability.pe_ratio');
-  if (profitability.inputs.fcf_source === 'N/A') imputedFields.push('profitability.fcf');
-  if (profitability.inputs.roic_source === 'N/A') imputedFields.push('profitability.roic');
-  if (typeof metric['psTTM'] !== 'number' && typeof metric['psAnnual'] !== 'number') imputedFields.push('profitability.ps');
-  if (typeof metric['evEbitdaTTM'] !== 'number' && typeof metric['evEbitdaAnnual'] !== 'number') imputedFields.push('profitability.ev_ebitda');
-  if (input.finnhubEarnings.length === 0) imputedFields.push('profitability.earnings_consistency');
-  if (tt?.daysTillEarnings == null) imputedFields.push('profitability.earnings_dte');
-  if (safety.piotroski.change_signals.computable_count === 0) imputedFields.push('profitability.fscore_change_signals');
-  // Growth sub-scores
-  if (typeof metric['revenueGrowthTTMYoy'] !== 'number') imputedFields.push('growth.revenue');
-  if (typeof metric['epsGrowthTTMYoy'] !== 'number') imputedFields.push('growth.eps');
-  if (typeof metric['dividendGrowthRate5Y'] !== 'number') imputedFields.push('growth.dividend');
-  // Fundamental risk sub-scores
-  const af = input.annualFinancials;
-  const hasCfData = af?.currentYear?.operatingCashFlow != null && af?.priorYear?.operatingCashFlow != null;
-  const hasFcfTTM = typeof metric['freeCashFlowPerShareTTM'] === 'number';
-  if (!hasCfData && !hasFcfTTM) imputedFields.push('fundamentalRisk.cash_flow_stability');
-  if (input.finnhubEarnings.length < 2) imputedFields.push('fundamentalRisk.earnings_predictability');
-  if (typeof metric['assetTurnoverTTM'] !== 'number') imputedFields.push('fundamentalRisk.asset_turnover');
+  // Build DataConfidence — KILL-3: derived from the traces' actual exclusions
+  // (no drift). Nothing is imputed anymore: a missing component is EXCLUDED
+  // and the weights renormalized, so imputed_fields is empty and
+  // excluded_fields carries the full missing list.
+  const excludedFields: string[] = [
+    ...(safety.excluded_components ?? []),
+    ...(profitability.excluded_components ?? []),
+    ...(growth.excluded_components ?? []),
+    ...(fundamentalRisk.excluded_components ?? []),
+  ];
 
-  const totalSubScores = 5 + 10 + 3 + 3; // safety(5 main) + profitability(10: 6 margin/return/valuation + 1 fcf + 3 earnings) + growth(3) + fundamentalRisk(3)
+  // safety(6) + profitability(11: 8 components + 3 EQ internals) + growth(3)
+  // + fundamentalRisk(3). Was 21 with lendability untracked — the favorable
+  // 60 imputation was invisible to confidence; now counted.
+  const totalSubScores = 6 + 11 + 3 + 3;
   const dataConfidence: DataConfidence = {
     total_sub_scores: totalSubScores,
-    imputed_sub_scores: imputedFields.length,
-    confidence: round(1 - imputedFields.length / totalSubScores, 4),
-    imputed_fields: imputedFields,
+    imputed_sub_scores: excludedFields.length,
+    confidence: round(1 - excludedFields.length / totalSubScores, 4),
+    imputed_fields: [],
+    excluded_fields: excludedFields,
+    // "computed from N/M signals"
+    active_signal_count: totalSubScores - excludedFields.length,
   };
 
   return {

--- a/src/lib/convergence/regime.ts
+++ b/src/lib/convergence/regime.ts
@@ -1,4 +1,5 @@
 import type { ConvergenceInput, RegimeResult, DataConfidence, CrossAssetCorrelations, FredMacroData } from './types';
+import { combineWeighted } from './weighted-combiner';
 
 function clamp(v: number, min: number, max: number): number {
   return Math.max(min, Math.min(max, v));
@@ -48,9 +49,11 @@ function isStale(dateStr: string | null): boolean {
 
 // ===== STEP A — NORMALIZE MACRO INDICATORS TO 0-100 =====
 // Each indicator scored relative to its long-run median via sigmoid.
-// At median → 50. Above → >50. Below → <50.
+// At median → 50 (a LEGITIMATE neutral computed from a present value).
 // spread ≈ 1 std dev of the series; controls sensitivity.
 // invert=true for indicators where lower is better (e.g., unemployment).
+// KILL-3: a NULL series returns null — the signal is EXCLUDED from its
+// composite and the remaining weights renormalize. Never imputed as 50.
 
 function baselineScore(value: number, median: number, spread: number, invert = false): number {
   const deviation = (value - median) / spread;
@@ -59,81 +62,81 @@ function baselineScore(value: number, median: number, spread: number, invert = f
 }
 
 // GDP growth (%): Higher = stronger economy. Baseline 2.5%.
-function normalizeGdp(v: number | null): number {
-  if (v === null) return 50;
+function normalizeGdp(v: number | null): number | null {
+  if (v === null) return null;
   const b = MACRO_BASELINES.gdp_growth;
   return baselineScore(v, b.median, b.spread);
 }
 
 // Unemployment (%): INVERTED — lower = better. Baseline 5.0%.
-function normalizeUnemployment(v: number | null): number {
-  if (v === null) return 50;
+function normalizeUnemployment(v: number | null): number | null {
+  if (v === null) return null;
   const b = MACRO_BASELINES.unemployment;
   return baselineScore(v, b.median, b.spread, true);
 }
 
 // Non-farm payrolls (thousands/month): Higher = better. Baseline 150K.
-function normalizeNfp(v: number | null): number {
-  if (v === null) return 50;
+function normalizeNfp(v: number | null): number | null {
+  if (v === null) return null;
   const b = MACRO_BASELINES.nfp;
   return baselineScore(v, b.median, b.spread);
 }
 
 // Consumer Confidence (U of Michigan): Higher = better. Baseline 85.
-function normalizeConsumerConfidence(v: number | null): number {
-  if (v === null) return 50;
+function normalizeConsumerConfidence(v: number | null): number | null {
+  if (v === null) return null;
   const b = MACRO_BASELINES.consumer_sentiment;
   return baselineScore(v, b.median, b.spread);
 }
 
 // Initial Jobless Claims (thousands): INVERTED — lower = better. Baseline 225K.
 // Rising claims (above trailing average) = bearish labor signal.
-function normalizeIcsa(v: number | null): number {
-  if (v === null) return 50;
+function normalizeIcsa(v: number | null): number | null {
+  if (v === null) return null;
   const b = MACRO_BASELINES.icsa;
   return baselineScore(v, b.median, b.spread, true);
 }
 
 // NFCI: INVERTED — negative values = loose conditions (bullish), positive = tight (bearish).
 // Zero = neutral. Positive values signal tightening financial conditions.
-function normalizeNfci(v: number | null): number {
-  if (v === null) return 50;
+function normalizeNfci(v: number | null): number | null {
+  if (v === null) return null;
   const b = MACRO_BASELINES.nfci;
   return baselineScore(v, b.median, b.spread, true);
 }
 
 // CPI YoY (%): Higher = more inflation. Baseline 2.5%.
-function normalizeCpiYoy(v: number | null): number {
-  if (v === null) return 50;
+function normalizeCpiYoy(v: number | null): number | null {
+  if (v === null) return null;
   const b = MACRO_BASELINES.cpi_yoy;
   return baselineScore(v, b.median, b.spread);
 }
 
 // CPI MoM (%): Higher = more inflation. Baseline 0.2%.
-function normalizeCpiMom(v: number | null): number {
-  if (v === null) return 50;
+function normalizeCpiMom(v: number | null): number | null {
+  if (v === null) return null;
   const b = MACRO_BASELINES.cpi_mom;
   return baselineScore(v, b.median, b.spread);
 }
 
 // Fed Funds Rate (%): Higher = tighter / more inflationary signal. Baseline 3.0%.
-function normalizeFedFunds(v: number | null): number {
-  if (v === null) return 50;
+function normalizeFedFunds(v: number | null): number | null {
+  if (v === null) return null;
   const b = MACRO_BASELINES.fed_funds;
   return baselineScore(v, b.median, b.spread);
 }
 
 // 10Y Treasury Yield (%): Higher = more inflation signal. Baseline 3.5%.
-function normalizeTreasury10y(v: number | null): number {
-  if (v === null) return 50;
+function normalizeTreasury10y(v: number | null): number | null {
+  if (v === null) return null;
   const b = MACRO_BASELINES.treasury_10y;
   return baselineScore(v, b.median, b.spread);
 }
 
 // 5-Year Breakeven Inflation (%): Score as deviation from 2.0% Fed target.
 // > 3.0% → elevated inflation expectations. < 1.5% → deflation risk. 2.0-2.5% → neutral.
-function normalizeBreakeven5y(v: number | null): number {
-  if (v === null) return 50;
+function normalizeBreakeven5y(v: number | null): number | null {
+  if (v === null) return null;
   const b = MACRO_BASELINES.breakeven_5y;
   return baselineScore(v, b.median, b.spread);
 }
@@ -141,65 +144,70 @@ function normalizeBreakeven5y(v: number | null): number {
 // ===== STEP A — COMPOSITE GROWTH & INFLATION SIGNALS =====
 
 interface SignalResult {
-  score: number;
-  sub_scores: Record<string, number>;
+  // KILL-3: null only when EVERY component series is missing (scoreRegime
+  // then fails loud — the gate never scores on zero real macro data).
+  score: number | null;
+  sub_scores: Record<string, number | null>;
+  active_signal_count: number;
+  total_signal_count: number;
+  excluded: string[];
 }
 
 function computeGrowthSignal(input: ConvergenceInput): SignalResult {
   const m = input.fredMacro;
-  const gdpScore = normalizeGdp(m.gdp);
-  const unempScore = normalizeUnemployment(m.unemployment);
-  const nfpScore = normalizeNfp(m.nonfarmPayrolls);
-  const ccScore = normalizeConsumerConfidence(m.consumerConfidence);
-  const icsaScore = normalizeIcsa(m.initialClaims);
-  const nfciScore = normalizeNfci(m.nfci);
-
-  // Reweighted: original 4 indicators + 2 new ones
-  // GDP 0.25, Unemployment 0.20, NFP 0.20, Consumer Confidence 0.15, ICSA 0.10, NFCI 0.10
-  const score = round(
-    0.25 * gdpScore + 0.20 * unempScore + 0.20 * nfpScore +
-    0.15 * ccScore + 0.10 * icsaScore + 0.10 * nfciScore,
-    1,
-  );
+  // Weights: GDP 0.25, Unemployment 0.20, NFP 0.20, Consumer Confidence 0.15, ICSA 0.10, NFCI 0.10
+  // KILL-3 / EDGE-2 combiner: a null series is EXCLUDED and the remaining
+  // weights renormalize — never imputed as neutral 50.
+  const components = [
+    { key: 'gdp', weight: 0.25, score: normalizeGdp(m.gdp) },
+    { key: 'unemployment', weight: 0.20, score: normalizeUnemployment(m.unemployment) },
+    { key: 'nfp', weight: 0.20, score: normalizeNfp(m.nonfarmPayrolls) },
+    { key: 'consumer_confidence', weight: 0.15, score: normalizeConsumerConfidence(m.consumerConfidence) },
+    { key: 'initial_claims', weight: 0.10, score: normalizeIcsa(m.initialClaims) },
+    { key: 'nfci', weight: 0.10, score: normalizeNfci(m.nfci) },
+  ];
+  const combined = combineWeighted(components);
 
   return {
-    score,
+    score: combined.score,
     sub_scores: {
-      gdp_score: gdpScore,
-      unemployment_score: unempScore,
-      nfp_score: nfpScore,
-      consumer_confidence_score: ccScore,
-      icsa_score: icsaScore,
-      nfci_score: nfciScore,
+      gdp_score: components[0].score,
+      unemployment_score: components[1].score,
+      nfp_score: components[2].score,
+      consumer_confidence_score: components[3].score,
+      icsa_score: components[4].score,
+      nfci_score: components[5].score,
     },
+    active_signal_count: combined.activeCount,
+    total_signal_count: combined.totalCount,
+    excluded: combined.excludedKeys.map(k => `growth.${k}`),
   };
 }
 
 function computeInflationSignal(input: ConvergenceInput): SignalResult {
   const m = input.fredMacro;
-  const cpiYoyScore = normalizeCpiYoy(m.cpi);
-  const cpiMomScore = normalizeCpiMom(m.cpiMom ?? null);
-  const fedFundsScore = normalizeFedFunds(m.fedFunds);
-  const t10yScore = normalizeTreasury10y(m.treasury10y);
-  const breakeven5yScore = normalizeBreakeven5y(m.breakeven5y);
-
-  // Reweighted: original 4 + breakeven5y
-  // CPI YoY 0.30, CPI MoM 0.20, Fed Funds 0.15, Treasury 10Y 0.15, Breakeven 5Y 0.20
-  const score = round(
-    0.30 * cpiYoyScore + 0.20 * cpiMomScore + 0.15 * fedFundsScore +
-    0.15 * t10yScore + 0.20 * breakeven5yScore,
-    1,
-  );
+  // Weights: CPI YoY 0.30, CPI MoM 0.20, Fed Funds 0.15, Treasury 10Y 0.15, Breakeven 5Y 0.20
+  const components = [
+    { key: 'cpi_yoy', weight: 0.30, score: normalizeCpiYoy(m.cpi) },
+    { key: 'cpi_mom', weight: 0.20, score: normalizeCpiMom(m.cpiMom ?? null) },
+    { key: 'fed_funds', weight: 0.15, score: normalizeFedFunds(m.fedFunds) },
+    { key: 'treasury_10y', weight: 0.15, score: normalizeTreasury10y(m.treasury10y) },
+    { key: 'breakeven_5y', weight: 0.20, score: normalizeBreakeven5y(m.breakeven5y) },
+  ];
+  const combined = combineWeighted(components);
 
   return {
-    score,
+    score: combined.score,
     sub_scores: {
-      cpi_yoy_score: cpiYoyScore,
-      cpi_mom_score: cpiMomScore,
-      fed_funds_score: fedFundsScore,
-      treasury_10y_score: t10yScore,
-      breakeven_5y_score: breakeven5yScore,
+      cpi_yoy_score: components[0].score,
+      cpi_mom_score: components[1].score,
+      fed_funds_score: components[2].score,
+      treasury_10y_score: components[3].score,
+      breakeven_5y_score: components[4].score,
     },
+    active_signal_count: combined.activeCount,
+    total_signal_count: combined.totalCount,
+    excluded: combined.excludedKeys.map(k => `inflation.${k}`),
   };
 }
 
@@ -558,10 +566,26 @@ export function scoreRegime(input: ConvergenceInput): RegimeResult {
   const growth = computeGrowthSignal(input);
   const inflation = computeInflationSignal(input);
 
+  // KILL-3 fail-loud: with ZERO real macro series on a side there is nothing
+  // honest to classify a regime from. No imputation — throw; the pipeline's
+  // per-ticker catch declares the failure in errors[]. (Excluding the whole
+  // gate from the composite instead would need scan_snapshots.regimeScore to
+  // become nullable — a migration, flagged for Alex — so all-missing fails
+  // loud rather than fabricating.)
+  if (growth.score == null || inflation.score == null) {
+    const missing = [
+      growth.score == null ? 'ALL 6 growth series' : null,
+      inflation.score == null ? 'ALL 5 inflation series' : null,
+    ].filter(Boolean).join(' and ');
+    throw new Error(`Regime gate cannot compute: ${missing} missing from FRED — no imputation (KILL-3)`);
+  }
+  const growthScore = growth.score;
+  const inflationScore = inflation.score;
+
   // Step B: Regime classification (with yield curve + credit stress modifiers)
   const { regime_scores, dominant } = classifyRegime(
-    growth.score,
-    inflation.score,
+    growthScore,
+    inflationScore,
     macro.yieldCurveSpread,
     macro.hySpread,
   );
@@ -626,29 +650,24 @@ export function scoreRegime(input: ConvergenceInput): RegimeResult {
     modifierNote = 'spy_correlation: not_available — using base regime score unmodified';
   }
 
-  // Build DataConfidence — track which macro fields are imputed (null → default 50)
-  const imputedFields: string[] = [];
-  if (macro.gdp === null) imputedFields.push('growth.gdp');
-  if (macro.unemployment === null) imputedFields.push('growth.unemployment');
-  if (macro.nonfarmPayrolls === null) imputedFields.push('growth.nfp');
-  if (macro.consumerConfidence === null) imputedFields.push('growth.consumer_confidence');
-  if (macro.initialClaims === null) imputedFields.push('growth.initial_claims');
-  if (macro.nfci === null) imputedFields.push('growth.nfci');
-  if (macro.cpi === null) imputedFields.push('inflation.cpi_yoy');
-  if ((macro.cpiMom ?? null) === null) imputedFields.push('inflation.cpi_mom');
-  if (macro.fedFunds === null) imputedFields.push('inflation.fed_funds');
-  if (macro.treasury10y === null) imputedFields.push('inflation.treasury_10y');
-  if (macro.breakeven5y === null) imputedFields.push('inflation.breakeven_5y');
-  // Regime signals (not scored directly but tracked for completeness)
-  if (macro.yieldCurveSpread === null) imputedFields.push('regime.yield_curve_spread');
-  if (macro.hySpread === null) imputedFields.push('regime.hy_spread');
-  if (!input.crossAssetCorrelations) imputedFields.push('regime.cross_asset_correlations');
+  // Build DataConfidence — KILL-3: missing macro series are EXCLUDED and the
+  // composite weights renormalized (never imputed as 50). excluded_fields is
+  // derived from the combiners' actual exclusions so tracking cannot drift.
+  // The two classification modifiers and the cross-asset adjustment simply do
+  // not apply when their series is missing — also recorded as exclusions.
+  const excludedFields: string[] = [...growth.excluded, ...inflation.excluded];
+  if (macro.yieldCurveSpread === null) excludedFields.push('regime.yield_curve_spread');
+  if (macro.hySpread === null) excludedFields.push('regime.hy_spread');
+  if (!input.crossAssetCorrelations) excludedFields.push('regime.cross_asset_correlations');
   const totalSubScores = 14; // 6 growth + 5 inflation + 2 regime signals + 1 cross-asset
   const dataConfidence: DataConfidence = {
     total_sub_scores: totalSubScores,
-    imputed_sub_scores: imputedFields.length,
-    confidence: round(1 - imputedFields.length / totalSubScores, 4),
-    imputed_fields: imputedFields,
+    imputed_sub_scores: excludedFields.length,
+    confidence: round(1 - excludedFields.length / totalSubScores, 4),
+    imputed_fields: [],
+    excluded_fields: excludedFields,
+    // "computed from N/M signals"
+    active_signal_count: totalSubScores - excludedFields.length,
   };
 
   // Staleness flags for weekly series
@@ -661,7 +680,9 @@ export function scoreRegime(input: ConvergenceInput): RegimeResult {
     data_confidence: dataConfidence,
     breakdown: {
       growth_signal: {
-        score: growth.score,
+        score: growthScore,
+        active_signal_count: growth.active_signal_count,
+        total_signal_count: growth.total_signal_count,
         sub_scores: {
           gdp_score: growth.sub_scores.gdp_score,
           unemployment_score: growth.sub_scores.unemployment_score,
@@ -681,7 +702,9 @@ export function scoreRegime(input: ConvergenceInput): RegimeResult {
         stale_flags: staleFlags.length > 0 ? staleFlags : undefined,
       },
       inflation_signal: {
-        score: inflation.score,
+        score: inflationScore,
+        active_signal_count: inflation.active_signal_count,
+        total_signal_count: inflation.total_signal_count,
         sub_scores: {
           cpi_yoy_score: inflation.sub_scores.cpi_yoy_score,
           cpi_mom_score: inflation.sub_scores.cpi_mom_score,

--- a/src/lib/convergence/types.ts
+++ b/src/lib/convergence/types.ts
@@ -492,6 +492,11 @@ export interface SubScoreTrace {
   inputs: Record<string, number | string | boolean | null>;
   formula: string;
   notes: string;
+  // KILL-3: N/M declaration — components actually computed from real data vs
+  // total, and which were EXCLUDED (missing source → dropped + renormalized).
+  active_signal_count?: number;
+  total_signal_count?: number;
+  excluded_components?: string[];
 }
 
 // -- Vol Edge --
@@ -591,13 +596,14 @@ export interface VolEdgeResult {
 // -- Quality Gate --
 
 export interface SafetyTrace extends SubScoreTrace {
+  // KILL-3: null = source data missing → component EXCLUDED + renormalized
   sub_scores: {
-    liquidity_rating_score: number;
-    market_cap_score: number;
-    volume_score: number;
-    lendability_score: number;
-    beta_score: number;
-    debt_to_equity_score: number;
+    liquidity_rating_score: number | null;
+    market_cap_score: number | null;
+    volume_score: number | null;
+    lendability_score: number | null;
+    beta_score: number | null;
+    debt_to_equity_score: number | null;
   };
   piotroski: {
     available_signals: number;
@@ -624,7 +630,8 @@ export interface SafetyTrace extends SubScoreTrace {
   borrow_rate_adjustment: {
     borrow_rate: number | null;
     penalty: number;
-    score_before_penalty: number;
+    // KILL-3: null when the whole safety section had no component data
+    score_before_penalty: number | null;
   };
   revenue_concentration?: {
     hhi: number | null;
@@ -635,20 +642,21 @@ export interface SafetyTrace extends SubScoreTrace {
 }
 
 export interface ProfitabilityTrace extends SubScoreTrace {
+  // KILL-3: null = source data missing → component EXCLUDED + renormalized
   sub_scores: {
-    gross_margin_score: number;
-    roe_score: number;
-    roa_score: number;
-    roic_score: number;
-    pe_score: number;
-    ps_score: number;
-    ev_ebitda_score: number;
-    fcf_score: number;
+    gross_margin_score: number | null;
+    roe_score: number | null;
+    roa_score: number | null;
+    roic_score: number | null;
+    pe_score: number | null;
+    ps_score: number | null;
+    ev_ebitda_score: number | null;
+    fcf_score: number | null;
   };
   earnings_quality: {
-    surprise_consistency: number;
-    dte_score: number;
-    beat_rate: number;
+    surprise_consistency: number | null;
+    dte_score: number | null;
+    beat_rate: number | null;
     earnings_detail: {
       total_quarters: number;
       beats: number;
@@ -660,7 +668,7 @@ export interface ProfitabilityTrace extends SubScoreTrace {
     earnings_quality_ensemble?: {
       finnhub_eq_score: number | null;
       finnhub_eq_letter: string | null;
-      sue_score: number;
+      sue_score: number | null;
       ensemble_agreement: 'agree' | 'disagree' | 'unavailable';
       confidence_modifier: number;
     };
@@ -684,18 +692,20 @@ export interface EarningsQualityTrace extends SubScoreTrace {
 }
 
 export interface GrowthTrace extends SubScoreTrace {
+  // KILL-3: null = source data missing → component EXCLUDED + renormalized
   sub_scores: {
-    revenue_growth_score: number;
-    eps_growth_score: number;
-    dividend_growth_score: number;
+    revenue_growth_score: number | null;
+    eps_growth_score: number | null;
+    dividend_growth_score: number | null;
   };
 }
 
 export interface FundamentalRiskTrace extends SubScoreTrace {
+  // KILL-3: null = source data missing → component EXCLUDED + renormalized
   sub_scores: {
-    cash_flow_stability_score: number;
-    earnings_predictability_score: number;
-    asset_turnover_score: number;
+    cash_flow_stability_score: number | null;
+    earnings_predictability_score: number | null;
+    asset_turnover_score: number | null;
   };
   cash_flow_detail?: {
     cf_stability_source: string;
@@ -735,13 +745,16 @@ export interface RegimeResult {
   breakdown: {
     growth_signal: {
       score: number;
+      // KILL-3: N/M declaration; null sub-score = series missing → excluded
+      active_signal_count?: number;
+      total_signal_count?: number;
       sub_scores: {
-        gdp_score: number;
-        unemployment_score: number;
-        nfp_score: number;
-        consumer_confidence_score: number;
-        icsa_score: number;
-        nfci_score: number;
+        gdp_score: number | null;
+        unemployment_score: number | null;
+        nfp_score: number | null;
+        consumer_confidence_score: number | null;
+        icsa_score: number | null;
+        nfci_score: number | null;
       };
       raw_values: {
         gdp: number | null;
@@ -755,12 +768,15 @@ export interface RegimeResult {
     };
     inflation_signal: {
       score: number;
+      // KILL-3: N/M declaration; null sub-score = series missing → excluded
+      active_signal_count?: number;
+      total_signal_count?: number;
       sub_scores: {
-        cpi_yoy_score: number;
-        cpi_mom_score: number;
-        fed_funds_score: number;
-        treasury_10y_score: number;
-        breakeven_5y_score: number;
+        cpi_yoy_score: number | null;
+        cpi_mom_score: number | null;
+        fed_funds_score: number | null;
+        treasury_10y_score: number | null;
+        breakeven_5y_score: number | null;
       };
       raw_values: {
         cpi_yoy: number | null;

--- a/src/lib/convergence/weighted-combiner.ts
+++ b/src/lib/convergence/weighted-combiner.ts
@@ -1,0 +1,32 @@
+/**
+ * KILL-3: shared EDGE-2 combiner — sum weight×score over the PRESENT
+ * (non-null) components only and divide by their summed weight. A missing
+ * component is EXCLUDED and the remaining weights renormalize; it is never
+ * imputed with a penalty or neutral value. Mirrors the array-based combiner
+ * EDGE-2/EDGE-2b built in info-edge.ts (:1313-1334) and EDGE-4 in vol-edge.
+ */
+
+export interface WeightedComponent {
+  key: string;
+  weight: number;
+  score: number | null; // null = source data absent → excluded
+}
+
+export interface CombineResult {
+  /** Renormalized weighted score over present components; null when NONE present. */
+  score: number | null;
+  activeWeight: number;
+  activeCount: number;
+  totalCount: number;
+  excludedKeys: string[];
+}
+
+export function combineWeighted(components: WeightedComponent[]): CombineResult {
+  const active = components.filter((c): c is WeightedComponent & { score: number } => c.score !== null);
+  const excludedKeys = components.filter(c => c.score === null).map(c => c.key);
+  const activeWeight = active.reduce((s, c) => s + c.weight, 0);
+  const score = active.length > 0 && activeWeight > 0
+    ? Math.round((active.reduce((s, c) => s + c.weight * c.score, 0) / activeWeight) * 10) / 10
+    : null;
+  return { score, activeWeight, activeCount: active.length, totalCount: components.length, excludedKeys };
+}


### PR DESCRIPTION
… excluded + renormalized

The 34 verified imputed-on-missing sites die; every legitimate neutral band computed from present data stays (classified per the EDGE-2b distinction, full table in audit-reports/KILL-3-gate-imputation-audit.md):

- regime.ts: all 11 'if (v === null) return 50' normalizers now return null; growth/inflation composites use the shared EDGE-2 combiner (missing series excluded, weights renormalized). All-series-missing on either side fails loud (throw → pipeline errors[]) rather than fabricating — gate-level exclusion would need scan_snapshots.regimeScore nullable (migration, flagged for Alex).
- quality-gate.ts: all 22 penalty-40 / neutral-50 / favorable-60 defaults die, including the untracked lendability=60 optimistic imputation and the fabricated worst-case beatRate=0. Every component is null-when-missing; each section combines + renormalizes over present components; an empty section is EXCLUDED (weight 0, EXCLUDED formula — vol-edge precedent) and the gate renormalizes 0.40/0.30/0.15/0.15 over active sections; all-empty fails loud. Modifiers (Altman cap, borrow penalty, HHI, F-Score, EQ ensemble) apply only to computed scores. Non-dividend payers are no longer systematically penalized 40 for having no dividend history.
- info-edge.ts: unparseable EDGAR totalHits (null) no longer scores the most bullish 'no material events' tier — material_event_flag is excluded and auto-declared.
- N/M declarations: both gates' DataConfidence now carry excluded_fields (derived from the combiners — cannot drift) + active_signal_count (regime 14, quality 23 — lendability and beat_rate now counted); exposed in pipeline quality_detail/regime_detail and the UI drill Conf lines ('computed from N/M signals'), matching info-edge/vol-edge.
- Shared combiner extracted to weighted-combiner.ts (EDGE-2 precedent).

No route/auth changes, nothing in PUBLIC_PATHS.