### PR TITLE
TIER-FLAG-CLEANUP: retire orphaned plaid/tradingAnalytics tier flags …

### DIFF
--- a/src/app/api/trading/realized-pnl/route.ts
+++ b/src/app/api/trading/realized-pnl/route.ts
@@ -23,9 +23,11 @@ import { requireTabAccess } from '@/lib/auth-helpers';
  *   • Drawdown — no peak/trough data exists. `tracked: false`.
  *
  * PAYWALL ruling (supersedes the earlier "requireTier is correctly absent" note): this route IS
- * the "Trading P&L analytics" feature sold on the Pro tier (tiers.ts tradingAnalytics), so it is
- * tier-gated even though it spends no external money — the gate here is the PAYWALL, not a
- * cost control. Free tier → 403 (tradingAnalytics: false); Pro/Pro+ → allowed; admin bypasses.
+ * the Trading P&L analytics feature — a paid module surface, so it is gated even though it
+ * spends no external money; the gate here is the PAYWALL, not a cost control. Since
+ * TAB-SERVER-GATE that gate is the tab:trade entitlement (requireTabAccess below):
+ * unentitled → 403; tab:trade or bundle:all → allowed; admin bypasses. (The old
+ * tier-based 'tradingAnalytics' flag was retired by TIER-FLAG-CLEANUP.)
  */
 
 // Trading entity — IMMUTABLE entity_id (psql-confirmed; entity_type is inconsistent across seeds —

--- a/src/components/home/ModuleLauncher.tsx
+++ b/src/components/home/ModuleLauncher.tsx
@@ -332,11 +332,11 @@ export default function ModuleLauncher({ onRequireAuth, onTabChange }: Props) {
   // onLinkAccount — faithful to dashboard/page.tsx:334 (openPlaidLink): open Plaid Link
   // with the auth-gated link token; on success POST the auth-gated /api/plaid/exchange-token
   // then re-read the cockpit. The dashboard's free-tier upgrade-modal branch is intentionally
-  // omitted: TAB-SHOW-AND-GATE made this surface tab-entitlement-gated, and Plaid itself
-  // stays TIER-gated server-side (/api/plaid/link-token requireTier('plaid')) — a
-  // tab-entitled free-tier user gets no link token, so this button no-ops until the
-  // tier/entitlement seam is ruled in the server-gate PR (item 4). Guards on token +
-  // window.Plaid exactly like the dashboard (no fallback).
+  // omitted: this surface and the server routes it calls are both tab:books-gated
+  // (TAB-SHOW-AND-GATE client-side; TAB-SERVER-GATE flipped /api/plaid/link-token +
+  // exchange-token to requireTabAccess('tab:books')) — an unentitled user gets no link
+  // token, so this button no-ops. Guards on token + window.Plaid exactly like the
+  // dashboard (no fallback).
   const booksLinkAccount = () => {
     if (!booksLinkToken || !(window as any).Plaid) return; // eslint-disable-line @typescript-eslint/no-explicit-any
     (window as any).Plaid.create({ // eslint-disable-line @typescript-eslint/no-explicit-any

--- a/src/lib/auth-helpers.ts
+++ b/src/lib/auth-helpers.ts
@@ -36,7 +36,7 @@ export async function requireUser() {
  * Returns null if allowed, or a NextResponse 403 if blocked.
  *
  * Usage in any API route:
- *   const gate = requireTier(user.tier, 'plaid');
+ *   const gate = requireTier(user.tier, 'ai');
  *   if (gate) return gate;
  */
 export function requireTier(tier: string | null | undefined, feature: keyof TierConfig, userId?: string | null): NextResponse | null {

--- a/src/lib/tiers.ts
+++ b/src/lib/tiers.ts
@@ -10,9 +10,11 @@
  * The MODULES (Trade/Books/Tax/Compliance incl. Plaid sync, trading analytics,
  * wash sales, reconciliation, spending insights) are NOT tier features anymore —
  * they are per-tab entitlements (hasTabAccess, src/lib/entitlements.ts).
- * The 'plaid' and 'tradingAnalytics' flags below have ZERO requireTier callers
- * left; kept only for canAccess compatibility until a cleanup PR retires them.
- * maxLinkedAccounts is defined but ENFORCED NOWHERE (standing flagged follow-up).
+ * The orphaned 'plaid' and 'tradingAnalytics' flags were RETIRED by
+ * TIER-FLAG-CLEANUP (zero live gate readers after TAB-SERVER-GATE).
+ * maxLinkedAccounts is defined but not enforced — DEFERRED BY RULING
+ * (audit-reports/MAXLINKED-RULING.md): no cap on tab:books buyers now;
+ * usage-tiered pricing is a future feature.
  *
  * NOTE: All paid tiers are currently gated as "Coming Soon" for public users.
  * Only the admin user (ADMIN_USER_ID) has full access to all features.
@@ -25,10 +27,8 @@ export type Tier = 'free' | 'pro' | 'pro_plus';
 
 export interface TierConfig {
   label: string;
-  plaid: boolean;
   ai: boolean;
   manualEntry: boolean;
-  tradingAnalytics: boolean;
   tripPlanning: boolean;
   tripAI: boolean;
   placesSearch: boolean;
@@ -38,10 +38,8 @@ export interface TierConfig {
 const TIER_MAP: Record<Tier, TierConfig> = {
   free: {
     label: 'Free',
-    plaid: false,
     ai: false,
     manualEntry: true,
-    tradingAnalytics: false,
     tripPlanning: true,
     tripAI: false,
     placesSearch: false,
@@ -49,10 +47,8 @@ const TIER_MAP: Record<Tier, TierConfig> = {
   },
   pro: {
     label: 'Pro',
-    plaid: true,
     ai: false,
     manualEntry: true,
-    tradingAnalytics: true,
     tripPlanning: true,
     tripAI: false,
     placesSearch: true,
@@ -60,10 +56,8 @@ const TIER_MAP: Record<Tier, TierConfig> = {
   },
   pro_plus: {
     label: 'Pro+',
-    plaid: true,
     ai: true,
     manualEntry: true,
-    tradingAnalytics: true,
     tripPlanning: true,
     tripAI: true,
     placesSearch: true,


### PR DESCRIPTION
…(dead after tab-gating)

Phase 1 proved zero live gate readers for both flags (full grep sweep, src/ and repo-wide): no requireTier('plaid'|'tradingAnalytics'), no canAccess with either key, no property reads on TierConfig — the live requireTier call sites use only 'ai', 'tripAI', 'placesSearch'. The flags were orphaned when TAB-SERVER-GATE flipped Plaid routes to tab:books and trading analytics to tab:trade.

Removed: the two flag fields from the TierConfig interface and all three tier value blocks (tiers.ts — the only non-comment change). Also fixed the dead comments that still named them: auth-helpers.ts requireTier JSDoc example ('plaid' → live 'ai'), ModuleLauncher.tsx stale claim that link-token was still tier-gated (it is tab:books- gated), realized-pnl stale PAYWALL doc block (gate is tab:trade), and the tiers.ts header (retirement recorded; maxLinkedAccounts line now cites the MAXLINKED-RULING deferral).

No gate weakened: diff tripwire confirms the only non-comment lines changed are the 8 flag-definition removals; every requireTabAccess gate untouched. tsc clean; next build "Compiled successfully".


Claude-Session: https://claude.ai/code/session_0166NgTwN2YavGPvPwra9Ycz