### PR TITLE
TRADE-SHOWCASE: add the actual trade card (generate→link→grade story)…

### DIFF
--- a/src/components/home/TabShowcases.tsx
+++ b/src/components/home/TabShowcases.tsx
@@ -37,6 +37,7 @@ import TabShowcaseTemplate, { type ShowcaseStep } from '@/components/home/TabSho
 import {
   ScannerPanelDemo,
   TrackRecordMirror,
+  TradeCardMirror,
   GradedCardMirror,
   DeepDiveMirror,
   TRADE_UNLOCK_CTA_ID,
@@ -152,7 +153,7 @@ interface ShowcaseProps {
 // Static, zero fetches — no scan fires for a logged-out visitor.
 
 const TRADE_PIPE_STEPS: ShowcaseStep[] = [
-  { code: 'A', label: 'TT Scanner', summary: '475 symbols fetched — the full S&P 500 universe' },
+  { code: 'A', label: 'TT Scanner', summary: '475 symbols fetched (S&P 500 example run; Nasdaq 100 = 101)' },
   { code: 'B', label: 'Pre-Filter', summary: 'ranked by IV rank, IV–HV spread, liquidity' },
   { code: 'C', label: 'Hard Exclusions', summary: 'no premium (IV–HV ≤ 0) or illiquid → eliminated' },
   { code: 'D', label: 'Top-N Selection', summary: 'top 40 carried forward (scan size 20 × 2)' },
@@ -178,8 +179,8 @@ export function TradeShowcase({ currentUserId, onRequireAuth }: ShowcaseProps) {
   return (
     <TabShowcaseTemplate
       heroBadge="The Trade tab"
-      headline="475 stocks in. One decision out."
-      subcopy="Live prices from TastyTrade. Company numbers from Finnhub. Macro from FRED. Filings from SEC EDGAR. The mood from Grok. Twenty steps and four gates later you get a sized suggestion — or an honest NO TRADE."
+      headline="An entire index in. One decision out."
+      subcopy="Pick your universe — the S&P 500 (475 stocks) or the Nasdaq 100 (101), with more indexes already wired into the engine. Live prices from TastyTrade. Company numbers from Finnhub. Macro from FRED. Filings from SEC EDGAR. The mood from Grok. Twenty steps and four gates later you get a sized suggestion — or an honest NO TRADE."
       // TRADE-SHOWCASE-ORDER: the scanner renders BEFORE the pipe (preSteps) —
       // in the real product you set filters and hit Scan, THEN the pipe runs.
       preSteps={<ScannerPanelDemo currentUserId={currentUserId} onRequireAuth={onRequireAuth} />}
@@ -188,14 +189,22 @@ export function TradeShowcase({ currentUserId, onRequireAuth }: ShowcaseProps) {
       steps={TRADE_PIPE_STEPS}
       stepsFooter={
         <p className="text-xs text-text-muted">
-          Example funnel: <span className="font-mono text-text-primary">475 → 52 → 40 → 20 → 9</span>{' '}
+          Example funnel (S&P 500 run): <span className="font-mono text-text-primary">475 → 52 → 40 → 20 → 9</span>{' '}
           (universe → hard filters → enriched → scored → selected) · 128 Finnhub calls · ~94s runtime.
-          475, 40, 20 and 9 are the real defaults; the rest are sample counts.
+          475 is the S&P 500 list size; 40, 20 and 9 are the real defaults; the rest are sample counts.
         </p>
       }
       sample={
         <>
           <TrackRecordMirror />
+          {/* The generate→link→grade story, one trade end to end: the scanner
+              generates the card, you link it to the real position, it grades
+              itself predicted-vs-actual. */}
+          <TradeCardMirror />
+          <p className="text-sm text-text-secondary">
+            Link that card to the real position when you take the trade — and after it closes, it
+            grades itself against what actually happened:
+          </p>
           <GradedCardMirror />
           <DeepDiveMirror />
         </>

--- a/src/components/home/TradeShowcaseSections.tsx
+++ b/src/components/home/TradeShowcaseSections.tsx
@@ -137,6 +137,72 @@ export function TrackRecordMirror() {
   );
 }
 
+// ── 4b. THE TRADE CARD — faithful mirror of the scanner's generated card ────
+// Mirrors the deep-dive "Trade Setup" card (ConvergenceIntelligence.tsx:729-764):
+// legs, then COLLECT · MAX LOSS · POP (method) · EV · EV/RISK · R:R, then
+// B/E · HV POP · THETA/day · VEGA/pt · KELLY — exactly the metrics the real
+// card carries (plus DTE/Exp from the Trade Lab queued row, TradeLabPanel.tsx:432-435).
+//
+// EXAMPLE NUMBER RECONCILIATION (same ACME trade the graded card below shows,
+// so the generate→link→grade story is one trade end to end):
+//   COLLECT $185   = (4.20 − 2.35) × 100
+//   MAX LOSS $315  = ($5 width − $1.85 credit) × 100
+//   R:R 0.59       = 185 / 315
+//   B/E $173.15    = 175 short strike − 1.85 credit
+//   EV +$40        = 0.71×185 − 0.29×315 (two-outcome sanity math; the real
+//                    card's EV comes from the engine's three-outcome model)
+//   EV/RISK 0.127  = 40 / 315
+//   KELLY 3.4%     = computed with the REAL quarter-Kelly formula the live
+//                    card uses (CI:704-708): winRate = HV POP 0.68, ratio =
+//                    185/315 → (0.68×0.587 − 0.32)/0.587 × 0.25 = 0.0338
+//   POP 71% (N(d2)), HV POP 68%, THETA +$3.10/day, VEGA/pt −$9.00 are labeled
+//   example model outputs (signs correct for a credit spread: +theta, −vega).
+
+export function TradeCardMirror() {
+  return (
+    <div className="rounded-lg border border-border bg-white">
+      <SectionTitle title="The trade card — every selected ticker becomes one: the full trade, priced and sized" tag="Example data" />
+      <div className="p-4">
+        {/* Header — mirrors the queued Trade Lab row meta (TradeLabPanel.tsx:404-435). */}
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="font-mono text-base font-bold text-text-primary">ACME</span>
+          <span className="text-xs font-medium text-text-secondary">Bull Put Spread</span>
+          <span className="rounded bg-brand-green/10 px-1.5 py-0.5 text-[9px] font-bold text-brand-green">BULLISH</span>
+          <span className="rounded bg-brand-amber px-1.5 py-0.5 text-[9px] font-bold text-white">Queued</span>
+          <span className="text-[10px] text-text-faint">21 DTE · Exp Jul 31</span>
+        </div>
+        {/* Trade Setup — mirrors CI:729-740. */}
+        <div className="mt-3">
+          <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-text-muted">Trade Setup</p>
+          <div className="font-mono text-xs">
+            <div><span className="font-bold text-brand-red">SELL</span><span className="text-text-muted"> PUT </span><span className="text-text-primary">$175</span><span className="text-text-faint">  $4.20</span></div>
+            <div><span className="font-bold text-brand-green">BUY </span><span className="text-text-muted"> PUT </span><span className="text-text-primary">$170</span><span className="text-text-faint">  $2.35</span></div>
+          </div>
+          {/* Metrics line 1 — mirrors CI:741-761. */}
+          <p className="mt-2 text-xs">
+            <span className="font-bold text-brand-green">COLLECT $185</span>
+            <span className="text-text-muted"> · MAX LOSS </span><span className="text-brand-red">-$315</span>
+            <span className="text-text-muted"> · POP </span><span className="text-text-primary">71%</span><span className="text-text-faint"> (N(d2))</span>
+            <span className="text-text-muted"> · EV </span><span className="text-brand-green">+$40</span>
+            <span className="text-text-muted"> · EV/RISK </span><span className="text-text-primary">0.127</span>
+            <span className="text-text-muted"> · R:R </span><span className="text-text-primary">0.59</span>
+          </p>
+          {/* Metrics line 2 — mirrors CI:762-764. */}
+          <p className="mt-0.5 text-xs text-text-muted">
+            B/E <span className="text-text-primary">$173.15</span> · HV POP <span className="text-text-primary">68%</span> · THETA <span className="text-brand-green">+$3.10/day</span> · VEGA/pt <span className="text-brand-red">-$9.00</span> · KELLY <span className="text-text-primary">3.4%</span>
+          </p>
+        </div>
+        <p className="mt-3 text-xs text-text-muted">
+          The scanner writes the whole trade down: the exact legs at live prices, what you collect,
+          the most you can lose, the odds two ways (option-implied and history-implied), the
+          expected value, and how big Kelly says to size it. No vibes — a priced claim you can
+          hold it to.
+        </p>
+      </div>
+    </div>
+  );
+}
+
 // ── 5. GRADED TRADE CARD — faithful mirror of the Trade Lab scorecard ───────
 
 // Internally coherent example (labeled): a $5-wide bull put spread sold for a


### PR DESCRIPTION
… + universe-agnostic headline

(1) THE MISSING TRADE CARD: new TradeCardMirror section — a faithful mirror of the scanner's generated card, slotted between the track record and the graded card so the story reads: scanner generates the card -> you link it to the real position -> it grades itself predicted-vs-actual (one connective teaching line between the two cards). Layout mirrors the deep-dive Trade Setup card (ConvergenceIntelligence.tsx:729-764: legs, then COLLECT · MAX LOSS · POP (N(d2)) · EV · EV/RISK · R:R, then B/E · HV POP · THETA/day · VEGA/pt · KELLY) plus the queued-row meta (DTE/Exp, TradeLabPanel.tsx:432-435). Same ACME bull put spread as the graded card, end to end. Example numbers reconcile and the code comment shows the math: COLLECT 185 = (4.20-2.35)x100; MAX LOSS 315 = (5-1.85)x100; R:R 0.59; B/E 173.15 = 175-1.85; EV +40 = .71x185-.29x315 (two-outcome sanity; real EV is the engine's three-outcome model); EV/RISK 0.127; KELLY 3.4% computed with the REAL quarter-Kelly formula the live card uses (CI:704-708) from HV POP 68% and 185/315. Signs correct for a credit spread (+theta, -vega). Example-tagged.

(2) HEADLINE TRUTH: "475 stocks in" hardcoded one universe; the real scanner toggles S&P 500 | Nasdaq 100 (ScanFilterForm.tsx:35), and the engine already carries more index lists (pipeline.ts getUniverseSymbols). Hero is now "An entire index in. One decision out."; subcopy names the real toggle (S&P 500 475 / Nasdaq 100 101) + more indexes wired in; step A and the funnel footer label 475 as the S&P 500 example run.

Composition + copy only: zero fetch/gate/logic changes (tripwire's one hit is the word "fetched" in a copy string). tsc clean; next build "Compiled successfully".


Claude-Session: https://claude.ai/code/session_0166NgTwN2YavGPvPwra9Ycz