### PR TITLE
KILL-6: vol-edge imputation kill — last live-path violations

### DIFF
--- a/audit-reports/KILL-5-final-census-audit.md
+++ b/audit-reports/KILL-5-final-census-audit.md
@@ -14,11 +14,11 @@
 
 ## FINAL CENSUS RECONCILIATION — the violations column
 
-**145 total census violations → 111 closed by KILL-1..5 (69 pattern + all 42 silent catches) → 34 REMAIN**, each below (none silently dropped):
+**145 total census violations → 123 closed by KILL-1..6 (81 pattern + all 42 silent catches) → 22 REMAIN** (updated by KILL-6), each below (none silently dropped):
 
 | Remaining cluster | Sites | What it is |
 |---|---|---|
-| vol-edge.ts (12) | :270, :276, :282, :452, :610, :703, :768, :784, :875, :930, :940, :1024 | the penalty-40s on missing IVP / IV-HV / HV-accel / term-structure / sanitized-candles / 52-week data; skew+GEX neutral-50s when the chain is present but unusable; the `treasury10y ?? 4.5` risk-free rate in GEX. Needs a KILL-3-style component conversion of vol-edge (its own PR — same size as KILL-3) |
+| ~~vol-edge.ts (12)~~ **CLOSED by KILL-6** | :270, :276, :282, :452, :610, :703, :768, :784, :875, :930, :940, :1024 | all 12 converted to null → excluded → renormalized (see audit-reports/KILL-6-vol-edge-audit.md); the GEX rate now consumes the real fetched DGS10 or excludes |
 | backtest/simulate route (7) | :79-:83, :87, :88 | missing backtester fields become $0 prices/P&L presented as results — backtest surface rework, own PR |
 | data-fetchers.ts (7) | :1011, :1382, :2060, :2181, :2190, :2191, :2193 | insider `transactionDate ?? 'unknown'` corrupting date-max; missing headline imputed neutral into sentiment; candle `time \|\| 0` (1970 candle), high/low imputed as open, volume imputed 0 |
 | quotes route (4) | :50, :51, :52, :60 | `\|\| 0` quote parse; one-sided quotes silently halve the mid |

--- a/audit-reports/KILL-6-vol-edge-audit.md
+++ b/audit-reports/KILL-6-vol-edge-audit.md
@@ -1,0 +1,40 @@
+# KILL-6 Audit — vol-edge imputation kill (the last live-scoring-path cluster)
+
+**Date:** 2026-07-06 · **Branch:** `claude/kill-6-vol-edge-kill` · **Base:** main @ `9902d94f` (KILL-5 `7e71ce42` verified present)
+
+## Classification of the 12 rows (verified verbatim on base; census line refs)
+
+| Site (base line) | Code | Verdict | Evidence |
+|---|---|---|---|
+| :270 `ivp !== null ? clamp(ivp,0,100) : 40` | penalty on missing IVP | **DIES** | assigned because missing; entered mispricing at 0.30 (via IVComposite) |
+| :276 `ivHvSpreadScoreRaw = 40` | penalty on missing spread | **DIES** | entered at 0.25 |
+| :282 `hvAccelScoreRaw = 40` | penalty on missing HV60/90 | **DIES** | entered at 0.15 |
+| :452 term `<2 exps → score 40` | penalty on missing term structure | **DIES** → section EXCLUDED + gate renormalizes | the 40 entered at 0.25 gate weight |
+| :610/:615 technicals `<20 sanitized → 40` | penalty; REACHABLE (raw ≥20 but sanitized <20 — the caller checked raw length) | **DIES** → section EXCLUDED; scoreVolEdge now always delegates to scoreTechnicals' own exclusion | closed the raw-vs-sanitized gap the census flagged as untracked |
+| :703 `high52wScore = 40` | penalty on missing Finnhub 52-wk | **DIES** → component excluded, technicals renormalizes ÷0.85 |
+| :768 skew no-chain `50` | trace value (already weight-excluded by caller) | **DIES as display** — trace now reads EXCLUDED/0, never a fabricated neutral 50 |
+| :784 skew no-7DTE-exp `50` | **imputed-on-missing** — the ruling the mandate asked for: the code computes NOTHING here (`vol_skew_25d: null, pc_iv_ratio_atm: null`); the 50 exists only because the inputs are absent. Not a thin-data neutral. | **DIES** → EXCLUDED at live weight |
+| :875 skew neither-metric `50` | same — no per-strike IV delivered for either metric | **DIES** → EXCLUDED. **STAYS, cited:** the single-metric paths (one of volSkew/PCR present → score from that metric, labeled in the formula) — computed from present data |
+| :930 gex no-chain `50` | trace value (weight-excluded by caller) | **DIES as display** — EXCLUDED trace |
+| :940 `(treasury10y ?? 4.5)/100` | hardcoded rate over a fetched series | **DIES** — see rate finding |
+| :1024 gex flip-null `50` | `distanceToFlipPct` null only when NO strike had usable OI+IV — inputs missing | **DIES** → EXCLUDED |
+
+**The rate finding:** we DO fetch a real risk-free series — `treasury10y` = FRED **DGS10** (`data-fetchers.ts:598`), already consumed by the regime gate. The `?? 4.5` silently priced BS gamma off a hardcoded rate whenever the fetch failed. Now: real DGS10 consumed (recorded in the trace inputs); DGS10 null → GEX EXCLUDED with a formula stating exactly why — never 4.5.
+
+**Other STAYS (cited):** hvAccel FLAT=50 (:301, real HV tier), term fixed-tier 50 (:558, real slope), trend/bollinger/volume 50 initializers (:678/:698/:710 — dead behind the ≥20-sanitized-candle guarantee; volume's zero-volume case remains the census GRAY pending Alex), skew metric initializers (:893/:900 — now unreachable as defaults), RSI 55 neutral band (real RSI), display thresholds (:939), hv_accel peer-mean-0 z (census GRAY, untouched), `percentileRank` empty→50 (guarded-unreachable).
+
+## Combiner state + conversion
+
+Pre-KILL-6, `scoreVolEdge` was a hand-written branch tree over (hasCandles × hasChainData) with manual renormalization — correct for whole-section chain/candle absence but blind to every other exclusion combination. Converted to the shared `combineWeighted` over the five sections (0.40/0.25/0.15/0.10/0.10), each section declaring its own computability via `active_signal_count` (KILL-3 pattern); mispricing/technicals additionally combine their own components. All five sections excluded → fail-loud throw (`scan_snapshots.volEdgeScore` is non-nullable — gate exclusion is a migration, flagged). DataConfidence is now fully trace-derived: `imputed_fields: []` (nothing is imputed anywhere in vol-edge), `excluded_fields` from the traces, `active_signal_count` N/M unchanged in shape (EDGE-4 already exposed it to the pipeline detail + UI Conf line).
+
+## Blast radius
+
+Consumers verified: pipeline `vol_edge_detail` reads score/weight/formula (numbers; excluded sections show 0-weight + EXCLUDED formula — the established vol-edge display); `chainInputs`/snapshot `spotPrice` read `technicals.indicators.latest_close` (null on excluded trace — both already guarded); `TechnicalsTrace.sub_scores` and `iv_composite_score` made nullable in types; trade-cards/UI render from formula strings and null-guarded fields. No consumer coerces null to a number.
+
+## Verification
+
+Executed traces: many-feeds-missing ticker → vol-edge = 75 from the one present component (IV_HV), mispricing weight renormalized to 1.0, all seven exclusions declared, **N/M 1/8**, `imputed_fields` empty; **true-0 IVP scores as a real lowest-percentile value** (not excluded); GEX with a live chain + DGS10 null → EXCLUDED with the DGS10 formula, with DGS10=4.2 → score 85 and `risk_free_rate: 4.2` recorded; all-five-missing → throws the KILL-6 message. Remaining `= 40/50` literals in the file are all real-data tiers or dead initializers (each cited above). Tripwire on added lines: the only `??` is `(active_signal_count ?? 1)` — a type-level presence check (every vol-edge trace now sets the field explicitly); no value defaults. `tsc` exit 0; `next build` compiled successfully (standing sandbox Plaid-env limit unrelated).
+
+## Updated reconciliation
+
+**145 census violations → 123 closed by KILL-1..6 (81 pattern + 42 catches) → 22 remain:** backtest/simulate (7), data-fetchers candle/insider/headline imputation (7), quotes route (4), sentiment persisted 0/0 (2), chains route (1), custom-card missing-price leg-drop (1). None are in the live scan-scoring path — remaining clusters are backtest, display/quote routes, and secondary fetch surfaces.

--- a/src/lib/convergence/types.ts
+++ b/src/lib/convergence/types.ts
@@ -524,7 +524,7 @@ export interface MispricingTrace extends SubScoreTrace {
   iv_composite: {
     iv_rank: number | null;
     iv_percentile: number | null;
-    iv_composite_score: number;
+    iv_composite_score: number | null; // KILL-6: null = IVP and IVR both missing
     iv_composite_method: string;
     high_conviction_iv: boolean;
     vol_regime: 'POST_SPIKE' | 'SPIKE_BUILDING' | 'NORMAL';
@@ -542,12 +542,13 @@ export interface TermStructureTrace extends SubScoreTrace {
 }
 
 export interface TechnicalsTrace extends SubScoreTrace {
+  // KILL-6: null = component/section source data missing → excluded + renormalized
   sub_scores: {
-    rsi_score: number;
-    trend_score: number;
-    bollinger_score: number;
-    volume_score: number;
-    high52w_score: number;
+    rsi_score: number | null;
+    trend_score: number | null;
+    bollinger_score: number | null;
+    volume_score: number | null;
+    high52w_score: number | null;
   };
   indicators: {
     rsi_14: number | null;

--- a/src/lib/convergence/vol-edge.ts
+++ b/src/lib/convergence/vol-edge.ts
@@ -1,3 +1,4 @@
+import { combineWeighted } from './weighted-combiner';
 import type {
   ConvergenceInput,
   VolEdgeResult,
@@ -264,22 +265,23 @@ function scoreMispricing(input: ConvergenceInput): MispricingTrace {
     vrpSourceLabel = 'EXCLUDED — no own-history VRP distribution (< 20 distinct scan days in 365d of scan_snapshots)';
   }
 
-  // --- Raw scores (baseline, always computed) ---
+  // --- Raw scores (KILL-6: missing → null → EXCLUDED + renormalized; the
+  // old penalty-40s entered the composite whenever a feed was absent) ---
 
-  // IVP component (0.30): IVP directly maps 0-100
-  const ivpScoreRaw = ivp !== null ? clamp(ivp, 0, 100) : 40; // penalty default — missing IVP
+  // IVP component: IVP directly maps 0-100
+  const ivpScoreRaw: number | null = ivp !== null ? clamp(ivp, 0, 100) : null;
 
-  // IVR component: same identity mapping as IVP (null if unavailable → fallback to IVP only)
+  // IVR component: same identity mapping as IVP (null if unavailable)
   const ivrScoreRaw = ivr !== null ? clamp(ivr, 0, 100) : null;
 
-  // IV-HV spread component (0.25): higher absolute spread = more mispricing
-  let ivHvSpreadScoreRaw = 40; // penalty default — missing IV-HV spread
+  // IV-HV spread component: higher absolute spread = more mispricing
+  let ivHvSpreadScoreRaw: number | null = null;
   if (ivHvSpread !== null) {
     ivHvSpreadScoreRaw = clamp((Math.abs(ivHvSpread) / 20) * 100, 0, 100);
   }
 
-  // HV acceleration component (0.15): HV30 vs HV60 vs HV90 trend
-  let hvAccelScoreRaw = 40; // penalty default — missing HV data
+  // HV acceleration component: HV30 vs HV60 vs HV90 trend
+  let hvAccelScoreRaw: number | null = null;
   let hvTrend = 'UNKNOWN (missing HV data)';
   if (hv30 !== null && hv60 !== null && hv90 !== null) {
     if (hv30 < hv60 && hv60 < hv90) {
@@ -308,9 +310,9 @@ function scoreMispricing(input: ConvergenceInput): MispricingTrace {
   // EDGE-4: VRP is NOT in these branches — it is scored only against its own
   // history above (the old peer iv_hv_spread proxy percentile and the
   // zScore(vrp, 0, …) fallback are removed).
-  let ivpScore = ivpScoreRaw;
-  let ivHvSpreadScore = ivHvSpreadScoreRaw;
-  let hvAccelScore = hvAccelScoreRaw;
+  let ivpScore: number | null = ivpScoreRaw;
+  let ivHvSpreadScore: number | null = ivHvSpreadScoreRaw;
+  let hvAccelScore: number | null = hvAccelScoreRaw;
 
   const peerMetrics = peerEntry?.metrics;
 
@@ -352,32 +354,37 @@ function scoreMispricing(input: ConvergenceInput): MispricingTrace {
   // --- IV Composite: blend IVP and IVR when both available ---
   // IVR uses raw score (no IVR-specific peer stats); IVP retains peer transform.
   const ivrScore = ivrScoreRaw; // null if IVR unavailable
-  let ivCompositeScore: number;
+  let ivCompositeScore: number | null;
   let ivCompositeMethod: string;
-  if (ivrScore !== null) {
-    ivCompositeScore = round(0.60 * ivpScore + 0.40 * ivrScore, 1);
-    ivCompositeMethod = '0.60×IVP + 0.40×IVR';
-  } else {
-    ivCompositeScore = ivpScore;
-    ivCompositeMethod = 'IVP only (IVR unavailable)';
-  }
+  // KILL-6: IVP missing no longer scores 40 — the composite renormalizes over
+  // whichever of IVP/IVR is present; both missing → EXCLUDED (null).
+  const ivcCombined = combineWeighted([
+    { key: 'ivp', weight: 0.60, score: ivpScore },
+    { key: 'ivr', weight: 0.40, score: ivrScore },
+  ]);
+  ivCompositeScore = ivcCombined.score;
+  if (ivpScore !== null && ivrScore !== null) ivCompositeMethod = '0.60×IVP + 0.40×IVR';
+  else if (ivpScore !== null) ivCompositeMethod = 'IVP only (IVR unavailable)';
+  else if (ivrScore !== null) ivCompositeMethod = 'IVR only (IVP unavailable)';
+  else ivCompositeMethod = 'EXCLUDED (IVP and IVR unavailable)';
 
   // Weights: 0.30×VRP + 0.30×IVComposite + 0.25×IV_HV_spread + 0.15×HV_accel
-  // EDGE-4 / EDGE-2 combiner: sum weight×score over the PRESENT components
-  // only and divide by their summed weight — a null VRP is excluded and the
-  // remaining weights renormalize (never imputed, never proxied).
-  const components: { w: number; s: number }[] = [];
-  if (vrpScore !== null) components.push({ w: 0.30, s: vrpScore });
-  components.push({ w: 0.30, s: ivCompositeScore });
-  components.push({ w: 0.25, s: ivHvSpreadScore });
-  components.push({ w: 0.15, s: hvAccelScore });
-  const activeWeight = components.reduce((sum, c) => sum + c.w, 0);
-  let score = round(components.reduce((sum, c) => sum + c.w * c.s, 0) / activeWeight, 1);
+  // EDGE-4/KILL-6 combiner: every missing component is EXCLUDED and the
+  // remaining weights renormalize (never imputed, never proxied). All four
+  // missing → the whole mispricing section is EXCLUDED from vol-edge.
+  const mispricingCombined = combineWeighted([
+    { key: 'vrp', weight: 0.30, score: vrpScore },
+    { key: 'ivp', weight: 0.30, score: ivCompositeScore },
+    { key: 'iv_hv_spread', weight: 0.25, score: ivHvSpreadScore },
+    { key: 'hv_accel', weight: 0.15, score: hvAccelScore },
+  ]);
+  const activeWeight = mispricingCombined.activeWeight;
+  let score = mispricingCombined.score;
 
   // High Conviction Bonus: when IVP and IVR both > 50 and within 15 points, add +5
   const highConvictionIv = ivp !== null && ivr !== null &&
     ivp > 50 && ivr > 50 && Math.abs(ivp - ivr) <= 15;
-  if (highConvictionIv) {
+  if (score !== null && highConvictionIv) {
     score = Math.min(100, round(score + 5, 1));
   }
 
@@ -401,17 +408,24 @@ function scoreMispricing(input: ConvergenceInput): MispricingTrace {
   // EDGE-4: the formula string the UI shows carries the VRP source label —
   // own-history percentile when present, or the explicit exclusion +
   // renormalization when absent. What the UI shows == what fires.
+  const fmtM = (v: number | null) => (v !== null ? String(round(v, 1)) : 'EXCLUDED');
   const vrpTerm = vrpScore !== null
     ? `0.30×VRP(${round(vrpScore, 1)} [${vrpSourceLabel}])`
-    : `VRP ${vrpSourceLabel} — remaining weights renormalized ÷${round(activeWeight, 2)}`;
-  const formula = `${vrpTerm} + 0.30×IVComposite(${round(ivCompositeScore, 1)} [${ivCompositeMethod}]) + 0.25×IV_HV(${round(ivHvSpreadScore, 1)}) + 0.15×HV_accel(${round(hvAccelScore, 1)}) = ${round(score)}${highConvictionIv ? ' +5 high conviction' : ''} [${mode}]`;
+    : `VRP ${vrpSourceLabel}`;
+  const formula = `${vrpTerm} + 0.30×IVComposite(${fmtM(ivCompositeScore)} [${ivCompositeMethod}]) + 0.25×IV_HV(${fmtM(ivHvSpreadScore)}) + 0.15×HV_accel(${fmtM(hvAccelScore)})${mispricingCombined.excludedKeys.length > 0 && score !== null ? ` [missing excluded, weights renormalized ÷${round(activeWeight, 2)}]` : ''} = ${score !== null ? round(score) : 'EXCLUDED (no component data)'}${highConvictionIv && score !== null ? ' +5 high conviction' : ''} [${mode}]`;
 
   const vrpNote = vrpScore !== null
     ? `VRP=${round(vrpScore)}(own-history percentile,z=${zScores.vrp_z ?? 'null'})`
     : 'VRP=EXCLUDED(no own-history distribution)';
+  const fmtN = (v: number | null) => (v !== null ? String(round(v)) : 'EXCLUDED');
   return {
-    score: round(score),
+    // KILL-6: 0 + weight set to 0 by scoreVolEdge when the whole section is
+    // EXCLUDED (no component data) — never an imputed value.
+    score: score !== null ? round(score) : 0,
     weight: 0.50,
+    active_signal_count: mispricingCombined.activeCount,
+    total_signal_count: mispricingCombined.totalCount,
+    excluded_components: mispricingCombined.excludedKeys.map(k => `mispricing.${k}`),
     inputs: {
       IV_30: iv30,
       HV_30: hv30,
@@ -426,13 +440,13 @@ function scoreMispricing(input: ConvergenceInput): MispricingTrace {
     z_scores: zScores,
     formula,
     notes: hasPeerZScores
-      ? `${vrpNote}, IVComposite=${round(ivCompositeScore)}(IVP=${round(ivpScore)},IVR=${ivrScore !== null ? round(ivrScore) : 'N/A'}), IV_HV=${round(ivHvSpreadScore)}(raw=${round(ivHvSpreadScoreRaw)},z=${zScores.iv_hv_z}), HV_accel=${round(hvAccelScore)}(raw=${round(hvAccelScoreRaw)},z=${zScores.hv_accel_z})`
-      : `${vrpNote}, IVComposite=${round(ivCompositeScore)}(IVP=${round(ivpScore)},IVR=${ivrScore !== null ? round(ivrScore) : 'N/A'}), IV_HV=${round(ivHvSpreadScore)}, HV_accel=${round(hvAccelScore)}`,
+      ? `${vrpNote}, IVComposite=${fmtN(ivCompositeScore)}(IVP=${fmtN(ivpScore)},IVR=${ivrScore !== null ? round(ivrScore) : 'N/A'}), IV_HV=${fmtN(ivHvSpreadScore)}(raw=${fmtN(ivHvSpreadScoreRaw)},z=${zScores.iv_hv_z}), HV_accel=${fmtN(hvAccelScore)}(raw=${fmtN(hvAccelScoreRaw)},z=${zScores.hv_accel_z})`
+      : `${vrpNote}, IVComposite=${fmtN(ivCompositeScore)}(IVP=${fmtN(ivpScore)},IVR=${ivrScore !== null ? round(ivrScore) : 'N/A'}), IV_HV=${fmtN(ivHvSpreadScore)}, HV_accel=${fmtN(hvAccelScore)}`,
     hv_trend: hvTrend,
     iv_composite: {
       iv_rank: ivr,
       iv_percentile: ivp,
-      iv_composite_score: round(ivCompositeScore, 1),
+      iv_composite_score: ivCompositeScore !== null ? round(ivCompositeScore, 1) : null,
       iv_composite_method: ivCompositeMethod,
       high_conviction_iv: highConvictionIv,
       vol_regime: volRegime,
@@ -448,11 +462,16 @@ function scoreTermStructure(input: ConvergenceInput): TermStructureTrace {
   const earningsDate = input.ttScanner?.earningsDate ?? null;
 
   if (ts.length < 2) {
+    // KILL-6: < 2 expirations means the slope is NOT COMPUTABLE — the section
+    // is EXCLUDED (weight 0, renormalized by scoreVolEdge), never a penalty 40.
     return {
-      score: 40,
+      score: 0,
       weight: 0.30,
+      active_signal_count: 0,
+      total_signal_count: 1,
+      excluded_components: ['term_structure'],
       inputs: { expirations_available: ts.length },
-      formula: 'Insufficient term structure data (< 2 expirations) → penalty default 40 (missing data)',
+      formula: 'EXCLUDED — insufficient term structure data (< 2 expirations); no imputed score, weight renormalized',
       notes: 'Need at least 2 expirations to compute slope',
       shape: 'UNKNOWN',
       richest_tenor: null,
@@ -574,6 +593,9 @@ function scoreTermStructure(input: ConvergenceInput): TermStructureTrace {
   return {
     score: round(shapeScore),
     weight: 0.30,
+    active_signal_count: 1,
+    total_signal_count: 1,
+    excluded_components: [],
     inputs: {
       front_month_iv: round(frontIV, 2),
       back_month_iv: round(backIV, 2),
@@ -606,13 +628,19 @@ function scoreTechnicals(input: ConvergenceInput): TechnicalsTrace {
   );
 
   if (candles.length < 20) {
+    // KILL-6: fewer than 20 SANITIZED candles (raw feed may have had more —
+    // this path was reachable and scored a penalty 40) → the whole technicals
+    // section is EXCLUDED (weight 0, renormalized by scoreVolEdge).
     return {
-      score: 40,
+      score: 0,
       weight: 0.20,
+      active_signal_count: 0,
+      total_signal_count: 1,
+      excluded_components: ['technicals'],
       inputs: { candles_available: candles.length },
-      formula: `Insufficient candle data (${candles.length} < 20 required) → penalty default 40 (missing data)`,
+      formula: `EXCLUDED — insufficient candle data (${candles.length} sanitized < 20 required); no imputed score, weight renormalized`,
       notes: 'Need at least 20 candles for Bollinger Bands and SMA calculations',
-      sub_scores: { rsi_score: 40, trend_score: 40, bollinger_score: 40, volume_score: 40, high52w_score: 40 },
+      sub_scores: { rsi_score: null, trend_score: null, bollinger_score: null, volume_score: null, high52w_score: null },
       indicators: {
         rsi_14: null, rsi_trace: null, sma_20: null, sma_50: null, latest_close: null,
         bb_upper: null, bb_lower: null, bb_middle: null, bb_position: null, bb_width: null,
@@ -700,7 +728,9 @@ function scoreTechnicals(input: ConvergenceInput): TechnicalsTrace {
     ? round((latestClose - low52wNum) / (high52wNum - low52wNum), 4)
     : null;
 
-  let high52wScore = 40; // penalty default — missing Finnhub 52-week data
+  // KILL-6: missing Finnhub 52-week data → component EXCLUDED + renormalized
+  // (was a penalty 40 entering at 0.15 weight).
+  let high52wScore: number | null = null;
   if (high52wRatio !== null) {
     if (high52wRatio >= 0.95) high52wScore = 85;
     else if (high52wRatio >= 0.90) high52wScore = 75;
@@ -711,15 +741,27 @@ function scoreTechnicals(input: ConvergenceInput): TechnicalsTrace {
   }
 
   // Weighted combination: RSI 25%, trend 25%, bollinger 20%, volume 15%, 52-week high 15%
-  const score = round(
-    0.25 * rsiScore + 0.25 * trendScore + 0.20 * bollingerScore + 0.15 * volumeScore + 0.15 * high52wScore, 1,
-  );
+  // KILL-6 combiner: a missing 52-week-high component is EXCLUDED and the
+  // remaining weights renormalize (RSI/trend/BB/volume are always computable
+  // from the >= 20 real candles guaranteed above).
+  const techCombined = combineWeighted([
+    { key: 'rsi', weight: 0.25, score: rsiScore },
+    { key: 'trend', weight: 0.25, score: trendScore },
+    { key: 'bollinger', weight: 0.20, score: bollingerScore },
+    { key: 'volume', weight: 0.15, score: volumeScore },
+    { key: 'high52w', weight: 0.15, score: high52wScore },
+  ]);
+  const score = techCombined.score as number; // >= 4 components always present
 
-  const formula = `0.25×RSI(${round(rsiScore)}) + 0.25×Trend(${round(trendScore)}) + 0.20×BB(${round(bollingerScore)}) + 0.15×Vol(${round(volumeScore)}) + 0.15×52WkHigh(${round(high52wScore)}) = ${score}`;
+  const fmtT = (v: number | null) => (v !== null ? String(round(v)) : 'EXCLUDED');
+  const formula = `0.25×RSI(${round(rsiScore)}) + 0.25×Trend(${round(trendScore)}) + 0.20×BB(${round(bollingerScore)}) + 0.15×Vol(${round(volumeScore)}) + 0.15×52WkHigh(${fmtT(high52wScore)})${high52wScore === null ? ` [missing excluded, weights renormalized ÷0.85]` : ''} = ${score}`;
 
   return {
     score: round(score),
     weight: 0.20,
+    active_signal_count: techCombined.activeCount,
+    total_signal_count: techCombined.totalCount,
+    excluded_components: techCombined.excludedKeys.map(k => `technicals.${k}`),
     inputs: {
       candles_available: candles.length,
       latest_close: latestClose,
@@ -731,7 +773,7 @@ function scoreTechnicals(input: ConvergenceInput): TechnicalsTrace {
       trend_score: round(trendScore),
       bollinger_score: round(bollingerScore),
       volume_score: round(volumeScore),
-      high52w_score: round(high52wScore),
+      high52w_score: high52wScore !== null ? round(high52wScore) : null,
     },
     indicators: {
       rsi_14: rsiResult.rsi,
@@ -764,13 +806,16 @@ function scoreOptionsSkew(input: ConvergenceInput): SkewTrace {
   const spot = flow?.underlyingPrice ?? null;
 
   if (!chain || chain.length === 0 || spot === null || spot <= 0) {
+    // KILL-6: no chain data → EXCLUDED (weight 0, renormalized) — the old
+    // trace displayed a fabricated neutral 50.
     return {
-      score: 50, weight: 0.10,
+      score: 0, weight: 0.10,
+      active_signal_count: 0, total_signal_count: 1, excluded_components: ['skew'],
       inputs: { data_available: false },
-      formula: 'No options chain data → neutral default 50',
+      formula: 'EXCLUDED — no options chain data; no imputed score, weight renormalized',
       notes: 'Skew scoring requires per-strike IV data from options chain',
       vol_skew_25d: null, pc_iv_ratio_atm: null,
-      skew_direction: 'neutral', skew_score: 50,
+      skew_direction: 'neutral', skew_score: 0,
     };
   }
 
@@ -780,13 +825,16 @@ function scoreOptionsSkew(input: ConvergenceInput): SkewTrace {
     .sort((a, b) => Math.abs(a.dte - 30) - Math.abs(b.dte - 30));
 
   if (sorted.length === 0) {
+    // KILL-6: chain present but no usable expiration — the metric inputs are
+    // MISSING, not thin: EXCLUDED, never a neutral 50 at live weight.
     return {
-      score: 50, weight: 0.10,
+      score: 0, weight: 0.10,
+      active_signal_count: 0, total_signal_count: 1, excluded_components: ['skew'],
       inputs: { data_available: false, expirations: chain.length },
-      formula: 'No expirations >= 7 DTE → neutral default 50',
+      formula: 'EXCLUDED — no expirations >= 7 DTE; no imputed score, weight renormalized',
       notes: 'Need at least one expiration with 7+ DTE for skew computation',
       vol_skew_25d: null, pc_iv_ratio_atm: null,
-      skew_direction: 'neutral', skew_score: 50,
+      skew_direction: 'neutral', skew_score: 0,
     };
   }
 
@@ -864,15 +912,27 @@ function scoreOptionsSkew(input: ConvergenceInput): SkewTrace {
   // Weighted blend: 60% vol skew (more informative), 40% PC IV ratio
   const hasVolSkew = volSkew25d !== null;
   const hasPCR = pcIvRatioAtm !== null;
+  // KILL-6: single-metric paths STAY (computed from present data, labeled by
+  // the formula); NEITHER metric computable = the per-strike IV needed is
+  // MISSING → the section is EXCLUDED, never a fabricated neutral 50.
+  if (!hasVolSkew && !hasPCR) {
+    return {
+      score: 0, weight: 0.10,
+      active_signal_count: 0, total_signal_count: 1, excluded_components: ['skew'],
+      inputs: { data_available: false, expiration_used: nearExp.expirationDate, dte: nearExp.dte, spot_price: round(spot, 2) },
+      formula: 'EXCLUDED — no per-strike IV usable for either skew metric; no imputed score, weight renormalized',
+      notes: 'Neither 25d vol skew nor ATM put/call IV ratio computable from the chain feed',
+      vol_skew_25d: null, pc_iv_ratio_atm: null,
+      skew_direction: 'neutral', skew_score: 0,
+    };
+  }
   let skewScore: number;
   if (hasVolSkew && hasPCR) {
     skewScore = round(0.60 * skewScoreFromVol + 0.40 * skewScoreFromPCR, 1);
   } else if (hasVolSkew) {
     skewScore = skewScoreFromVol;
-  } else if (hasPCR) {
-    skewScore = skewScoreFromPCR;
   } else {
-    skewScore = 50;
+    skewScore = skewScoreFromPCR;
   }
 
   const skewDirection: 'bullish' | 'bearish' | 'neutral' =
@@ -883,6 +943,9 @@ function scoreOptionsSkew(input: ConvergenceInput): SkewTrace {
   return {
     score: round(skewScore),
     weight: 0.10,
+    active_signal_count: 1,
+    total_signal_count: 1,
+    excluded_components: [],
     inputs: {
       data_available: true,
       expiration_used: nearExp.expirationDate,
@@ -926,18 +989,34 @@ function scoreGammaExposure(input: ConvergenceInput): GEXTrace {
   const spot = flow?.underlyingPrice ?? null;
 
   if (!chain || chain.length === 0 || spot === null || spot <= 0) {
+    // KILL-6: no chain data → EXCLUDED (weight 0, renormalized) — the old
+    // trace displayed a fabricated neutral 50.
     return {
-      score: 50, weight: 0.10,
+      score: 0, weight: 0.10,
+      active_signal_count: 0, total_signal_count: 1, excluded_components: ['gex'],
       inputs: { data_available: false },
-      formula: 'No options chain data → neutral default 50',
+      formula: 'EXCLUDED — no options chain data; no imputed score, weight renormalized',
       notes: 'GEX scoring requires per-strike OI and IV data from options chain',
       net_gex: null, gex_flip_strike: null,
-      distance_to_flip_pct: null, gex_regime: 'neutral', gex_score: 50,
+      distance_to_flip_pct: null, gex_regime: 'neutral', gex_score: 0,
     };
   }
 
-  // Risk-free rate from FRED treasury 10Y, fallback 4.5%
-  const rfr = (input.fredMacro?.treasury10y ?? 4.5) / 100;
+  // KILL-6: the risk-free rate is the REAL fetched FRED 10Y (DGS10) — the old
+  // `?? 4.5` silently priced BS gamma off a hardcoded rate whenever the series
+  // was missing. Missing rate → GEX is not computable honestly → EXCLUDED.
+  if (input.fredMacro?.treasury10y == null) {
+    return {
+      score: 0, weight: 0.10,
+      active_signal_count: 0, total_signal_count: 1, excluded_components: ['gex'],
+      inputs: { data_available: true, risk_free_rate: null },
+      formula: 'EXCLUDED — FRED treasury10y (DGS10) unavailable; BS gamma needs the real risk-free rate (never a hardcoded 4.5%); weight renormalized',
+      notes: 'GEX requires the fetched DGS10 rate — feed unavailable this run',
+      net_gex: null, gex_flip_strike: null,
+      distance_to_flip_pct: null, gex_regime: 'neutral', gex_score: 0,
+    };
+  }
+  const rfr = input.fredMacro.treasury10y / 100;
 
   // Compute GEX across all near-term expirations
   // For each strike: call_GEX = call_OI × call_gamma × 100 × spot
@@ -1016,13 +1095,21 @@ function scoreGammaExposure(input: ConvergenceInput): GEXTrace {
   // High positive GEX (spot well above flip) → low realized vol → high score
   // Negative GEX (spot below flip) → amplified moves → low score
   // Near flip → neutral
-  let gexScore: number;
-  if (distanceToFlipPct !== null) {
-    // Map distance: +5% → 85, +2% → 70, 0% → 50, -2% → 30, -5% → 15
-    gexScore = clamp(round(50 + distanceToFlipPct * 7), 0, 100);
-  } else {
-    gexScore = 50;
+  // KILL-6: distanceToFlipPct is null only when NO strike had usable OI+IV
+  // (perStrikeGex empty) — the inputs are MISSING → EXCLUDED, never a 50.
+  if (distanceToFlipPct === null) {
+    return {
+      score: 0, weight: 0.10,
+      active_signal_count: 0, total_signal_count: 1, excluded_components: ['gex'],
+      inputs: { data_available: true, spot_price: round(spot, 2), risk_free_rate: round(rfr * 100, 2), strikes_computed: 0 },
+      formula: 'EXCLUDED — no strike had usable OI+IV to compute dealer gamma; no imputed score, weight renormalized',
+      notes: 'GEX flip point not computable from the chain feed',
+      net_gex: null, gex_flip_strike: null,
+      distance_to_flip_pct: null, gex_regime: 'neutral', gex_score: 0,
+    };
   }
+  // Map distance: +5% → 85, +2% → 70, 0% → 50, -2% → 30, -5% → 15
+  const gexScore: number = clamp(round(50 + distanceToFlipPct * 7), 0, 100);
 
   // Normalize net GEX for display (in millions of dollar-gamma)
   const netGexDisplay = round(totalGex / 1_000_000, 2);
@@ -1032,6 +1119,9 @@ function scoreGammaExposure(input: ConvergenceInput): GEXTrace {
   return {
     score: round(gexScore),
     weight: 0.10,
+    active_signal_count: 1,
+    total_signal_count: 1,
+    excluded_components: [],
     inputs: {
       data_available: true,
       spot_price: round(spot, 2),
@@ -1056,8 +1146,10 @@ export function scoreVolEdge(input: ConvergenceInput): VolEdgeResult {
   const termStructure = scoreTermStructure(input);
   const skew = scoreOptionsSkew(input);
   const gex = scoreGammaExposure(input);
-  const hasCandles = input.candles.length >= 20;
-  const hasChainData = (input.optionsFlow?.chainDetail?.length ?? 0) > 0;
+  // KILL-6: scoreTechnicals handles its own exclusion (< 20 SANITIZED candles
+  // → EXCLUDED trace) — the old raw-length check here missed the case where
+  // raw >= 20 but sanitized < 20, which then scored a penalty 40.
+  const technicals: TechnicalsTrace = scoreTechnicals(input);
 
   // Weight rebalance (before → after):
   //   Mispricing:      0.50 → 0.40
@@ -1070,131 +1162,56 @@ export function scoreVolEdge(input: ConvergenceInput): VolEdgeResult {
   //   - Skew measures directionality of the vol surface, not the level
   //   - GEX measures dealer positioning's effect on realized volatility
 
-  // Assign weights based on data availability
-  mispricing.weight = 0.40;
-  termStructure.weight = 0.25;
+  // KILL-6 / EDGE-2 combiner: a section whose trace declares zero computable
+  // components (active_signal_count 0) is EXCLUDED and the remaining section
+  // weights renormalize — generalizing the old hand-written branch tree.
+  const sectionActive = (t: { active_signal_count?: number }) => (t.active_signal_count ?? 1) > 0;
+  const gateCombined = combineWeighted([
+    { key: 'mispricing', weight: 0.40, score: sectionActive(mispricing) ? mispricing.score : null },
+    { key: 'term_structure', weight: 0.25, score: sectionActive(termStructure) ? termStructure.score : null },
+    { key: 'technicals', weight: 0.15, score: sectionActive(technicals) ? technicals.score : null },
+    { key: 'skew', weight: 0.10, score: sectionActive(skew) ? skew.score : null },
+    { key: 'gex', weight: 0.10, score: sectionActive(gex) ? gex.score : null },
+  ]);
 
-  let technicals: TechnicalsTrace;
-  let score: number;
-
-  if (hasCandles) {
-    technicals = scoreTechnicals(input);
-    technicals.weight = 0.15;
-
-    if (hasChainData) {
-      // Full 5-component weighting
-      score = round(
-        mispricing.weight * mispricing.score +
-        termStructure.weight * termStructure.score +
-        technicals.weight * technicals.score +
-        skew.weight * skew.score +
-        gex.weight * gex.score,
-        1,
-      );
-    } else {
-      // No chain data — exclude skew+GEX, renormalize
-      // mispricing 0.40/0.80=0.50, term 0.25/0.80=0.3125, tech 0.15/0.80=0.1875
-      const denom = mispricing.weight + termStructure.weight + technicals.weight;
-      score = round(
-        (mispricing.weight / denom) * mispricing.score +
-        (termStructure.weight / denom) * termStructure.score +
-        (technicals.weight / denom) * technicals.score,
-        1,
-      );
-      mispricing.weight = round(mispricing.weight / denom, 4);
-      termStructure.weight = round(termStructure.weight / denom, 4);
-      technicals.weight = round(technicals.weight / denom, 4);
-      skew.weight = 0;
-      gex.weight = 0;
-    }
-  } else {
-    // No candle data — exclude technicals
-    technicals = {
-      score: 0,
-      weight: 0,
-      inputs: { candles_available: input.candles.length },
-      formula: 'EXCLUDED — no candle data available.',
-      notes: 'Technicals excluded. No fabricated scores.',
-      sub_scores: { rsi_score: 0, trend_score: 0, bollinger_score: 0, volume_score: 0, high52w_score: 0 },
-      indicators: {
-        rsi_14: null, rsi_trace: null, sma_20: null, sma_50: null, latest_close: null,
-        bb_upper: null, bb_lower: null, bb_middle: null, bb_position: null, bb_width: null,
-        high52w_ratio: null, high52w_range_position: null,
-        avg_volume_5d: null, avg_volume_20d: null, volume_ratio: null,
-      },
-      candles_used: 0,
-    };
-
-    if (hasChainData) {
-      // No candles but have chain: mispricing + term + skew + gex
-      const denom = mispricing.weight + termStructure.weight + skew.weight + gex.weight;
-      score = round(
-        (mispricing.weight / denom) * mispricing.score +
-        (termStructure.weight / denom) * termStructure.score +
-        (skew.weight / denom) * skew.score +
-        (gex.weight / denom) * gex.score,
-        1,
-      );
-      mispricing.weight = round(mispricing.weight / denom, 4);
-      termStructure.weight = round(termStructure.weight / denom, 4);
-      skew.weight = round(skew.weight / denom, 4);
-      gex.weight = round(gex.weight / denom, 4);
-    } else {
-      // No candles, no chain: mispricing + term only
-      const denom = mispricing.weight + termStructure.weight;
-      score = round(
-        (mispricing.weight / denom) * mispricing.score +
-        (termStructure.weight / denom) * termStructure.score,
-        1,
-      );
-      mispricing.weight = round(mispricing.weight / denom, 4);
-      termStructure.weight = round(termStructure.weight / denom, 4);
-      skew.weight = 0;
-      gex.weight = 0;
-    }
+  // KILL-6 fail-loud: with zero real data across all five sections there is
+  // nothing honest to score (scan_snapshots.volEdgeScore is non-nullable —
+  // gate-level exclusion is a migration, flagged for Alex).
+  if (gateCombined.score == null) {
+    throw new Error('Vol-edge gate cannot compute: all five sections lack source data — no imputation (KILL-6)');
   }
+  const score = gateCombined.score;
 
-  // Build DataConfidence
-  // imputed = a placeholder value is still in the score (penalty defaults);
-  // excluded = the signal was dropped and the weights renormalized (EDGE-2
-  // pattern). Confidence counts both as "missing" — a sub-score is either
-  // computed from full real data or it isn't.
-  const tt = input.ttScanner;
-  const imputedFields: string[] = [];
-  const excludedFields: string[] = [];
-  // Mispricing sub-scores
-  // EDGE-4: VRP is excluded+renormalized (never imputed) when its own-history
-  // distribution is unavailable — derived from the actual null trace so
-  // tracking cannot drift from the score math.
-  if (mispricing.vrp_score === null) excludedFields.push('mispricing.vrp');
-  if (tt?.ivPercentile == null) imputedFields.push('mispricing.ivp');
-  if (tt?.ivHvSpread == null) imputedFields.push('mispricing.iv_hv_spread');
-  if (tt?.hv30 == null || tt?.hv60 == null || tt?.hv90 == null) imputedFields.push('mispricing.hv_accel');
-  // Term structure
-  const tsLen = tt?.termStructure?.length ?? 0;
-  if (tsLen < 2) imputedFields.push('term_structure');
-  // Technicals (excluded + renormalized when no candles — see scoring above)
-  if (!hasCandles) {
-    excludedFields.push('technicals');
-  } else {
-    if (!input.finnhubFundamentals?.metric?.['52WeekHigh']) imputedFields.push('technicals.high52w');
-  }
-  // Skew + GEX (excluded + renormalized when no chain data — see scoring above)
-  if (!hasChainData) {
-    excludedFields.push('skew');
-    excludedFields.push('gex');
-  }
-  // mispricing(4) + term(1) + technicals(5 or 1) + skew(1) + gex(1)
-  const totalSubScores = 4 + 1 + (hasCandles ? 5 : 1) + 1 + 1;
-  const missingCount = imputedFields.length + excludedFields.length;
+  // Renormalized section weights written back onto the traces; excluded
+  // sections show weight 0 with an EXCLUDED formula.
+  const renorm = (w: number, active: boolean) => (active ? round(w / gateCombined.activeWeight, 4) : 0);
+  mispricing.weight = renorm(0.40, sectionActive(mispricing));
+  termStructure.weight = renorm(0.25, sectionActive(termStructure));
+  technicals.weight = renorm(0.15, sectionActive(technicals));
+  skew.weight = renorm(0.10, sectionActive(skew));
+  gex.weight = renorm(0.10, sectionActive(gex));
+
+  // Build DataConfidence — KILL-6: nothing is imputed anywhere in vol-edge
+  // anymore; every missing component/section is EXCLUDED + renormalized, and
+  // the tracking is derived from the traces' own exclusions (cannot drift).
+  const technicalsExcluded = !sectionActive(technicals);
+  const excludedFields: string[] = [
+    ...(mispricing.excluded_components ?? []),
+    ...(sectionActive(termStructure) ? [] : ['term_structure']),
+    ...(technicalsExcluded ? ['technicals'] : (technicals.excluded_components ?? [])),
+    ...(sectionActive(skew) ? [] : ['skew']),
+    ...(sectionActive(gex) ? [] : ['gex']),
+  ];
+  // mispricing(4) + term(1) + technicals(5, or 1 when the whole section is
+  // excluded) + skew(1) + gex(1)
+  const totalSubScores = 4 + 1 + (technicalsExcluded ? 1 : 5) + 1 + 1;
   const dataConfidence: DataConfidence = {
     total_sub_scores: totalSubScores,
-    imputed_sub_scores: missingCount,
-    confidence: round(1 - missingCount / totalSubScores, 4),
-    imputed_fields: imputedFields,
+    imputed_sub_scores: excludedFields.length,
+    confidence: round(1 - excludedFields.length / totalSubScores, 4),
+    imputed_fields: [],
     excluded_fields: excludedFields,
-    // "computed from N/M signals" — every excluded entry above corresponds to
-    // exactly one counted sub-score (technicals counts as 1 when !hasCandles)
+    // "computed from N/M signals"
     active_signal_count: totalSubScores - excludedFields.length,
   };
 


### PR DESCRIPTION
All 12 remaining vol-edge census violations converted to null → excluded → renormalized via the shared combiner (EDGE-2/KILL-3 pattern):

- mispricing: IVP/IV-HV/HV-accel penalty-40s die; IVComposite renormalizes over whichever of IVP/IVR is present (a true-0 IVP scores as real data); all four components missing → the section is EXCLUDED from the gate.
- term structure: <2 expirations is EXCLUDED (weight 0, renormalized), never a penalty 40 at 0.25 gate weight.
- technicals: the raw-vs-sanitized candle gap is closed (scoreVolEdge now always delegates to scoreTechnicals' own exclusion — <20 sanitized candles no longer scores a penalty 40); missing 52-week data excludes that component and renormalizes ÷0.85.
- skew/GEX: 'chain present but unusable' paths (no 7+DTE expiration, no per-strike IV for either metric, no strike with usable OI+IV) are ruled imputed-on-missing — the code computes nothing there — and are EXCLUDED at live weight, never a fabricated neutral 50. Single-metric skew paths stay (computed from present data, labeled).
- Risk-free rate: GEX now consumes the REAL fetched FRED DGS10 (data-fetchers.ts:598) and records it in the trace; DGS10 missing → GEX excluded with the reason — the hardcoded '?? 4.5' dies.
- scoreVolEdge: hand-written branch tree replaced by the shared section combiner; all five sections missing fails loud (volEdgeScore is a non-nullable snapshot column — gate exclusion is a migration, flagged); DataConfidence fully trace-derived, imputed_fields now empty.

CENSUS RECONCILIATION UPDATED: 145 → 123 closed by KILL-1..6 → 22 remain (none in the live scan-scoring path); KILL-5 audit table marked.

No route/auth changes, nothing in PUBLIC_PATHS.