### PR TITLE
KILL-5: final census kill — no defaults in iv30/hv30, PoP dividend ha…

### DIFF
--- a/audit-reports/KILL-5-final-census-audit.md
+++ b/audit-reports/KILL-5-final-census-audit.md
@@ -1,0 +1,33 @@
+# KILL-5 Audit — final census kill + full reconciliation
+
+**Date:** 2026-07-06 · **Branch:** `claude/kill-5-final-census-kill` · **Base:** main @ `27e0272a` (KILL-4 `38abe820` verified present)
+
+## Phase 1 rulings (verified on base)
+
+**1. `pipeline.ts:1630-31` `iv30 ?? 30 / hv30 ?? 25`** (+ `strategy-builder.ts:855` `?? 0.30`, `:870` `?? iv`, test route `:301-2`) — consumers post-KILL-2/3/4: iv → σ in every breakeven_d2 PoP + edgeRatio; hv → HV-adjusted credit PoP (`computeHvAdjustedPoP`), the unlimited-risk sizing proxy `hvProxyML`, edgeRatio. EDGE-3's HV10>IV gate confirmed independent (uses leg IVs + hv10). **Ruling: iv30 becomes REQUIRED-REAL** (`GenerateParams.iv30: number`; callers skip + declare — near-dead for the pipeline thanks to hard Filter 3, but the fabricated 30-vol path is gone); **hv30 becomes nullable**: hv-adjusted PoP → `hvPop = null` (declared field + run-level declaration), EV uses the card's own computed PoP (a real labeled statistic, not a substitute), unlimited-risk candidates are REJECTED with the true reason (never proxied), edgeRatio excluded → composite renormalizes 50/30 of 80.
+
+**2. `probability.ts:56` missing q** — real source: TT market-metrics `dividend-yield` → `tt.dividendYield` (already fetched; **percentage points** — UI renders `toFixed(2) + '%'` at `ConvergenceIntelligence.tsx:579` — so q = value/100). **Ruling (from consumption):** PoP is a SCORED input (Gate B pass/fail, EV, composite ranking) — a silent q=0 assumption is a default on a scored path, so per Standing Ruling 2 it is not permitted. But full exclusion isn't needed either: the flow already contains an honest fallback statistic — the delta-approximation PoP every card starts with. **q present (incl. true 0 = real non-payer) → d2 drift is `r − q − σ²/2`; q absent → the breakeven_d2 UPGRADE IS SKIPPED**, PoP stays `delta_approx` (truthfully labeled by the existing `popMethod` field) and the run declares `dividend yield unavailable — … never assumed 0` on the rejections surface. `calcD2/probAbove/probBelow/probBetween` take a required `dividendYield` param — no default exists in the file.
+
+**3. `info-edge.ts:74/:88/:102/:123` analyst_consensus internals** — all four imputed-on-missing defaults die (40/40/50/40 → null → excluded → renormalized via the shared EDGE-2 combiner). **Stays, cited:** the 50 at (old) `:117` for a KNOWN mixed direction — computed from two present growth directions, a genuine neutral band. `analyst_consensus` itself becomes nullable like the other nine sub-scores (all-components-missing → excluded from info-edge); the EDGE-2b under-declared `imputed_fields` block (`:1347-8` old) is replaced by trace-derived exclusions (`analyst_consensus.estimate_level` etc. — cannot drift); all-ten-signals-missing now fails loud (scan_snapshots.infoEdgeScore is non-nullable — gate exclusion is a migration, flagged). Consumers: pipeline `info_edge_detail` `?.score ?? null` (EDGE-2b UI renders '—'); trade-cards null-guards.
+
+**4. `pipeline.ts:2315` display VRP `iv30² − hv30²`** — no rationale comment exists. **Ruling (3/5): one definition everywhere** — aligned to the simple difference `iv30 − hv30` the scorer uses (Goyal & Saretto 2009; vol-edge).
+
+## FINAL CENSUS RECONCILIATION — the violations column
+
+**145 total census violations → 111 closed by KILL-1..5 (69 pattern + all 42 silent catches) → 34 REMAIN**, each below (none silently dropped):
+
+| Remaining cluster | Sites | What it is |
+|---|---|---|
+| vol-edge.ts (12) | :270, :276, :282, :452, :610, :703, :768, :784, :875, :930, :940, :1024 | the penalty-40s on missing IVP / IV-HV / HV-accel / term-structure / sanitized-candles / 52-week data; skew+GEX neutral-50s when the chain is present but unusable; the `treasury10y ?? 4.5` risk-free rate in GEX. Needs a KILL-3-style component conversion of vol-edge (its own PR — same size as KILL-3) |
+| backtest/simulate route (7) | :79-:83, :87, :88 | missing backtester fields become $0 prices/P&L presented as results — backtest surface rework, own PR |
+| data-fetchers.ts (7) | :1011, :1382, :2060, :2181, :2190, :2191, :2193 | insider `transactionDate ?? 'unknown'` corrupting date-max; missing headline imputed neutral into sentiment; candle `time \|\| 0` (1970 candle), high/low imputed as open, volume imputed 0 |
+| quotes route (4) | :50, :51, :52, :60 | `\|\| 0` quote parse; one-sided quotes silently halve the mid |
+| sentiment.ts (2) | :288, :289 | stage-2 scoring failure imputes score=0/magnitude=0 with no error field on the persisted result |
+| chains route (1) | :86 | parse-boundary imputation |
+| strategy-builder (1) | :1206 | buildCustomCard still silently drops missing-PRICE legs while naming the full strategy (the greeks half was fixed in KILL-2; also entangled with a census GRAY on custom-path EDGE-1 gating) |
+
+KILL-6 candidates in priority order: vol-edge (scored path), data-fetchers candle/insider imputation (persisted/scored), quotes/chains/simulate (display+backtest surfaces), sentiment error channel, custom-card leg handling.
+
+## Verification
+
+Greps: no `?? 30 / ?? 25 / ?? 0.30 / ?? iv` remain outside kill-documentation comments; analyst penalty defaults gone. Tripwire on added lines: no value defaults (the flagged `?? 0` are a null-guarded display count and the pre-existing `maxLoss ?? 0` behind the `effectiveML > 0` compute guard). Executed trace: hv30+q present (q = **true 0**, non-payer) → breakeven_d2 PoP + hvPop computed; both ABSENT → PoP stays delta_approx (declared), unlimited-risk candidate rejected with the true reason (declared), zero fabricated values; `calcD2` with q=3% < q=0 confirms drift correction. `tsc` exit 0; `next build` compiled successfully (standing sandbox Plaid-env limit unrelated). No route/auth changes, nothing in PUBLIC_PATHS.

--- a/src/app/api/test/convergence/route.ts
+++ b/src/app/api/test/convergence/route.ts
@@ -291,15 +291,18 @@ export async function GET(request: Request) {
   // KILL-2: a missing IV rank is null at the parse boundary now — it cannot
   // select the vol-regime strategy menu, so the chain section is skipped and
   // declared (never an imputed rank).
-  if (currentPrice > 0 && ttScannerResult.data && ttScannerResult.data.ivRank == null) {
-    chainRejections = [{ strategy: 'all', reason: 'IV rank unavailable from market-metrics — chain/trade-card build skipped (no imputed rank)', gate: 'construction' }];
+  if (currentPrice > 0 && ttScannerResult.data && (ttScannerResult.data.ivRank == null || ttScannerResult.data.iv30 == null)) {
+    chainRejections = [{ strategy: 'all', reason: `${ttScannerResult.data.ivRank == null ? 'IV rank' : 'IV30'} unavailable from market-metrics — chain/trade-card build skipped (no imputed value)`, gate: 'construction' }];
   }
-  if (currentPrice > 0 && ttScannerResult.data && ttScannerResult.data.ivRank != null) {
+  if (currentPrice > 0 && ttScannerResult.data && ttScannerResult.data.ivRank != null && ttScannerResult.data.iv30 != null) {
     try {
       // TT scanner returns iv30/hv30 as percentages (e.g. 27.16 for 27.16%)
       // Chain fetcher / strategy builder expects decimals (e.g. 0.2716)
-      const rawIv30 = ttScannerResult.data.iv30 ?? 30;
-      const rawHv30 = ttScannerResult.data.hv30 ?? 25;
+      // KILL-5: no fabricated vols — iv30 missing skips the chain section
+      // (declared below); hv30/dividendYield pass through as null.
+      const rawIv30 = ttScannerResult.data.iv30;
+      const rawHv30 = ttScannerResult.data.hv30;
+      const rawDivYield = ttScannerResult.data.dividendYield;
       if (fredResult.data.fedFunds == null) {
         throw new Error(
           'FRED FEDFUNDS rate is null — cannot compute PoP. ' +
@@ -317,7 +320,8 @@ export async function GET(request: Request) {
         currentPrice,
         ivRank: ttScannerResult.data.ivRank,
         iv30: rawIv30 / 100,
-        hv30: rawHv30 / 100,
+        hv30: rawHv30 != null ? rawHv30 / 100 : null,
+        dividendYield: rawDivYield != null && Number.isFinite(rawDivYield) ? rawDivYield / 100 : null,
         hv10: hv10Pct != null ? hv10Pct / 100 : null,
         riskFreeRate: fredResult.data.fedFunds / 100,
       }];

--- a/src/lib/convergence/chain-fetcher.ts
+++ b/src/lib/convergence/chain-fetcher.ts
@@ -13,8 +13,12 @@ export interface ChainTickerInput {
   direction: string;
   currentPrice: number;
   ivRank: number;        // 0-1 scale
+  // KILL-5: iv30 required-real (callers skip + declare when the source did not
+  // deliver it — never a fabricated 30-vol). hv30/dividendYield null = source
+  // did not deliver; downstream declares and excludes, never substitutes.
   iv30: number;          // decimal e.g. 0.42
-  hv30: number;          // decimal e.g. 0.25
+  hv30: number | null;   // decimal e.g. 0.25, null = unavailable
+  dividendYield: number | null; // decimal e.g. 0.02, true 0 = real non-payer
   // EDGE-3: 10-day realized vol, decimal (e.g. 0.55). Required — null means not
   // computable from candle history; the HV10>IV gate then declares itself
   // not-evaluated instead of running on an invented value.
@@ -374,6 +378,7 @@ export async function fetchChainAndBuildCards(
             symbol: ticker.symbol,
             iv30: ticker.iv30,
             hv30: ticker.hv30,
+            dividendYield: ticker.dividendYield,
             hv10: ticker.hv10,
             riskFreeRate: ticker.riskFreeRate,
           });

--- a/src/lib/convergence/info-edge.ts
+++ b/src/lib/convergence/info-edge.ts
@@ -1,3 +1,4 @@
+import { combineWeighted } from './weighted-combiner';
 import type {
   ConvergenceInput,
   InfoEdgeResult,
@@ -40,7 +41,7 @@ function computeSurpriseThreshold(surprises: number[]): number {
 // Estimate revision momentum: EPS level, dispersion, revenue-EPS alignment, consensus breadth
 // (Chan, Jegadeesh & Lakonishok 1996). Price targets and U/D events now scored independently.
 
-function scoreAnalystConsensus(input: ConvergenceInput): AnalystConsensusTrace {
+function scoreAnalystConsensus(input: ConvergenceInput): AnalystConsensusTrace | null {
   const recs = input.finnhubRecommendations;
   const estimates = input.finnhubEstimates;
   const earnings = input.finnhubEarnings;
@@ -71,7 +72,9 @@ function scoreAnalystConsensus(input: ConvergenceInput): AnalystConsensusTrace {
 
   // ===== SUB-SCORE 1: Estimate Level (25%) =====
   // Chan, Jegadeesh & Lakonishok 1996: forward-vs-trailing EPS growth proxy
-  let estimateLevelScore = 40; // penalty default
+  // KILL-5: missing estimate/earnings data → null → EXCLUDED + renormalized
+  // (was a penalty 40 that entered the score whenever the feed was absent).
+  let estimateLevelScore: number | null = null;
   let epsGrowthDirection: string | null = null;
   if (forwardEps !== null && trailingActualEps !== null && Math.abs(trailingActualEps) > 0.01) {
     const growth = (forwardEps - trailingActualEps) / Math.abs(trailingActualEps);
@@ -85,7 +88,7 @@ function scoreAnalystConsensus(input: ConvergenceInput): AnalystConsensusTrace {
 
   // ===== SUB-SCORE 2: Estimate Dispersion (25%) =====
   // Diether, Malloy & Scherbina 2002: high disagreement predicts low returns
-  let estimateDispersionScore = 40; // penalty default
+  let estimateDispersionScore: number | null = null; // KILL-5: missing → excluded
   let epsDispersionPct: number | null = null;
   if (nextQEps && Math.abs(nextQEps.epsAvg) > 0.01) {
     epsDispersionPct = round(((nextQEps.epsHigh - nextQEps.epsLow) / Math.abs(nextQEps.epsAvg)) * 100, 2);
@@ -99,7 +102,10 @@ function scoreAnalystConsensus(input: ConvergenceInput): AnalystConsensusTrace {
 
   // ===== SUB-SCORE 3: Revenue-EPS Alignment (15%) =====
   // Cross-validates earnings quality: both up = organic growth, mixed = fragile
-  let revenueEpsAlignmentScore = 50; // neutral default
+  // KILL-5: null when the alignment is not computable (missing revenue
+  // estimates or unknown directions). The 50 for a KNOWN mixed direction
+  // (one up, one down — line below) is a genuine neutral band and stays.
+  let revenueEpsAlignmentScore: number | null = null;
   let revenueGrowthDirection: string | null = null;
   if (nextQRev && nextQRev.revenueAvg > 0) {
     const pastRev = estimates?.revenueEstimates
@@ -120,7 +126,7 @@ function scoreAnalystConsensus(input: ConvergenceInput): AnalystConsensusTrace {
 
   // ===== SUB-SCORE 4: Consensus Breadth (35%) =====
   // Buy/sell ratio (60%) + coverage depth (40%)
-  let consensusBreadthScore = 40; // penalty default
+  let consensusBreadthScore: number | null = null; // KILL-5: no recs → excluded
   if (latest && total > 0) {
     const bullish = latest.strongBuy + latest.buy;
     const bullishPct = bullish / total;
@@ -141,17 +147,23 @@ function scoreAnalystConsensus(input: ConvergenceInput): AnalystConsensusTrace {
     consensusBreadthScore = round(0.60 * ratioScore + 0.40 * coverageScore, 1);
   }
 
-  // ===== Weighted combination =====
+  // ===== Weighted combination (KILL-5 / EDGE-2 combiner) =====
   // 0.25 EstLevel + 0.25 Dispersion + 0.15 RevEpsAlign + 0.35 ConsensusBreadth
-  const score = round(
-    0.25 * estimateLevelScore +
-    0.25 * estimateDispersionScore +
-    0.15 * revenueEpsAlignmentScore +
-    0.35 * consensusBreadthScore,
-    1,
-  );
+  // Missing components are EXCLUDED and the remaining weights renormalize;
+  // ALL four missing → the whole sub-score is null (excluded from info-edge).
+  const acCombined = combineWeighted([
+    { key: 'estimate_level', weight: 0.25, score: estimateLevelScore },
+    { key: 'estimate_dispersion', weight: 0.25, score: estimateDispersionScore },
+    { key: 'revenue_eps_alignment', weight: 0.15, score: revenueEpsAlignmentScore },
+    { key: 'consensus_breadth', weight: 0.35, score: consensusBreadthScore },
+  ]);
+  if (acCombined.score == null) {
+    return null; // no analyst/estimate data at all — excluded, weights re-normalize
+  }
+  const score = acCombined.score;
 
-  const formula = `0.25×EstLevel(${round(estimateLevelScore)}) + 0.25×Dispersion(${round(estimateDispersionScore)}) + 0.15×RevEpsAlign(${round(revenueEpsAlignmentScore)}) + 0.35×Breadth(${round(consensusBreadthScore)}) = ${score}`;
+  const fmtA = (v: number | null) => (v !== null ? String(round(v)) : 'EXCLUDED');
+  const formula = `0.25×EstLevel(${fmtA(estimateLevelScore)}) + 0.25×Dispersion(${fmtA(estimateDispersionScore)}) + 0.15×RevEpsAlign(${fmtA(revenueEpsAlignmentScore)}) + 0.35×Breadth(${fmtA(consensusBreadthScore)})${acCombined.excludedKeys.length > 0 ? ` [missing excluded, weights renormalized ÷${Math.round(acCombined.activeWeight * 100) / 100}]` : ''} = ${score}`;
 
   const notes = [
     `fwdEPS=${forwardEps ?? 'N/A'}`,
@@ -160,9 +172,13 @@ function scoreAnalystConsensus(input: ConvergenceInput): AnalystConsensusTrace {
     latest ? `${latest.strongBuy}SB/${latest.buy}B/${latest.hold}H/${latest.sell}S/${latest.strongSell}SS` : 'no recs',
   ].join(', ');
 
+  const rA = (v: number | null) => (v !== null ? round(v) : null);
   return {
     score: round(score),
     weight: 0.15,
+    active_signal_count: acCombined.activeCount,
+    total_signal_count: acCombined.totalCount,
+    excluded_components: acCombined.excludedKeys.map(k => `analyst_consensus.${k}`),
     inputs: {
       periods_available: sorted.length,
       latest_period: latest?.period ?? null,
@@ -174,10 +190,10 @@ function scoreAnalystConsensus(input: ConvergenceInput): AnalystConsensusTrace {
     formula,
     notes,
     sub_scores: {
-      estimate_level_score: round(estimateLevelScore),
-      estimate_dispersion_score: round(estimateDispersionScore),
-      revenue_eps_alignment_score: round(revenueEpsAlignmentScore),
-      consensus_breadth_score: round(consensusBreadthScore),
+      estimate_level_score: rA(estimateLevelScore),
+      estimate_dispersion_score: rA(estimateDispersionScore),
+      revenue_eps_alignment_score: rA(revenueEpsAlignmentScore),
+      consensus_breadth_score: rA(consensusBreadthScore),
     },
     indicators: {
       forward_eps: forwardEps,
@@ -1322,7 +1338,11 @@ export function scoreInfoEdge(input: ConvergenceInput): InfoEdgeResult {
   // neutral value. All nine data-dependent sub-scores are nullable; only
   // analyst_consensus always returns a trace, so activeWeight >= 0.15 > 0.
   const TOTAL_SUB_SCORES = 10; // analyst, price_target, upgrade_downgrade, insider, earnings, flow, news, institutional, fund_ownership, material_event
-  const activeSubScores: SubScoreTrace[] = [analystConsensus];
+  // KILL-5: analyst_consensus is nullable like every other sub-score — its
+  // internal components no longer impute 40/50 on missing data, so a ticker
+  // with zero analyst/estimate coverage EXCLUDES the signal entirely.
+  const activeSubScores: SubScoreTrace[] = [];
+  if (analystConsensus != null) activeSubScores.push(analystConsensus);
   if (priceTargetSignal != null) activeSubScores.push(priceTargetSignal);
   if (upgradeDowngradeSignal != null) activeSubScores.push(upgradeDowngradeSignal);
   if (insiderActivity != null) activeSubScores.push(insiderActivity);
@@ -1337,6 +1357,13 @@ export function scoreInfoEdge(input: ConvergenceInput): InfoEdgeResult {
   const activeWeight = activeSubScores.reduce((sum, s) => sum + s.weight, 0);
   const baseScore = activeSubScores.reduce((sum, s) => sum + s.weight * s.score, 0);
 
+  // KILL-3/KILL-5 fail-loud: with zero real data across all ten signals there
+  // is nothing honest to score (scan_snapshots.infoEdgeScore is non-nullable —
+  // gate-level exclusion is a migration, flagged for Alex).
+  if (activeSubScores.length === 0 || activeWeight <= 0) {
+    throw new Error('Info-edge gate cannot compute: all ten signals lack source data — no imputation (KILL-5)');
+  }
+
   let score = round(baseScore / activeWeight, 1);
 
   // Filing recency: event-driven overlay (does NOT rebalance weights)
@@ -1346,18 +1373,15 @@ export function scoreInfoEdge(input: ConvergenceInput): InfoEdgeResult {
   }
 
   // Build DataConfidence
-  // EDGE-2b: imputedFields now covers ONLY analyst_consensus, the one sub-score
-  // that still blends component-level defaults internally when parts of its data
-  // are missing (out of this PR's mandate — documented for follow-up).
+  // KILL-5: nothing is imputed anywhere in info-edge anymore — the
+  // analyst_consensus internals now exclude + renormalize like everything
+  // else, so imputed_fields is empty and all tracking is exclusion-based,
+  // derived from the actual null traces (cannot drift).
   const imputedFields: string[] = [];
-  if (input.finnhubRecommendations.length === 0 && !input.finnhubEstimates) imputedFields.push('analyst_consensus');
-  else if (!input.finnhubEstimates) imputedFields.push('analyst_consensus.estimates');
 
-  // EDGE-2/EDGE-2b: excluded (dropped + re-normalized), NOT imputed. Derived from
-  // the sub-scores/components that actually returned null above, so tracking
-  // cannot drift from the score math. Dotted entries are components excluded and
-  // renormalized INSIDE a sub-score that still computed from its remaining data.
   const excludedFields: string[] = [];
+  if (analystConsensus == null) excludedFields.push('analyst_consensus');
+  else excludedFields.push(...(analystConsensus.excluded_components ?? []));
   if (priceTargetSignal == null) excludedFields.push('price_target_signal');
   if (upgradeDowngradeSignal == null) excludedFields.push('upgrade_downgrade_signal');
   if (insiderActivity == null) excludedFields.push('insider_activity');

--- a/src/lib/convergence/pipeline.ts
+++ b/src/lib/convergence/pipeline.ts
@@ -1441,9 +1441,10 @@ export async function runPipeline(
           fed_net_liquidity_raw: scoring.regime.breakdown.fed_net_liquidity_signal.raw_value ?? null,
         } : null,
         info_edge_detail: scoring ? {
+          // KILL-5: null score/weight = analyst signal excluded (no data)
           analyst_consensus: {
-            score: scoring.info_edge.breakdown.analyst_consensus.score,
-            weight: scoring.info_edge.breakdown.analyst_consensus.weight,
+            score: scoring.info_edge.breakdown.analyst_consensus?.score ?? null,
+            weight: scoring.info_edge.breakdown.analyst_consensus?.weight ?? null,
           },
           // EDGE-2b: null score/weight = signal excluded (no data) and weights
           // renormalized — never a number invented for display.
@@ -1586,6 +1587,7 @@ export async function runPipeline(
   try {
     // Build input for chain fetcher from top 9 tickers
     const chainSkippedNoIvp: string[] = [];
+    const chainSkippedNoIv30: string[] = [];
     const chainInputs = top9.map(row => {
       const ticker = scoredTickers.find(t => t.symbol === row.symbol);
       if (!ticker) return null;
@@ -1615,6 +1617,14 @@ export async function runPipeline(
         return null;
       }
 
+      // KILL-5: iv30 drives σ in every breakeven_d2 PoP — without it nothing
+      // can be priced honestly. Skip + declare (hard Filter 3 makes this
+      // near-unreachable, but the old path fabricated a 30-vol here).
+      if (tt.iv30 == null) {
+        chainSkippedNoIv30.push(row.symbol);
+        return null;
+      }
+
       // EDGE-3: 10-day realized vol for the HV10>IV sanity gate — same
       // computation as the displayed vol cone (computeCloseToCloseHV, percent),
       // converted to decimal. null when candle history is insufficient; the
@@ -1627,8 +1637,16 @@ export async function runPipeline(
         direction: s.strategy_suggestion.direction,
         currentPrice: latestClose,
         ivRank: (s.vol_edge.breakdown.mispricing.inputs.IV_percentile as number) / 100,
-        iv30: (tt.iv30 ?? 30) / 100,
-        hv30: (tt.hv30 ?? 25) / 100,
+        // KILL-5: no fabricated vols. iv30 is guaranteed non-null by hard
+        // Filter 3 for pipeline tickers, but verified — a null skips the
+        // ticker with a declaration, never a fabricated 30-vol. hv30 and
+        // dividendYield pass through as null when the source did not deliver
+        // them; the strategy builder declares and excludes per consumer.
+        iv30: tt.iv30 / 100,
+        hv30: tt.hv30 != null ? tt.hv30 / 100 : null,
+        // TT delivers dividend-yield in percentage points (UI renders it with
+        // toFixed(2) + '%'); q wants a decimal. A true 0 stays 0 (non-payer).
+        dividendYield: tt.dividendYield != null && Number.isFinite(tt.dividendYield) ? tt.dividendYield / 100 : null,
         hv10: hv10Pct != null ? hv10Pct / 100 : null,
         riskFreeRate: fedFundsRate,
       };
@@ -1636,6 +1654,9 @@ export async function runPipeline(
 
     if (chainSkippedNoIvp.length > 0) {
       dataGaps.push(`trade_cards: ${chainSkippedNoIvp.length} ticker(s) skipped — IV percentile unavailable, cannot select the vol-regime strategy menu (no imputed rank): ${chainSkippedNoIvp.join(', ')}`);
+    }
+    if (chainSkippedNoIv30.length > 0) {
+      dataGaps.push(`trade_cards: ${chainSkippedNoIv30.length} ticker(s) skipped — IV30 unavailable, cannot price strategies (no fabricated vol): ${chainSkippedNoIv30.join(', ')}`);
     }
 
     if (chainInputs.length > 0) {
@@ -2312,7 +2333,10 @@ function buildRankedRows(
     const signals: string[] = [];
     if (ivp != null) signals.push(`IVP=${round(ivp, 0)}%`);
     if (tt.iv30 != null && tt.hv30 != null) {
-      const vrp = round(tt.iv30 ** 2 - tt.hv30 ** 2, 0);
+      // KILL-5 no-drift: ONE VRP definition everywhere — the simple difference
+      // iv30 − hv30 the scorer uses (Goyal & Saretto 2009; vol-edge). The old
+      // display showed the variance form iv30² − hv30² with no stated rationale.
+      const vrp = round(tt.iv30 - tt.hv30, 1);
       signals.push(`VRP=${vrp}`);
     }
     if (hvTrend && !hvTrend.startsWith('UNKNOWN')) {

--- a/src/lib/convergence/probability.ts
+++ b/src/lib/convergence/probability.ts
@@ -32,12 +32,16 @@ export function normalCDF(x: number): number {
 /**
  * Calculate d2 for Black-Scholes at a given target price.
  *
- * d2 = [ln(S/K) + (r - sigma^2/2)T] / (sigma * sqrt(T))
+ * d2 = [ln(S/K) + (r - q - sigma^2/2)T] / (sigma * sqrt(T))
  *
  * Where:
  *   S = current underlying price
  *   K = target price (breakeven)
  *   r = risk-free rate (from FRED FEDFUNDS series, converted to decimal). Required — no default.
+ *   q = continuous dividend yield (decimal, e.g. 0.02 for 2%). Required — no
+ *       default (KILL-5). A true 0 from the source IS data (non-payer). When
+ *       the yield is UNKNOWN the caller must not call this with an assumed 0 —
+ *       omitting q overstated drift and flattered PoP for dividend payers.
  *   sigma = implied volatility (annualized, as decimal e.g. 0.25 for 25%)
  *   T = time to expiration in years
  *
@@ -49,11 +53,12 @@ export function calcD2(
   iv: number,
   dteYears: number,
   riskFreeRate: number,
+  dividendYield: number,
 ): number | null {
   if (spotPrice <= 0 || targetPrice <= 0 || iv <= 0 || dteYears <= 0) return null;
 
   const sqrtT = Math.sqrt(dteYears);
-  const d2 = (Math.log(spotPrice / targetPrice) + (riskFreeRate - iv * iv / 2) * dteYears) / (iv * sqrtT);
+  const d2 = (Math.log(spotPrice / targetPrice) + (riskFreeRate - dividendYield - iv * iv / 2) * dteYears) / (iv * sqrtT);
   return d2;
 }
 
@@ -67,8 +72,9 @@ export function probAbove(
   iv: number,
   dteYears: number,
   riskFreeRate: number,
+  dividendYield: number,
 ): number | null {
-  const d2 = calcD2(spotPrice, targetPrice, iv, dteYears, riskFreeRate);
+  const d2 = calcD2(spotPrice, targetPrice, iv, dteYears, riskFreeRate, dividendYield);
   if (d2 === null) return null;
   return normalCDF(d2);
 }
@@ -83,8 +89,9 @@ export function probBelow(
   iv: number,
   dteYears: number,
   riskFreeRate: number,
+  dividendYield: number,
 ): number | null {
-  const above = probAbove(spotPrice, targetPrice, iv, dteYears, riskFreeRate);
+  const above = probAbove(spotPrice, targetPrice, iv, dteYears, riskFreeRate, dividendYield);
   if (above === null) return null;
   return 1 - above;
 }
@@ -104,9 +111,10 @@ export function probBetween(
   iv: number,
   dteYears: number,
   riskFreeRate: number,
+  dividendYield: number,
 ): number | null {
-  const aboveLower = probAbove(spotPrice, lowerPrice, iv, dteYears, riskFreeRate);
-  const aboveUpper = probAbove(spotPrice, upperPrice, iv, dteYears, riskFreeRate);
+  const aboveLower = probAbove(spotPrice, lowerPrice, iv, dteYears, riskFreeRate, dividendYield);
+  const aboveUpper = probAbove(spotPrice, upperPrice, iv, dteYears, riskFreeRate, dividendYield);
   if (aboveLower === null || aboveUpper === null) return null;
   return aboveLower - aboveUpper;
 }

--- a/src/lib/convergence/trade-cards.ts
+++ b/src/lib/convergence/trade-cards.ts
@@ -86,10 +86,10 @@ function formatPlainEnglish(scoring: FullScoringResult, input: ConvergenceInput)
   // --- Info Edge signals ---
   const ie = scoring.info_edge;
 
-  // Analyst consensus
+  // Analyst consensus (KILL-5: trace is null when no analyst data — skip)
   const analystTrace = ie.breakdown.analyst_consensus;
-  const totalAnalysts = analystTrace.raw_counts.total;
-  if (totalAnalysts > 0) {
+  const totalAnalysts = analystTrace?.raw_counts.total ?? 0;
+  if (analystTrace && totalAnalysts > 0) {
     const buyPct = Math.round(((analystTrace.raw_counts.strongBuy + analystTrace.raw_counts.buy) / totalAnalysts) * 100);
     if (buyPct >= 70) {
       signals.push(`Wall Street is bullish — ${buyPct}% of ${totalAnalysts} analysts rate this a Buy or Strong Buy.`);
@@ -238,8 +238,9 @@ function regimeContext(scoring: FullScoringResult): string {
 // ===== ANALYST CONSENSUS LABEL =====
 
 function analystConsensusLabel(scoring: FullScoringResult): string | null {
-  const counts = scoring.info_edge.breakdown.analyst_consensus.raw_counts;
-  if (counts.total === 0) return null;
+  // KILL-5: null trace = no analyst data — no label, never a placeholder
+  const counts = scoring.info_edge.breakdown.analyst_consensus?.raw_counts;
+  if (!counts || counts.total === 0) return null;
   const buyPct = (counts.strongBuy + counts.buy) / counts.total;
   const sellPct = (counts.strongSell + counts.sell) / counts.total;
   if (buyPct >= 0.7) return 'Strong Buy';

--- a/src/lib/convergence/types.ts
+++ b/src/lib/convergence/types.ts
@@ -836,11 +836,12 @@ export interface RegimeResult {
 // -- Info Edge --
 
 export interface AnalystConsensusTrace extends SubScoreTrace {
+  // KILL-5: null = component's source data missing → excluded + renormalized
   sub_scores: {
-    estimate_level_score: number;
-    estimate_dispersion_score: number;
-    revenue_eps_alignment_score: number;
-    consensus_breadth_score: number;
+    estimate_level_score: number | null;
+    estimate_dispersion_score: number | null;
+    revenue_eps_alignment_score: number | null;
+    consensus_breadth_score: number | null;
   };
   indicators: {
     forward_eps: number | null;
@@ -1020,7 +1021,8 @@ export interface InfoEdgeResult {
   data_confidence: DataConfidence;
   filing_recency: FilingRecencyTrace;
   breakdown: {
-    analyst_consensus: AnalystConsensusTrace;
+    // KILL-5: null = no analyst/estimate data at all — excluded + renormalized
+    analyst_consensus: AnalystConsensusTrace | null;
     // EDGE-2b: every sub-score below is null when its data source is absent —
     // excluded from the composite and the remaining weights re-normalized.
     price_target_signal: PriceTargetSignalTrace | null;

--- a/src/lib/strategy-builder.ts
+++ b/src/lib/strategy-builder.ts
@@ -84,6 +84,7 @@ function calculateBreakevenPoP(
   dte: number,
   isCredit: boolean,
   riskFreeRate: number,
+  dividendYield: number,
 ): { pop: number; method: 'breakeven_d2' } | null {
   if (breakevens.length === 0 || spotPrice <= 0 || iv <= 0 || dte <= 0) return null;
 
@@ -98,11 +99,11 @@ function calculateBreakevenPoP(
       // Put credit spread: breakeven is below spot → profit if price ABOVE breakeven
       // Call credit spread: breakeven is above spot → profit if price BELOW breakeven
       if (be < spotPrice) {
-        const p = probAbove(spotPrice, be, iv, dteYears, riskFreeRate);
+        const p = probAbove(spotPrice, be, iv, dteYears, riskFreeRate, dividendYield);
         if (p === null) return null;
         return { pop: Math.max(0, Math.min(1, p)), method: 'breakeven_d2' };
       } else {
-        const p = probAbove(spotPrice, be, iv, dteYears, riskFreeRate);
+        const p = probAbove(spotPrice, be, iv, dteYears, riskFreeRate, dividendYield);
         if (p === null) return null;
         // Price needs to stay below breakeven
         return { pop: Math.max(0, Math.min(1, 1 - p)), method: 'breakeven_d2' };
@@ -112,11 +113,11 @@ function calculateBreakevenPoP(
       // Bull call spread: breakeven above spot → profit if price ABOVE breakeven
       // Bear put spread: breakeven below spot → profit if price BELOW breakeven
       if (be > spotPrice) {
-        const p = probAbove(spotPrice, be, iv, dteYears, riskFreeRate);
+        const p = probAbove(spotPrice, be, iv, dteYears, riskFreeRate, dividendYield);
         if (p === null) return null;
         return { pop: Math.max(0, Math.min(1, p)), method: 'breakeven_d2' };
       } else {
-        const p = probAbove(spotPrice, be, iv, dteYears, riskFreeRate);
+        const p = probAbove(spotPrice, be, iv, dteYears, riskFreeRate, dividendYield);
         if (p === null) return null;
         return { pop: Math.max(0, Math.min(1, 1 - p)), method: 'breakeven_d2' };
       }
@@ -127,12 +128,12 @@ function calculateBreakevenPoP(
     const [lowerBE, upperBE] = sorted;
     if (isCredit) {
       // Iron condor, short strangle, short straddle: profit if price stays BETWEEN breakevens
-      const p = probBetween(spotPrice, lowerBE, upperBE, iv, dteYears, riskFreeRate);
+      const p = probBetween(spotPrice, lowerBE, upperBE, iv, dteYears, riskFreeRate, dividendYield);
       if (p === null) return null;
       return { pop: Math.max(0, Math.min(1, p)), method: 'breakeven_d2' };
     } else {
       // Long straddle, long strangle: profit if price goes OUTSIDE breakevens
-      const p = probBetween(spotPrice, lowerBE, upperBE, iv, dteYears, riskFreeRate);
+      const p = probBetween(spotPrice, lowerBE, upperBE, iv, dteYears, riskFreeRate, dividendYield);
       if (p === null) return null;
       return { pop: Math.max(0, Math.min(1, 1 - p)), method: 'breakeven_d2' };
     }
@@ -224,8 +225,16 @@ export interface GenerateParams {
   expiration: string;
   dte: number;
   symbol?: string;        // for debug logging
-  iv30?: number;          // implied volatility decimal (e.g. 0.42 for 42%)
-  hv30?: number;          // 30-day HV decimal (e.g. 0.25 for 25%)
+  // KILL-5: REQUIRED and real — no `?? 0.30` fabrication. Callers skip the
+  // ticker (declared) when iv30 is missing; σ drives every breakeven_d2 PoP.
+  iv30: number;
+  // KILL-5: null = HV30 not delivered by the source. HV-adjusted PoP and the
+  // unlimited-risk HV proxy are then NOT computable — declared, never `?? iv`.
+  hv30: number | null;
+  // KILL-5: continuous dividend yield q, decimal. A true 0 IS data (non-payer).
+  // null = source did not deliver the field — the breakeven_d2 PoP upgrade is
+  // SKIPPED (PoP stays delta_approx, labeled) rather than assuming q=0.
+  dividendYield: number | null;
   // EDGE-3: 10-day realized vol, decimal (e.g. 0.55 for 55%). Required — the caller
   // must decide; null = not computable from candle history, in which case the
   // HV10>IV gate declares itself not-evaluated (never imputed, never silent).
@@ -852,38 +861,68 @@ export function generateStrategies(params: GenerateParams): GenerateResult {
   console.log(`[StrategyBuilder] ${sym}: pre-filter cards=${cards.length} [${cards.map(c => c.name).join(', ')}]`);
 
   // ─── Upgrade PoP: delta approximation → N(d2) at breakeven ────
-  const iv = params.iv30 ?? 0.30;
+  // KILL-5: iv30 is required-real (no `?? 0.30`); q is required for the d2
+  // drift (r − q − σ²/2). When q is UNKNOWN the upgrade is SKIPPED — PoP
+  // stays the delta approximation (a real, labeled statistic) rather than
+  // pricing every dividend payer with an assumed q=0.
+  const iv = params.iv30;
+  const q = params.dividendYield;
 
-  for (const card of cards) {
-    if (card.breakevens.length === 0 || card.pop == null) continue;
-    const isCredit = CREDIT_STRATEGIES.includes(card.name) || (card.netCredit != null && card.netCredit > 0);
-    const bePoP = calculateBreakevenPoP(card.breakevens, currentPrice, iv, dte, isCredit, params.riskFreeRate);
-    if (bePoP) {
-      const deltaPop = card.pop;
-      card.pop = Math.round(bePoP.pop * 100) / 100;
-      card.popMethod = bePoP.method;
-      console.log(`[StrategyBuilder] ${sym}: PoP upgrade "${card.name}" — delta=${(deltaPop * 100).toFixed(1)}% → N(d2)=${(bePoP.pop * 100).toFixed(1)}% (IV=${(iv * 100).toFixed(1)}%, DTE=${dte}, BEs=[${card.breakevens.join(', ')}])`);
+  if (q == null) {
+    rejections.push({
+      strategy: 'all',
+      reason: 'dividend yield unavailable — breakeven N(d2) PoP not computed (needs q; never assumed 0); PoP stays delta_approx',
+      gate: 'construction',
+    });
+  } else {
+    for (const card of cards) {
+      if (card.breakevens.length === 0 || card.pop == null) continue;
+      const isCredit = CREDIT_STRATEGIES.includes(card.name) || (card.netCredit != null && card.netCredit > 0);
+      const bePoP = calculateBreakevenPoP(card.breakevens, currentPrice, iv, dte, isCredit, params.riskFreeRate, q);
+      if (bePoP) {
+        const deltaPop = card.pop;
+        card.pop = Math.round(bePoP.pop * 100) / 100;
+        card.popMethod = bePoP.method;
+        console.log(`[StrategyBuilder] ${sym}: PoP upgrade "${card.name}" — delta=${(deltaPop * 100).toFixed(1)}% → N(d2)=${(bePoP.pop * 100).toFixed(1)}% (IV=${(iv * 100).toFixed(1)}%, q=${(q * 100).toFixed(2)}%, DTE=${dte}, BEs=[${card.breakevens.join(', ')}])`);
+      }
     }
   }
 
   // ─── Compute HV-Adjusted EV for each card ──────────────────────
-  const hv = params.hv30 ?? iv;
+  // KILL-5: hv30 is null when the source did not deliver it — never `?? iv`.
+  // With hv null: no HV-adjusted PoP (EV uses the card's own PoP, declared),
+  // and no HV proxy for unlimited risk (those candidates are REJECTED below).
+  const hv = params.hv30;
   // Safety cap: if IV/HV ratio > 4, cap at 4 to prevent unrealistic adjustments
-  const cappedHv = iv > 0 && hv > 0 && iv / hv > 4 ? iv / 4 : hv;
-  const hvProxyML = currentPrice * cappedHv * Math.sqrt(dte / 365) * 2.5 * 100;
+  const cappedHv = hv != null ? (iv > 0 && hv > 0 && iv / hv > 4 ? iv / 4 : hv) : null;
+  const hvProxyML = cappedHv != null ? currentPrice * cappedHv * Math.sqrt(dte / 365) * 2.5 * 100 : null;
+
+  if (hv == null) {
+    rejections.push({
+      strategy: 'all',
+      reason: 'hv30 unavailable — HV-adjusted PoP not computed (EV uses un-adjusted PoP, hvPop=null); unlimited-risk sizing not computable (those candidates rejected, never proxied)',
+      gate: 'construction',
+    });
+  }
 
   for (const card of cards) {
     if (card.pop == null) continue;
     const mp = card.maxProfit ?? 0;
     const isCredit = CREDIT_STRATEGIES.includes(card.name);
 
-    // HV-adjusted PoP for credit strategies; delta PoP for debit
-    const hvPop = isCredit ? computeHvAdjustedPoP(card, currentPrice, cappedHv, dte) : card.pop;
-    card.hvPop = isCredit ? Math.round(hvPop * 1000) / 1000 : null;
+    // HV-adjusted PoP for credit strategies; delta PoP for debit.
+    // hv missing → hvPop stays null (declared) and EV falls through to the
+    // card's own computed PoP — a real statistic, not a substitute value.
+    const hvPop = isCredit && cappedHv != null ? computeHvAdjustedPoP(card, currentPrice, cappedHv, dte) : null;
+    card.hvPop = hvPop != null ? Math.round(hvPop * 1000) / 1000 : null;
+
+    // KILL-5: unlimited-risk sizing needs the HV proxy — without hv30 the EV
+    // is not computable; the candidate is rejected (with reason) in the gate.
+    if (card.isUnlimited && hvProxyML == null) continue;
 
     // Use HV-based proxy for unlimited risk (actual expected movement, not inflated IV)
-    const effectiveML = card.isUnlimited ? hvProxyML : (card.maxLoss ?? 0);
-    const evPop = isCredit ? hvPop : card.pop;
+    const effectiveML = card.isUnlimited ? (hvProxyML as number) : (card.maxLoss ?? 0);
+    const evPop = isCredit ? (hvPop ?? card.pop) : card.pop;
 
     if (mp > 0 && effectiveML > 0) {
       // Extract short/long deltas for three-outcome model
@@ -982,9 +1021,20 @@ export function generateStrategies(params: GenerateParams): GenerateResult {
       }
     }
 
+    // KILL-5: unlimited-risk candidate without hv30 — the HV sizing proxy is
+    // not computable; REJECTED with the true reason, never proxied.
+    if (card.isUnlimited && hvProxyML == null) {
+      rejections.push({
+        strategy: card.name,
+        reason: 'hv30 unavailable — unlimited-risk sizing (HV proxy) not computable; rejected, never proxied',
+        gate: 'construction',
+      });
+      return false;
+    }
+
     // Gate A: EV must be positive (uses hvPoP for credit, deltaPoP for debit)
     if (card.ev <= 0) {
-      const effectiveML = card.isUnlimited ? hvProxyML : (card.maxLoss ?? 0);
+      const effectiveML = card.isUnlimited ? (hvProxyML as number) : (card.maxLoss ?? 0);
       console.log(`[StrategyBuilder] ${sym}: EV GATE rejected "${card.name}" — EV=$${card.ev.toFixed(0)} (hvPoP=${card.hvPop?.toFixed(3) ?? 'n/a'}, deltaPoP=${card.pop?.toFixed(3)}, mp=$${card.maxProfit}, ml=$${effectiveML.toFixed(0)})`);
       const strikes = card.legs.map(l => l.strike).sort((a, b) => a - b);
       const sw = strikes.length >= 2 ? strikes[1] - strikes[0] : 0;
@@ -1047,7 +1097,9 @@ export function generateStrategies(params: GenerateParams): GenerateResult {
   }
 
   // ─── Edge-Aware Composite Scoring ───────────────────────────────
-  const edgeRatio = iv > 0 ? Math.max(0, (iv - hv)) / iv : 0;
+  // KILL-5: the IV-HV edge ratio needs a real hv30 — when missing, the term
+  // is EXCLUDED and the remaining composite weights renormalize (50/30 of 80).
+  const edgeRatio = hv != null && iv > 0 ? Math.max(0, (iv - hv)) / iv : null;
   filtered.sort((a, b) => {
     const scoreA = computeCompositeScore(a);
     const scoreB = computeCompositeScore(b);
@@ -1055,9 +1107,12 @@ export function generateStrategies(params: GenerateParams): GenerateResult {
   });
 
   function computeCompositeScore(card: StrategyCard): number {
-    const effectiveML = card.isUnlimited ? hvProxyML : (card.maxLoss ?? 0);
+    // hvProxyML is non-null for every surviving unlimited-risk card (rejected above)
+    const effectiveML = card.isUnlimited ? (hvProxyML as number) : (card.maxLoss ?? 0);
     const thetaEff = effectiveML > 0 ? Math.abs(card.thetaPerDay) / effectiveML * 100 : 0;
-    return (card.evPerRisk * 50) + (thetaEff * 30) + (edgeRatio * 20);
+    const base = (card.evPerRisk * 50) + (thetaEff * 30);
+    // edgeRatio excluded (hv30 missing) → renormalize the 50/30 weights to 100
+    return edgeRatio != null ? base + (edgeRatio * 20) : base * (100 / 80);
   }
 
   // Persist composite scores on each card


### PR DESCRIPTION
…ndling ruled, analyst internals excluded, one VRP definition

- iv30 is required-real for strategy building: the pipeline/test route skip a ticker (declared in data_gaps/rejections) instead of pricing it as a fabricated 30-vol; strategy-builder's '?? 0.30' dies.
- hv30 is nullable end-to-end: '?? 25'/'?? iv' die; without hv30 the HV-adjusted PoP is null (declared), EV uses the card's own computed PoP, unlimited-risk candidates are REJECTED with the true reason (never proxied), and the composite's edge-ratio term is excluded with the 50/30 weights renormalized.
- Dividend yield q enters d2 (r − q − σ²/2): required param, fed from the already-fetched TT dividend-yield (percentage points → decimal; a true 0 IS data — real non-payer). q absent → the breakeven_d2 upgrade is SKIPPED and PoP stays delta_approx (truthfully labeled via popMethod) with a declared reason — never an assumed q=0 on a scored input.
- analyst_consensus internals (40/40/50/40 on missing data) die: null → excluded → renormalized via the shared combiner; the known-mixed- direction 50 stays (genuine neutral from present data); the sub-score itself is nullable like the other nine; tracking is trace-derived; all ten signals missing fails loud.
- One VRP definition everywhere: the ranked-row display now shows iv30 − hv30 (the scored definition), not the unexplained variance form.

CENSUS RECONCILIATION: 145 violations → 111 closed by KILL-1..5 (69 pattern + all 42 silent catches) → 34 remain, enumerated in audit-reports/KILL-5-final-census-audit.md (vol-edge 12, simulate 7, data-fetchers 7, quotes 4, sentiment 2, chains 1, custom-card 1).

No route/auth changes, nothing in PUBLIC_PATHS.