### PR TITLE
TRADE-SHOWCASE-FULL: full-product logged-out showcase — real filter p…

### DIFF
--- a/src/components/home/TabShowcaseTemplate.tsx
+++ b/src/components/home/TabShowcaseTemplate.tsx
@@ -47,9 +47,12 @@ export interface TabShowcaseTemplateProps {
   /** Rail-level honesty tag (e.g. "Example scan — real steps, sample counts"). */
   stepsTag: string;
   steps: ShowcaseStep[];
-  /** Title over the concept cards (e.g. "The four gates"). */
-  cardsTitle: string;
-  cards: ShowcaseConceptCard[];
+  /** Optional footer inside the pipe card (e.g. the funnel/runtime line). */
+  stepsFooter?: ReactNode;
+  /** Title over the concept cards (e.g. "The four gates"). Optional — a tab
+   *  may teach its concepts inside richer sections instead. */
+  cardsTitle?: string;
+  cards?: ShowcaseConceptCard[];
   /** The honest sample block (tab-specific; engine-derived where possible). */
   sample: ReactNode;
   /** One teaching line under the sample (e.g. the no-manufactured-trades line). */
@@ -58,7 +61,7 @@ export interface TabShowcaseTemplateProps {
   cta: ReactNode;
 }
 
-function ExampleTag({ text }: { text: string }) {
+export function ExampleTag({ text }: { text: string }) {
   return (
     <span className="inline-block rounded border border-brand-amber/40 bg-brand-amber/10 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-brand-amber">
       {text}
@@ -73,6 +76,7 @@ export default function TabShowcaseTemplate({
   stepsTitle,
   stepsTag,
   steps,
+  stepsFooter,
   cardsTitle,
   cards,
   sample,
@@ -110,21 +114,24 @@ export default function TabShowcaseTemplate({
             </li>
           ))}
         </ol>
+        {stepsFooter && <div className="border-t border-border px-4 py-2.5">{stepsFooter}</div>}
       </div>
 
-      {/* ── Concept cards (the four gates, for Trade) ── */}
-      <div>
-        <p className="mb-2 text-[11px] font-bold uppercase tracking-wider text-text-muted">{cardsTitle}</p>
-        <div className="grid gap-3 sm:grid-cols-2">
-          {cards.map((c) => (
-            <div key={c.name} className="rounded-lg border border-border bg-white p-4">
-              <p className="font-semibold text-brand-purple">{c.name}</p>
-              <p className="mt-1 text-sm text-text-primary">{c.asks}</p>
-              <p className="mt-2 text-xs leading-relaxed text-text-muted">{c.measures}</p>
-            </div>
-          ))}
+      {/* ── Concept cards (optional — a tab may teach inside richer sections) ── */}
+      {cards && cards.length > 0 && (
+        <div>
+          {cardsTitle && <p className="mb-2 text-[11px] font-bold uppercase tracking-wider text-text-muted">{cardsTitle}</p>}
+          <div className="grid gap-3 sm:grid-cols-2">
+            {cards.map((c) => (
+              <div key={c.name} className="rounded-lg border border-border bg-white p-4">
+                <p className="font-semibold text-brand-purple">{c.name}</p>
+                <p className="mt-1 text-sm text-text-primary">{c.asks}</p>
+                <p className="mt-2 text-xs leading-relaxed text-text-muted">{c.measures}</p>
+              </div>
+            ))}
+          </div>
         </div>
-      </div>
+      )}
 
       {/* ── The honest sample ── */}
       {sample}

--- a/src/components/home/TabShowcases.tsx
+++ b/src/components/home/TabShowcases.tsx
@@ -27,12 +27,20 @@
 
 import { useState } from 'react';
 import { Lock } from 'lucide-react';
-// SHOWROOM-TRUTH-FIX: engine-computed demo rows (real scoreAll on declared
-// fictional inputs) — see tradeShowcaseRows.ts for the declared fixture.
-import { TRADE_SHOWCASE_ROWS, TRADE_SHOWCASE_BRAKE } from '@/components/home/tradeShowcaseRows';
 // TRADE-SHOWCASE-BUILD: the reusable Plaid-style showcase template (hero band +
-// real pipe rail + concept cards + honest sample + CTA) — tabs 2–9 reuse it.
-import TabShowcaseTemplate, { type ShowcaseStep, type ShowcaseConceptCard } from '@/components/home/TabShowcaseTemplate';
+// real pipe rail + optional concept cards + sample/CTA slots) — tabs 2–9 reuse it.
+import TabShowcaseTemplate, { type ShowcaseStep } from '@/components/home/TabShowcaseTemplate';
+// TRADE-SHOWCASE-FULL: the full-product sections (real interactive filter
+// panel + track-record / graded-card / deep-dive mirrors per the
+// TRADE-FULL-INVENTORY rulings). Engine-real values come from the scoreAll
+// fixture inside these sections.
+import {
+  ScannerPanelDemo,
+  TrackRecordMirror,
+  GradedCardMirror,
+  DeepDiveMirror,
+  TRADE_UNLOCK_CTA_ID,
+} from '@/components/home/TradeShowcaseSections';
 
 // ── shared chrome ────────────────────────────────────────────────────────────
 
@@ -166,34 +174,7 @@ const TRADE_PIPE_STEPS: ShowcaseStep[] = [
   { code: 'T', label: 'Save & Return', summary: 'snapshot saved for the self-graded record' },
 ];
 
-// Drawn from the gates' real explainer copy (ConvergenceIntelligence.tsx:874-877).
-const TRADE_GATE_CARDS: ShowcaseConceptCard[] = [
-  {
-    name: 'Vol Edge',
-    asks: 'Are these options priced rich against how the stock actually moves?',
-    measures: 'VRP z-score, IV percentile, term-structure shape, skew asymmetry, dealer gamma exposure. Above 50 = options look expensive = edge for premium sellers.',
-  },
-  {
-    name: 'Quality',
-    asks: 'Is the company underneath actually healthy?',
-    measures: 'Piotroski F-Score safety, profitability margins, earnings quality (accruals + beat rate), growth trajectory. Above 50 = high-quality underlying.',
-  },
-  {
-    name: 'Regime',
-    asks: 'Does today’s macro backdrop favor this trade at all?',
-    measures: 'Scored from 14 FRED macro indicators — GDP, CPI, Fed Funds, yield curve, credit spreads. Above 50 = favorable macro backdrop.',
-  },
-  {
-    name: 'Info Edge',
-    asks: 'Do the people with better information seem to know something?',
-    measures: 'Insider net purchases (MSPR), institutional ownership changes, analyst upgrades/downgrades, earnings surprise (SUE), news sentiment. Above 50 = positive information asymmetry.',
-  },
-];
-
 export function TradeShowcase({ currentUserId, onRequireAuth }: ShowcaseProps) {
-  // Drift-proof teaching line: derived from the engine rows themselves — it
-  // names the NO-TRADE case only if the engine actually produced one.
-  const noTradeRow = TRADE_SHOWCASE_ROWS.find((r) => r.positionSizePct === 0);
   return (
     <TabShowcaseTemplate
       heroBadge="The Trade tab"
@@ -202,87 +183,33 @@ export function TradeShowcase({ currentUserId, onRequireAuth }: ShowcaseProps) {
       stepsTitle="The pipe — 20 steps, A to T"
       stepsTag="Example scan — real steps, sample counts"
       steps={TRADE_PIPE_STEPS}
-      cardsTitle="The four gates — every ticker answers all four"
-      cards={TRADE_GATE_CARDS}
-      teachingLine={
-        noTradeRow
-          ? `In this example scan ${noTradeRow.ticker} came out "${noTradeRow.gate}". The engine will not manufacture a trade just to have something to sell — when convergence fails, the honest output is no trade.`
-          : undefined
+      stepsFooter={
+        <p className="text-xs text-text-muted">
+          Example funnel: <span className="font-mono text-text-primary">475 → 52 → 40 → 20 → 9</span>{' '}
+          (universe → hard filters → enriched → scored → selected) · 128 Finnhub calls · ~94s runtime.
+          475, 40, 20 and 9 are the real defaults; the rest are sample counts.
+        </p>
+      }
+      sample={
+        <>
+          <ScannerPanelDemo currentUserId={currentUserId} onRequireAuth={onRequireAuth} />
+          <TrackRecordMirror />
+          <GradedCardMirror />
+          <DeepDiveMirror />
+        </>
       }
       cta={
-        <LockedTabCard
-          tabKey="tab:trade"
-          label="Trading"
-          valueLine="Run live scans on real market data, with the reconcile queue and the self-graded record."
-          currentUserId={currentUserId}
-          onRequireAuth={onRequireAuth}
-        />
+        <div id={TRADE_UNLOCK_CTA_ID}>
+          <LockedTabCard
+            tabKey="tab:trade"
+            label="Trading"
+            valueLine="Run live scans on real market data, with the reconcile queue and the self-graded record."
+            currentUserId={currentUserId}
+            onRequireAuth={onRequireAuth}
+          />
+        </div>
       }
-      sample={<TradeSampleResult />}
     />
-  );
-}
-
-/** The honest sample result: rows computed by the real scoreAll() on declared
- *  fictional inputs (tradeShowcaseRows.ts) — gate captions verbatim. */
-function TradeSampleResult() {
-  return (
-    <div className="space-y-3">
-      <div className="flex flex-wrap items-center gap-2">
-        <p className="text-[11px] font-bold uppercase tracking-wider text-text-muted">A finished scan — scored by the real engine</p>
-        <DemoTag />
-      </div>
-      <div className="overflow-x-auto rounded-lg border border-border bg-white">
-        <table className="w-full min-w-[640px] text-sm">
-          <thead>
-            <tr className="border-b border-border text-left text-[11px] uppercase tracking-wider text-text-muted">
-              <th className="px-3 py-2 font-medium">Ticker</th>
-              <th className="px-3 py-2 font-medium text-right">Vol edge</th>
-              <th className="px-3 py-2 font-medium text-right">Quality</th>
-              <th className="px-3 py-2 font-medium text-right">Regime</th>
-              <th className="px-3 py-2 font-medium text-right">Info edge</th>
-              <th className="px-3 py-2 font-medium text-right">Composite</th>
-              <th className="px-3 py-2 font-medium">Suggestion</th>
-            </tr>
-          </thead>
-          <tbody>
-            {TRADE_SHOWCASE_ROWS.map((r) => (
-              <tr key={r.ticker} className="border-b border-border-light last:border-0">
-                <td className="px-3 py-2 font-mono font-semibold text-text-primary">{r.ticker}</td>
-                <td className="px-3 py-2 text-right">{r.volEdge ?? '—'}</td>
-                <td className="px-3 py-2 text-right">{r.quality ?? '—'}</td>
-                <td className="px-3 py-2 text-right">{r.regime ?? '—'}</td>
-                <td className="px-3 py-2 text-right">{r.infoEdge ?? '—'}</td>
-                <td className="px-3 py-2 text-right font-semibold">{r.composite ?? '—'}</td>
-                {/* The engine's own gate caption, verbatim; the strategy renders
-                    only when the engine actually sized the trade above zero. */}
-                <td className="px-3 py-2 text-xs text-text-secondary">
-                  {r.gate}
-                  {r.positionSizePct > 0 && ` · ${r.strategy} · ${r.suggestedDte} DTE`}
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
-      <div className="grid gap-3 sm:grid-cols-3 text-xs text-text-secondary">
-        <div className="rounded-lg border border-border bg-white p-3">
-          <p className="font-semibold text-text-primary">Honest by construction</p>
-          <p className="mt-1">Every score declares its inputs — &quot;computed from 14/16 signals&quot; — and missing data is excluded, never faked.</p>
-        </div>
-        <div className="rounded-lg border border-border bg-white p-3">
-          <p className="font-semibold text-text-primary">The survival brake</p>
-          {/* The engine's own brake declaration for the declared demo macro —
-              rendered verbatim, never asserted by hand. */}
-          <p className="mt-1">Backwardation or elevated VVIX cuts short-vol suggestions automatically — declared on every run, e.g. <span className="font-mono">{TRADE_SHOWCASE_BRAKE.declaration}</span>.</p>
-        </div>
-        <div className="rounded-lg border border-border bg-white p-3">
-          <p className="font-semibold text-text-primary">Graded against reality</p>
-          <p className="mt-1">Every scan is snapshotted and later scored against what actually happened — a public, self-graded track record.</p>
-        </div>
-      </div>
-      <p className="text-xs text-text-faint">Data, not directives — analytics you act on independently. Fictional tickers with declared example inputs — but every score above was computed by the real scoring engine on those inputs; nothing is a live price or a recommendation.</p>
-    </div>
   );
 }
 

--- a/src/components/home/TradeShowcaseSections.tsx
+++ b/src/components/home/TradeShowcaseSections.tsx
@@ -1,0 +1,329 @@
+'use client';
+
+/**
+ * TRADE-SHOWCASE-FULL: the full-product sections of the logged-out Trade
+ * showcase, built to the TRADE-FULL-INVENTORY rulings (audit-reports/
+ * TRADE-FULL-INVENTORY.md, Phase 2 table):
+ *
+ *  • ScannerPanelDemo — DIRECT REUSE ruling: the REAL ScanFilterForm mounts
+ *    presentationally (it is props+callbacks only, zero fetches —
+ *    ScanFilterForm.tsx:10-12). Local state, DEFAULT_FILTERS; the Scan button
+ *    NEVER fires a scan — logged-out it opens the signup modal, logged-in
+ *    (but locked) it scrolls to the Unlock CTA.
+ *  • TrackRecordMirror — STATIC MIRROR ruling: TradeRecord self-fetches
+ *    (TradeRecord.tsx:47-50) so it cannot mount logged-out; this mirrors its
+ *    exact section order (denominator-first counts, W–L–BE of decided, net
+ *    P&L, the max-loss integrity line, A–F grades) with labeled example values.
+ *  • GradedCardMirror — STATIC MIRROR ruling: TradeLabPanel self-fetches
+ *    (TradeLabPanel.tsx:118-131); this mirrors the expanded scorecard layout
+ *    (:565-679): legs, PREDICTED vs ACTUAL, actual P&L, grade badge, thesis
+ *    ✓/✗ mechanic, regime line. Example values are internally coherent
+ *    (credit 1.85 on a $5-wide spread → max profit $185 / max loss $315 /
+ *    R:R 0.59; exit 0.43 → P&L +$142 ≤ max profit) and labeled EXAMPLE.
+ *    The regime line is the ENGINE's own brake declaration (engine-real).
+ *  • DeepDiveMirror — EXAMPLE-FED ruling: gate scores are ENGINE-REAL from
+ *    the scoreAll fixture (tradeShowcaseRows.ts); FOR vs AGAINST is DERIVED
+ *    from those engine gates (>50 = for, ≤50 = against — the engine's own
+ *    above-50 convention); the strategy-rejection line mirrors the real
+ *    rejection_reasons shape (ConvergenceIntelligence.tsx:71-76) as a labeled
+ *    example; the NO-TRADE teaching quotes the engine's caption verbatim.
+ *
+ * SHOW discipline: ZERO fetches, zero paid calls, nothing personal, no
+ * auth/gate logic. All example values labeled.
+ */
+
+import { useRef, useState } from 'react';
+import ScanFilterForm from '@/components/trading/ScanFilterForm';
+import type { ScannerFilters } from '@/lib/convergence/filter-types';
+import { DEFAULT_FILTERS } from '@/lib/convergence/filter-types';
+import { TRADE_SHOWCASE_ROWS, TRADE_SHOWCASE_BRAKE } from '@/components/home/tradeShowcaseRows';
+import { ExampleTag } from '@/components/home/TabShowcaseTemplate';
+
+/** id the Scan button scrolls to for logged-in-but-locked viewers. */
+export const TRADE_UNLOCK_CTA_ID = 'trade-unlock-cta';
+
+function SectionTitle({ title, tag }: { title: string; tag?: string }) {
+  return (
+    <div className="flex flex-wrap items-center gap-2 border-b border-border px-4 py-2.5">
+      <p className="text-[11px] font-bold uppercase tracking-wider text-text-muted">{title}</p>
+      {tag && <ExampleTag text={tag} />}
+    </div>
+  );
+}
+
+// ── 3. THE SCANNER — the REAL filter panel, interactive ─────────────────────
+
+export function ScannerPanelDemo({
+  currentUserId,
+  onRequireAuth,
+}: {
+  currentUserId: string;
+  onRequireAuth: () => void;
+}) {
+  const [universe, setUniverse] = useState('sp500');
+  const [filters, setFilters] = useState<ScannerFilters>(DEFAULT_FILTERS);
+  // The real form calls scanTriggerRef.current() on Scan. Here that NEVER
+  // fires a scan: logged-out → signup modal; logged-in (locked) → the CTA.
+  const scanRef = useRef<(() => void) | null>(null);
+  scanRef.current = () => {
+    if (!currentUserId) {
+      onRequireAuth();
+    } else {
+      document.getElementById(TRADE_UNLOCK_CTA_ID)?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+  };
+
+  return (
+    <div className="rounded-lg border border-border bg-white">
+      <SectionTitle title="The scanner — every control is real. Set your filters, hit Scan." />
+      <div className="p-4">
+        <ScanFilterForm
+          scannerUniverse={universe}
+          setScannerUniverse={setUniverse}
+          scannerFilters={filters}
+          onFiltersChange={setFilters}
+          scanTriggerRef={scanRef}
+          showHeader={false}
+        />
+      </div>
+      <p className="border-t border-border px-4 py-2 text-xs text-text-muted">
+        This is the live tab&rsquo;s actual filter panel — 4 liquidity gates, 6 edge metrics, 16
+        strategies, DTE and width — not a mockup. Scan here takes you to sign-up; no scan runs
+        until you&rsquo;re in.
+      </p>
+    </div>
+  );
+}
+
+// ── 4. TRACK RECORD — faithful static mirror of TradeRecord.tsx ─────────────
+
+export function TrackRecordMirror() {
+  return (
+    <div className="rounded-lg border border-border bg-white text-xs text-text-secondary">
+      <SectionTitle title="The track record — self-graded, denominator first" tag="Example data" />
+      {/* Mirrors TradeRecord.tsx section order exactly (:131-181). */}
+      <div className="border-b border-border px-4 py-2">
+        Record: <span className="font-mono font-semibold text-text-primary">7</span> linked trades
+        {' · '}<span className="font-mono font-semibold text-text-primary">3</span> closed positions unlinked (excluded)
+        {' · '}<span className="font-mono font-semibold text-text-primary">2</span> cards queued, not yet linked
+      </div>
+      <div className="border-b border-border px-4 py-2">
+        <span className="font-mono font-semibold text-text-primary">7W – 0L – 0BE</span> of{' '}
+        <span className="font-mono font-semibold text-text-primary">7</span> decided
+      </div>
+      <div className="border-b border-border px-4 py-2">
+        Net P&amp;L: <span className="font-mono font-semibold text-brand-green">$1,284</span>
+        <span className="text-text-faint"> (linked trades only)</span>
+      </div>
+      <div className="border-b border-border px-4 py-2">
+        Max-loss model: <span className="font-mono font-semibold text-text-primary">7</span> of{' '}
+        <span className="font-mono font-semibold text-text-primary">7</span> linked trades stayed within their card&rsquo;s stated max loss.
+      </div>
+      <div className="border-b border-border px-4 py-2">
+        Grades:{' '}
+        <span className="font-mono">A <span className="font-semibold text-text-primary">3</span></span>
+        {' · '}<span className="font-mono">B <span className="font-semibold text-text-primary">3</span></span>
+        {' · '}<span className="font-mono">C <span className="font-semibold text-text-primary">1</span></span>
+        {' · '}<span className="font-mono">D <span className="font-semibold text-text-primary">0</span></span>
+        {' · '}<span className="font-mono">F <span className="font-semibold text-text-primary">0</span></span>
+      </div>
+      <p className="px-4 py-2 text-text-muted">
+        No cherry-picking: the record leads with what it excludes (unlinked positions are counted and
+        declared, never hidden), a win rate never appears without its denominator, and every trade
+        that breaks its claimed max loss is listed by name. Example numbers — your record starts at
+        zero and only ever shows what actually happened.
+      </p>
+    </div>
+  );
+}
+
+// ── 5. GRADED TRADE CARD — faithful mirror of the Trade Lab scorecard ───────
+
+// Internally coherent example (labeled): a $5-wide bull put spread sold for a
+// 1.85 credit → max profit $185, max loss $315, R:R 0.59; closed at 0.43 →
+// actual P&L +$142 (inside the claimed max loss, hence the A).
+const EXAMPLE_CARD = {
+  symbol: 'ACME',
+  strategy: 'Bull Put Spread',
+  direction: 'BULLISH',
+  status: 'Graded',
+  legs: [
+    { side: 'SELL', type: 'PUT', strike: 175, price: 4.2 },
+    { side: 'BUY', type: 'PUT', strike: 170, price: 2.35 },
+  ],
+  predicted: { maxProfit: '$185', maxLoss: '-$315', pop: '71.0%', rr: '0.59', entry: '$1.85' },
+  actual: { pl: '+$142', entry: '$1.85', exit: '$0.43', grade: 'A' },
+  thesis: [
+    { point: 'IV is rich vs realized — premium seller gets paid to wait', result: true },
+    { point: 'Support holds above the short strike through expiration', result: true },
+    { point: 'Earnings drift continues after the beat', result: false },
+  ],
+};
+
+export function GradedCardMirror() {
+  return (
+    <div className="rounded-lg border border-border bg-white">
+      <SectionTitle title="A graded trade card — predicted vs what actually happened" tag="Example data" />
+      <div className="p-4">
+        {/* Card header row — mirrors TradeLabPanel.tsx:401-419. */}
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="font-mono text-base font-bold text-text-primary">{EXAMPLE_CARD.symbol}</span>
+          <span className="text-xs font-medium text-text-secondary">{EXAMPLE_CARD.strategy}</span>
+          <span className="rounded bg-brand-green/10 px-1.5 py-0.5 text-[9px] font-bold text-brand-green">{EXAMPLE_CARD.direction}</span>
+          <span className="rounded bg-brand-purple px-1.5 py-0.5 text-[9px] font-bold text-white">{EXAMPLE_CARD.status}</span>
+          <span className="rounded bg-brand-green px-2 py-0.5 text-sm font-black text-white">{EXAMPLE_CARD.actual.grade}</span>
+        </div>
+        {/* Legs — mirrors :421-429. */}
+        <div className="mt-1.5 flex flex-wrap gap-3 font-mono text-[11px] text-text-muted">
+          {EXAMPLE_CARD.legs.map((leg) => (
+            <span key={`${leg.side}-${leg.strike}`}>
+              <span className={leg.side === 'SELL' ? 'text-brand-red' : 'text-brand-green'}>{leg.side}</span>
+              {' '}{leg.type} ${leg.strike} @ ${leg.price.toFixed(2)}
+            </span>
+          ))}
+        </div>
+        {/* PREDICTED vs ACTUAL — mirrors the expanded scorecard :565-639. */}
+        <div className="mt-3 grid grid-cols-2 gap-4 border-t border-border pt-3 text-xs">
+          <div>
+            <p className="mb-2 text-[10px] font-bold uppercase tracking-wider text-text-muted">Predicted</p>
+            <div className="space-y-1">
+              <div className="flex justify-between"><span className="text-text-muted">Max Profit</span><span className="font-mono font-bold text-brand-green">{EXAMPLE_CARD.predicted.maxProfit}</span></div>
+              <div className="flex justify-between"><span className="text-text-muted">Max Loss</span><span className="font-mono font-bold text-brand-red">{EXAMPLE_CARD.predicted.maxLoss}</span></div>
+              <div className="flex justify-between"><span className="text-text-muted">Est. PoP</span><span className="font-mono font-bold">{EXAMPLE_CARD.predicted.pop}</span></div>
+              <div className="flex justify-between"><span className="text-text-muted">R:R</span><span className="font-mono font-bold">{EXAMPLE_CARD.predicted.rr}</span></div>
+              <div className="flex justify-between"><span className="text-text-muted">Entry Price</span><span className="font-mono font-bold">{EXAMPLE_CARD.predicted.entry}</span></div>
+            </div>
+          </div>
+          <div>
+            <p className="mb-2 text-[10px] font-bold uppercase tracking-wider text-text-muted">Actual</p>
+            <div className="space-y-1">
+              <div className="flex justify-between"><span className="text-text-muted">P&amp;L</span><span className="font-mono font-bold text-brand-green">{EXAMPLE_CARD.actual.pl}</span></div>
+              <div className="flex justify-between"><span className="text-text-muted">Entry Price</span><span className="font-mono font-bold">{EXAMPLE_CARD.actual.entry}</span></div>
+              <div className="flex justify-between"><span className="text-text-muted">Exit Price</span><span className="font-mono font-bold">{EXAMPLE_CARD.actual.exit}</span></div>
+              <div className="mt-1 flex items-center justify-between"><span className="text-text-muted">Grade</span><span className="rounded bg-brand-green px-3 py-1 font-black text-white">{EXAMPLE_CARD.actual.grade}</span></div>
+            </div>
+          </div>
+        </div>
+        {/* Thesis with ✓/✗ grading — mirrors :641-661. */}
+        <div className="mt-3 border-t border-border pt-3">
+          <p className="mb-1.5 text-[10px] font-bold uppercase tracking-wider text-text-muted">Thesis — graded after the outcome</p>
+          <div className="space-y-1 text-xs">
+            {EXAMPLE_CARD.thesis.map((t) => (
+              <div key={t.point} className="flex gap-2">
+                <span className="w-4 shrink-0 text-center">
+                  {t.result ? <span className="text-brand-green">✓</span> : <span className="text-brand-red">✗</span>}
+                </span>
+                <span className="text-text-secondary">{t.point}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+        {/* Regime — the ENGINE's own brake declaration (engine-real). */}
+        <div className="mt-3 border-t border-border pt-3">
+          <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-text-muted">Regime</p>
+          <p className="font-mono text-xs text-text-secondary">{TRADE_SHOWCASE_BRAKE.declaration}</p>
+        </div>
+        <p className="mt-3 text-xs text-text-muted">
+          Every card writes its claim down BEFORE the trade — max loss, probability, the thesis in
+          plain language — then gets linked to the real closed position and graded against what
+          happened. A wrong thesis point stays ✗ on the record forever.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+// ── 6. DEEP DIVE — engine-real gates + derived FOR/AGAINST ──────────────────
+
+const GATE_META: { key: 'volEdge' | 'quality' | 'regime' | 'infoEdge'; name: string; asks: string }[] = [
+  { key: 'volEdge', name: 'Vol Edge', asks: 'Are these options priced rich vs how the stock actually moves?' },
+  { key: 'quality', name: 'Quality', asks: 'Is the company underneath actually healthy?' },
+  { key: 'regime', name: 'Regime', asks: 'Does today’s macro backdrop favor this trade?' },
+  { key: 'infoEdge', name: 'Info Edge', asks: 'Do the people with better information seem to know something?' },
+];
+
+export function DeepDiveMirror() {
+  // Engine-real: the fixture row the engine sized largest is the deep-dive
+  // subject; the NO-TRADE teaching row is whichever the engine sized at zero.
+  const rows = [...TRADE_SHOWCASE_ROWS].sort((a, b) => b.positionSizePct - a.positionSizePct);
+  const subject = rows[0];
+  const noTrade = TRADE_SHOWCASE_ROWS.find((r) => r.positionSizePct === 0);
+  // FOR vs AGAINST derived from the engine's own gates (>50 = for, else against
+  // — the engine's above-50 convention, composite.ts:141-145).
+  const gates = GATE_META.map((g) => ({ ...g, score: subject[g.key] }));
+  const forGates = gates.filter((g) => g.score != null && g.score > 50);
+  const againstGates = gates.filter((g) => g.score == null || g.score <= 50);
+
+  return (
+    <div className="rounded-lg border border-border bg-white">
+      <SectionTitle title={`The deep dive — why ${subject.ticker}, and why NOT everything else`} tag="Example data" />
+      <div className="space-y-4 p-4 text-xs">
+        {/* WHY THIS TICKER — mirrors TickerChapter (CI:256-257); scores engine-real. */}
+        <div>
+          <p className="mb-1.5 text-[10px] font-bold uppercase tracking-wider text-brand-purple">Why this ticker</p>
+          <p className="text-sm text-text-secondary">
+            {subject.ticker} led this example scan: the engine scored it{' '}
+            <span className="font-mono">&ldquo;{subject.gate}&rdquo;</span> and suggested{' '}
+            <span className="font-semibold text-text-primary">{subject.strategy}</span> at {subject.suggestedDte} DTE.
+            Every number below was computed by the real scoring engine on the declared example inputs.
+          </p>
+          <div className="mt-2 grid gap-2 sm:grid-cols-4">
+            {gates.map((g) => (
+              <div key={g.key} className="rounded border border-border-light bg-bg-row p-2">
+                <div className="flex items-baseline justify-between">
+                  <span className="font-semibold text-text-primary">{g.name}</span>
+                  <span className={`font-mono font-bold ${g.score != null && g.score > 50 ? 'text-brand-green' : 'text-text-muted'}`}>{g.score ?? '—'}</span>
+                </div>
+                <p className="mt-1 text-[11px] leading-snug text-text-muted">{g.asks}</p>
+              </div>
+            ))}
+          </div>
+          <p className="mt-2 text-text-muted">
+            Composite <span className="font-mono font-semibold text-text-primary">{subject.composite ?? '—'}</span> — above 50 means the gate found edge; missing data is excluded and declared, never scored as neutral.
+          </p>
+        </div>
+
+        {/* FOR vs AGAINST — mirrors the card section (CI:465), derived from engine gates. */}
+        <div className="grid gap-3 border-t border-border pt-3 sm:grid-cols-2">
+          <div>
+            <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-brand-green">For</p>
+            <ul className="space-y-1 text-text-secondary">
+              {forGates.map((g) => (
+                <li key={g.key}>• {g.name} {g.score} — {g.asks.replace(/\?$/, '')}: the engine says yes.</li>
+              ))}
+            </ul>
+          </div>
+          <div>
+            <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-brand-red">Against</p>
+            <ul className="space-y-1 text-text-secondary">
+              {againstGates.length > 0 ? (
+                againstGates.map((g) => (
+                  <li key={g.key}>• {g.name} {g.score ?? '—'} — at or below 50: no edge claimed here, and it drags the composite.</li>
+                ))
+              ) : (
+                <li className="text-text-muted">• All four gates cleared 50 in this example.</li>
+              )}
+            </ul>
+          </div>
+        </div>
+
+        {/* Why NOT other strategies — mirrors the rejection_reasons shape (CI:71-76). */}
+        <div className="border-t border-border pt-3">
+          <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-text-muted">Why not the others</p>
+          <p className="text-text-secondary">
+            Strategies that fail a gate are rejected with the failing rule and numbers, e.g.{' '}
+            <span className="font-mono">Short Strangle — rejected: unlimited risk vs your DEFINED_ONLY filter</span>{' '}
+            (example). And when convergence itself fails, the engine says so
+            {noTrade && (
+              <>
+                {' '}— in this example scan {noTrade.ticker} came out{' '}
+                <span className="font-mono">&ldquo;{noTrade.gate}&rdquo;</span>
+              </>
+            )}
+            . It will not manufacture a trade just to have something to sell.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
…anel, full pipeline, track record, graded card, deep dive

Rebuilds the logged-out Trade showcase to show the ENTIRE product per the TRADE-FULL-INVENTORY rulings (d8e7bb39), replacing the reduced summary. Page order: purple hero -> full 20-step pipe rail (with the example funnel 475 -> 52 -> 40 -> 20 -> 9, Finnhub calls, runtime; real defaults stated as real, sample counts labeled) -> the REAL ScanFilterForm mounted interactively -> track-record mirror -> graded trade card mirror -> deep dive -> Unlock CTA.

Per-section rulings applied:
- Scanner: DIRECT REUSE — ScanFilterForm is props+callbacks with zero fetches (ScanFilterForm.tsx:10-12); mounted with local state + DEFAULT_FILTERS; every real control interactive (universe, direction, premium, risk, DTE, width, 4 liquidity gates, 6 edge metrics, 16 strategy chips). Scan NEVER fires a scan: logged-out -> signup modal, logged-in-locked -> scrolls to the Unlock CTA anchor.
- Track record: STATIC MIRROR of TradeRecord.tsx:131-181 section order (denominator-first counts, 7W-0L-0BE of 7, net P&L, max-loss integrity line, A-F grades), Example-data tagged, with the no-cherry-picking teaching line ("your record starts at zero").
- Graded card: STATIC MIRROR of the Trade Lab expanded scorecard (TradeLabPanel.tsx:565-679): legs, PREDICTED vs ACTUAL, actual P&L, grade badge, thesis with the ✓/✗ grading mechanic (one honest ✗ shown), regime line = the ENGINE's own brake declaration. Example values internally coherent (1.85 credit on $5 width -> $185/$315 -> R:R 0.59; exit 0.43 -> +$142).
- Deep dive: EXAMPLE-FED — gate scores are ENGINE-REAL from the scoreAll fixture; FOR vs AGAINST is DERIVED from the engine's own above-50 gates; rejection line mirrors the real rejection_reasons shape (labeled example); NO-TRADE teaching quotes the engine caption verbatim. Drift-proof: subject = the row the engine sized largest.
- CTA: existing LockedTabCard checkout-entitlement flow, anchored.

Template stays the reusable pattern (richest instance): cards made optional + stepsFooter slot added + ExampleTag exported; the new sections flow through the sample slot. Tabs 2-9 unaffected.

Zero fetches/effects on the new surface (grep clean); no auth/gate/api/middleware change (diff empty outside components/home). tsc clean; next build "Compiled successfully".


Claude-Session: https://claude.ai/code/session_0166NgTwN2YavGPvPwra9Ycz