### PR TITLE
KILL-7: peripheral census kill — census violations closed

### DIFF
--- a/audit-reports/KILL-6-vol-edge-audit.md
+++ b/audit-reports/KILL-6-vol-edge-audit.md
@@ -37,4 +37,4 @@ Executed traces: many-feeds-missing ticker → vol-edge = 75 from the one presen
 
 ## Updated reconciliation
 
-**145 census violations → 123 closed by KILL-1..6 (81 pattern + 42 catches) → 22 remain:** backtest/simulate (7), data-fetchers candle/insider/headline imputation (7), quotes route (4), sentiment persisted 0/0 (2), chains route (1), custom-card missing-price leg-drop (1). None are in the live scan-scoring path — remaining clusters are backtest, display/quote routes, and secondary fetch surfaces.
+**145 census violations → 123 closed by KILL-1..6 → 22 remained, ALL CLOSED by KILL-7** (see audit-reports/KILL-7-peripheral-census-audit.md). **Final: 145/145 closed, 0 remain.**

--- a/audit-reports/KILL-7-peripheral-census-audit.md
+++ b/audit-reports/KILL-7-peripheral-census-audit.md
@@ -1,0 +1,38 @@
+# KILL-7 Audit — peripheral census kill (closes the FALLBACK-CENSUS violations column)
+
+**Date:** 2026-07-06 · **Branch:** `claude/kill-7-peripheral-census-close` · **Base:** main @ `ee8f8df9` (KILL-6 `09496816` verified present)
+
+## Classification of the final 22 (all verified on base; all DIE)
+
+| Cluster | Sites | Was | Now |
+|---|---|---|---|
+| backtest/simulate (7) | `:79-:83, :87, :88` | `parseFloat(x \|\| 0)` — missing backtester fields presented as $0 prices/P&L/holding-days; daily rows with no pnl as $0 rows | nulls + a `missing_fields` declaration on the response; daily rows without a pnl EXCLUDED with `daily_rows_excluded_missing_pnl` count — a fake $0 result can no longer be read as a real one |
+| data-fetchers insider dates (2) | old `:1011` (live, now `fetchInsiderTransactions`) + `:1382` (deprecated Form4 XML) | `transactionDate ?? 'unknown'` — the string 'unknown' sorts ABOVE every ISO date, corrupting `latestTransactionDate` max | a transaction with neither transaction nor filing date is EXCLUDED; live path declares `insider-transactions PARTIAL: N excluded` on the `{data,error}` channel (pipeline E10 already surfaces it) |
+| data-fetchers headline (1) | old `:2060` | an article with NO headline classified as 'neutral' confidence 1.0, diluting sentiment | skipped + `articles_skipped_no_headline` count on NewsSentimentData |
+| data-fetchers candles (4) | old `:2181, :2190, :2191, :2193` | `time \|\| 0` → a 1970-dated candle; missing high/low imputed as the open; missing volume imputed 0 | a bar missing time/high/low/volume is MALFORMED → skipped + counted in `CandleBatchStats.malformed_candles` (declared, never patched) |
+| quotes route (4) | `:50, :51, :52, :60-61` | `\|\| 0` on bid/ask/sizes/last/volume; a one-sided quote silently halved the mid | `numOrNull` everywhere; `mid` exists only when BOTH sides are live; true 0s preserved |
+| sentiment (2) | `:295-296` (census `:288-289`) | stage-2 scoring failure persisted `score: 0, magnitude: 0` — indistinguishable from a real neutral | returns the existing DECLARED failure shape (`emptyResult` with an explicit error) |
+| chains route (1) | `:86` | `strike: Number(x \|\| 0)` — a fabricated $0 strike | unparseable strike rows skipped + `strikes_skipped_no_price` declared on the response |
+| custom-card (1) | strategy-builder `buildCustomCard` | a leg with no live price was silently DROPPED while the card kept the full strategy's name/pricing | any unpriceable leg fails the WHOLE card (null) — consistent with the KILL-2 greeks rule; zero in-repo callers |
+
+## The two gray rulings (from what the code distinguishes)
+
+**(a) zero-volume → 50:** the flow metric is `volumeRatio = vol5d / vol20d`, guarded by `vol20d > 0`. A REAL 20-day zero-volume reading makes the ratio **n/0 — mathematically undefined**, so the component is EXCLUDED (renormalized by the KILL-6 technicals combiner), never a neutral 50. The genuine-zero datum that IS computable — `vol5d = 0` over a positive `vol20d` → ratio 0 → low-volume tier — stays. Trace: 25 zero-volume candles → `volume_score: null`, formula `0.15×Vol(EXCLUDED) … [volume+high52w excluded, weights renormalized ÷0.7]`, declared in excluded_fields.
+
+**(b) hv-accel z vs assumed mean 0:** sector-stats held NO hv_accel distribution (only hv30/hv60 levels) but holds the raw peer data — so per the EDGE-4 precedent the REAL distribution is now computed (`hv_accel: computeMetricStats(t.hv30 − t.hv60)` in `sector-stats.ts`), and vol-edge's z uses its real mean/std (the old code used mean **0** against the peers' hv30-LEVEL std — two fabrications at once). The percentile branch had the same disease (ranked the accel VALUE against hv30 LEVELS) — also moved to the real `hv_accel` sortedValues. No distribution → no transform; the component keeps its raw own-data tier score (real HVs). Trace: peers with accel spreads [-2,1,2,5,5] → mean 2.2, std 2.95 → `hv_accel_z = 0.95` = (5−2.2)/2.95, hand-verified.
+
+## The backtest ruling
+
+A backtest reporting $0 where data was missing is a fake result: the honest shape is null + declaration at the trade level (`missing_fields`) and EXCLUSION at the row level (`daily_rows_excluded_missing_pnl`) — never a $0 row. Implemented exactly so; the response shape is additive (no consumer breaks; no in-repo consumer reads the simulate response fields numerically today).
+
+## Legitimate survivors near the edits (cited, unchanged)
+
+`chains/route.ts:45` `dte_min ?? 0` — request-parameter default (0 = no lower DTE bound), not market data. `data-fetchers:983` `form ?? 'unknown'` — a filing-TYPE display label in a trace, never aggregated (the censused violations were the DATE sites, fixed).
+
+## FINAL RECONCILIATION
+
+**145 census violations → 145 closed by KILL-1..7 → 0 REMAIN.** Every one of the 103 pattern rows and 42 silent-catch rows in audit-reports/FALLBACK-CENSUS.md is accounted for across KILL-1 (1), KILL-2 (24), KILL-3 (34), KILL-4 (42), KILL-5 (8), KILL-6 (12), KILL-7 (22 + the two gray rulings), verified site-by-site against the census extraction — no row claimed closed without a cited fix. The census GRAY column (101 rows) remains open for Alex's product rulings except the two ruled here and those already settled by standing rulings (true-0, missing≠0).
+
+## Verification
+
+Tripwire on added lines: clean (no `\|\| n` / `?? n` value defaults; the only nearby matches are the two cited legitimate survivors, both pre-existing). Executed traces per cluster above; route clusters verified by code-path (they require live TT/backtester sessions). `tsc` exit 0; `next build` compiled successfully (standing sandbox Plaid-env limit unrelated). No route/auth changes, nothing in PUBLIC_PATHS.

--- a/src/app/api/tastytrade/backtest/simulate/route.ts
+++ b/src/app/api/tastytrade/backtest/simulate/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { getTastytradeSessionToken } from '@/lib/tastytrade';
 import { requireAdmin } from '@/lib/require-admin';
+import { numOrNull } from '@/lib/parse-num';
 import type { BacktestManagement } from '@/lib/backtest-translator';
 
 const BACKTESTER_BASE = 'https://backtester.vast.tastyworks.com';
@@ -72,22 +73,45 @@ export async function POST(request: Request) {
     const data = await resp.json();
     console.log('[Backtest Simulate] Response body preview:', JSON.stringify(data).slice(0, 500));
 
+    // KILL-7: a backtest that reports $0 where the backtester sent nothing is
+    // a FAKE result. Missing fields are null and DECLARED in missing_fields;
+    // daily rows without a pnl are EXCLUDED and counted, never $0 rows.
+    const entryPrice = numOrNull(data['entry-price']);
+    const exitPrice = numOrNull(data['exit-price']);
+    const pnl = numOrNull(data['pnl']) ?? numOrNull(data['profit-loss']);
+    const pnlPercent = numOrNull(data['pnl-percent']) ?? numOrNull(data['return-percent']);
+    const holdingDaysRaw = numOrNull(data['holding-days']) ?? numOrNull(data['days-held']);
+    const holdingDays = holdingDaysRaw != null ? Math.trunc(holdingDaysRaw) : null;
+
+    const rawDaily: any[] = Array.isArray(data['daily-pnl']) ? data['daily-pnl'] : [];
+    const dailyPnl = rawDaily
+      .map((d: any) => ({ date: d['date'], pnl: numOrNull(d['pnl']), underlyingPrice: numOrNull(d['underlying-price']) }))
+      .filter((d: any) => d.date && d.pnl != null);
+    const dailyRowsExcluded = rawDaily.length - dailyPnl.length;
+
+    const missingFields = [
+      entryPrice == null ? 'entry_price' : null,
+      exitPrice == null ? 'exit_price' : null,
+      pnl == null ? 'pnl' : null,
+      pnlPercent == null ? 'pnl_percent' : null,
+      holdingDays == null ? 'holding_days' : null,
+    ].filter((f): f is string => f != null);
+
     return NextResponse.json({
       trade: {
         entryDate: data['entry-date'] || entryDate,
         exitDate: data['exit-date'] || '',
-        entryPrice: parseFloat(data['entry-price'] || 0),
-        exitPrice: parseFloat(data['exit-price'] || 0),
-        pnl: parseFloat(data['pnl'] || data['profit-loss'] || 0),
-        pnlPercent: parseFloat(data['pnl-percent'] || data['return-percent'] || 0),
-        holdingDays: parseInt(data['holding-days'] || data['days-held'] || 0, 10),
+        entryPrice,
+        exitPrice,
+        pnl,
+        pnlPercent,
+        holdingDays,
         exitReason: data['exit-reason'] || data['close-reason'] || 'expiration',
-        dailyPnl: (data['daily-pnl'] || []).map((d: any) => ({
-          date: d['date'],
-          pnl: parseFloat(d['pnl'] || 0),
-          underlyingPrice: parseFloat(d['underlying-price'] || 0),
-        })),
+        dailyPnl,
       },
+      // KILL-7 declaration: what the backtester did NOT deliver
+      missing_fields: missingFields,
+      daily_rows_excluded_missing_pnl: dailyRowsExcluded,
     });
 
   } catch (error: any) {

--- a/src/app/api/tastytrade/chains/route.ts
+++ b/src/app/api/tastytrade/chains/route.ts
@@ -59,6 +59,7 @@ export async function POST(request: Request) {
     now.setHours(0, 0, 0, 0);
     const expirations: any[] = [];
     const seen = new Set<string>();
+    let strikesSkippedNoPrice = 0; // KILL-7: declared in the response
 
     for (const chain of chainTypes) {
       const nestedExpirations = chain['expirations'] || [];
@@ -82,8 +83,15 @@ export async function POST(request: Request) {
         for (const s of (Array.isArray(strikeList) ? strikeList : [])) {
           const callOcc: string = s['call'] || '';
           const putOcc: string = s['put'] || '';
+          // KILL-7: a strike row without a parseable strike price is unusable —
+          // skipped + counted, never a fabricated $0 strike.
+          const strikePrice = s['strike-price'] != null && Number.isFinite(Number(s['strike-price'])) ? Number(s['strike-price']) : null;
+          if (strikePrice == null || strikePrice <= 0) {
+            strikesSkippedNoPrice++;
+            continue;
+          }
           strikes.push({
-            strike: Number(s['strike-price'] || 0),
+            strike: strikePrice,
             call: callOcc || null,
             put: putOcc || null,
             callStreamerSymbol: s['call-streamer-symbol'] || occToDxFeed(callOcc),
@@ -102,7 +110,7 @@ export async function POST(request: Request) {
     // Sort by DTE ascending
     expirations.sort((a, b) => a.dte - b.dte);
 
-    return NextResponse.json({ chain: { symbol, expirations } });
+    return NextResponse.json({ chain: { symbol, expirations }, strikes_skipped_no_price: strikesSkippedNoPrice });
   } catch (error: any) {
     console.error('[Tastytrade] Chains error:', error);
     return NextResponse.json({ error: 'Failed to fetch option chain' }, { status: 500 });

--- a/src/app/api/tastytrade/quotes/route.ts
+++ b/src/app/api/tastytrade/quotes/route.ts
@@ -4,6 +4,7 @@ import { getAuthenticatedClient } from '@/lib/tastytrade';
 import { MarketDataSubscriptionType } from '@tastytrade/api';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { requireAdmin } from '@/lib/require-admin';
+import { numOrNull, firstNumOrNull } from '@/lib/parse-num';
 
 export async function POST(request: Request) {
   try {
@@ -46,19 +47,24 @@ export async function POST(request: Request) {
         const sym = (evt['eventSymbol'] as string) || '';
         const type = (evt['eventType'] as string) || '';
         if (type === 'Quote' && expected.has(sym.toUpperCase())) {
+          // KILL-7: absent/unparseable → null, never 0 — and the mid exists
+          // only when BOTH sides are live (a one-sided quote used to silently
+          // halve the mid). A true source 0 stays 0.
+          const bid = numOrNull(evt['bidPrice']);
+          const ask = numOrNull(evt['askPrice']);
           quotes[sym] = {
-            bid: Number(evt['bidPrice'] || 0),
-            ask: Number(evt['askPrice'] || 0),
-            mid: (Number(evt['bidPrice'] || 0) + Number(evt['askPrice'] || 0)) / 2,
-            bidSize: Number(evt['bidSize'] || 0),
-            askSize: Number(evt['askSize'] || 0),
+            bid,
+            ask,
+            mid: bid != null && ask != null ? (bid + ask) / 2 : null,
+            bidSize: numOrNull(evt['bidSize']),
+            askSize: numOrNull(evt['askSize']),
           };
         } else if (type === 'Trade' && expected.has(sym.toUpperCase())) {
           if (!quotes[sym]) {
             quotes[sym] = {};
           }
-          quotes[sym].last = Number(evt['price'] || 0);
-          quotes[sym].volume = Number(evt['dayVolume'] || evt['volume'] || 0);
+          quotes[sym].last = numOrNull(evt['price']);
+          quotes[sym].volume = firstNumOrNull(evt['dayVolume'], evt['volume']);
         }
       }
     });

--- a/src/lib/convergence/data-fetchers.ts
+++ b/src/lib/convergence/data-fetchers.ts
@@ -1,3 +1,4 @@
+import { numOrNull } from '@/lib/parse-num';
 import type {
   CandleData,
   FinnhubFundamentals,
@@ -1053,17 +1054,28 @@ export async function fetchInsiderTransactions(
 
     // Map Finnhub transactions to SECForm4Transaction[]
     const transactions: SECForm4Transaction[] = [];
+    let txSkippedNoDate = 0; // KILL-7: declared on the result
     for (const tx of rawTxs) {
       const code = (tx.transactionCode ?? '').toUpperCase();
       const change = tx.change ?? 0;
       if (change === 0) continue;
+
+      // KILL-7: a transaction with NO date (neither transaction nor filing
+      // date) cannot be temporally aggregated — the old 'unknown' string
+      // corrupted the latestTransactionDate max ('u' sorts above every ISO
+      // date). Excluded + declared, never a placeholder.
+      const txDate = tx.transactionDate ?? tx.filingDate ?? null;
+      if (txDate == null) {
+        txSkippedNoDate++;
+        continue;
+      }
 
       const price = tx.transactionPrice != null && tx.transactionPrice > 0 ? tx.transactionPrice : null;
       const shares = Math.abs(change);
 
       transactions.push({
         filerName: tx.name ?? 'Unknown',
-        transactionDate: tx.transactionDate ?? tx.filingDate ?? 'unknown',
+        transactionDate: txDate,
         transactionType: code,
         sharesTraded: shares,
         pricePerShare: price,
@@ -1162,7 +1174,13 @@ export async function fetchInsiderTransactions(
     };
 
     insiderTxCache.set(symbol, { data: result, fetchedAt: Date.now() });
-    return { data: result, error: null };
+    return {
+      data: result,
+      // KILL-7: dateless transactions are excluded from aggregation — declared
+      error: txSkippedNoDate > 0
+        ? `insider-transactions PARTIAL: ${txSkippedNoDate} transaction(s) excluded — no transaction/filing date (never placeholder-dated)`
+        : null,
+    };
   } catch (e: unknown) {
     return { data: null, error: `insider-transactions: ${e instanceof Error ? e.message : String(e)}` };
   }
@@ -1442,9 +1460,12 @@ function parseForm4Xml(xml: string): SECForm4Transaction[] {
     // but include all types in the data for completeness
     const txType = codeStr.toUpperCase();
 
+    // KILL-7: no date → transaction excluded (the 'unknown' string corrupted
+    // date-max aggregation); this deprecated path has no in-repo callers.
+    if (transactionDate == null) continue;
     transactions.push({
       filerName,
-      transactionDate: transactionDate ?? 'unknown',
+      transactionDate,
       transactionType: txType,
       sharesTraded: Math.abs(shares),
       pricePerShare: price !== null && !isNaN(price) ? price : null,
@@ -2146,8 +2167,16 @@ export async function fetchNewsSentiment(
     const allHeadlines: NewsHeadlineEntry[] = [];
     const sourceDistribution: Record<string, number> = {};
 
-    function classifyArticle(article: RawArticle): NewsHeadlineEntry {
+    // KILL-7: an article with NO headline cannot be classified — it was
+    // imputed as 'neutral' with confidence 1.0, diluting the sentiment score.
+    // Skipped + counted, never classified from nothing.
+    let articlesSkippedNoHeadline = 0;
+    function classifyArticle(article: RawArticle): NewsHeadlineEntry | null {
       const headline = article.headline || '';
+      if (headline.trim() === '') {
+        articlesSkippedNoHeadline++;
+        return null;
+      }
       const source = article.source || '';
       const datetime = article.datetime || 0;
       const url = article.url || '';
@@ -2157,6 +2186,7 @@ export async function fetchNewsSentiment(
 
     for (const article of articles7dRaw) {
       const entry = classifyArticle(article);
+      if (!entry) continue;
       headlines7d.push(entry);
       allHeadlines.push(entry);
       sourceDistribution[entry.source] = (sourceDistribution[entry.source] || 0) + 1;
@@ -2164,6 +2194,7 @@ export async function fetchNewsSentiment(
 
     for (const article of articles8_30dRaw) {
       const entry = classifyArticle(article);
+      if (!entry) continue;
       headlines8_30d.push(entry);
       allHeadlines.push(entry);
       sourceDistribution[entry.source] = (sourceDistribution[entry.source] || 0) + 1;
@@ -2216,6 +2247,7 @@ export async function fetchNewsSentiment(
       tier1_ratio: tier1Ratio,
       headlines: allHeadlines,
       classification_method: 'finnhub-native',
+      articles_skipped_no_headline: articlesSkippedNoHeadline,
     };
 
     return { data: result, error: null };
@@ -2231,6 +2263,9 @@ export interface CandleBatchStats {
   symbols_with_data: number;
   symbols_failed: string[];
   elapsed_ms: number;
+  // KILL-7: bars the feed sent without time/high/low/volume — skipped, never
+  // patched with fabricated fields (declared, was silently imputed before)
+  malformed_candles: number;
 }
 
 export async function fetchTTCandlesBatch(
@@ -2239,7 +2274,7 @@ export async function fetchTTCandlesBatch(
 ): Promise<{ data: Map<string, CandleData[]>; stats: CandleBatchStats }> {
   const start = Date.now();
   const data = new Map<string, CandleData[]>();
-  const stats: CandleBatchStats = { total_candles: 0, symbols_with_data: 0, symbols_failed: [], elapsed_ms: 0 };
+  const stats: CandleBatchStats = { total_candles: 0, symbols_with_data: 0, symbols_failed: [], elapsed_ms: 0, malformed_candles: 0 };
 
   if (symbols.length === 0) {
     stats.elapsed_ms = Date.now() - start;
@@ -2268,19 +2303,29 @@ export async function fetchTTCandlesBatch(
         const sym = eventSymbol.replace(/\{.*\}$/, '');
         if (!sym || !data.has(sym)) continue;
 
-        const time = Number(evt['time'] || 0);
-        const open = evt['open'] != null ? Number(evt['open']) : 0;
-        const close = evt['close'] != null ? Number(evt['close']) : 0;
-        if (open <= 0 || close <= 0) continue;
+        // KILL-7: a bar missing time/high/low/volume is MALFORMED — it was
+        // fabricated before (time||0 → a 1970 candle; high/low imputed as the
+        // open; volume imputed 0). Skipped + counted, never patched.
+        const time = numOrNull(evt['time']);
+        const open = numOrNull(evt['open']);
+        const close = numOrNull(evt['close']);
+        const high = numOrNull(evt['high']);
+        const low = numOrNull(evt['low']);
+        const volume = numOrNull(evt['volume']);
+        if (time == null || time <= 0 || open == null || open <= 0 || close == null || close <= 0 ||
+            high == null || low == null || volume == null) {
+          stats.malformed_candles++;
+          continue;
+        }
 
         data.get(sym)!.push({
           time,
           date: new Date(time).toISOString().slice(0, 10),
           open,
-          high: evt['high'] != null ? Number(evt['high']) : open,
-          low: evt['low'] != null ? Number(evt['low']) : open,
+          high,
+          low,
           close,
-          volume: evt['volume'] != null ? Number(evt['volume']) : 0,
+          volume,
         });
       }
     });

--- a/src/lib/convergence/pipeline.ts
+++ b/src/lib/convergence/pipeline.ts
@@ -1209,7 +1209,7 @@ export async function runPipeline(
 
   // ===== STEP F2: Fetch candle data and re-score with real technicals =====
   console.log('[Pipeline] Step F2: Fetching candle data for scored tickers...');
-  let candleStats: CandleBatchStats = { total_candles: 0, symbols_with_data: 0, symbols_failed: [], elapsed_ms: 0 };
+  let candleStats: CandleBatchStats = { total_candles: 0, symbols_with_data: 0, symbols_failed: [], elapsed_ms: 0, malformed_candles: 0 };
   const scoredSymbols = scoredTickers.map(t => t.symbol);
   // Hoist candle data so G2.5 re-scoring can access it
   const candleDataMap = new Map<string, CandleData[]>();

--- a/src/lib/convergence/sector-stats.ts
+++ b/src/lib/convergence/sector-stats.ts
@@ -18,6 +18,9 @@ export interface PeerStats {
     hv30: PeerMetricStats;
     hv60: PeerMetricStats;
     hv90: PeerMetricStats;
+    // KILL-7: the REAL peer distribution of hv30 − hv60 — the HV-acceleration
+    // z previously assumed mean=0 against the peers' hv30-LEVEL std.
+    hv_accel: PeerMetricStats;
     iv30: PeerMetricStats;
     pe_ratio: PeerMetricStats;
     market_cap: PeerMetricStats;
@@ -95,6 +98,7 @@ function buildPeerStats(
         hv30: { ...empty },
         hv60: { ...empty },
         hv90: { ...empty },
+        hv_accel: { ...empty },
         iv30: { ...empty },
         pe_ratio: { ...empty },
         market_cap: { ...empty },
@@ -119,6 +123,7 @@ function buildPeerStats(
       hv30: computeMetricStats(tickers.map(t => t.hv30)),
       hv60: computeMetricStats(tickers.map(t => t.hv60)),
       hv90: computeMetricStats(tickers.map(t => t.hv90)),
+      hv_accel: computeMetricStats(tickers.map(t => (t.hv30 != null && t.hv60 != null ? t.hv30 - t.hv60 : null))),
       iv30: computeMetricStats(tickers.map(t => t.iv30)),
       pe_ratio: computeMetricStats(tickers.map(t => t.peRatio)),
       market_cap: computeMetricStats(tickers.map(t => t.marketCap)),

--- a/src/lib/convergence/sentiment.ts
+++ b/src/lib/convergence/sentiment.ts
@@ -290,10 +290,17 @@ export async function fetchSentiment(symbol: string): Promise<SentimentResult> {
     const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
     console.log(`[Sentiment] ${symbol}: ${posts.length} posts, score=${scoreResult?.score ?? 'N/A'} in ${elapsed}s`);
 
+    // KILL-7: a stage-2 scoring failure is a DECLARED failure — the old
+    // score=0/magnitude=0 imputation was indistinguishable from a genuinely
+    // neutral reading on the persisted result.
+    if (scoreResult == null) {
+      return emptyResult(symbol, 'stage-2 scoring failed — posts found but no score computed (no imputed neutral)');
+    }
+
     return {
       symbol,
-      score: scoreResult?.score ?? 0,
-      magnitude: scoreResult?.magnitude ?? 0,
+      score: scoreResult.score,
+      magnitude: scoreResult.magnitude,
       postCount: posts.length,
       bullishCount,
       bearishCount,

--- a/src/lib/convergence/types.ts
+++ b/src/lib/convergence/types.ts
@@ -286,6 +286,9 @@ export interface NewsSentimentData {
   source_distribution: Record<string, number>;
   tier1_ratio: number;
   headlines: NewsHeadlineEntry[];
+  // KILL-7: articles the feed sent without a headline — skipped, never
+  // classified as an imputed 'neutral' (declared count)
+  articles_skipped_no_headline?: number;
   classification_method: string; // 'finnhub-native'
 }
 

--- a/src/lib/convergence/vol-edge.ts
+++ b/src/lib/convergence/vol-edge.ts
@@ -180,7 +180,6 @@ function computeZScores(
   const m = stats.metrics;
   const rawIvpStats = m['iv_percentile'];
   const ivHvStats = m['iv_hv_spread'];
-  const hv30Stats = m['hv30'];
 
   // Peer stats for IVP are computed from raw scanner data (0-1 scale),
   // but the scorer normalizes IVP to 0-100. Align scales before z-score.
@@ -192,9 +191,13 @@ function computeZScores(
   const ivpZ = ivpStats ? zScore(ivp, ivpStats.mean, ivpStats.std) : null;
   const ivHvZ = ivHvStats ? zScore(ivHvSpread, ivHvStats.mean, ivHvStats.std) : null;
 
-  // HV acceleration z-score: how unusual is HV30-HV60 spread vs peers' HV30 spread
+  // KILL-7 gray ruling (b): the HV-acceleration z uses the REAL peer
+  // distribution of hv30 − hv60 (sector-stats now computes it) — never the
+  // old assumed mean=0 against the peers' hv30-LEVEL std. No distribution →
+  // no z (the component keeps its raw own-data tier score).
   const hvAccel = (hv30 !== null && hv60 !== null) ? hv30 - hv60 : null;
-  const hvAccelZ = hv30Stats ? zScore(hvAccel, 0, hv30Stats.std) : null;
+  const hvAccelStats = m['hv_accel'];
+  const hvAccelZ = hvAccelStats ? zScore(hvAccel, hvAccelStats.mean, hvAccelStats.std) : null;
 
   // Determine transform type based on peer count
   const peerCount = stats.ticker_count ?? 0;
@@ -320,8 +323,8 @@ function scoreMispricing(input: ConvergenceInput): MispricingTrace {
     // Percentile ranking: value's rank within sorted peer values → 0-100 score
     const rawIvpSorted = peerMetrics['iv_percentile']?.sortedValues;
     const ivHvSorted = peerMetrics['iv_hv_spread']?.sortedValues;
-    // HV accel uses hv30 peers
-    const hv30Sorted = peerMetrics['hv30']?.sortedValues;
+    // KILL-7: HV accel ranks against the REAL peer hv_accel distribution
+    const hvAccelSorted = peerMetrics['hv_accel']?.sortedValues;
 
     if (ivp !== null && rawIvpSorted?.length) {
       // Align scale: sorted values may be 0-1, ivp is 0-100
@@ -333,9 +336,9 @@ function scoreMispricing(input: ConvergenceInput): MispricingTrace {
     if (ivHvSpread !== null && ivHvSorted?.length) {
       ivHvSpreadScore = round(percentileRank(ivHvSpread, ivHvSorted), 1);
     }
-    if (hv30 !== null && hv60 !== null && hv30Sorted?.length) {
+    if (hv30 !== null && hv60 !== null && hvAccelSorted?.length) {
       const hvAccelVal = hv30 - hv60;
-      hvAccelScore = round(percentileRank(hvAccelVal, hv30Sorted), 1);
+      hvAccelScore = round(percentileRank(hvAccelVal, hvAccelSorted), 1);
     }
   } else if (hasPeerZScores && zScores.transform === 'z-score-fallback') {
     // 3-4 peers: z-score with reduced multiplier (10) and extended clip (±5 SD)
@@ -707,7 +710,11 @@ function scoreTechnicals(input: ConvergenceInput): TechnicalsTrace {
   const vol20d = candles.length >= 20 ? round(mean(candles.slice(-20).map(c => c.volume))) : null;
   const volumeRatio = vol5d !== null && vol20d !== null && vol20d > 0 ? round(vol5d / vol20d, 4) : null;
 
-  let volumeScore = 50;
+  // KILL-7 gray ruling (a): volumeRatio is null only when vol20d === 0 — the
+  // ratio vol5d/0 is mathematically UNDEFINED, so the component is EXCLUDED
+  // (renormalized by the technicals combiner), never a neutral 50. A true
+  // vol5d=0 over a positive vol20d IS data and scores the low-volume tier.
+  let volumeScore: number | null = null;
   if (volumeRatio !== null) {
     if (volumeRatio > 1.5) volumeScore = 70;      // Elevated volume → more liquid
     else if (volumeRatio > 1.2) volumeScore = 62;
@@ -754,7 +761,8 @@ function scoreTechnicals(input: ConvergenceInput): TechnicalsTrace {
   const score = techCombined.score as number; // >= 4 components always present
 
   const fmtT = (v: number | null) => (v !== null ? String(round(v)) : 'EXCLUDED');
-  const formula = `0.25×RSI(${round(rsiScore)}) + 0.25×Trend(${round(trendScore)}) + 0.20×BB(${round(bollingerScore)}) + 0.15×Vol(${round(volumeScore)}) + 0.15×52WkHigh(${fmtT(high52wScore)})${high52wScore === null ? ` [missing excluded, weights renormalized ÷0.85]` : ''} = ${score}`;
+  const excludedTech = [volumeScore === null ? 'volume' : null, high52wScore === null ? 'high52w' : null].filter(Boolean);
+  const formula = `0.25×RSI(${round(rsiScore)}) + 0.25×Trend(${round(trendScore)}) + 0.20×BB(${round(bollingerScore)}) + 0.15×Vol(${fmtT(volumeScore)}) + 0.15×52WkHigh(${fmtT(high52wScore)})${excludedTech.length > 0 ? ` [${excludedTech.join('+')} excluded, weights renormalized ÷${round(techCombined.activeWeight, 2)}]` : ''} = ${score}`;
 
   return {
     score: round(score),
@@ -772,7 +780,7 @@ function scoreTechnicals(input: ConvergenceInput): TechnicalsTrace {
       rsi_score: round(rsiScore),
       trend_score: round(trendScore),
       bollinger_score: round(bollingerScore),
-      volume_score: round(volumeScore),
+      volume_score: volumeScore !== null ? round(volumeScore) : null,
       high52w_score: high52wScore !== null ? round(high52wScore) : null,
     },
     indicators: {

--- a/src/lib/strategy-builder.ts
+++ b/src/lib/strategy-builder.ts
@@ -1280,7 +1280,10 @@ export function buildCustomCard(
     const bid: number | null = g.bid ?? null;
     const ask: number | null = g.ask ?? null;
     const price = cl.side === 'sell' ? bid : ask;
-    if (price == null || price <= 0) continue;
+    // KILL-7: a custom leg without a live price fails the WHOLE card — the
+    // old `continue` silently dropped the leg while still naming and pricing
+    // the card as the full strategy the user built.
+    if (price == null || price <= 0) return null;
     const midVal = bid != null && ask != null ? (ask + bid) / 2 : 0;
     const wide = midVal > 0 ? (ask! - bid!) / midVal > 0.50 : false;
     // KILL-2: same rule as makeLeg — a leg without complete greeks cannot be


### PR DESCRIPTION
The final 22 FALLBACK-CENSUS violation rows die, plus the two gray rulings:

- backtest/simulate: missing backtester fields are null + declared in missing_fields; daily rows without a pnl are EXCLUDED and counted — never $0 prices/P&L presented as results.
- data-fetchers: insider transactions with no date are excluded + declared (the 'unknown' string sorted above every ISO date, corrupting the latest-transaction max); headline-less articles are skipped + counted instead of classified as imputed 'neutral'; malformed candle bars (missing time/high/low/volume) are skipped + counted in CandleBatchStats.malformed_candles — never a 1970 candle, an open-imputed high/low, or a fabricated 0 volume.
- quotes route: numOrNull everywhere; the mid exists only when BOTH sides are live (a one-sided quote used to silently halve the mid); true 0s preserved.
- sentiment: a stage-2 scoring failure returns the DECLARED failure shape instead of persisting score=0/magnitude=0 that read as a real neutral.
- chains route: unparseable strike rows are skipped + declared (strikes_skipped_no_price), never a $0 strike.
- custom-card: any unpriceable leg fails the WHOLE card (KILL-2 greeks rule extended to prices) — no silently-partial strategy.

GRAY RULINGS (from the code's own math):
(a) zero 20-day volume makes the flow ratio n/0 — undefined → the volume
    component is EXCLUDED + renormalized, never a neutral 50; vol5d=0 over
    positive vol20d stays (real datum).
(b) the HV-acceleration z now uses the REAL peer distribution of
    hv30−hv60 (new hv_accel metric in sector-stats), replacing the assumed
    mean-0 against the peers' hv30-LEVEL std; the percentile branch moves
    off its hv30-level proxy to the same real distribution.

FINAL RECONCILIATION: 145/145 census violations closed by KILL-1..7 — 0 remain (site-by-site accounting in the audit reports).

No route/auth changes, nothing in PUBLIC_PATHS.