### PR TITLE
SCAN-SPEND-QUOTA: per-user run quota on the Trade scan pipeline (clos…

### DIFF
--- a/src/app/api/trading/convergence/route.ts
+++ b/src/app/api/trading/convergence/route.ts
@@ -3,6 +3,7 @@ import { runPipeline } from '@/lib/convergence/pipeline';
 import type { PipelineResult } from '@/lib/convergence/pipeline';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { requireTabAccess } from '@/lib/auth-helpers';
+import { requireScanRateLimit } from '@/lib/scan-rate-limit';
 import { prisma } from '@/lib/prisma';
 
 export const maxDuration = 300;
@@ -49,8 +50,10 @@ export async function GET(request: Request) {
     // param parsing, cache read, SSE stream, or runPipeline — no paid call fires
     // for an unentitled user. NOTE: the pipeline reads MARKET data only via the
     // shared TT session (chains/quotes/candles), never account state — the
-    // account-reading tastytrade/* routes stay requireAdmin (SEC4). Known gap,
-    // flagged not fixed here: no per-user scan spend quota beyond the 15-min cache.
+    // account-reading tastytrade/* routes stay requireAdmin (SEC4).
+    // SCAN-SPEND-QUOTA closes the gap previously flagged here: a per-user run
+    // quota (requireScanRateLimit) sits at BOTH pipeline-fire points below —
+    // after this tab gate, before runPipeline. Cache hits stay free.
     const userEmail = await getVerifiedEmail();
     if (!userEmail) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
@@ -78,6 +81,13 @@ export async function GET(request: Request) {
 
     // ===== SSE STREAMING PATH =====
     if (stream) {
+      // SCAN-SPEND-QUOTA: the stream path NEVER reads the cache — every stream
+      // request runs the full paid pipeline — so the per-user run quota is
+      // checked BEFORE the stream (and any paid call) starts. Over-quota → a
+      // plain 429 + Retry-After instead of an SSE response.
+      const scanQuota = await requireScanRateLimit(gateUser.id);
+      if (scanQuota) return scanQuota;
+
       // Resolve userId for snapshot logging
       let userId: string | undefined;
       let snapshotLookupError: string | null = null;
@@ -138,6 +148,13 @@ export async function GET(request: Request) {
     }
 
     // Cache miss or refresh — run full pipeline
+    // SCAN-SPEND-QUOTA: quota is checked AFTER the cache read (a cache hit above
+    // returned without consuming quota — it fires no paid call) and BEFORE
+    // runPipeline. refresh=true skipped the cache, so it lands here and pays
+    // quota like any other full run.
+    const scanQuota = await requireScanRateLimit(gateUser.id);
+    if (scanQuota) return scanQuota;
+
     console.log(`[Convergence Route] Cache MISS (limit=${limit}, refresh=${refresh}, universe=${universe ?? 'all'})`);
 
     // Resolve userId for snapshot logging (non-blocking — pipeline runs even if lookup fails)

--- a/src/lib/scan-rate-limit.ts
+++ b/src/lib/scan-rate-limit.ts
@@ -1,0 +1,62 @@
+import { NextResponse } from 'next/server';
+import { rateLimit, RateLimitError } from '@/lib/rateLimit';
+
+// SCAN-SPEND-QUOTA: per-user RUN quota for the Trade scan/convergence pipeline.
+// The scan route gates tab ACCESS (requireTabAccess('tab:trade')) but not volume;
+// one entitled user could loop scans and each run fires the full paid surface
+// (Finnhub batch + TastyTrade chains + xAI sentiment on the top-9). The 15-min
+// in-memory cache is NOT a per-user brake: it is keyed (limit, universe) only,
+// refresh=true bypasses it, and the SSE stream path never reads it — every
+// stream request runs the full pipeline.
+//
+// This is a SEPARATE bucket from ai:${userId} (ai-rate-limit.ts) on purpose:
+// one scan run is far heavier than one LLM call (a whole pipeline of paid
+// fetches), so sharing the 30/hr AI bucket would either starve interactive AI
+// use or under-cap scans. Same durable rateLimit() helper, scan-specific key —
+// no new limiter shape invented.
+//
+// Env-tunable, mirroring ai-rate-limit.ts (AI_RATE_LIMIT / AI_RATE_WINDOW) and
+// rateLimit.ts's searchRateLimitDefaults pattern, so Alex can retune without a
+// deploy.
+//
+// ⚠️ PROPOSED DEFAULTS — pending Alex's ruling. No scan-rate precedent existed
+// to mirror; 4 runs / hour / user aligns with the 15-minute cache cadence (data
+// refreshes at most every 15 min, so >4 fresh runs/hr buys no new information)
+// while capping a runaway loop at 4 full pipeline runs instead of unbounded
+// paid-API spend. Adjust via SCAN_RATE_LIMIT / SCAN_RATE_WINDOW, or change the
+// constants below.
+const SCAN_RATE_LIMIT_DEFAULT = 4;
+const SCAN_RATE_WINDOW_DEFAULT = 3600; // seconds (1 hour)
+
+function scanRateDefaults(): { limit: number; windowSeconds: number } {
+  const limit = parseInt(process.env.SCAN_RATE_LIMIT || '', 10);
+  const windowSeconds = parseInt(process.env.SCAN_RATE_WINDOW || '', 10);
+  return {
+    limit: Number.isFinite(limit) && limit > 0 ? limit : SCAN_RATE_LIMIT_DEFAULT,
+    windowSeconds: Number.isFinite(windowSeconds) && windowSeconds > 0 ? windowSeconds : SCAN_RATE_WINDOW_DEFAULT,
+  };
+}
+
+/**
+ * Per-user run quota for the scan/convergence pipeline. Returns a 429
+ * NextResponse (with Retry-After) when the user has exceeded the window, else
+ * null (caller proceeds). Call AFTER requireTabAccess('tab:trade') and BEFORE
+ * runPipeline fires — cache hits stay free (don't consume quota) and no paid
+ * call fires on an over-quota request. Fail-loud: a non-RateLimitError from
+ * the durable counter rethrows — never a default-allow past the quota.
+ */
+export async function requireScanRateLimit(userId: string): Promise<NextResponse | null> {
+  const { limit, windowSeconds } = scanRateDefaults();
+  try {
+    await rateLimit(`scan:${userId}`, { limit, windowSeconds });
+    return null;
+  } catch (error) {
+    if (error instanceof RateLimitError) {
+      return NextResponse.json(
+        { error: 'Scan run limit reached — please wait before running another scan.' },
+        { status: 429, headers: { 'Retry-After': String(error.retryAfterSeconds) } }
+      );
+    }
+    throw error;
+  }
+}


### PR DESCRIPTION
…e the tab-gated scan cost hole)

Phase 1 (audit) established the scan's paid surface per run — Finnhub batch (pipeline.ts:765), TastyTrade market-data chains (pipeline.ts:384), xAI sentiment on the top-9 (pipeline.ts:1571), plus free FRED/SEC EDGAR — and that its ONLY brake was the 15-min in-memory cache, which is not per-user, is bypassed by refresh=true, and is never read by the SSE stream path (every stream request runs the full pipeline). No requireAiRateLimit either: the shared ai:$ bucket never covered the scan.

Fix — no new limiter invented, the existing pattern mirrored exactly:

- src/lib/scan-rate-limit.ts (new): requireScanRateLimit(userId), a structural mirror of ai-rate-limit.ts over the same durable rateLimit() helper, keyed scan:userId (separate bucket — one scan run is far heavier than one LLM call). Env-tunable via SCAN_RATE_LIMIT / SCAN_RATE_WINDOW. ⚠️ PROPOSED DEFAULTS pending Alex's ruling: 4 runs / hour / user, aligned to the 15-min cache cadence. Fail-loud: non-RateLimitError rethrows — never a default-allow past the quota.

- src/app/api/trading/convergence/route.ts: quota checked at BOTH pipeline-fire points, after the tab:trade gate and before runPipeline — stream path before the SSE stream starts (it never reads the cache), and non-stream path after the cache read (cache hits stay free; refresh=true pays quota). Over-quota → 429 with Retry-After; no paid call fires.

Verified: tsc clean; gate→quota→pipeline order confirmed at both fire points; tripwire grep clean (no default-allow/silent catch/fallback in added lines); behavioral trace green (4 allowed → 5th 429 w/ Retry-After, per-user isolation, env override, fail-loud on counter error); next build passes.


Claude-Session: https://claude.ai/code/session_0166NgTwN2YavGPvPwra9Ycz