### PR TITLE
KILL-4: fail-loud restoration — failed fetches declare, never masquer…

### DIFF
--- a/audit-reports/KILL-4-fail-loud-audit.md
+++ b/audit-reports/KILL-4-fail-loud-audit.md
@@ -1,0 +1,44 @@
+# KILL-4 Audit — fail-loud restoration: the 42 silent-swallow catches
+
+**Date:** 2026-07-06 · **Branch:** `claude/kill-4-fail-loud-catches` · **Base:** main @ `5be860a5` (KILL-3 `267de2c0` verified present)
+
+All 42 census (c)-rows verified on base and classified. **(a) rethrow: 0** — every swallow guards a per-item/per-feed step inside a larger run where aborting the whole scan on one symbol's feed failure would be worse than declaring; the honest fix everywhere is **(b) declare** with an explicit failure marker. **(b): 40 · (c) justified: 2.**
+
+## (b) DECLARED — 40 sites
+
+| Cluster | Sites (census refs) | Fix |
+|---|---|---|
+| pipeline enrichment loops (9) | :769-:912 (`<map>.set(symbol, null)` on throw) | Each catch now mirrors its loop's `result.error` declaration: null still flows to the KILL-2/3 exclusion machinery, and `errors[]` gets `Step EN (<feed> SYM) FAILED: <msg>` |
+| pipeline peers (1) | :555 | Still degrades to GICS tier, but `errors[]` declares the degradation per symbol |
+| pipeline 10-K text (1) | :929 | Declared in `errors[]` (enhancement, but no longer silent) |
+| pipeline trade-cards (1) | :1872 | `errors[]` + `data_gaps` — an exception-emptied card list is now distinguishable from "no strategies passed" |
+| Finnhub estimates (8) | :95-:98 fetch, :105/:116/:129/:140 parse (+ HTTP-not-ok branches) | New failure channel: `FinnhubEstimateData.feedErrors` |
+| Finnhub ticker (5) | :199/:214/:231/:246/:253 (+ HTTP branches) | **`FinnhubData.feedErrors: string[]`** — the missing error channel the census called out; no-key case declares "all Finnhub feeds unavailable" |
+| Finnhub batch | (bonus: the per-symbol batch catch) | `FinnhubBatchStats.error_messages` aggregates `SYM feed: msg`; the empty fallback shape carries `feedErrors` |
+| quarterly statements (3) | :401-:403 `.catch(() => null)` | Named per-statement failures; all-empty returns `statement fetch FAILED — bs/ic/cf: …`; **partial data returns data + `PARTIAL:` error together** (pipeline E8 already pushes `result.error`) |
+| institutional ownership (4) | :1730/:1731 fetch, :1742/:1749 parse | Same partial-declaration pattern (pipeline E6 pushes it) |
+| SEC Form 4 (1) | :1257 per-filing skip | Skips counted; result carries `PARTIAL: N/M filing(s) failed — aggregates undercount` (zero in-repo callers, fixed for the export) |
+| chain-fetcher per-ticker (1) | :446 | Empty cards now accompanied by a `strategy generation FAILED` rejection entry on the existing rejections surface |
+| chain-fetcher fatal (1) | :531 | **`ChainFetchResult.fatal_error: string \| null`** — the typed failure; pipeline declares into `errors[]` + `data_gaps`; test route declares onto its rejections surface |
+| balances / positions routes (2) | :47 / :51 | Responses gain `failed_accounts: [{account, error}]` — a failed account no longer vanishes from a 200 |
+| scanner route (1) | :199 | Response gains `batch_errors` + `symbols_failed_count` — `totalScanned` no longer masquerades as coverage |
+| convergence route (2) | :73 / :129 | User-lookup failure captured; `result.data_gaps` gains `snapshot_logging: SKIPPED — … no scan_snapshots audit trail` on both SSE and non-stream paths |
+
+## (c) JUSTIFIED — 2 sites (inline comments added)
+
+- `sentiment.ts:109` parseJSON catch — the null IS handled loudly by both callers (console.warn + declared failure); the lost parse detail is now console.warn'd in the catch.
+- `sentiment.ts:165` `.catch(() => '')` — swallows only the failure to READ an error-response body for a log line; the HTTP failure itself is already declared with status.
+
+Not in the 42 and unchanged: `data-fetchers.ts:904` (CIK helper null → callers' declared `{data:null, error}` results — census class (b) already).
+
+## Failure-channel design (Phase 1 item 3)
+
+`{data, error}` is the file's established fetcher convention — extended, not replaced: per-feed failures ride `feedErrors` (FinnhubData / FinnhubEstimateData), batch failures ride `stats.error_messages`, chain failures ride `fatal_error`, route failures ride response fields. Surfacing: pipeline pushes every feed failure into **`errors[]`** (capped at 50 + truncation notice) and a summary **`data_gaps`** entry (`finnhub: N feed failure(s) — affected signals excluded per gate (feed unavailable)…`); both are existing returned/rendered surfaces. Exclusion itself needs no new work — a failed feed produces null/[] which the KILL-2/KILL-3 combiners already exclude and count in the N/M declarations; KILL-4 adds the CAUSE.
+
+## Forced-failure trace (executed)
+
+Killed the Finnhub feed (no API key): `fetchFinnhubTicker('AAPL')` → `feedErrors: ['FINNHUB_API_KEY not configured — all Finnhub feeds unavailable']` with null/empty data; `fetchFinnhubBatch(['AAPL','MSFT'])` → `stats.error_messages` lists both symbols. From there the cited path: pipeline post-fetch block → `data_gaps` 'feed unavailable' declaration + `errors[]`; the null fundamentals/empty arrays flow into the KILL-3 combiners → components excluded → gate N/M drops → declared. Nothing imputed anywhere on the path.
+
+## Tripwire + build
+
+Grep of added lines for value defaults: clean — no `|| <n>` / `?? <n>` / literal score assignments (the only string coalesces are `?? 'unknown error'` on error MESSAGES, not data). `tsc` exit 0; `next build` → `✓ Compiled successfully` + types validated (standing sandbox limit: `PLAID_CLIENT_ID` unset on the unrelated admin Plaid route). No retries added, no route/auth changes, nothing in PUBLIC_PATHS.

--- a/src/app/api/tastytrade/balances/route.ts
+++ b/src/app/api/tastytrade/balances/route.ts
@@ -32,6 +32,7 @@ export async function GET() {
     const accountNumbers = connection?.accountNumbers || [];
 
     const balances: any[] = [];
+    const failedAccounts: { account: string; error: string }[] = [];
 
     for (const acct of accountNumbers) {
       try {
@@ -46,10 +47,13 @@ export async function GET() {
         });
       } catch (err: any) {
         console.error(`[Tastytrade] Failed to fetch balances for ${acct}:`, err?.message);
+        // KILL-4: the failed account is DECLARED in the response — a missing
+        // account must not silently vanish from a 200.
+        failedAccounts.push({ account: acct, error: err?.message ?? 'unknown error' });
       }
     }
 
-    return NextResponse.json({ balances });
+    return NextResponse.json({ balances, failed_accounts: failedAccounts });
   } catch (error: any) {
     console.error('[Tastytrade] Balances error:', error);
     return NextResponse.json({ error: 'Failed to fetch balances' }, { status: 500 });

--- a/src/app/api/tastytrade/positions/route.ts
+++ b/src/app/api/tastytrade/positions/route.ts
@@ -32,6 +32,7 @@ export async function GET() {
     const accountNumbers = connection?.accountNumbers || [];
 
     const allPositions: any[] = [];
+    const failedAccounts: { account: string; error: string }[] = [];
 
     for (const acct of accountNumbers) {
       try {
@@ -50,10 +51,13 @@ export async function GET() {
         allPositions.push(...mapped);
       } catch (err: any) {
         console.error(`[Tastytrade] Failed to fetch positions for ${acct}:`, err?.message);
+        // KILL-4: the failed account is DECLARED — its positions must not
+        // silently vanish from a 200 that still lists the account.
+        failedAccounts.push({ account: acct, error: err?.message ?? 'unknown error' });
       }
     }
 
-    return NextResponse.json({ positions: allPositions, accounts: accountNumbers });
+    return NextResponse.json({ positions: allPositions, accounts: accountNumbers, failed_accounts: failedAccounts });
   } catch (error: any) {
     console.error('[Tastytrade] Positions error:', error);
     return NextResponse.json({ error: 'Failed to fetch positions' }, { status: 500 });

--- a/src/app/api/tastytrade/scanner/route.ts
+++ b/src/app/api/tastytrade/scanner/route.ts
@@ -190,6 +190,10 @@ export async function GET(request: Request) {
       batches.push(symbols.slice(i, i + BATCH_SIZE));
     }
 
+    // KILL-4: a failed batch of up to 50 symbols must not silently vanish
+    // while totalScanned still reports the full universe — declared below.
+    const batchErrors: string[] = [];
+    let symbolsFailedCount = 0;
     const batchResults = await Promise.all(
       batches.map(async (batch) => {
         try {
@@ -199,6 +203,8 @@ export async function GET(request: Request) {
           return Array.isArray(raw) ? raw : [];
         } catch (err) {
           console.error('[Scanner] Batch error:', err);
+          batchErrors.push(`batch of ${batch.length} symbols FAILED: ${err instanceof Error ? err.message : String(err)}`);
+          symbolsFailedCount += batch.length;
           return [];
         }
       })
@@ -277,6 +283,10 @@ export async function GET(request: Request) {
       metrics: ranked,
       excluded_missing_iv_rank: { count: excludedSymbols.length, symbols: excludedSymbols },
       totalScanned: totalSymbols,
+      // KILL-4: fetch failures declared — totalScanned is the REQUESTED count,
+      // batch_errors/symbols_failed_count say how much of it actually failed.
+      batch_errors: batchErrors,
+      symbols_failed_count: symbolsFailedCount,
       universe,
       fetchedAt: new Date().toISOString(),
     });

--- a/src/app/api/test/convergence/route.ts
+++ b/src/app/api/test/convergence/route.ts
@@ -198,7 +198,8 @@ export async function GET(request: Request) {
     }),
     fetchFinnhubTicker(symbol, finnhubKey || undefined).catch((e): FinnhubData => {
       fetchErrors.finnhub = e instanceof Error ? e.message : String(e);
-      return { fundamentals: null, recommendations: [], insiderSentiment: [], earnings: [], estimateData: null };
+      // KILL-4: typed failure — all feeds unavailable, declared
+      return { fundamentals: null, recommendations: [], insiderSentiment: [], earnings: [], estimateData: null, feedErrors: [`all: ${e instanceof Error ? e.message : String(e)}`] };
     }),
     fredKey
       ? fetchFredMacro(fredKey).catch(e => ({
@@ -324,6 +325,10 @@ export async function GET(request: Request) {
       const chainResult = await fetchChainAndBuildCards(chainInput);
       const strategyCards = chainResult.cards.get(symbol) || [];
       chainRejections = chainResult.rejections.get(symbol) || [];
+      // KILL-4: a fatal chain failure is DECLARED on the rejections surface
+      if (chainResult.fatal_error) {
+        chainRejections = [...chainRejections, { strategy: 'all', reason: `chain fetch FAILED: ${chainResult.fatal_error} — empty cards are a feed failure, not "no strategies passed"`, gate: 'construction' }];
+      }
 
       chainStats = {
         chain_symbols_fetched: chainResult.stats.chain_symbols_fetched,

--- a/src/app/api/trading/convergence/route.ts
+++ b/src/app/api/trading/convergence/route.ts
@@ -67,11 +67,14 @@ export async function GET(request: Request) {
     if (stream) {
       // Resolve userId for snapshot logging
       let userId: string | undefined;
+      let snapshotLookupError: string | null = null;
       try {
         const user = await prisma.users.findFirst({ where: { email: { equals: userEmail, mode: 'insensitive' } } });
         userId = user?.id;
-      } catch {
-        // Non-critical
+      } catch (e: unknown) {
+        // KILL-4: still non-fatal (pipeline runs without snapshots), but the
+        // skipped audit trail is DECLARED on the result below.
+        snapshotLookupError = e instanceof Error ? e.message : String(e);
       }
 
       const encoder = new TextEncoder();
@@ -82,6 +85,9 @@ export async function GET(request: Request) {
           };
           try {
             const result = await runPipeline(limit, userId, universe, (event) => send(event));
+            if (snapshotLookupError) {
+              result.data_gaps.push(`snapshot_logging: SKIPPED — user lookup failed (${snapshotLookupError}); this run left no scan_snapshots audit trail`);
+            }
             // Cache the final result so the follow-up fetch is instant
             setCache(limit, result, universe);
             send({ step: 'done', label: 'Complete', data: {} });
@@ -123,15 +129,21 @@ export async function GET(request: Request) {
 
     // Resolve userId for snapshot logging (non-blocking — pipeline runs even if lookup fails)
     let userId: string | undefined;
+    let snapshotLookupError: string | null = null;
     try {
       const user = await prisma.users.findFirst({ where: { email: { equals: userEmail, mode: 'insensitive' } } });
       userId = user?.id;
-    } catch {
-      // Non-critical — snapshot logging will be skipped
+    } catch (e: unknown) {
+      // KILL-4: still non-fatal, but the skipped snapshot audit trail is
+      // DECLARED on the result below.
+      snapshotLookupError = e instanceof Error ? e.message : String(e);
     }
 
     const start = Date.now();
     const result = await runPipeline(limit, userId, universe);
+    if (snapshotLookupError) {
+      result.data_gaps.push(`snapshot_logging: SKIPPED — user lookup failed (${snapshotLookupError}); this run left no scan_snapshots audit trail`);
+    }
     const elapsed = Date.now() - start;
     console.log(`[Convergence Route] Pipeline completed in ${elapsed}ms`);
 

--- a/src/lib/convergence/chain-fetcher.ts
+++ b/src/lib/convergence/chain-fetcher.ts
@@ -63,6 +63,10 @@ export interface ChainFetchResult {
   marketOpen: boolean;
   marketNote?: string;
   optionsFlowMap: Map<string, OptionsFlowData>;
+  // KILL-4: a fatal chain-fetch failure (auth, streamer, chain API) is a
+  // TYPED failure — an empty result with this set means "fetch FAILED",
+  // never "no strategies passed". Callers must declare it.
+  fatal_error: string | null;
 }
 
 // ===== HELPERS =====
@@ -127,7 +131,7 @@ export async function fetchChainAndBuildCards(
 
   if (tickers.length === 0) {
     stats.elapsed_ms = Date.now() - start;
-    return { cards, rejections, stats, perTickerStats, marketOpen, marketNote, optionsFlowMap };
+    return { cards, rejections, stats, perTickerStats, marketOpen, marketNote, optionsFlowMap, fatal_error: null };
   }
 
   try {
@@ -249,7 +253,7 @@ export async function fetchChainAndBuildCards(
     if (allStreamerSymbols.length === 0) {
       console.warn('[ChainFetcher] No streamer symbols to subscribe to');
       stats.elapsed_ms = Date.now() - start;
-      return { cards, rejections, stats, perTickerStats, marketOpen, marketNote, optionsFlowMap };
+      return { cards, rejections, stats, perTickerStats, marketOpen, marketNote, optionsFlowMap, fatal_error: null };
     }
 
     stats.streamer_symbols_subscribed = allStreamerSymbols.length;
@@ -451,7 +455,17 @@ export async function fetchChainAndBuildCards(
       } catch (e: unknown) {
         const msg = e instanceof Error ? e.message : String(e);
         console.error(`[ChainFetcher] ${ticker.symbol}: Strategy generation failed:`, msg);
+        // KILL-4: the empty card list must carry a failure marker — an
+        // exception is not "no strategies passed". Declared on the existing
+        // rejections surface.
         cards.set(ticker.symbol, []);
+        const existing = rejections.get(ticker.symbol) ?? [];
+        existing.push({
+          strategy: 'all',
+          reason: `strategy generation FAILED: ${msg} — empty card list is a failure, not "no strategies passed"`,
+          gate: 'construction',
+        });
+        rejections.set(ticker.symbol, existing);
       }
     }
 
@@ -545,12 +559,14 @@ export async function fetchChainAndBuildCards(
   } catch (e: unknown) {
     const msg = e instanceof Error ? e.message : String(e);
     console.error('[ChainFetcher] Fatal error:', msg);
-    // Return empty map — pipeline continues without trade cards
+    // KILL-4: the pipeline still continues without trade cards, but the
+    // result is no longer success-shaped — fatal_error is set and the
+    // caller DECLARES it (errors[] + data_gaps).
     stats.elapsed_ms = Date.now() - start;
-    return { cards, rejections, stats, perTickerStats, marketOpen, marketNote, optionsFlowMap };
+    return { cards, rejections, stats, perTickerStats, marketOpen, marketNote, optionsFlowMap, fatal_error: msg };
   }
 
   stats.elapsed_ms = Date.now() - start;
   console.log(`[ChainFetcher] Complete in ${stats.elapsed_ms}ms: ${stats.chain_symbols_fetched} chains, ${stats.total_trade_cards} cards`);
-  return { cards, rejections, stats, perTickerStats, marketOpen, marketNote, optionsFlowMap };
+  return { cards, rejections, stats, perTickerStats, marketOpen, marketNote, optionsFlowMap, fatal_error: null };
 }

--- a/src/lib/convergence/data-fetchers.ts
+++ b/src/lib/convergence/data-fetchers.ts
@@ -53,12 +53,18 @@ export interface FinnhubData {
   insiderSentiment: FinnhubInsiderSentiment[];
   earnings: FinnhubEarnings[];
   estimateData: FinnhubEstimateData | null;
+  // KILL-4 failure channel: per-endpoint fetch/parse/HTTP failures. A failed
+  // feed is DECLARED here — an empty array/null with no feedErrors entry
+  // genuinely means "fetched, empty"; with an entry it means "feed unavailable".
+  feedErrors: string[];
 }
 
 export interface FinnhubBatchStats {
   calls_made: number;
   errors: number;
   retries: number;
+  // KILL-4: per-symbol per-endpoint failure declarations ("SYM fundamentals: HTTP 429")
+  error_messages: string[];
 }
 
 // ===== HELPERS =====
@@ -90,12 +96,20 @@ async function fetchFinnhubEstimates(symbol: string, key: string): Promise<Finnh
   let revenueEstimates: FinnhubRevenueEstimate[] = [];
   let priceTarget: FinnhubPriceTarget | null = null;
   let upgradeDowngrade: FinnhubUpgradeDowngrade[] = [];
+  // KILL-4: every fetch/HTTP/parse failure is DECLARED on the result — a
+  // failed feed must never masquerade as "no estimates exist".
+  const feedErrors: string[] = [];
+  const declare = (feed: string, e: unknown) => {
+    const msg = e instanceof Error ? e.message : String(e);
+    console.error(`[Finnhub] ${feed} ${symbol}:`, msg);
+    feedErrors.push(`${feed}: ${msg}`);
+  };
 
   const [epsResp, revResp, ptResp, udResp] = await Promise.all([
-    fetchWithRetry(`https://finnhub.io/api/v1/stock/eps-estimate?symbol=${symbol}&freq=quarterly&token=${key}`).catch((e) => { console.error(`[Finnhub] eps-estimate ${symbol} fetch error:`, e instanceof Error ? e.message : String(e)); return null; }),
-    fetchWithRetry(`https://finnhub.io/api/v1/stock/revenue-estimate?symbol=${symbol}&freq=quarterly&token=${key}`).catch((e) => { console.error(`[Finnhub] revenue-estimate ${symbol} fetch error:`, e instanceof Error ? e.message : String(e)); return null; }),
-    fetchWithRetry(`https://finnhub.io/api/v1/stock/price-target?symbol=${symbol}&token=${key}`).catch((e) => { console.error(`[Finnhub] price-target ${symbol} fetch error:`, e instanceof Error ? e.message : String(e)); return null; }),
-    fetchWithRetry(`https://finnhub.io/api/v1/stock/upgrade-downgrade?symbol=${symbol}&token=${key}`).catch((e) => { console.error(`[Finnhub] upgrade-downgrade ${symbol} fetch error:`, e instanceof Error ? e.message : String(e)); return null; }),
+    fetchWithRetry(`https://finnhub.io/api/v1/stock/eps-estimate?symbol=${symbol}&freq=quarterly&token=${key}`).catch((e) => { declare('eps-estimate', e); return null; }),
+    fetchWithRetry(`https://finnhub.io/api/v1/stock/revenue-estimate?symbol=${symbol}&freq=quarterly&token=${key}`).catch((e) => { declare('revenue-estimate', e); return null; }),
+    fetchWithRetry(`https://finnhub.io/api/v1/stock/price-target?symbol=${symbol}&token=${key}`).catch((e) => { declare('price-target', e); return null; }),
+    fetchWithRetry(`https://finnhub.io/api/v1/stock/upgrade-downgrade?symbol=${symbol}&token=${key}`).catch((e) => { declare('upgrade-downgrade', e); return null; }),
   ]);
 
   if (epsResp?.ok) {
@@ -103,10 +117,10 @@ async function fetchFinnhubEstimates(symbol: string, key: string): Promise<Finnh
       const json = await epsResp.json();
       epsEstimates = Array.isArray(json?.data) ? json.data : [];
     } catch (e: unknown) {
-      console.error(`[Finnhub] eps-estimate ${symbol}:`, e instanceof Error ? e.message : String(e));
+      declare('eps-estimate', e);
     }
   } else if (epsResp) {
-    console.error(`[Finnhub] eps-estimate ${symbol}: HTTP ${epsResp.status}`);
+    declare('eps-estimate', `HTTP ${epsResp.status}`);
   }
 
   if (revResp?.ok) {
@@ -114,10 +128,10 @@ async function fetchFinnhubEstimates(symbol: string, key: string): Promise<Finnh
       const json = await revResp.json();
       revenueEstimates = Array.isArray(json?.data) ? json.data : [];
     } catch (e: unknown) {
-      console.error(`[Finnhub] revenue-estimate ${symbol}:`, e instanceof Error ? e.message : String(e));
+      declare('revenue-estimate', e);
     }
   } else if (revResp) {
-    console.error(`[Finnhub] revenue-estimate ${symbol}: HTTP ${revResp.status}`);
+    declare('revenue-estimate', `HTTP ${revResp.status}`);
   }
 
   if (ptResp?.ok) {
@@ -127,10 +141,10 @@ async function fetchFinnhubEstimates(symbol: string, key: string): Promise<Finnh
         priceTarget = json as FinnhubPriceTarget;
       }
     } catch (e: unknown) {
-      console.error(`[Finnhub] price-target ${symbol}:`, e instanceof Error ? e.message : String(e));
+      declare('price-target', e);
     }
   } else if (ptResp) {
-    console.error(`[Finnhub] price-target ${symbol}: HTTP ${ptResp.status}`);
+    declare('price-target', `HTTP ${ptResp.status}`);
   }
 
   if (udResp?.ok) {
@@ -138,13 +152,13 @@ async function fetchFinnhubEstimates(symbol: string, key: string): Promise<Finnh
       const json = await udResp.json();
       upgradeDowngrade = Array.isArray(json) ? json : [];
     } catch (e: unknown) {
-      console.error(`[Finnhub] upgrade-downgrade ${symbol}:`, e instanceof Error ? e.message : String(e));
+      declare('upgrade-downgrade', e);
     }
   } else if (udResp) {
-    console.error(`[Finnhub] upgrade-downgrade ${symbol}: HTTP ${udResp.status}`);
+    declare('upgrade-downgrade', `HTTP ${udResp.status}`);
   }
 
-  const result: FinnhubEstimateData = { epsEstimates, revenueEstimates, priceTarget, upgradeDowngrade };
+  const result: FinnhubEstimateData = { epsEstimates, revenueEstimates, priceTarget, upgradeDowngrade, feedErrors };
 
   // Only cache if we got meaningful data — prevents poisoning cache with empty results from rate limits / network errors
   const hasData = epsEstimates.length > 0 || revenueEstimates.length > 0 || priceTarget !== null || upgradeDowngrade.length > 0;
@@ -174,15 +188,24 @@ export async function fetchFinnhubTicker(
       insiderSentiment: [],
       earnings: [],
       estimateData: null,
+      feedErrors: ['FINNHUB_API_KEY not configured — all Finnhub feeds unavailable'],
     };
   }
 
-  // Fetch all 5 endpoints, each resilient to failure
+  // Fetch all 5 endpoints, each resilient to failure.
+  // KILL-4: every failure is DECLARED in feedErrors so a failed feed is
+  // distinguishable from "fetched, empty" all the way downstream.
   let fundamentals: FinnhubFundamentals | null = null;
   let recommendations: FinnhubRecommendation[] = [];
   let insiderSentiment: FinnhubInsiderSentiment[] = [];
   let earnings: FinnhubEarnings[] = [];
   let estimateData: FinnhubEstimateData | null = null;
+  const feedErrors: string[] = [];
+  const declareFeed = (feed: string, e: unknown) => {
+    const msg = e instanceof Error ? e.message : String(e);
+    console.error(`[Finnhub] ${feed} ${symbol}:`, msg);
+    feedErrors.push(`${feed}: ${msg}`);
+  };
 
   // 1. Fundamentals
   try {
@@ -194,10 +217,10 @@ export async function fetchFinnhubTicker(
       const metric = json?.metric || {};
       fundamentals = { metric, fieldCount: Object.keys(metric).length };
     } else {
-      console.error(`[Finnhub] fundamentals ${symbol}: HTTP ${resp.status}`);
+      declareFeed('fundamentals', `HTTP ${resp.status}`);
     }
   } catch (e: unknown) {
-    console.error(`[Finnhub] fundamentals ${symbol}:`, e instanceof Error ? e.message : String(e));
+    declareFeed('fundamentals', e);
   }
 
   // 2. Recommendations
@@ -209,10 +232,10 @@ export async function fetchFinnhubTicker(
       const json = await resp.json();
       recommendations = Array.isArray(json) ? json : [];
     } else {
-      console.error(`[Finnhub] recommendations ${symbol}: HTTP ${resp.status}`);
+      declareFeed('recommendations', `HTTP ${resp.status}`);
     }
   } catch (e: unknown) {
-    console.error(`[Finnhub] recommendations ${symbol}:`, e instanceof Error ? e.message : String(e));
+    declareFeed('recommendations', e);
   }
 
   // 3. Insider sentiment
@@ -226,10 +249,10 @@ export async function fetchFinnhubTicker(
       const json = await resp.json();
       insiderSentiment = json?.data || [];
     } else {
-      console.error(`[Finnhub] insider-sentiment ${symbol}: HTTP ${resp.status}`);
+      declareFeed('insider-sentiment', `HTTP ${resp.status}`);
     }
   } catch (e: unknown) {
-    console.error(`[Finnhub] insider-sentiment ${symbol}:`, e instanceof Error ? e.message : String(e));
+    declareFeed('insider-sentiment', e);
   }
 
   // 4. Earnings
@@ -241,20 +264,24 @@ export async function fetchFinnhubTicker(
       const json = await resp.json();
       earnings = Array.isArray(json) ? json : [];
     } else {
-      console.error(`[Finnhub] earnings ${symbol}: HTTP ${resp.status}`);
+      declareFeed('earnings', `HTTP ${resp.status}`);
     }
   } catch (e: unknown) {
-    console.error(`[Finnhub] earnings ${symbol}:`, e instanceof Error ? e.message : String(e));
+    declareFeed('earnings', e);
   }
 
   // 5. Premium estimates (EPS, revenue, price target, upgrade/downgrade)
   try {
     estimateData = await fetchFinnhubEstimates(symbol, key);
+    // Surface the estimate sub-feed failures on the ticker-level channel
+    if (estimateData.feedErrors && estimateData.feedErrors.length > 0) {
+      feedErrors.push(...estimateData.feedErrors.map(f => `estimates/${f}`));
+    }
   } catch (e: unknown) {
-    console.error(`[Finnhub] estimates ${symbol}:`, e instanceof Error ? e.message : String(e));
+    declareFeed('estimates', e);
   }
 
-  return { fundamentals, recommendations, insiderSentiment, earnings, estimateData };
+  return { fundamentals, recommendations, insiderSentiment, earnings, estimateData, feedErrors };
 }
 
 // ===== FINNHUB BATCH FETCHER =====
@@ -265,7 +292,7 @@ export async function fetchFinnhubBatch(
   apiKey?: string,
 ): Promise<{ data: Map<string, FinnhubData>; stats: FinnhubBatchStats }> {
   const data = new Map<string, FinnhubData>();
-  const stats: FinnhubBatchStats = { calls_made: 0, errors: 0, retries: 0 };
+  const stats: FinnhubBatchStats = { calls_made: 0, errors: 0, retries: 0, error_messages: [] };
 
   for (let i = 0; i < symbols.length; i++) {
     const symbol = symbols[i];
@@ -275,18 +302,27 @@ export async function fetchFinnhubBatch(
       const result = await fetchFinnhubTicker(symbol, apiKey);
       data.set(symbol, result);
 
+      // KILL-4: declare every per-endpoint failure on the batch channel
+      if (result.feedErrors.length > 0) {
+        stats.error_messages.push(...result.feedErrors.map(f => `${symbol} ${f}`));
+      }
+
       // Count errors: null fundamentals or empty arrays when we expected data
       if (!result.fundamentals) stats.errors++;
       if (result.recommendations.length === 0) stats.errors++;
     } catch (e: unknown) {
-      console.error(`[Finnhub Batch] ${symbol} failed:`, e instanceof Error ? e.message : String(e));
+      const msg = e instanceof Error ? e.message : String(e);
+      console.error(`[Finnhub Batch] ${symbol} failed:`, msg);
       stats.errors++;
+      // KILL-4: the empty shape carries the typed failure — declared
+      stats.error_messages.push(`${symbol} all: ${msg}`);
       data.set(symbol, {
         fundamentals: null,
         recommendations: [],
         insiderSentiment: [],
         earnings: [],
         estimateData: null,
+        feedErrors: [`all: ${msg}`],
       });
     }
 
@@ -397,10 +433,17 @@ export async function fetchQuarterlyFinancials(
 
   try {
     // Three calls: balance sheet, income statement, cash flow
+    // KILL-4: a failed statement fetch is DECLARED — a partial join must not
+    // masquerade as complete financials.
+    const statementFailures: string[] = [];
+    const stmtFail = (stmt: string) => (e: unknown) => {
+      statementFailures.push(`${stmt}: ${e instanceof Error ? e.message : String(e)}`);
+      return null;
+    };
     const [bsResp, icResp, cfResp] = await Promise.all([
-      fetchWithRetry(`https://finnhub.io/api/v1/stock/financials?symbol=${symbol}&statement=bs&freq=quarterly&token=${key}`).catch(() => null),
-      fetchWithRetry(`https://finnhub.io/api/v1/stock/financials?symbol=${symbol}&statement=ic&freq=quarterly&token=${key}`).catch(() => null),
-      fetchWithRetry(`https://finnhub.io/api/v1/stock/financials?symbol=${symbol}&statement=cf&freq=quarterly&token=${key}`).catch(() => null),
+      fetchWithRetry(`https://finnhub.io/api/v1/stock/financials?symbol=${symbol}&statement=bs&freq=quarterly&token=${key}`).catch(stmtFail('bs')),
+      fetchWithRetry(`https://finnhub.io/api/v1/stock/financials?symbol=${symbol}&statement=ic&freq=quarterly&token=${key}`).catch(stmtFail('ic')),
+      fetchWithRetry(`https://finnhub.io/api/v1/stock/financials?symbol=${symbol}&statement=cf&freq=quarterly&token=${key}`).catch(stmtFail('cf')),
     ]);
 
     type FinRow = Record<string, number | string | null | undefined>;
@@ -411,7 +454,12 @@ export async function fetchQuarterlyFinancials(
     const cfData: FinRow[] = cfResp?.ok ? ((await cfResp.json()) as FinResp)?.financials ?? [] : [];
 
     if (bsData.length === 0 && icData.length === 0 && cfData.length === 0) {
-      return { data: null, error: 'quarterly-financials: no data from any statement endpoint' };
+      return {
+        data: null,
+        error: statementFailures.length > 0
+          ? `quarterly-financials: statement fetch FAILED — ${statementFailures.join('; ')}`
+          : 'quarterly-financials: no data from any statement endpoint',
+      };
     }
 
     // Index by period string for cross-statement join
@@ -500,7 +548,14 @@ export async function fetchQuarterlyFinancials(
     };
 
     quarterlyFinancialsCache.set(symbol, { data: result, fetchedAt: Date.now() });
-    return { data: result, error: null };
+    // KILL-4: partial data is DECLARED — data + error both set means "usable
+    // but degraded", never silently complete-looking.
+    return {
+      data: result,
+      error: statementFailures.length > 0
+        ? `quarterly-financials PARTIAL: statement fetch failed — ${statementFailures.join('; ')}`
+        : null,
+    };
   } catch (e: unknown) {
     return { data: null, error: `quarterly-financials: ${e instanceof Error ? e.message : String(e)}` };
   }
@@ -1233,6 +1288,7 @@ export async function fetchSECForm4Data(
     // Step 3: Fetch and parse individual Form 4 XML filings (max 15 to limit API calls)
     const maxFilings = Math.min(form4Indices.length, 15);
     const transactions: SECForm4Transaction[] = [];
+    let filingFetchFailures = 0; // KILL-4: declared on the result
 
     for (let j = 0; j < maxFilings; j++) {
       const idx = form4Indices[j];
@@ -1254,8 +1310,11 @@ export async function fetchSECForm4Data(
         const xmlText = await xmlResp.text();
         const parsed = parseForm4Xml(xmlText);
         transactions.push(...parsed);
-      } catch {
-        // Skip individual filing parse errors
+      } catch (e: unknown) {
+        // KILL-4: skipped filings are counted and DECLARED on the result —
+        // silently omitting them undercounted every aggregate below.
+        filingFetchFailures++;
+        console.warn(`[SEC Form4] ${symbol}: filing ${accessionNumber} fetch/parse failed:`, e instanceof Error ? e.message : String(e));
       }
 
       await delay(110); // SEC rate limit: 10 req/sec → 100ms between
@@ -1335,7 +1394,13 @@ export async function fetchSECForm4Data(
     };
 
     secForm4Cache.set(symbol, { data: result, fetchedAt: Date.now() });
-    return { data: result, error: null };
+    // KILL-4: skipped filings mean the aggregates UNDERCOUNT — declared.
+    return {
+      data: result,
+      error: filingFetchFailures > 0
+        ? `sec-form4 PARTIAL: ${filingFetchFailures}/${maxFilings} filing(s) failed to fetch/parse — aggregates undercount`
+        : null,
+    };
   } catch (e: unknown) {
     return { data: null, error: `sec-form4: ${e instanceof Error ? e.message : String(e)}` };
   }
@@ -1726,9 +1791,16 @@ export async function fetchFinnhubInstitutionalOwnership(
 
   try {
     // Fetch both ownership endpoints in parallel
+    // KILL-4: endpoint failures are DECLARED — partial holders data must not
+    // masquerade as the full ownership picture.
+    const ownershipFailures: string[] = [];
+    const ownFail = (ep: string) => (e: unknown) => {
+      ownershipFailures.push(`${ep}: ${e instanceof Error ? e.message : String(e)}`);
+      return null;
+    };
     const [ownershipResp, fundResp] = await Promise.all([
-      fetchWithRetry(`https://finnhub.io/api/v1/stock/ownership?symbol=${symbol}&token=${key}`).catch(() => null),
-      fetchWithRetry(`https://finnhub.io/api/v1/stock/fund-ownership?symbol=${symbol}&token=${key}`).catch(() => null),
+      fetchWithRetry(`https://finnhub.io/api/v1/stock/ownership?symbol=${symbol}&token=${key}`).catch(ownFail('ownership')),
+      fetchWithRetry(`https://finnhub.io/api/v1/stock/fund-ownership?symbol=${symbol}&token=${key}`).catch(ownFail('fund-ownership')),
     ]);
 
     type OwnershipEntry = { share?: number; change?: number; filingDate?: string };
@@ -1739,18 +1811,29 @@ export async function fetchFinnhubInstitutionalOwnership(
       try {
         const json = await ownershipResp.json();
         if (Array.isArray(json?.ownership)) holders.push(...(json.ownership as OwnershipEntry[]));
-      } catch { /* ignore parse errors */ }
+      } catch (e: unknown) {
+        // KILL-4: parse failure declared, holders from this endpoint excluded
+        ownershipFailures.push(`ownership parse: ${e instanceof Error ? e.message : String(e)}`);
+      }
     }
 
     if (fundResp?.ok) {
       try {
         const json = await fundResp.json();
         if (Array.isArray(json?.ownership)) holders.push(...(json.ownership as OwnershipEntry[]));
-      } catch { /* ignore parse errors */ }
+      } catch (e: unknown) {
+        // KILL-4: parse failure declared, holders from this endpoint excluded
+        ownershipFailures.push(`fund-ownership parse: ${e instanceof Error ? e.message : String(e)}`);
+      }
     }
 
     if (holders.length === 0) {
-      return { data: null, error: 'institutional-ownership: no data from either endpoint' };
+      return {
+        data: null,
+        error: ownershipFailures.length > 0
+          ? `institutional-ownership: endpoint FAILED — ${ownershipFailures.join('; ')}`
+          : 'institutional-ownership: no data from either endpoint',
+      };
     }
 
     let totalShares = 0;
@@ -1780,7 +1863,14 @@ export async function fetchFinnhubInstitutionalOwnership(
     };
 
     institutionalOwnershipCache.set(symbol, { data: result, fetchedAt: Date.now() });
-    return { data: result, error: null };
+    // KILL-4: partial data is DECLARED — one endpoint failing must not
+    // silently present half the holders as the full picture.
+    return {
+      data: result,
+      error: ownershipFailures.length > 0
+        ? `institutional-ownership PARTIAL: ${ownershipFailures.join('; ')}`
+        : null,
+    };
   } catch (e: unknown) {
     return { data: null, error: `institutional-ownership: ${e instanceof Error ? e.message : String(e)}` };
   }

--- a/src/lib/convergence/pipeline.ts
+++ b/src/lib/convergence/pipeline.ts
@@ -555,8 +555,10 @@ export async function runPipeline(
       if (result.data && result.data.length > 0) {
         finnhubPeersMap[item.symbol] = result.data;
       }
-    } catch {
-      // Non-critical — fall through to GICS grouping
+    } catch (e: unknown) {
+      // KILL-4: still falls through to GICS grouping, but the failure is
+      // DECLARED — a degraded peer tier must not be silent.
+      errors.push(`Step E11a (finnhub-peers ${item.symbol}) FAILED: ${e instanceof Error ? e.message : String(e)} — peer grouping degraded to GICS tier`);
     }
   });
   // Hard 10-second cap on entire peers fetch step
@@ -762,6 +764,16 @@ export async function runPipeline(
   const finnhubMs = Date.now() - finnhubStart;
   console.log(`[Pipeline] Step E: Finnhub fetched in ${finnhubMs}ms`);
 
+  // KILL-4: per-endpoint Finnhub failures are DECLARED — a failed feed is
+  // "feed unavailable", never "fetched, empty". Affected signals are already
+  // excluded + renormalized by the gates; this surfaces the CAUSE.
+  if (finnhubResult.stats.error_messages.length > 0) {
+    const msgs = finnhubResult.stats.error_messages;
+    dataGaps.push(`finnhub: ${msgs.length} feed failure(s) — affected signals excluded per gate (feed unavailable). First ${Math.min(5, msgs.length)}: ${msgs.slice(0, 5).join(' | ')}`);
+    errors.push(...msgs.slice(0, 50).map(m => `Step E (finnhub feed) FAILED: ${m}`));
+    if (msgs.length > 50) errors.push(`Step E (finnhub feed): ${msgs.length - 50} further feed failure(s) truncated — see server logs`);
+  }
+
   // Fetch annual financials per symbol (for Piotroski YoY signals)
   const annualFinancialsMap = new Map<string, AnnualFinancials | null>();
   for (const symbol of topSymbols) {
@@ -770,7 +782,10 @@ export async function runPipeline(
       annualFinancialsMap.set(symbol, result.data);
       if (result.error) errors.push(`Step E (annual-financials ${symbol}): ${result.error}`);
     } catch (e: unknown) {
+      // KILL-4: a thrown fetch is DECLARED like the result.error path above —
+      // null still flows to exclusion, the cause reaches errors[].
       annualFinancialsMap.set(symbol, null);
+      errors.push(`Step E (annual-financials ${symbol}) FAILED: ${e instanceof Error ? e.message : String(e)}`);
     }
   }
 
@@ -808,7 +823,9 @@ export async function runPipeline(
           newsSentimentMap.set(symbol, result.data);
           if (result.error) errors.push(`Step E3 (news-sentiment ${symbol}): ${result.error}`);
         } catch (e: unknown) {
+          // KILL-4: a thrown fetch is DECLARED like the result.error path above
           newsSentimentMap.set(symbol, null);
+          errors.push(`Step E3 (news-sentiment ${symbol}) FAILED: ${e instanceof Error ? e.message : String(e)}`);
         }
         await new Promise(r => setTimeout(r, 800)); // Finnhub rate limit
       }
@@ -823,7 +840,9 @@ export async function runPipeline(
           finbertMap.set(symbol, result.data);
           if (result.error) errors.push(`Step E4 (finbert ${symbol}): ${result.error}`);
         } catch (e: unknown) {
+          // KILL-4: a thrown fetch is DECLARED like the result.error path above
           finbertMap.set(symbol, null);
+          errors.push(`Step E4 (finbert ${symbol}) FAILED: ${e instanceof Error ? e.message : String(e)}`);
         }
         await new Promise(r => setTimeout(r, 200)); // Finnhub rate limit
       }
@@ -838,7 +857,9 @@ export async function runPipeline(
           earningsQualityMap.set(symbol, result.data);
           if (result.error) errors.push(`Step E5 (earnings-quality ${symbol}): ${result.error}`);
         } catch (e: unknown) {
+          // KILL-4: a thrown fetch is DECLARED like the result.error path above
           earningsQualityMap.set(symbol, null);
+          errors.push(`Step E5 (earnings-quality ${symbol}) FAILED: ${e instanceof Error ? e.message : String(e)}`);
         }
         await new Promise(r => setTimeout(r, 200)); // Finnhub rate limit
       }
@@ -853,7 +874,9 @@ export async function runPipeline(
           institutionalOwnershipMap.set(symbol, result.data);
           if (result.error) errors.push(`Step E6 (institutional-ownership ${symbol}): ${result.error}`);
         } catch (e: unknown) {
+          // KILL-4: a thrown fetch is DECLARED like the result.error path above
           institutionalOwnershipMap.set(symbol, null);
+          errors.push(`Step E6 (institutional-ownership ${symbol}) FAILED: ${e instanceof Error ? e.message : String(e)}`);
         }
         await new Promise(r => setTimeout(r, 200)); // Finnhub rate limit
       }
@@ -868,7 +891,9 @@ export async function runPipeline(
           revenueBreakdownMap.set(symbol, result.data);
           if (result.error) errors.push(`Step E7 (revenue-breakdown ${symbol}): ${result.error}`);
         } catch (e: unknown) {
+          // KILL-4: a thrown fetch is DECLARED like the result.error path above
           revenueBreakdownMap.set(symbol, null);
+          errors.push(`Step E7 (revenue-breakdown ${symbol}) FAILED: ${e instanceof Error ? e.message : String(e)}`);
         }
         await new Promise(r => setTimeout(r, 200)); // Finnhub rate limit
       }
@@ -883,7 +908,9 @@ export async function runPipeline(
           quarterlyFinancialsMap.set(symbol, result.data);
           if (result.error) errors.push(`Step E8 (quarterly-financials ${symbol}): ${result.error}`);
         } catch (e: unknown) {
+          // KILL-4: a thrown fetch is DECLARED like the result.error path above
           quarterlyFinancialsMap.set(symbol, null);
+          errors.push(`Step E8 (quarterly-financials ${symbol}) FAILED: ${e instanceof Error ? e.message : String(e)}`);
         }
         await new Promise(r => setTimeout(r, 200)); // Finnhub rate limit (3 calls per symbol already batched)
       }
@@ -898,7 +925,9 @@ export async function runPipeline(
           secFilingMap.set(symbol, result.data);
           if (result.error) errors.push(`Step E9 (sec-edgar ${symbol}): ${result.error}`);
         } catch (e: unknown) {
+          // KILL-4: a thrown fetch is DECLARED like the result.error path above
           secFilingMap.set(symbol, null);
+          errors.push(`Step E9 (sec-edgar ${symbol}) FAILED: ${e instanceof Error ? e.message : String(e)}`);
         }
         await new Promise(r => setTimeout(r, 150)); // SEC rate limit: 10 req/sec → 150ms between
       }
@@ -913,7 +942,9 @@ export async function runPipeline(
           secForm4Map.set(symbol, result.data);
           if (result.error) errors.push(`Step E10 (insider-tx ${symbol}): ${result.error}`);
         } catch (e: unknown) {
+          // KILL-4: a thrown fetch is DECLARED like the result.error path above
           secForm4Map.set(symbol, null);
+          errors.push(`Step E10 (insider-tx ${symbol}) FAILED: ${e instanceof Error ? e.message : String(e)}`);
         }
         await new Promise(r => setTimeout(r, 200)); // Finnhub rate limit
       }
@@ -930,7 +961,9 @@ export async function runPipeline(
           }
           if (result.error) errors.push(`Step E11 (10k-text ${symbol}): ${result.error}`);
         } catch (e: unknown) {
-          // Non-fatal: text peer classification is an enhancement, not required
+          // KILL-4: non-fatal (text peers are an enhancement) but DECLARED —
+          // the symbol silently missing from textProfiles hid the cause.
+          errors.push(`Step E11 (10k-text ${symbol}) FAILED: ${e instanceof Error ? e.message : String(e)}`);
         }
         await new Promise(r => setTimeout(r, 150)); // SEC rate limit: 10 req/sec → 150ms between
       }
@@ -1130,6 +1163,7 @@ export async function runPipeline(
       insiderSentiment: [],
       earnings: [],
       estimateData: null,
+      feedErrors: [],
     };
 
     // Assemble ConvergenceInput (same structure as single-ticker route)
@@ -1606,6 +1640,12 @@ export async function runPipeline(
 
     if (chainInputs.length > 0) {
       const chainResult = await fetchChainAndBuildCards(chainInputs);
+      // KILL-4: a fatal chain failure is DECLARED — the empty card set is a
+      // failure, not a quiet no-strategies day.
+      if (chainResult.fatal_error) {
+        errors.push(`Step G2 (chain fetch) FAILED: ${chainResult.fatal_error}`);
+        dataGaps.push(`trade_cards: chain fetch FAILED (${chainResult.fatal_error}) — no trade cards this run is a feed failure, not "no strategies passed"`);
+      }
       chainStats = chainResult.stats;
       chainRejections = chainResult.rejections;
       perTickerStats = chainResult.perTickerStats;
@@ -1894,7 +1934,11 @@ export async function runPipeline(
     } catch (e: unknown) {
       const msg = e instanceof Error ? e.message : String(e);
       console.error(`[Pipeline] generateTradeCards failed for ${row.symbol}:`, msg);
+      // KILL-4: an exception-emptied card list must be distinguishable from a
+      // legitimate "no strategies passed" — declare on both surfaces.
       fullTradeCardsPerTicker[row.symbol] = [];
+      errors.push(`Step H (trade-cards ${row.symbol}) FAILED: ${msg}`);
+      dataGaps.push(`trade_cards: ${row.symbol} card generation FAILED (${msg}) — empty card list is a failure, not "no strategies passed"`);
     }
   }
 

--- a/src/lib/convergence/sentiment.ts
+++ b/src/lib/convergence/sentiment.ts
@@ -106,7 +106,11 @@ function parseJSON<T>(text: string): T | null {
 
   try {
     return JSON.parse(candidate) as T;
-  } catch {
+  } catch (e: unknown) {
+    // KILL-4 (c)-justified: the null IS handled loudly by both callers
+    // (console.warn + declared failure result upstream); only the parse
+    // detail was lost — now logged here.
+    console.warn('[Sentiment] JSON parse failed:', e instanceof Error ? e.message : String(e));
     return null;
   }
 }
@@ -162,7 +166,10 @@ Respond with JSON only, no other text:
   });
 
   if (!response.ok) {
-    const errorText = await response.text().catch(() => '');
+    // KILL-4 (c)-justified: this swallows only the failure to READ the error
+  // response body for the log line below — the HTTP failure itself is
+  // declared via console.error with status and the null return.
+  const errorText = await response.text().catch(() => '');
     console.error(`[Sentiment] Stage 1 API error ${response.status} for ${symbol}:`, errorText.substring(0, 500));
     return null;
   }

--- a/src/lib/convergence/types.ts
+++ b/src/lib/convergence/types.ts
@@ -115,6 +115,9 @@ export interface FinnhubEstimateData {
   revenueEstimates: FinnhubRevenueEstimate[];
   priceTarget: FinnhubPriceTarget | null;
   upgradeDowngrade: FinnhubUpgradeDowngrade[];
+  // KILL-4 failure channel: sub-feed fetch/HTTP/parse failures — an empty
+  // array with an entry here means "feed unavailable", not "no estimates".
+  feedErrors?: string[];
 }
 
 export interface FredMacroData {


### PR DESCRIPTION
…ade as empty

All 42 silent-swallow catches from FALLBACK-CENSUS Section 4 converted: 40 now DECLARE a typed failure, 2 are justified-silent with inline comments (sentiment error-body read + parse-null already handled loudly upstream).

Failure channels (extending the established {data, error} convention):
- FinnhubData.feedErrors / FinnhubEstimateData.feedErrors — per-endpoint fetch/HTTP/parse failures; 'fetched, empty' and 'feed unavailable' are now distinguishable. FinnhubBatchStats.error_messages aggregates them; the pipeline declares every feed failure into errors[] (capped) plus a data_gaps 'feed unavailable' summary.
- quarterly financials / institutional ownership / SEC Form 4: partial fetches return data + a PARTIAL error together (the pipeline loops already push result.error); all-failed returns name the failed endpoints instead of 'no data'.
- pipeline: all 12 swallowed catches (9 enrichment loops, peers, 10-K text, trade-card generation) now declare into errors[]/data_gaps while null continues to flow to the KILL-2/3 exclusion machinery.
- ChainFetchResult.fatal_error: a fatal chain failure is a typed failure, declared by the pipeline (errors[] + data_gaps) and the test route — an empty card set is no longer indistinguishable from a quiet day; the per-ticker strategy-generation catch adds a FAILED rejection entry.
- Routes: balances/positions responses gain failed_accounts, the scanner gains batch_errors + symbols_failed_count (totalScanned no longer masquerades as coverage), and the convergence route declares a skipped scan_snapshots audit trail in data_gaps on both SSE and non-stream paths.

No retries added, no defaults introduced (tripwire clean), no route/auth changes, nothing in PUBLIC_PATHS.