### PR TITLE
TAB-SERVER-GATE: flip all four tabs' USE routes to per-tab entitlemen…

### DIFF
--- a/src/app/api/account-tax-mappings/route.ts
+++ b/src/app/api/account-tax-mappings/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { getCurrentUser } from '@/lib/auth-helpers';
+import { requireTabAccess } from '@/lib/auth-helpers';
 
 // ═══════════════════════════════════════════════════════════════════
 // /api/account-tax-mappings
@@ -31,6 +32,9 @@ export async function GET(request: NextRequest) {
   try {
     const user = await getCurrentUser();
     if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    // TAB-SERVER-GATE: tab:tax entitlement (bundle:all included; admin bypass inside).
+    const tabGate = await requireTabAccess(user.id, 'tab:tax');
+    if (tabGate) return tabGate;
 
     const { searchParams } = new URL(request.url);
     const yearParam = searchParams.get('year');
@@ -122,6 +126,9 @@ export async function POST(request: NextRequest) {
   try {
     const user = await getCurrentUser();
     if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    // TAB-SERVER-GATE: tab:tax entitlement (bundle:all included; admin bypass inside).
+    const tabGate = await requireTabAccess(user.id, 'tab:tax');
+    if (tabGate) return tabGate;
 
     const body = await request.json();
     const { account_id, tax_form, form_line, tax_year, multiplier } = body as {
@@ -200,6 +207,9 @@ export async function DELETE(request: NextRequest) {
   try {
     const user = await getCurrentUser();
     if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    // TAB-SERVER-GATE: tab:tax entitlement (bundle:all included; admin bypass inside).
+    const tabGate = await requireTabAccess(user.id, 'tab:tax');
+    if (tabGate) return tabGate;
 
     // Accept id from body or query param
     let id: string | null = null;

--- a/src/app/api/accounts/route.ts
+++ b/src/app/api/accounts/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { requireTabAccess } from '@/lib/auth-helpers';
 
 export async function GET(request: NextRequest) {
   try {
@@ -17,6 +18,9 @@ export async function GET(request: NextRequest) {
     if (!user) {
       return NextResponse.json({ error: 'User not found' }, { status: 404 });
     }
+    // TAB-SERVER-GATE: tab:books entitlement (bundle:all included; admin bypass inside).
+    const tabGate = await requireTabAccess(user.id, 'tab:books');
+    if (tabGate) return tabGate;
 
     const items = await prisma.plaid_items.findMany({
       where: { userId: user.id },

--- a/src/app/api/ai/convergence-synthesis/route.ts
+++ b/src/app/api/ai/convergence-synthesis/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
-import { requireTier } from '@/lib/auth-helpers';
+import { requireTabAccess } from '@/lib/auth-helpers';
 import { requireAiRateLimit } from '@/lib/ai-rate-limit';
 import Anthropic from '@anthropic-ai/sdk';
 import { MODEL_SONNET_4 } from '@/lib/ai/client';
@@ -278,7 +278,8 @@ export async function POST(request: Request) {
     if (!user) {
       return NextResponse.json({ error: 'User not found' }, { status: 404 });
     }
-    const tierGate = requireTier(user.tier, 'ai', user.id);
+    // TAB-SERVER-GATE: tab:trade entitlement replaces the 'ai' tier gate
+    const tierGate = await requireTabAccess(user.id, 'tab:trade');
     if (tierGate) return tierGate;
 
     // SEC-5: per-user LLM volume cap (before the paid call).

--- a/src/app/api/ai/market-brief/route.ts
+++ b/src/app/api/ai/market-brief/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
-import { requireTier } from '@/lib/auth-helpers';
+import { requireTabAccess } from '@/lib/auth-helpers';
 import { requireAiRateLimit } from '@/lib/ai-rate-limit';
 import Anthropic from '@anthropic-ai/sdk';
 import { MODEL_SONNET_4 } from '@/lib/ai/client';
@@ -138,7 +138,8 @@ export async function POST(request: Request) {
     if (!user) {
       return NextResponse.json({ error: 'User not found' }, { status: 404 });
     }
-    const tierGate = requireTier(user.tier, 'ai', user.id);
+    // TAB-SERVER-GATE: tab:trade entitlement replaces the 'ai' tier gate
+    const tierGate = await requireTabAccess(user.id, 'tab:trade');
     if (tierGate) return tierGate;
 
     // SEC-5: per-user LLM volume cap (before the paid call).

--- a/src/app/api/ai/spending-insights/route.ts
+++ b/src/app/api/ai/spending-insights/route.ts
@@ -1,4 +1,4 @@
-import { requireTier } from '@/lib/auth-helpers';
+import { requireTabAccess } from '@/lib/auth-helpers';
 import { requireAiRateLimit } from '@/lib/ai-rate-limit';
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
@@ -19,7 +19,8 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: 'User not found' }, { status: 404 });
     }
 
-    const tierGate = requireTier(user.tier, 'ai', user.id);
+    // TAB-SERVER-GATE: tab:books entitlement replaces the 'ai' tier gate
+    const tierGate = await requireTabAccess(user.id, 'tab:books');
     if (tierGate) return tierGate;
 
     // SEC-5: per-user LLM volume cap (before the paid call).

--- a/src/app/api/ai/strategy-analysis/route.ts
+++ b/src/app/api/ai/strategy-analysis/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
-import { requireTier } from '@/lib/auth-helpers';
+import { requireTabAccess } from '@/lib/auth-helpers';
 import { requireAiRateLimit } from '@/lib/ai-rate-limit';
 import Anthropic from '@anthropic-ai/sdk';
 import { MODEL_SONNET_4 } from '@/lib/ai/client';
@@ -114,7 +114,8 @@ export async function POST(request: Request) {
     if (!user) {
       return NextResponse.json({ error: 'User not found' }, { status: 404 });
     }
-    const tierGate = requireTier(user.tier, 'ai', user.id);
+    // TAB-SERVER-GATE: tab:trade entitlement replaces the 'ai' tier gate
+    const tierGate = await requireTabAccess(user.id, 'tab:trade');
     if (tierGate) return tierGate;
 
     // SEC-5: per-user LLM volume cap (before the paid call).

--- a/src/app/api/bank-reconciliations/route.ts
+++ b/src/app/api/bank-reconciliations/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { Prisma } from '@prisma/client';
 import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { requireTabAccess } from '@/lib/auth-helpers';
 
 export async function GET(request: NextRequest) {
   try {
@@ -16,6 +17,9 @@ export async function GET(request: NextRequest) {
     if (!user) {
       return NextResponse.json({ error: 'User not found' }, { status: 404 });
     }
+    // TAB-SERVER-GATE: tab:books entitlement (bundle:all included; admin bypass inside).
+    const tabGate = await requireTabAccess(user.id, 'tab:books');
+    if (tabGate) return tabGate;
 
     const { searchParams } = new URL(request.url);
     const entityId = searchParams.get('entityId');
@@ -86,6 +90,9 @@ export async function POST(request: NextRequest) {
     if (!user) {
       return NextResponse.json({ error: 'User not found' }, { status: 404 });
     }
+    // TAB-SERVER-GATE: tab:books entitlement (bundle:all included; admin bypass inside).
+    const tabGate = await requireTabAccess(user.id, 'tab:books');
+    if (tabGate) return tabGate;
 
     const { accountId, periodEnd, statementBalance, bookBalance, items, status } = await request.json();
 

--- a/src/app/api/chart-of-accounts/[id]/route.ts
+++ b/src/app/api/chart-of-accounts/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { requireTabAccess } from '@/lib/auth-helpers';
 
 export async function PUT(
   request: Request,
@@ -18,6 +19,9 @@ export async function PUT(
     if (!user) {
       return NextResponse.json({ error: 'User not found' }, { status: 404 });
     }
+    // TAB-SERVER-GATE: tab:books entitlement (bundle:all included; admin bypass inside).
+    const tabGate = await requireTabAccess(user.id, 'tab:books');
+    if (tabGate) return tabGate;
 
     const { id } = await params;
     const body = await request.json();

--- a/src/app/api/chart-of-accounts/balances/route.ts
+++ b/src/app/api/chart-of-accounts/balances/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { requireTabAccess } from '@/lib/auth-helpers';
 
 export async function GET(request: Request) {
   try {
@@ -15,6 +16,9 @@ export async function GET(request: Request) {
     if (!user) {
       return NextResponse.json({ error: 'User not found' }, { status: 404 });
     }
+    // TAB-SERVER-GATE: tab:books entitlement (bundle:all included; admin bypass inside).
+    const tabGate = await requireTabAccess(user.id, 'tab:books');
+    if (tabGate) return tabGate;
 
     const { searchParams } = new URL(request.url);
     const entityId = searchParams.get('entityId');

--- a/src/app/api/chart-of-accounts/route.ts
+++ b/src/app/api/chart-of-accounts/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { ensureBookkeepingInitialized } from '@/lib/ensure-bookkeeping';
+import { requireTabAccess } from '@/lib/auth-helpers';
 
 export async function GET(request: Request) {
   try {
@@ -19,6 +20,9 @@ export async function GET(request: Request) {
     if (!user) {
       return NextResponse.json({ error: 'User not found' }, { status: 404 });
     }
+    // TAB-SERVER-GATE: tab:books entitlement (bundle:all included; admin bypass inside).
+    const tabGate = await requireTabAccess(user.id, 'tab:books');
+    if (tabGate) return tabGate;
 
     await ensureBookkeepingInitialized(user);
 
@@ -81,6 +85,9 @@ export async function POST(request: Request) {
     if (!user) {
       return NextResponse.json({ error: 'User not found' }, { status: 404 });
     }
+    // TAB-SERVER-GATE: tab:books entitlement (bundle:all included; admin bypass inside).
+    const tabGate = await requireTabAccess(user.id, 'tab:books');
+    if (tabGate) return tabGate;
 
     const { code, name, accountType, entityId } = await request.json();
 

--- a/src/app/api/citations/[id]/verify/route.ts
+++ b/src/app/api/citations/[id]/verify/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { requireTabAccess } from '@/lib/auth-helpers';
 import { verifyCitation } from '@/lib/citations/verifyCitation';
 import { writeAuditLog } from '@/lib/audit/writeAuditLog';
 import { rateLimit, RateLimitError } from '@/lib/rateLimit';
@@ -12,6 +13,19 @@ export async function POST(
   try {
     const userEmail = await getVerifiedEmail();
     if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    // TAB-SERVER-GATE: tab:compliance entitlement (bundle:all included; admin
+    // bypass inside). This shared regulatory library had auth-only access; use
+    // now requires the Compliance tab.
+    const gateUser = await prisma.users.findFirst({
+      where: { email: { equals: userEmail, mode: 'insensitive' } },
+      select: { id: true },
+    });
+    if (!gateUser) {
+      return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    }
+    const tabGate = await requireTabAccess(gateUser.id, 'tab:compliance');
+    if (tabGate) return tabGate;
 
     // COST/ABUSE GATE — verifyCitation() below makes outbound HTTP calls (HEAD+GET to the
     // citation's URLs) AND overwrites shared verification state on a GLOBAL citations row.

--- a/src/app/api/citations/route.ts
+++ b/src/app/api/citations/route.ts
@@ -1,11 +1,25 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { requireTabAccess } from '@/lib/auth-helpers';
 
 export async function GET(request: NextRequest) {
   try {
     const userEmail = await getVerifiedEmail();
     if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    // TAB-SERVER-GATE: tab:compliance entitlement (bundle:all included; admin
+    // bypass inside). This shared regulatory library had auth-only access; use
+    // now requires the Compliance tab.
+    const gateUser = await prisma.users.findFirst({
+      where: { email: { equals: userEmail, mode: 'insensitive' } },
+      select: { id: true },
+    });
+    if (!gateUser) {
+      return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    }
+    const tabGate = await requireTabAccess(gateUser.id, 'tab:compliance');
+    if (tabGate) return tabGate;
 
     const { searchParams } = new URL(request.url);
     const status = searchParams.get('status');

--- a/src/app/api/closing-periods/close/route.ts
+++ b/src/app/api/closing-periods/close/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { requireTabAccess } from '@/lib/auth-helpers';
 
 export async function POST(request: Request) {
   try {
@@ -15,6 +16,9 @@ export async function POST(request: Request) {
     if (!user) {
       return NextResponse.json({ error: 'User not found' }, { status: 404 });
     }
+    // TAB-SERVER-GATE: tab:books entitlement (bundle:all included; admin bypass inside).
+    const tabGate = await requireTabAccess(user.id, 'tab:books');
+    if (tabGate) return tabGate;
 
     const { entityId, year, month } = await request.json();
 

--- a/src/app/api/closing-periods/reopen/route.ts
+++ b/src/app/api/closing-periods/reopen/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { requireTabAccess } from '@/lib/auth-helpers';
 
 export async function POST(request: Request) {
   try {
@@ -15,6 +16,9 @@ export async function POST(request: Request) {
     if (!user) {
       return NextResponse.json({ error: 'User not found' }, { status: 404 });
     }
+    // TAB-SERVER-GATE: tab:books entitlement (bundle:all included; admin bypass inside).
+    const tabGate = await requireTabAccess(user.id, 'tab:books');
+    if (tabGate) return tabGate;
 
     const { entityId, year, month, notes } = await request.json();
 

--- a/src/app/api/closing-periods/route.ts
+++ b/src/app/api/closing-periods/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { requireTabAccess } from '@/lib/auth-helpers';
 
 export async function GET(request: NextRequest) {
   try {
@@ -15,6 +16,9 @@ export async function GET(request: NextRequest) {
     if (!user) {
       return NextResponse.json({ error: 'User not found' }, { status: 404 });
     }
+    // TAB-SERVER-GATE: tab:books entitlement (bundle:all included; admin bypass inside).
+    const tabGate = await requireTabAccess(user.id, 'tab:books');
+    if (tabGate) return tabGate;
 
     const { searchParams } = new URL(request.url);
     const entityId = searchParams.get('entityId');

--- a/src/app/api/compliance-tasks/[id]/citations/[citationId]/route.ts
+++ b/src/app/api/compliance-tasks/[id]/citations/[citationId]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { writeAuditLog } from '@/lib/audit/writeAuditLog';
+import { requireTabAccess } from '@/lib/auth-helpers';
 
 export async function DELETE(
   _request: NextRequest,
@@ -14,6 +15,9 @@ export async function DELETE(
 
     const user = await prisma.users.findFirst({ where: { email: { equals: userEmail, mode: 'insensitive' } } });
     if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    // TAB-SERVER-GATE: tab:compliance entitlement (bundle:all included; admin bypass inside).
+    const tabGate = await requireTabAccess(user.id, 'tab:compliance');
+    if (tabGate) return tabGate;
 
     // Verify task ownership via chain
     const task = await prisma.compliance_tasks.findUnique({

--- a/src/app/api/compliance-tasks/[id]/citations/route.ts
+++ b/src/app/api/compliance-tasks/[id]/citations/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { writeAuditLog } from '@/lib/audit/writeAuditLog';
+import { requireTabAccess } from '@/lib/auth-helpers';
 
 export async function POST(
   request: NextRequest,
@@ -14,6 +15,9 @@ export async function POST(
 
     const user = await prisma.users.findFirst({ where: { email: { equals: userEmail, mode: 'insensitive' } } });
     if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    // TAB-SERVER-GATE: tab:compliance entitlement (bundle:all included; admin bypass inside).
+    const tabGate = await requireTabAccess(user.id, 'tab:compliance');
+    if (tabGate) return tabGate;
 
     // Verify task ownership via chain
     const task = await prisma.compliance_tasks.findUnique({

--- a/src/app/api/compliance-tasks/[id]/route.ts
+++ b/src/app/api/compliance-tasks/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { writeAuditLog } from '@/lib/audit/writeAuditLog';
+import { requireTabAccess } from '@/lib/auth-helpers';
 
 async function getAuthUser(userEmail: string) {
   return prisma.users.findFirst({ where: { email: { equals: userEmail, mode: 'insensitive' } } });
@@ -25,6 +26,9 @@ export async function GET(
 
     const user = await getAuthUser(userEmail);
     if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    // TAB-SERVER-GATE: tab:compliance entitlement (bundle:all included; admin bypass inside).
+    const tabGate = await requireTabAccess(user.id, 'tab:compliance');
+    if (tabGate) return tabGate;
 
     const task = await prisma.compliance_tasks.findUnique({
       where: { id },
@@ -58,6 +62,9 @@ export async function PATCH(
 
     const user = await getAuthUser(userEmail);
     if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    // TAB-SERVER-GATE: tab:compliance entitlement (bundle:all included; admin bypass inside).
+    const tabGate = await requireTabAccess(user.id, 'tab:compliance');
+    if (tabGate) return tabGate;
 
     const existing = await getTaskWithOwnership(id);
     if (!existing || existing.workstream.project.mission.user_id !== user.id) {
@@ -146,6 +153,9 @@ export async function DELETE(
 
     const user = await getAuthUser(userEmail);
     if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    // TAB-SERVER-GATE: tab:compliance entitlement (bundle:all included; admin bypass inside).
+    const tabGate = await requireTabAccess(user.id, 'tab:compliance');
+    if (tabGate) return tabGate;
 
     const existing = await getTaskWithOwnership(id);
     if (!existing || existing.workstream.project.mission.user_id !== user.id) {

--- a/src/app/api/compliance-tasks/route.ts
+++ b/src/app/api/compliance-tasks/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { writeAuditLog } from '@/lib/audit/writeAuditLog';
+import { requireTabAccess } from '@/lib/auth-helpers';
 
 export async function GET(request: NextRequest) {
   try {
@@ -10,6 +11,9 @@ export async function GET(request: NextRequest) {
 
     const user = await prisma.users.findFirst({ where: { email: { equals: userEmail, mode: 'insensitive' } } });
     if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    // TAB-SERVER-GATE: tab:compliance entitlement (bundle:all included; admin bypass inside).
+    const tabGate = await requireTabAccess(user.id, 'tab:compliance');
+    if (tabGate) return tabGate;
 
     const { searchParams } = new URL(request.url);
     const workstream_id = searchParams.get('workstream_id');
@@ -64,6 +68,9 @@ export async function POST(request: NextRequest) {
 
     const user = await prisma.users.findFirst({ where: { email: { equals: userEmail, mode: 'insensitive' } } });
     if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    // TAB-SERVER-GATE: tab:compliance entitlement (bundle:all included; admin bypass inside).
+    const tabGate = await requireTabAccess(user.id, 'tab:compliance');
+    if (tabGate) return tabGate;
 
     const body = await request.json();
     const {

--- a/src/app/api/convergence/sentiment/route.ts
+++ b/src/app/api/convergence/sentiment/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { prisma } from '@/lib/prisma';
-import { requireTier } from '@/lib/auth-helpers';
+import { requireTabAccess } from '@/lib/auth-helpers';
 import { fetchSentimentBatch } from '@/lib/convergence/sentiment';
 
 export const maxDuration = 60;
@@ -18,7 +18,8 @@ export async function POST(req: Request) {
   if (!user) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
-  const tierGate = requireTier(user.tier, 'ai', user.id);
+  // TAB-SERVER-GATE: tab:trade entitlement replaces the 'ai' tier gate
+  const tierGate = await requireTabAccess(user.id, 'tab:trade');
   if (tierGate) return tierGate;
 
   let body: { symbols?: unknown };

--- a/src/app/api/cpa-export/route.ts
+++ b/src/app/api/cpa-export/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { Prisma } from '@prisma/client';
 import { prisma } from '@/lib/prisma';
 import { getCurrentUser } from '@/lib/auth-helpers';
+import { requireTabAccess } from '@/lib/auth-helpers';
 
 // ═══════════════════════════════════════════════════════════════════
 // CPA Export API — Single source of truth for the 4 accountant reports.
@@ -24,6 +25,9 @@ export async function GET(request: NextRequest) {
   try {
     const user = await getCurrentUser();
     if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    // TAB-SERVER-GATE: tab:tax entitlement (bundle:all included; admin bypass inside).
+    const tabGate = await requireTabAccess(user.id, 'tab:tax');
+    if (tabGate) return tabGate;
 
     const { searchParams } = new URL(request.url);
     const yearParam = searchParams.get('year');

--- a/src/app/api/discovery/profile/route.ts
+++ b/src/app/api/discovery/profile/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { writeAuditLog } from '@/lib/audit/writeAuditLog';
+import { requireTabAccess } from '@/lib/auth-helpers';
 
 export async function GET(_request: NextRequest) {
   try {
@@ -10,6 +11,9 @@ export async function GET(_request: NextRequest) {
 
     const user = await prisma.users.findFirst({ where: { email: { equals: userEmail, mode: 'insensitive' } } });
     if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    // TAB-SERVER-GATE: tab:compliance entitlement (bundle:all included; admin bypass inside).
+    const tabGate = await requireTabAccess(user.id, 'tab:compliance');
+    if (tabGate) return tabGate;
 
     const profile = await prisma.user_profiles.findUnique({ where: { user_id: user.id } });
     return NextResponse.json({ profile });
@@ -37,6 +41,9 @@ export async function POST(request: NextRequest) {
 
     const user = await prisma.users.findFirst({ where: { email: { equals: userEmail, mode: 'insensitive' } } });
     if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    // TAB-SERVER-GATE: tab:compliance entitlement (bundle:all included; admin bypass inside).
+    const tabGate = await requireTabAccess(user.id, 'tab:compliance');
+    if (tabGate) return tabGate;
 
     const body = await request.json();
     const {

--- a/src/app/api/discovery/proposals/[id]/accept/route.ts
+++ b/src/app/api/discovery/proposals/[id]/accept/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { materializeProposal } from '@/lib/discovery/materializeProposal';
+import { requireTabAccess } from '@/lib/auth-helpers';
 
 export async function POST(
   request: NextRequest,
@@ -14,6 +15,9 @@ export async function POST(
 
     const user = await prisma.users.findFirst({ where: { email: { equals: userEmail, mode: 'insensitive' } } });
     if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    // TAB-SERVER-GATE: tab:compliance entitlement (bundle:all included; admin bypass inside).
+    const tabGate = await requireTabAccess(user.id, 'tab:compliance');
+    if (tabGate) return tabGate;
 
     const proposal = await prisma.discovery_proposals.findUnique({
       where: { id },

--- a/src/app/api/discovery/proposals/[id]/reject/route.ts
+++ b/src/app/api/discovery/proposals/[id]/reject/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { writeAuditLog } from '@/lib/audit/writeAuditLog';
+import { requireTabAccess } from '@/lib/auth-helpers';
 
 export async function POST(
   request: NextRequest,
@@ -14,6 +15,9 @@ export async function POST(
 
     const user = await prisma.users.findFirst({ where: { email: { equals: userEmail, mode: 'insensitive' } } });
     if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    // TAB-SERVER-GATE: tab:compliance entitlement (bundle:all included; admin bypass inside).
+    const tabGate = await requireTabAccess(user.id, 'tab:compliance');
+    if (tabGate) return tabGate;
 
     const proposal = await prisma.discovery_proposals.findUnique({
       where: { id },

--- a/src/app/api/discovery/runs/[id]/route.ts
+++ b/src/app/api/discovery/runs/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { requireTabAccess } from '@/lib/auth-helpers';
 
 function serializeBigIntAndDecimal(obj: unknown): unknown {
   if (obj === null || obj === undefined) return obj;
@@ -35,6 +36,9 @@ export async function GET(
 
     const user = await prisma.users.findFirst({ where: { email: { equals: userEmail, mode: 'insensitive' } } });
     if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    // TAB-SERVER-GATE: tab:compliance entitlement (bundle:all included; admin bypass inside).
+    const tabGate = await requireTabAccess(user.id, 'tab:compliance');
+    if (tabGate) return tabGate;
 
     const run = await prisma.discovery_runs.findUnique({
       where: { id },

--- a/src/app/api/discovery/runs/route.ts
+++ b/src/app/api/discovery/runs/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { runDiscovery } from '@/lib/discovery/runDiscovery';
+import { requireTabAccess } from '@/lib/auth-helpers';
 
 export async function GET(_request: NextRequest) {
   try {
@@ -10,6 +11,9 @@ export async function GET(_request: NextRequest) {
 
     const user = await prisma.users.findFirst({ where: { email: { equals: userEmail, mode: 'insensitive' } } });
     if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    // TAB-SERVER-GATE: tab:compliance entitlement (bundle:all included; admin bypass inside).
+    const tabGate = await requireTabAccess(user.id, 'tab:compliance');
+    if (tabGate) return tabGate;
 
     const runs = await prisma.discovery_runs.findMany({
       where: { user_id: user.id },
@@ -36,6 +40,9 @@ export async function POST(_request: NextRequest) {
 
     const user = await prisma.users.findFirst({ where: { email: { equals: userEmail, mode: 'insensitive' } } });
     if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    // TAB-SERVER-GATE: tab:compliance entitlement (bundle:all included; admin bypass inside).
+    const tabGate = await requireTabAccess(user.id, 'tab:compliance');
+    if (tabGate) return tabGate;
 
     // Load user's profile
     const profile = await prisma.user_profiles.findUnique({ where: { user_id: user.id } });

--- a/src/app/api/finnhub/ticker-context/route.ts
+++ b/src/app/api/finnhub/ticker-context/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { requireTabAccess } from '@/lib/auth-helpers';
 
 export async function GET(request: Request) {
   const userEmail = await getVerifiedEmail();
@@ -13,6 +14,9 @@ export async function GET(request: Request) {
   if (!user) {
     return NextResponse.json({ error: 'User not found' }, { status: 404 });
   }
+  // TAB-SERVER-GATE: tab:trade entitlement (bundle:all included; admin bypass inside).
+  const tabGate = await requireTabAccess(user.id, 'tab:trade');
+  if (tabGate) return tabGate;
 
   const { searchParams } = new URL(request.url);
   const symbol = searchParams.get('symbol');

--- a/src/app/api/journal-entries/manual/route.ts
+++ b/src/app/api/journal-entries/manual/route.ts
@@ -4,6 +4,7 @@ import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { ensureBookkeepingInitialized } from '@/lib/ensure-bookkeeping';
 import { assertPeriodOpen, PeriodClosedError } from '@/lib/period-close-guard';
+import { requireTabAccess } from '@/lib/auth-helpers';
 
 export async function POST(request: Request) {
   try {
@@ -18,6 +19,9 @@ export async function POST(request: Request) {
     if (!user) {
       return NextResponse.json({ error: 'User not found' }, { status: 404 });
     }
+    // TAB-SERVER-GATE: tab:books entitlement (bundle:all included; admin bypass inside).
+    const tabGate = await requireTabAccess(user.id, 'tab:books');
+    if (tabGate) return tabGate;
 
     await ensureBookkeepingInitialized(user);
 

--- a/src/app/api/journal-entries/route.ts
+++ b/src/app/api/journal-entries/route.ts
@@ -4,6 +4,7 @@ import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { ensureBookkeepingInitialized } from '@/lib/ensure-bookkeeping';
 import { assertPeriodOpen, PeriodClosedError } from '@/lib/period-close-guard';
+import { requireTabAccess } from '@/lib/auth-helpers';
 
 export async function GET() {
   try {
@@ -14,6 +15,9 @@ export async function GET() {
       where: { email: { equals: userEmail, mode: 'insensitive' } }
     });
     if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    // TAB-SERVER-GATE: tab:books entitlement (bundle:all included; admin bypass inside).
+    const tabGate = await requireTabAccess(user.id, 'tab:books');
+    if (tabGate) return tabGate;
 
     await ensureBookkeepingInitialized(user);
 
@@ -39,6 +43,9 @@ export async function POST(request: Request) {
       where: { email: { equals: userEmail, mode: 'insensitive' } }
     });
     if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    // TAB-SERVER-GATE: tab:books entitlement (bundle:all included; admin bypass inside).
+    const tabGate = await requireTabAccess(user.id, 'tab:books');
+    if (tabGate) return tabGate;
 
     const body = await request.json();
     const { date, description, entityId, lines, status: entryStatus } = body;

--- a/src/app/api/journal-transactions/route.ts
+++ b/src/app/api/journal-transactions/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { requireTabAccess } from '@/lib/auth-helpers';
 
 export async function GET() {
   try {
@@ -15,6 +16,9 @@ export async function GET() {
     if (!user) {
       return NextResponse.json({ error: 'User not found' }, { status: 404 });
     }
+    // TAB-SERVER-GATE: tab:books entitlement (bundle:all included; admin bypass inside).
+    const tabGate = await requireTabAccess(user.id, 'tab:books');
+    if (tabGate) return tabGate;
 
     const journalEntries = await prisma.journal_entries.findMany({
       where: { userId: user.id },

--- a/src/app/api/ledger/route.ts
+++ b/src/app/api/ledger/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { requireTabAccess } from '@/lib/auth-helpers';
 
 export async function GET(request: NextRequest) {
   try {
@@ -15,6 +16,9 @@ export async function GET(request: NextRequest) {
     if (!user) {
       return NextResponse.json({ error: 'User not found' }, { status: 404 });
     }
+    // TAB-SERVER-GATE: tab:books entitlement (bundle:all included; admin bypass inside).
+    const tabGate = await requireTabAccess(user.id, 'tab:books');
+    if (tabGate) return tabGate;
 
     const { searchParams } = new URL(request.url);
     const accountCode = searchParams.get('accountCode');

--- a/src/app/api/merchant-mappings/route.ts
+++ b/src/app/api/merchant-mappings/route.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'crypto';
 import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { requireTabAccess } from '@/lib/auth-helpers';
 
 export async function GET(request: Request) {
   try {
@@ -16,6 +17,9 @@ export async function GET(request: Request) {
     if (!user) {
       return NextResponse.json({ error: 'User not found' }, { status: 404 });
     }
+    // TAB-SERVER-GATE: tab:books entitlement (bundle:all included; admin bypass inside).
+    const tabGate = await requireTabAccess(user.id, 'tab:books');
+    if (tabGate) return tabGate;
 
     const { searchParams } = new URL(request.url);
     const merchantName = searchParams.get('merchantName');
@@ -79,6 +83,9 @@ export async function POST(request: Request) {
     if (!user) {
       return NextResponse.json({ error: 'User not found' }, { status: 404 });
     }
+    // TAB-SERVER-GATE: tab:books entitlement (bundle:all included; admin bypass inside).
+    const tabGate = await requireTabAccess(user.id, 'tab:books');
+    if (tabGate) return tabGate;
 
     const body = await request.json();
     const { merchant_name, plaidCategoryPrimary, plaidCategoryDetailed, coaCode, subAccount } = body;

--- a/src/app/api/missions/[id]/route.ts
+++ b/src/app/api/missions/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { writeAuditLog } from '@/lib/audit/writeAuditLog';
+import { requireTabAccess } from '@/lib/auth-helpers';
 
 export async function GET(
   _request: NextRequest,
@@ -14,6 +15,9 @@ export async function GET(
 
     const user = await prisma.users.findFirst({ where: { email: { equals: userEmail, mode: 'insensitive' } } });
     if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    // TAB-SERVER-GATE: tab:compliance entitlement (bundle:all included; admin bypass inside).
+    const tabGate = await requireTabAccess(user.id, 'tab:compliance');
+    if (tabGate) return tabGate;
 
     const mission = await prisma.missions.findUnique({
       where: { id },
@@ -61,6 +65,9 @@ export async function PATCH(
 
     const user = await prisma.users.findFirst({ where: { email: { equals: userEmail, mode: 'insensitive' } } });
     if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    // TAB-SERVER-GATE: tab:compliance entitlement (bundle:all included; admin bypass inside).
+    const tabGate = await requireTabAccess(user.id, 'tab:compliance');
+    if (tabGate) return tabGate;
 
     const existing = await prisma.missions.findUnique({ where: { id } });
     if (!existing || existing.user_id !== user.id) {
@@ -129,6 +136,9 @@ export async function DELETE(
 
     const user = await prisma.users.findFirst({ where: { email: { equals: userEmail, mode: 'insensitive' } } });
     if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    // TAB-SERVER-GATE: tab:compliance entitlement (bundle:all included; admin bypass inside).
+    const tabGate = await requireTabAccess(user.id, 'tab:compliance');
+    if (tabGate) return tabGate;
 
     const existing = await prisma.missions.findUnique({ where: { id } });
     if (!existing || existing.user_id !== user.id) {

--- a/src/app/api/missions/route.ts
+++ b/src/app/api/missions/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { writeAuditLog } from '@/lib/audit/writeAuditLog';
+import { requireTabAccess } from '@/lib/auth-helpers';
 
 export async function GET(request: NextRequest) {
   try {
@@ -10,6 +11,9 @@ export async function GET(request: NextRequest) {
 
     const user = await prisma.users.findFirst({ where: { email: { equals: userEmail, mode: 'insensitive' } } });
     if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    // TAB-SERVER-GATE: tab:compliance entitlement (bundle:all included; admin bypass inside).
+    const tabGate = await requireTabAccess(user.id, 'tab:compliance');
+    if (tabGate) return tabGate;
 
     const { searchParams } = new URL(request.url);
     const status = searchParams.get('status');
@@ -45,6 +49,9 @@ export async function POST(request: NextRequest) {
 
     const user = await prisma.users.findFirst({ where: { email: { equals: userEmail, mode: 'insensitive' } } });
     if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    // TAB-SERVER-GATE: tab:compliance entitlement (bundle:all included; admin bypass inside).
+    const tabGate = await requireTabAccess(user.id, 'tab:compliance');
+    if (tabGate) return tabGate;
 
     const body = await request.json();
     const { title, description, entity_id, target_completion, framework_mappings } = body;

--- a/src/app/api/plaid/exchange-token/route.ts
+++ b/src/app/api/plaid/exchange-token/route.ts
@@ -1,4 +1,4 @@
-import { requireTier } from '@/lib/auth-helpers';
+import { requireTabAccess } from '@/lib/auth-helpers';
 import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { plaidClient } from '@/lib/plaid';
@@ -21,7 +21,8 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: 'User not found' }, { status: 404 });
     }
 
-    const tierGate = requireTier(user.tier, 'plaid', user.id);
+    // TAB-SERVER-GATE: tab:books entitlement replaces the 'plaid' tier gate
+    const tierGate = await requireTabAccess(user.id, 'tab:books');
     if (tierGate) return tierGate;
 
     const { publicToken } = await request.json();

--- a/src/app/api/plaid/items/route.ts
+++ b/src/app/api/plaid/items/route.ts
@@ -1,4 +1,4 @@
-import { requireTier } from '@/lib/auth-helpers';
+import { requireTabAccess } from '@/lib/auth-helpers';
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
@@ -19,7 +19,8 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: 'User not found' }, { status: 404 });
     }
 
-    const tierGate = requireTier(user.tier, 'plaid', user.id);
+    // TAB-SERVER-GATE: tab:books entitlement replaces the 'plaid' tier gate
+    const tierGate = await requireTabAccess(user.id, 'tab:books');
     if (tierGate) return tierGate;
 
     const items = await prisma.plaid_items.findMany({

--- a/src/app/api/plaid/link-token/route.ts
+++ b/src/app/api/plaid/link-token/route.ts
@@ -1,4 +1,4 @@
-import { requireTier } from '@/lib/auth-helpers';
+import { requireTabAccess } from '@/lib/auth-helpers';
 import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { plaidClient } from '@/lib/plaid';
@@ -21,7 +21,8 @@ export async function POST() {
       return NextResponse.json({ error: 'User not found' }, { status: 404 });
     }
 
-    const tierGate = requireTier(user.tier, 'plaid', user.id);
+    // TAB-SERVER-GATE: tab:books entitlement replaces the 'plaid' tier gate
+    const tierGate = await requireTabAccess(user.id, 'tab:books');
     if (tierGate) return tierGate;
 
     const configs = {

--- a/src/app/api/plaid/sync/route.ts
+++ b/src/app/api/plaid/sync/route.ts
@@ -2,7 +2,7 @@
 // This route is kept for backwards compatibility but should not be called
 // All sync operations should go through the canonical pipeline
 
-import { requireTier } from '@/lib/auth-helpers';
+import { requireTabAccess } from '@/lib/auth-helpers';
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { Configuration, PlaidApi, PlaidEnvironments } from 'plaid';
@@ -37,7 +37,8 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'User not found' }, { status: 404 });
     }
 
-    const tierGate = requireTier(user.tier, 'plaid', user.id);
+    // TAB-SERVER-GATE: tab:books entitlement replaces the 'plaid' tier gate
+    const tierGate = await requireTabAccess(user.id, 'tab:books');
     if (tierGate) return tierGate;
 
     const { itemId } = await request.json();

--- a/src/app/api/regulatory-sources/route.ts
+++ b/src/app/api/regulatory-sources/route.ts
@@ -1,11 +1,25 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { requireTabAccess } from '@/lib/auth-helpers';
 
 export async function GET(request: NextRequest) {
   try {
     const userEmail = await getVerifiedEmail();
     if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    // TAB-SERVER-GATE: tab:compliance entitlement (bundle:all included; admin
+    // bypass inside). This shared regulatory library had auth-only access; use
+    // now requires the Compliance tab.
+    const gateUser = await prisma.users.findFirst({
+      where: { email: { equals: userEmail, mode: 'insensitive' } },
+      select: { id: true },
+    });
+    if (!gateUser) {
+      return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    }
+    const tabGate = await requireTabAccess(gateUser.id, 'tab:compliance');
+    if (tabGate) return tabGate;
 
     const { searchParams } = new URL(request.url);
     const tier = searchParams.get('tier');

--- a/src/app/api/statements/analysis/route.ts
+++ b/src/app/api/statements/analysis/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { requireTabAccess } from '@/lib/auth-helpers';
 
 export async function GET(request: Request) {
   try {
@@ -15,6 +16,9 @@ export async function GET(request: Request) {
     if (!user) {
       return NextResponse.json({ error: 'User not found' }, { status: 404 });
     }
+    // TAB-SERVER-GATE: tab:books entitlement (bundle:all included; admin bypass inside).
+    const tabGate = await requireTabAccess(user.id, 'tab:books');
+    if (tabGate) return tabGate;
 
     const { searchParams } = new URL(request.url);
     const period = searchParams.get('period') || 'monthly';

--- a/src/app/api/statements/route.ts
+++ b/src/app/api/statements/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { Prisma } from '@prisma/client';
 import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { requireTabAccess } from '@/lib/auth-helpers';
 
 export async function GET(request: NextRequest) {
   try {
@@ -16,6 +17,9 @@ export async function GET(request: NextRequest) {
     if (!user) {
       return NextResponse.json({ error: 'User not found' }, { status: 404 });
     }
+    // TAB-SERVER-GATE: tab:books entitlement (bundle:all included; admin bypass inside).
+    const tabGate = await requireTabAccess(user.id, 'tab:books');
+    if (tabGate) return tabGate;
 
     const { searchParams } = new URL(request.url);
     const year = parseInt(searchParams.get('year') || String(new Date().getFullYear()), 10);

--- a/src/app/api/tax-estimate/route.ts
+++ b/src/app/api/tax-estimate/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { requireTabAccess } from '@/lib/auth-helpers';
 
 type FilingStatus = 'single' | 'married_joint' | 'married_separate' | 'head_of_household';
 
@@ -93,6 +94,9 @@ export async function POST(request: Request) {
       where: { email: { equals: userEmail, mode: 'insensitive' } },
     });
     if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    // TAB-SERVER-GATE: tab:tax entitlement (bundle:all included; admin bypass inside).
+    const tabGate = await requireTabAccess(user.id, 'tab:tax');
+    if (tabGate) return tabGate;
 
     const userId = user.id;
 

--- a/src/app/api/tax/calculate/route.ts
+++ b/src/app/api/tax/calculate/route.ts
@@ -4,6 +4,7 @@ import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { generateScheduleC, generateScheduleSE } from '@/lib/schedule-c-service';
 import { generateForm8949, generateScheduleD } from '@/lib/tax-report-service';
 import { generateForm1040 } from '@/lib/form-1040-service';
+import { requireTabAccess } from '@/lib/auth-helpers';
 
 function round2(n: number): number {
   return Math.round(n * 100) / 100;
@@ -50,6 +51,9 @@ export async function GET(request: Request) {
       where: { email: { equals: userEmail, mode: 'insensitive' } }
     });
     if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    // TAB-SERVER-GATE: tab:tax entitlement (bundle:all included; admin bypass inside).
+    const tabGate = await requireTabAccess(user.id, 'tab:tax');
+    if (tabGate) return tabGate;
 
     const { searchParams } = new URL(request.url);
     const yearParam = searchParams.get('year') || '2025';

--- a/src/app/api/tax/documents/route.ts
+++ b/src/app/api/tax/documents/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { requireTabAccess } from '@/lib/auth-helpers';
 
 export async function GET(request: Request) {
   try {
@@ -11,6 +12,9 @@ export async function GET(request: Request) {
       where: { email: { equals: userEmail, mode: 'insensitive' } }
     });
     if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    // TAB-SERVER-GATE: tab:tax entitlement (bundle:all included; admin bypass inside).
+    const tabGate = await requireTabAccess(user.id, 'tab:tax');
+    if (tabGate) return tabGate;
 
     const { searchParams } = new URL(request.url);
     const yearParam = searchParams.get('year');
@@ -38,6 +42,9 @@ export async function POST(request: Request) {
       where: { email: { equals: userEmail, mode: 'insensitive' } }
     });
     if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    // TAB-SERVER-GATE: tab:tax entitlement (bundle:all included; admin bypass inside).
+    const tabGate = await requireTabAccess(user.id, 'tab:tax');
+    if (tabGate) return tabGate;
 
     const { tax_year, doc_type, label, data } = await request.json();
 
@@ -96,6 +103,9 @@ export async function DELETE(request: Request) {
       where: { email: { equals: userEmail, mode: 'insensitive' } }
     });
     if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    // TAB-SERVER-GATE: tab:tax entitlement (bundle:all included; admin bypass inside).
+    const tabGate = await requireTabAccess(user.id, 'tab:tax');
+    if (tabGate) return tabGate;
 
     const { id } = await request.json();
     if (!id) return NextResponse.json({ error: 'id required' }, { status: 400 });

--- a/src/app/api/tax/export/route.ts
+++ b/src/app/api/tax/export/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { generateForm8949, generateForm8949CSV } from '@/lib/tax-report-service';
+import { requireTabAccess } from '@/lib/auth-helpers';
 
 /**
  * GET /api/tax/export?year=2025&format=8949
@@ -16,6 +17,9 @@ export async function GET(request: NextRequest) {
       where: { email: { equals: userEmail, mode: 'insensitive' } }
     });
     if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    // TAB-SERVER-GATE: tab:tax entitlement (bundle:all included; admin bypass inside).
+    const tabGate = await requireTabAccess(user.id, 'tab:tax');
+    if (tabGate) return tabGate;
 
     const yearParam = request.nextUrl.searchParams.get('year');
     const taxYear = yearParam ? parseInt(yearParam, 10) : new Date().getFullYear();

--- a/src/app/api/tax/generate-pdf/route.ts
+++ b/src/app/api/tax/generate-pdf/route.ts
@@ -4,6 +4,7 @@ import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { generateForm1040 } from '@/lib/form-1040-service';
 import { generateTaxReport } from '@/lib/tax-report-service';
 import { generateAllFormsPDF, generateSingleFormPDF } from '@/lib/tax-pdf-service';
+import { requireTabAccess } from '@/lib/auth-helpers';
 
 export async function GET(request: Request) {
   try {
@@ -18,6 +19,9 @@ export async function GET(request: Request) {
     if (!user) {
       return NextResponse.json({ error: 'User not found' }, { status: 404 });
     }
+    // TAB-SERVER-GATE: tab:tax entitlement (bundle:all included; admin bypass inside).
+    const tabGate = await requireTabAccess(user.id, 'tab:tax');
+    if (tabGate) return tabGate;
 
     const { searchParams } = new URL(request.url);
     const yearParam = searchParams.get('year') || '2025';

--- a/src/app/api/tax/overrides/route.ts
+++ b/src/app/api/tax/overrides/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { requireTabAccess } from '@/lib/auth-helpers';
 
 const ALLOWED_FIELD_KEYS = [
   'w2_gross_wages',
@@ -27,6 +28,9 @@ export async function GET(request: NextRequest) {
       where: { email: { equals: userEmail, mode: 'insensitive' } },
     });
     if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    // TAB-SERVER-GATE: tab:tax entitlement (bundle:all included; admin bypass inside).
+    const tabGate = await requireTabAccess(user.id, 'tab:tax');
+    if (tabGate) return tabGate;
 
     const yearParam = request.nextUrl.searchParams.get('year');
     const taxYear = yearParam ? parseInt(yearParam, 10) : new Date().getFullYear();
@@ -66,6 +70,9 @@ export async function POST(request: NextRequest) {
       where: { email: { equals: userEmail, mode: 'insensitive' } },
     });
     if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    // TAB-SERVER-GATE: tab:tax entitlement (bundle:all included; admin bypass inside).
+    const tabGate = await requireTabAccess(user.id, 'tab:tax');
+    if (tabGate) return tabGate;
 
     const body = await request.json();
     const { year, overrides } = body as { year: number; overrides: Record<string, string> };

--- a/src/app/api/tax/report/route.ts
+++ b/src/app/api/tax/report/route.ts
@@ -4,6 +4,7 @@ import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { generateTaxReport } from '@/lib/tax-report-service';
 import { generateScheduleC, generateScheduleSE } from '@/lib/schedule-c-service';
 import { generateForm1040 } from '@/lib/form-1040-service';
+import { requireTabAccess } from '@/lib/auth-helpers';
 
 /**
  * GET /api/tax/report?year=2025
@@ -23,6 +24,9 @@ export async function GET(request: NextRequest) {
       where: { email: { equals: userEmail, mode: 'insensitive' } }
     });
     if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    // TAB-SERVER-GATE: tab:tax entitlement (bundle:all included; admin bypass inside).
+    const tabGate = await requireTabAccess(user.id, 'tab:tax');
+    if (tabGate) return tabGate;
 
     const yearParam = request.nextUrl.searchParams.get('year');
     const taxYear = yearParam ? parseInt(yearParam, 10) : new Date().getFullYear();

--- a/src/app/api/tax/wash-sales/route.ts
+++ b/src/app/api/tax/wash-sales/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { detectWashSales, applyWashSaleAdjustments } from '@/lib/wash-sale-service';
+import { requireTabAccess } from '@/lib/auth-helpers';
 
 /**
  * GET /api/tax/wash-sales
@@ -16,6 +17,9 @@ export async function GET() {
       where: { email: { equals: userEmail, mode: 'insensitive' } }
     });
     if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    // TAB-SERVER-GATE: tab:tax entitlement (bundle:all included; admin bypass inside).
+    const tabGate = await requireTabAccess(user.id, 'tab:tax');
+    if (tabGate) return tabGate;
 
     const result = await detectWashSales(user.id);
 
@@ -76,6 +80,9 @@ export async function POST() {
       where: { email: { equals: userEmail, mode: 'insensitive' } }
     });
     if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    // TAB-SERVER-GATE: tab:tax entitlement (bundle:all included; admin bypass inside).
+    const tabGate = await requireTabAccess(user.id, 'tab:tax');
+    if (tabGate) return tabGate;
 
     // Detect first
     const { violations, summary } = await detectWashSales(user.id);

--- a/src/app/api/trade-card-links/route.ts
+++ b/src/app/api/trade-card-links/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { requireTabAccess } from '@/lib/auth-helpers';
 
 /**
  * SEC-2: the user's investment_transaction ids — the ownership handle for
@@ -29,6 +30,9 @@ export async function POST(request: NextRequest) {
       where: { email: { equals: userEmail, mode: 'insensitive' } }
     });
     if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    // TAB-SERVER-GATE: tab:trade entitlement (bundle:all included; admin bypass inside).
+    const tabGate = await requireTabAccess(user.id, 'tab:trade');
+    if (tabGate) return tabGate;
 
     const { trade_card_id, trade_num } = await request.json();
     if (!trade_card_id || !trade_num) {
@@ -118,6 +122,9 @@ export async function DELETE(request: NextRequest) {
       where: { email: { equals: userEmail, mode: 'insensitive' } }
     });
     if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    // TAB-SERVER-GATE: tab:trade entitlement (bundle:all included; admin bypass inside).
+    const tabGate = await requireTabAccess(user.id, 'tab:trade');
+    if (tabGate) return tabGate;
 
     const { id } = await request.json();
     if (!id) return NextResponse.json({ error: 'Required: id (link id)' }, { status: 400 });
@@ -163,6 +170,9 @@ export async function GET(request: NextRequest) {
       where: { email: { equals: userEmail, mode: 'insensitive' } }
     });
     if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    // TAB-SERVER-GATE: tab:trade entitlement (bundle:all included; admin bypass inside).
+    const tabGate = await requireTabAccess(user.id, 'tab:trade');
+    if (tabGate) return tabGate;
 
     const params = request.nextUrl.searchParams;
 

--- a/src/app/api/trade-cards/route.ts
+++ b/src/app/api/trade-cards/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { requireTabAccess } from '@/lib/auth-helpers';
 
 /**
  * POST /api/trade-cards — Save a card to the queue
@@ -14,6 +15,9 @@ export async function POST(request: NextRequest) {
       where: { email: { equals: userEmail, mode: 'insensitive' } }
     });
     if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    // TAB-SERVER-GATE: tab:trade entitlement (bundle:all included; admin bypass inside).
+    const tabGate = await requireTabAccess(user.id, 'tab:trade');
+    if (tabGate) return tabGate;
 
     const body = await request.json();
     const {
@@ -138,6 +142,9 @@ export async function GET(request: NextRequest) {
       where: { email: { equals: userEmail, mode: 'insensitive' } }
     });
     if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    // TAB-SERVER-GATE: tab:trade entitlement (bundle:all included; admin bypass inside).
+    const tabGate = await requireTabAccess(user.id, 'tab:trade');
+    if (tabGate) return tabGate;
 
     const statusFilter = request.nextUrl.searchParams.get('status');
 
@@ -171,6 +178,9 @@ export async function DELETE(request: NextRequest) {
       where: { email: { equals: userEmail, mode: 'insensitive' } }
     });
     if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    // TAB-SERVER-GATE: tab:trade entitlement (bundle:all included; admin bypass inside).
+    const tabGate = await requireTabAccess(user.id, 'tab:trade');
+    if (tabGate) return tabGate;
 
     const { id } = await request.json();
     if (!id) return NextResponse.json({ error: 'Required: id' }, { status: 400 });
@@ -212,6 +222,9 @@ export async function PATCH(request: NextRequest) {
       where: { email: { equals: userEmail, mode: 'insensitive' } }
     });
     if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    // TAB-SERVER-GATE: tab:trade entitlement (bundle:all included; admin bypass inside).
+    const tabGate = await requireTabAccess(user.id, 'tab:trade');
+    if (tabGate) return tabGate;
 
     const { id, status } = await request.json();
     if (!id || !status) {

--- a/src/app/api/trading-journal/route.ts
+++ b/src/app/api/trading-journal/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { requireTabAccess } from '@/lib/auth-helpers';
 
 export async function GET() {
   try {
@@ -11,6 +12,9 @@ export async function GET() {
       where: { email: { equals: userEmail, mode: 'insensitive' } }
     });
     if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    // TAB-SERVER-GATE: tab:trade entitlement (bundle:all included; admin bypass inside).
+    const tabGate = await requireTabAccess(user.id, 'tab:trade');
+    if (tabGate) return tabGate;
 
     const entries = await prisma.trade_journal_entries.findMany({
       where: { userId: user.id },
@@ -33,6 +37,9 @@ export async function POST(request: Request) {
       where: { email: { equals: userEmail, mode: 'insensitive' } }
     });
     if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    // TAB-SERVER-GATE: tab:trade entitlement (bundle:all included; admin bypass inside).
+    const tabGate = await requireTabAccess(user.id, 'tab:trade');
+    if (tabGate) return tabGate;
 
     const body = await request.json();
     const { tradeNum, entryType, thesis, setup, emotion, mistakes, lessons, rating, tags } = body;
@@ -95,6 +102,9 @@ export async function DELETE(request: Request) {
       where: { email: { equals: userEmail, mode: 'insensitive' } }
     });
     if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    // TAB-SERVER-GATE: tab:trade entitlement (bundle:all included; admin bypass inside).
+    const tabGate = await requireTabAccess(user.id, 'tab:trade');
+    if (tabGate) return tabGate;
 
     const { searchParams } = new URL(request.url);
     const id = searchParams.get('id');

--- a/src/app/api/trading/commit-to-ledger/route.ts
+++ b/src/app/api/trading/commit-to-ledger/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { assertPeriodOpen, PeriodClosedError } from '@/lib/period-close-guard';
+import { requireTabAccess } from '@/lib/auth-helpers';
 
 function dollarsToCents(amount: number): bigint {
   return BigInt(Math.round(amount * 100));
@@ -24,6 +25,9 @@ export async function POST(request: NextRequest) {
     if (!user) {
       return NextResponse.json({ error: 'User not found' }, { status: 404 });
     }
+    // TAB-SERVER-GATE: tab:trade entitlement (bundle:all included; admin bypass inside).
+    const tabGate = await requireTabAccess(user.id, 'tab:trade');
+    if (tabGate) return tabGate;
 
     const { tradeNums } = await request.json();
     if (!tradeNums || !Array.isArray(tradeNums) || tradeNums.length === 0) {

--- a/src/app/api/trading/convergence/route.ts
+++ b/src/app/api/trading/convergence/route.ts
@@ -1,7 +1,8 @@
 import { NextResponse } from 'next/server';
 import { runPipeline } from '@/lib/convergence/pipeline';
 import type { PipelineResult } from '@/lib/convergence/pipeline';
-import { requireAdmin } from '@/lib/require-admin';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { requireTabAccess } from '@/lib/auth-helpers';
 import { prisma } from '@/lib/prisma';
 
 export const maxDuration = 300;
@@ -41,16 +42,28 @@ function setCache(limit: number, data: PipelineResult, universe?: string): void 
 
 export async function GET(request: Request) {
   try {
-    // TRADING-PR-SEC: this scan runs the convergence pipeline, which hits PAID
-    // data feeds (TastyTrade / Finnhub / FRED / xAI). Gate it to the admin/owner
-    // (OWNER_EMAIL — Alex, the sole admin today) using the existing requireAdmin
-    // helper. requireAdmin returns 401 for guests and 403 for non-admins BEFORE
-    // any param parsing, cache read, SSE stream, or runPipeline — so no paid call
-    // fires for unauthorized users. Hard gate, no fallback. (Same pattern as the
-    // src/app/api/admin/* routes.)
-    const adminResult = await requireAdmin();
-    if (adminResult instanceof NextResponse) return adminResult;
-    const userEmail = adminResult; // the verified admin email
+    // TAB-SERVER-GATE (supersedes TRADING-PR-SEC's admin-only ruling): the scan
+    // hits PAID data feeds (TastyTrade market data / Finnhub / FRED / xAI), so it
+    // is gated to the tab:trade entitlement (or bundle:all; admin bypass inside
+    // requireTabAccess) — pay for the Trade tab and scans run. 401/403 BEFORE any
+    // param parsing, cache read, SSE stream, or runPipeline — no paid call fires
+    // for an unentitled user. NOTE: the pipeline reads MARKET data only via the
+    // shared TT session (chains/quotes/candles), never account state — the
+    // account-reading tastytrade/* routes stay requireAdmin (SEC4). Known gap,
+    // flagged not fixed here: no per-user scan spend quota beyond the 15-min cache.
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    const gateUser = await prisma.users.findFirst({
+      where: { email: { equals: userEmail, mode: 'insensitive' } },
+      select: { id: true },
+    });
+    if (!gateUser) {
+      return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    }
+    const tabGate = await requireTabAccess(gateUser.id, 'tab:trade');
+    if (tabGate) return tabGate;
 
     const { searchParams } = new URL(request.url);
 

--- a/src/app/api/trading/coverage/route.ts
+++ b/src/app/api/trading/coverage/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { requireTabAccess } from '@/lib/auth-helpers';
 
 /**
  * RISK-1 — GET /api/trading/coverage
@@ -27,6 +28,9 @@ export async function GET() {
     if (!user) {
       return NextResponse.json({ error: 'User not found' }, { status: 404 });
     }
+    // TAB-SERVER-GATE: tab:trade entitlement (bundle:all included; admin bypass inside).
+    const tabGate = await requireTabAccess(user.id, 'tab:trade');
+    if (tabGate) return tabGate;
 
     // 1. Investment-transaction count + date range (user-scoped via accounts relation).
     const txnAgg = await prisma.investment_transactions.aggregate({

--- a/src/app/api/trading/realized-pnl/route.ts
+++ b/src/app/api/trading/realized-pnl/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
-import { requireTier } from '@/lib/auth-helpers';
+import { requireTabAccess } from '@/lib/auth-helpers';
 
 /**
  * GET /api/trading/realized-pnl — the SEPARATE Trading panel's data (NOT a runway).
@@ -48,7 +48,8 @@ export async function GET() {
 
     // PAYWALL: Trading P&L analytics is a paid (Pro) feature — same requireTier
     // pattern as ai/cart-plan/route.ts:89-90.
-    const tierGate = requireTier(user.tier, 'tradingAnalytics', user.id);
+    // TAB-SERVER-GATE: tab:trade entitlement replaces the 'tradingAnalytics' tier gate
+    const tierGate = await requireTabAccess(user.id, 'tab:trade');
     if (tierGate) return tierGate;
 
     const userId = user.id;

--- a/src/app/api/trading/trades/route.ts
+++ b/src/app/api/trading/trades/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { requireTabAccess } from '@/lib/auth-helpers';
 
 export async function GET() {
   try {
@@ -11,6 +12,9 @@ export async function GET() {
       where: { email: { equals: userEmail, mode: 'insensitive' } }
     });
     if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    // TAB-SERVER-GATE: tab:trade entitlement (bundle:all included; admin bypass inside).
+    const tabGate = await requireTabAccess(user.id, 'tab:trade');
+    if (tabGate) return tabGate;
 
     // ========== OPTION TRADES (from investment_transactions) ==========
     const committedTxns = await prisma.investment_transactions.findMany({

--- a/src/app/api/transactions/sync-complete/route.ts
+++ b/src/app/api/transactions/sync-complete/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { plaidClient } from '@/lib/plaid';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { requireTabAccess } from '@/lib/auth-helpers';
 
 export const maxDuration = 300; // 5 minutes for Pro plan
 
@@ -20,6 +21,9 @@ export async function POST() {
     if (!user) {
       return NextResponse.json({ error: 'User not found' }, { status: 404 });
     }
+    // TAB-SERVER-GATE: tab:books entitlement (bundle:all included; admin bypass inside).
+    const tabGate = await requireTabAccess(user.id, 'tab:books');
+    if (tabGate) return tabGate;
 
     const plaidItems = await prisma.plaid_items.findMany({
       where: { userId: user.id },

--- a/src/app/api/transactions/sync-full/route.ts
+++ b/src/app/api/transactions/sync-full/route.ts
@@ -6,6 +6,7 @@ import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { plaidClient } from '@/lib/plaid';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { requireTabAccess } from '@/lib/auth-helpers';
 
 export async function POST() {
   console.warn('DEPRECATED: /api/transactions/sync-full called — use /api/transactions/sync-complete');
@@ -23,6 +24,9 @@ export async function POST() {
     if (!user) {
       return NextResponse.json({ error: 'User not found' }, { status: 404 });
     }
+    // TAB-SERVER-GATE: tab:books entitlement (bundle:all included; admin bypass inside).
+    const tabGate = await requireTabAccess(user.id, 'tab:books');
+    if (tabGate) return tabGate;
 
     const plaidItems = await prisma.plaid_items.findMany({
       where: { userId: user.id },

--- a/src/app/api/transactions/sync/route.ts
+++ b/src/app/api/transactions/sync/route.ts
@@ -6,6 +6,7 @@ import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { plaidClient } from '@/lib/plaid';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { requireTabAccess } from '@/lib/auth-helpers';
 
 export async function POST() {
   console.warn('DEPRECATED: /api/transactions/sync called — use /api/transactions/sync-complete');
@@ -23,6 +24,9 @@ export async function POST() {
     if (!user) {
       return NextResponse.json({ error: 'User not found' }, { status: 404 });
     }
+    // TAB-SERVER-GATE: tab:books entitlement (bundle:all included; admin bypass inside).
+    const tabGate = await requireTabAccess(user.id, 'tab:books');
+    if (tabGate) return tabGate;
 
     const plaidItems = await prisma.plaid_items.findMany({
       where: { userId: user.id },

--- a/src/app/api/trial-balance/route.ts
+++ b/src/app/api/trial-balance/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { Prisma } from '@prisma/client';
 import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { requireTabAccess } from '@/lib/auth-helpers';
 
 // GAAP-Compliant Trial Balance API
 //
@@ -36,6 +37,9 @@ export async function GET(request: NextRequest) {
     if (!user) {
       return NextResponse.json({ error: 'User not found' }, { status: 404 });
     }
+    // TAB-SERVER-GATE: tab:books entitlement (bundle:all included; admin bypass inside).
+    const tabGate = await requireTabAccess(user.id, 'tab:books');
+    if (tabGate) return tabGate;
 
     const { searchParams } = new URL(request.url);
     const entityId = searchParams.get('entityId');

--- a/src/app/api/workbench/search/route.ts
+++ b/src/app/api/workbench/search/route.ts
@@ -11,6 +11,8 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { prisma } from '@/lib/prisma';
+import { requireTabAccess } from '@/lib/auth-helpers';
 import { searchCorpus } from '@/lib/corpus/retrieve';
 import type { RetrievalMode } from '@/lib/corpus/retrieve';
 
@@ -27,6 +29,18 @@ export async function POST(request: NextRequest) {
   if (!email) {
     return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
   }
+
+  // TAB-SERVER-GATE: tab:compliance entitlement (bundle:all included; admin
+  // bypass inside) — BEFORE the paid Voyage embedding/rerank call below.
+  const gateUser = await prisma.users.findFirst({
+    where: { email: { equals: email, mode: 'insensitive' } },
+    select: { id: true },
+  });
+  if (!gateUser) {
+    return NextResponse.json({ error: 'User not found' }, { status: 404 });
+  }
+  const tabGate = await requireTabAccess(gateUser.id, 'tab:compliance');
+  if (tabGate) return tabGate;
 
   try {
     const body = (await request.json()) as SearchRequestBody;

--- a/src/app/api/year-end-close/route.ts
+++ b/src/app/api/year-end-close/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { Prisma } from '@prisma/client';
 import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { requireTabAccess } from '@/lib/auth-helpers';
 
 // GAAP Year-End Close API
 //
@@ -38,6 +39,9 @@ export async function POST(request: NextRequest) {
     if (!user) {
       return NextResponse.json({ error: 'User not found' }, { status: 404 });
     }
+    // TAB-SERVER-GATE: tab:books entitlement (bundle:all included; admin bypass inside).
+    const tabGate = await requireTabAccess(user.id, 'tab:books');
+    if (tabGate) return tabGate;
 
     const { entityId, year } = await request.json();
 
@@ -338,6 +342,9 @@ export async function GET(request: NextRequest) {
     if (!user) {
       return NextResponse.json({ error: 'User not found' }, { status: 404 });
     }
+    // TAB-SERVER-GATE: tab:books entitlement (bundle:all included; admin bypass inside).
+    const tabGate = await requireTabAccess(user.id, 'tab:books');
+    if (tabGate) return tabGate;
 
     const { searchParams } = new URL(request.url);
     const entityId = searchParams.get('entityId');


### PR DESCRIPTION
…t (pay = tab works)

63 route files, 89 gate sites: Trade (scan requireAdmin→tab:trade; trades/coverage/ commit/journal/cards/links/ticker-context added; realized-pnl + 4 AI routes swapped from tier), Books (4 Plaid routes tier→tab:books; sync/journal/ledger/statements/ COA/reconciliation/close/trial-balance/merchants/accounts/spending-insights), Tax (all tax routes + estimate + mappings + cpa-export), Compliance (citations/ discovery/tasks/missions/regulatory-sources/workbench-search incl. Voyage+Anthropic paid calls). KEPT requireAdmin: all 13 tastytrade/* (SEC4 — shared FIRM brokerage account, account-data exposure), close-outcomes, test/convergence, data-observatory. KEPT FREE: transactions/manual (free-tier manualEntry). AI rate limits retained.


Claude-Session: https://claude.ai/code/session_0166NgTwN2YavGPvPwra9Ycz