### PR TITLE
TRADE-SHOWCASE-ORDER: scanner before pipeline — match the real produc…

### DIFF
--- a/src/components/home/TabShowcaseTemplate.tsx
+++ b/src/components/home/TabShowcaseTemplate.tsx
@@ -42,6 +42,10 @@ export interface TabShowcaseTemplateProps {
   headline: string;
   /** Teaching subcopy: the real data sources + what the pipe does. */
   subcopy: string;
+  /** Optional section(s) rendered BETWEEN the hero and the pipe rail — for
+   *  content that precedes the pipe in the real product flow (e.g. Trade's
+   *  filter panel: you set filters and hit Scan, THEN the pipe runs). */
+  preSteps?: ReactNode;
   /** Title over the pipe rail (e.g. "The pipe — 20 steps, A to T"). */
   stepsTitle: string;
   /** Rail-level honesty tag (e.g. "Example scan — real steps, sample counts"). */
@@ -73,6 +77,7 @@ export default function TabShowcaseTemplate({
   heroBadge,
   headline,
   subcopy,
+  preSteps,
   stepsTitle,
   stepsTag,
   steps,
@@ -96,6 +101,9 @@ export default function TabShowcaseTemplate({
         <h3 className="mt-3 text-3xl font-light tracking-tight sm:text-4xl">{headline}</h3>
         <p className="mt-3 max-w-2xl text-sm leading-relaxed text-white/75">{subcopy}</p>
       </div>
+
+      {/* ── Pre-pipe section(s) — the real flow's first act (optional) ── */}
+      {preSteps}
 
       {/* ── The real pipe, as a compact rail ── */}
       <div className="rounded-lg border border-border bg-white">

--- a/src/components/home/TabShowcases.tsx
+++ b/src/components/home/TabShowcases.tsx
@@ -180,7 +180,10 @@ export function TradeShowcase({ currentUserId, onRequireAuth }: ShowcaseProps) {
       heroBadge="The Trade tab"
       headline="475 stocks in. One decision out."
       subcopy="Live prices from TastyTrade. Company numbers from Finnhub. Macro from FRED. Filings from SEC EDGAR. The mood from Grok. Twenty steps and four gates later you get a sized suggestion — or an honest NO TRADE."
-      stepsTitle="The pipe — 20 steps, A to T"
+      // TRADE-SHOWCASE-ORDER: the scanner renders BEFORE the pipe (preSteps) —
+      // in the real product you set filters and hit Scan, THEN the pipe runs.
+      preSteps={<ScannerPanelDemo currentUserId={currentUserId} onRequireAuth={onRequireAuth} />}
+      stepsTitle="Hit Scan, and this runs — 20 steps, A to T"
       stepsTag="Example scan — real steps, sample counts"
       steps={TRADE_PIPE_STEPS}
       stepsFooter={
@@ -192,7 +195,6 @@ export function TradeShowcase({ currentUserId, onRequireAuth }: ShowcaseProps) {
       }
       sample={
         <>
-          <ScannerPanelDemo currentUserId={currentUserId} onRequireAuth={onRequireAuth} />
           <TrackRecordMirror />
           <GradedCardMirror />
           <DeepDiveMirror />


### PR DESCRIPTION
…t flow

The showcase taught the flow backwards: the pipe rail rendered first, then the filter panel. In the real product you set filters and hit Scan, THEN the 20 steps run. New order: hero -> scanner (real ScanFilterForm) -> pipeline (header reframed to "Hit Scan, and this runs — 20 steps, A to T") -> track record -> graded card -> deep dive -> unlock CTA.

Done via a new optional preSteps slot on TabShowcaseTemplate (rendered between hero and the pipe rail); Trade moves ScannerPanelDemo from the sample slot into it. The template's only composer is TradeShowcase — Books/Tax/Compliance use their own layouts and render byte-identically (optional prop, no default-path change).

Order/composition only: no content, logic, fetch, or gate changes (diff is 12 lines across template + composition; tripwire grep clean). tsc clean; next build "Compiled successfully".


Claude-Session: https://claude.ai/code/session_0166NgTwN2YavGPvPwra9Ycz