### PR TITLE
TRADE-SHOWCASE-REAL-COMPONENTS: mount the real cockpit components wit…

### DIFF
--- a/src/components/home/TabShowcases.tsx
+++ b/src/components/home/TabShowcases.tsx
@@ -36,10 +36,9 @@ import TabShowcaseTemplate, { type ShowcaseStep } from '@/components/home/TabSho
 // fixture inside these sections.
 import {
   ScannerPanelDemo,
+  RealCockpitDemo,
   TrackRecordMirror,
-  TradeCardMirror,
   GradedCardMirror,
-  DeepDiveMirror,
   TRADE_UNLOCK_CTA_ID,
 } from '@/components/home/TradeShowcaseSections';
 
@@ -197,16 +196,17 @@ export function TradeShowcase({ currentUserId, onRequireAuth }: ShowcaseProps) {
       sample={
         <>
           <TrackRecordMirror />
-          {/* The generate→link→grade story, one trade end to end: the scanner
-              generates the card, you link it to the real position, it grades
-              itself predicted-vs-actual. */}
-          <TradeCardMirror />
+          {/* TRADE-SHOWCASE-REAL-COMPONENTS: the REAL cockpit — the live
+              ScannerResultsTable + TickerChapter deep dive mounted on the
+              declared example payload. The generate→link→grade story is one
+              GLOBEX Iron Condor end to end: the cockpit generates it, the
+              replica below shows it linked and graded. */}
+          <RealCockpitDemo currentUserId={currentUserId} onRequireAuth={onRequireAuth} />
           <p className="text-sm text-text-secondary">
-            Link that card to the real position when you take the trade — and after it closes, it
-            grades itself against what actually happened:
+            Queue that card, link it to the real position when you take the trade — and after it
+            closes, it grades itself against what actually happened:
           </p>
           <GradedCardMirror />
-          <DeepDiveMirror />
         </>
       }
       cta={

--- a/src/components/home/TradeShowcaseSections.tsx
+++ b/src/components/home/TradeShowcaseSections.tsx
@@ -1,32 +1,30 @@
 'use client';
 
 /**
- * TRADE-SHOWCASE-FULL: the full-product sections of the logged-out Trade
- * showcase, built to the TRADE-FULL-INVENTORY rulings (audit-reports/
- * TRADE-FULL-INVENTORY.md, Phase 2 table):
+ * TRADE-SHOWCASE-FULL / TRADE-SHOWCASE-REAL-COMPONENTS: the full-product
+ * sections of the logged-out Trade showcase, per the TRADE-FULL-INVENTORY
+ * rulings and the Phase-1 mountability audit:
  *
- *  • ScannerPanelDemo — DIRECT REUSE ruling: the REAL ScanFilterForm mounts
- *    presentationally (it is props+callbacks only, zero fetches —
- *    ScanFilterForm.tsx:10-12). Local state, DEFAULT_FILTERS; the Scan button
- *    NEVER fires a scan — logged-out it opens the signup modal, logged-in
- *    (but locked) it scrolls to the Unlock CTA.
+ *  • ScannerPanelDemo — REAL ScanFilterForm mounted (props+callbacks only,
+ *    zero fetches — ScanFilterForm.tsx:10-12). Scan NEVER fires a scan.
+ *  • RealCockpitDemo — the REAL ScannerResultsTable (zero fetches/effects,
+ *    fully props-driven — ScannerResultsTable.tsx:58-69) and the REAL
+ *    TickerChapter deep dive (exported, ConvergenceIntelligence.tsx:212;
+ *    AccountSizeContext defaults to 0 = the honest "no dollar math" state,
+ *    CI:23) mounted on the declared example payload
+ *    (tradeShowcasePayload.ts). Gate results are ENGINE-REAL (scoreAll
+ *    fixture); chain/card values are declared examples, tagged. The
+ *    Queue-Card / save callbacks route to signup — nothing persists.
  *  • TrackRecordMirror — STATIC MIRROR ruling: TradeRecord self-fetches
- *    (TradeRecord.tsx:47-50) so it cannot mount logged-out; this mirrors its
- *    exact section order (denominator-first counts, W–L–BE of decided, net
- *    P&L, the max-loss integrity line, A–F grades) with labeled example values.
- *  • GradedCardMirror — STATIC MIRROR ruling: TradeLabPanel self-fetches
- *    (TradeLabPanel.tsx:118-131); this mirrors the expanded scorecard layout
- *    (:565-679): legs, PREDICTED vs ACTUAL, actual P&L, grade badge, thesis
- *    ✓/✗ mechanic, regime line. Example values are internally coherent
- *    (credit 1.85 on a $5-wide spread → max profit $185 / max loss $315 /
- *    R:R 0.59; exit 0.43 → P&L +$142 ≤ max profit) and labeled EXAMPLE.
- *    The regime line is the ENGINE's own brake declaration (engine-real).
- *  • DeepDiveMirror — EXAMPLE-FED ruling: gate scores are ENGINE-REAL from
- *    the scoreAll fixture (tradeShowcaseRows.ts); FOR vs AGAINST is DERIVED
- *    from those engine gates (>50 = for, ≤50 = against — the engine's own
- *    above-50 convention); the strategy-rejection line mirrors the real
- *    rejection_reasons shape (ConvergenceIntelligence.tsx:71-76) as a labeled
- *    example; the NO-TRADE teaching quotes the engine's caption verbatim.
+ *    (TradeRecord.tsx:47-50); mirrors its exact section order (:131-181).
+ *  • GradedCardMirror — STATIC REPLICA ruling: TradeLabPanel self-fetches
+ *    (TradeLabPanel.tsx:118-135) and its card rows are inline JSX (no props
+ *    seam), so it cannot mount; this replica follows the real JSX structure
+ *    — row header (:404-419), legs line (:421-429), meta row (:432-438),
+ *    right-rail numbers (:442-462), expanded scorecard PREDICTED vs ACTUAL
+ *    (:565-639), thesis ✓/✗ (:641-661), regime (:663-669), notes (:671-677)
+ *    — on the SAME GLOBEX Iron Condor the cockpit above generates, so the
+ *    generate→link→grade story is one trade end to end.
  *
  * SHOW discipline: ZERO fetches, zero paid calls, nothing personal, no
  * auth/gate logic. All example values labeled.
@@ -34,10 +32,17 @@
 
 import { useRef, useState } from 'react';
 import ScanFilterForm from '@/components/trading/ScanFilterForm';
+import ScannerResultsTable from '@/components/convergence/ScannerResultsTable';
+import { TickerChapter } from '@/components/convergence/ConvergenceIntelligence';
 import type { ScannerFilters } from '@/lib/convergence/filter-types';
 import { DEFAULT_FILTERS } from '@/lib/convergence/filter-types';
-import { TRADE_SHOWCASE_ROWS, TRADE_SHOWCASE_BRAKE } from '@/components/home/tradeShowcaseRows';
 import { ExampleTag } from '@/components/home/TabShowcaseTemplate';
+import {
+  SHOWCASE_RESULTS,
+  SHOWCASE_REJECTIONS,
+  SHOWCASE_PROGRESS,
+  SHOWCASE_DEEP_DIVE,
+} from '@/components/home/tradeShowcasePayload';
 
 /** id the Scan button scrolls to for logged-in-but-locked viewers. */
 export const TRADE_UNLOCK_CTA_ID = 'trade-unlock-cta';
@@ -51,7 +56,7 @@ function SectionTitle({ title, tag }: { title: string; tag?: string }) {
   );
 }
 
-// ── 3. THE SCANNER — the REAL filter panel, interactive ─────────────────────
+// ── THE SCANNER — the REAL filter panel, interactive ────────────────────────
 
 export function ScannerPanelDemo({
   currentUserId,
@@ -95,7 +100,81 @@ export function ScannerPanelDemo({
   );
 }
 
-// ── 4. TRACK RECORD — faithful static mirror of TradeRecord.tsx ─────────────
+// ── THE COCKPIT — the REAL results table + REAL deep dive, example payload ──
+
+export function RealCockpitDemo({
+  currentUserId,
+  onRequireAuth,
+}: {
+  currentUserId: string;
+  onRequireAuth: () => void;
+}) {
+  // Queue-Card / save actions route to signup (logged-out) or the CTA
+  // (logged-in but locked) — nothing is persisted from the showcase.
+  const routeAway = async () => {
+    if (!currentUserId) {
+      onRequireAuth();
+    } else {
+      document.getElementById(TRADE_UNLOCK_CTA_ID)?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-lg border border-border bg-white">
+        <SectionTitle
+          title="The results — the real table, the real deep dive"
+          tag="Example scan — engine-real gate scores, declared example chain/card values"
+        />
+        <div className="p-3">
+          {/* The REAL power table (13 sortable columns, expandable rows).
+              GLOBEX carries the full Iron Condor card; ACME and INITECH show
+              the honest no-card cases with their rejection reasons. */}
+          <ScannerResultsTable
+            results={SHOWCASE_RESULTS}
+            rejectionMap={SHOWCASE_REJECTIONS}
+            savedCards={new Map()}
+            savingCards={new Set()}
+            saveErrors={new Map()}
+            onSaveCard={routeAway}
+            onRemoveCard={routeAway}
+            pipelineProgress={SHOWCASE_PROGRESS}
+          />
+        </div>
+      </div>
+      <div className="rounded-lg border border-border bg-white">
+        <SectionTitle
+          title="Every selected ticker gets this — the full deep dive"
+          tag="Example data"
+        />
+        <div className="p-3">
+          {/* The REAL TickerChapter: WHY THIS TICKER / CHAIN FETCH / STRATEGY
+              SCORING / THE TRADE card with COLLECT · MAX LOSS · POP · EV ·
+              EV/RISK · R:R · B/E · HV POP · THETA · VEGA · KELLY, then gate
+              bars, vol detail, company & macro, info signals — rendered by
+              the live component from the payload. */}
+          <TickerChapter
+            detail={SHOWCASE_DEEP_DIVE}
+            savedCards={new Map()}
+            savingCards={new Set()}
+            saveErrors={new Map()}
+            onSave={routeAway}
+            onRemove={routeAway}
+            pipelineProgress={SHOWCASE_PROGRESS}
+          />
+        </div>
+      </div>
+      <p className="text-xs text-text-muted">
+        Everything above is the real cockpit UI, rendered from a declared example scan: the four
+        gate scores were computed by the real scoring engine on the declared inputs; option-chain
+        and card values are internally-coherent examples (a logged-out page fetches nothing). When
+        convergence fails, the row says so — no trade is manufactured to fill the table.
+      </p>
+    </div>
+  );
+}
+
+// ── TRACK RECORD — faithful static mirror of TradeRecord.tsx ────────────────
 
 export function TrackRecordMirror() {
   return (
@@ -137,144 +216,87 @@ export function TrackRecordMirror() {
   );
 }
 
-// ── 4b. THE TRADE CARD — faithful mirror of the scanner's generated card ────
-// Mirrors the deep-dive "Trade Setup" card (ConvergenceIntelligence.tsx:729-764):
-// legs, then COLLECT · MAX LOSS · POP (method) · EV · EV/RISK · R:R, then
-// B/E · HV POP · THETA/day · VEGA/pt · KELLY — exactly the metrics the real
-// card carries (plus DTE/Exp from the Trade Lab queued row, TradeLabPanel.tsx:432-435).
-//
-// EXAMPLE NUMBER RECONCILIATION (same ACME trade the graded card below shows,
-// so the generate→link→grade story is one trade end to end):
-//   COLLECT $185   = (4.20 − 2.35) × 100
-//   MAX LOSS $315  = ($5 width − $1.85 credit) × 100
-//   R:R 0.59       = 185 / 315
-//   B/E $173.15    = 175 short strike − 1.85 credit
-//   EV +$40        = 0.71×185 − 0.29×315 (two-outcome sanity math; the real
-//                    card's EV comes from the engine's three-outcome model)
-//   EV/RISK 0.127  = 40 / 315
-//   KELLY 3.4%     = computed with the REAL quarter-Kelly formula the live
-//                    card uses (CI:704-708): winRate = HV POP 0.68, ratio =
-//                    185/315 → (0.68×0.587 − 0.32)/0.587 × 0.25 = 0.0338
-//   POP 71% (N(d2)), HV POP 68%, THETA +$3.10/day, VEGA/pt −$9.00 are labeled
-//   example model outputs (signs correct for a credit spread: +theta, −vega).
+// ── GRADED TRADE CARD — structural replica of the Trade Lab card ────────────
+// Cannot mount the real component (self-fetching, inline rows); this replica
+// follows TradeLabPanel's JSX structure line for line (cites in the header
+// comment above). SAME trade as the cockpit's Iron Condor: entry credit
+// $1.20, closed at $0.35 → P&L = (1.20 − 0.35) × 100 = +$85, inside the
+// claimed $380 max loss → graded. Predicted values identical to the card
+// above (COLLECT $120 / MAX LOSS $380 / POP 78% / R:R 0.32).
 
-export function TradeCardMirror() {
-  return (
-    <div className="rounded-lg border border-border bg-white">
-      <SectionTitle title="The trade card — every selected ticker becomes one: the full trade, priced and sized" tag="Example data" />
-      <div className="p-4">
-        {/* Header — mirrors the queued Trade Lab row meta (TradeLabPanel.tsx:404-435). */}
-        <div className="flex flex-wrap items-center gap-2">
-          <span className="font-mono text-base font-bold text-text-primary">ACME</span>
-          <span className="text-xs font-medium text-text-secondary">Bull Put Spread</span>
-          <span className="rounded bg-brand-green/10 px-1.5 py-0.5 text-[9px] font-bold text-brand-green">BULLISH</span>
-          <span className="rounded bg-brand-amber px-1.5 py-0.5 text-[9px] font-bold text-white">Queued</span>
-          <span className="text-[10px] text-text-faint">21 DTE · Exp Jul 31</span>
-        </div>
-        {/* Trade Setup — mirrors CI:729-740. */}
-        <div className="mt-3">
-          <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-text-muted">Trade Setup</p>
-          <div className="font-mono text-xs">
-            <div><span className="font-bold text-brand-red">SELL</span><span className="text-text-muted"> PUT </span><span className="text-text-primary">$175</span><span className="text-text-faint">  $4.20</span></div>
-            <div><span className="font-bold text-brand-green">BUY </span><span className="text-text-muted"> PUT </span><span className="text-text-primary">$170</span><span className="text-text-faint">  $2.35</span></div>
-          </div>
-          {/* Metrics line 1 — mirrors CI:741-761. */}
-          <p className="mt-2 text-xs">
-            <span className="font-bold text-brand-green">COLLECT $185</span>
-            <span className="text-text-muted"> · MAX LOSS </span><span className="text-brand-red">-$315</span>
-            <span className="text-text-muted"> · POP </span><span className="text-text-primary">71%</span><span className="text-text-faint"> (N(d2))</span>
-            <span className="text-text-muted"> · EV </span><span className="text-brand-green">+$40</span>
-            <span className="text-text-muted"> · EV/RISK </span><span className="text-text-primary">0.127</span>
-            <span className="text-text-muted"> · R:R </span><span className="text-text-primary">0.59</span>
-          </p>
-          {/* Metrics line 2 — mirrors CI:762-764. */}
-          <p className="mt-0.5 text-xs text-text-muted">
-            B/E <span className="text-text-primary">$173.15</span> · HV POP <span className="text-text-primary">68%</span> · THETA <span className="text-brand-green">+$3.10/day</span> · VEGA/pt <span className="text-brand-red">-$9.00</span> · KELLY <span className="text-text-primary">3.4%</span>
-          </p>
-        </div>
-        <p className="mt-3 text-xs text-text-muted">
-          The scanner writes the whole trade down: the exact legs at live prices, what you collect,
-          the most you can lose, the odds two ways (option-implied and history-implied), the
-          expected value, and how big Kelly says to size it. No vibes — a priced claim you can
-          hold it to.
-        </p>
-      </div>
-    </div>
-  );
-}
-
-// ── 5. GRADED TRADE CARD — faithful mirror of the Trade Lab scorecard ───────
-
-// Internally coherent example (labeled): a $5-wide bull put spread sold for a
-// 1.85 credit → max profit $185, max loss $315, R:R 0.59; closed at 0.43 →
-// actual P&L +$142 (inside the claimed max loss, hence the A).
-const EXAMPLE_CARD = {
-  symbol: 'ACME',
-  strategy: 'Bull Put Spread',
-  direction: 'BULLISH',
-  status: 'Graded',
+const REPLICA = {
+  symbol: 'GLOBEX',
+  strategy: 'Iron Condor',
+  direction: 'NEUTRAL',
   legs: [
-    { side: 'SELL', type: 'PUT', strike: 175, price: 4.2 },
-    { side: 'BUY', type: 'PUT', strike: 170, price: 2.35 },
+    { side: 'SELL', type: 'PUT', strike: 90, price: 1.15 },
+    { side: 'BUY', type: 'PUT', strike: 85, price: 0.55 },
+    { side: 'SELL', type: 'CALL', strike: 105, price: 1.05 },
+    { side: 'BUY', type: 'CALL', strike: 110, price: 0.45 },
   ],
-  predicted: { maxProfit: '$185', maxLoss: '-$315', pop: '71.0%', rr: '0.59', entry: '$1.85' },
-  actual: { pl: '+$142', entry: '$1.85', exit: '$0.43', grade: 'A' },
+  meta: 'Queued Jul 12, 9:41 AM · 30 DTE · Exp Aug 11 · Trade #1042 · Linked Jul 13',
+  predicted: { maxProfit: '$120', maxLoss: '-$380', pop: '78.0%', rr: '0.32', entry: '$1.20' },
+  actual: { pl: '+$85', entry: '$1.20', exit: '$0.35', grade: 'B' },
   thesis: [
-    { point: 'IV is rich vs realized — premium seller gets paid to wait', result: true },
-    { point: 'Support holds above the short strike through expiration', result: true },
-    { point: 'Earnings drift continues after the beat', result: false },
+    { point: 'Price stays inside the 90–105 range through expiration', result: true },
+    { point: 'IV bleeds off after the macro print — premium decays our way', result: true },
+    { point: 'Volume returns to the sector and lifts the floor', result: false },
   ],
+  notes: 'Closed at 70% of max profit on day 19 — mechanical take-profit.',
 };
 
 export function GradedCardMirror() {
   return (
     <div className="rounded-lg border border-border bg-white">
-      <SectionTitle title="A graded trade card — predicted vs what actually happened" tag="Example data" />
-      <div className="p-4">
-        {/* Card header row — mirrors TradeLabPanel.tsx:401-419. */}
+      <SectionTitle title="After the trade — the card grades itself against reality" tag="Example data" />
+      {/* Row container: graded + positive P&L → green tint (TradeLabPanel.tsx:394-398). */}
+      <div className="bg-green-50 px-4 py-3">
+        {/* Header row — mirrors :404-419. */}
         <div className="flex flex-wrap items-center gap-2">
-          <span className="font-mono text-base font-bold text-text-primary">{EXAMPLE_CARD.symbol}</span>
-          <span className="text-xs font-medium text-text-secondary">{EXAMPLE_CARD.strategy}</span>
-          <span className="rounded bg-brand-green/10 px-1.5 py-0.5 text-[9px] font-bold text-brand-green">{EXAMPLE_CARD.direction}</span>
-          <span className="rounded bg-brand-purple px-1.5 py-0.5 text-[9px] font-bold text-white">{EXAMPLE_CARD.status}</span>
-          <span className="rounded bg-brand-green px-2 py-0.5 text-sm font-black text-white">{EXAMPLE_CARD.actual.grade}</span>
+          <span className="font-mono text-base font-bold text-text-primary">{REPLICA.symbol}</span>
+          <span className="text-xs font-medium text-text-secondary">{REPLICA.strategy}</span>
+          <span className="rounded px-1.5 py-0.5 text-[9px] font-bold" style={{ background: '#334155', color: '#94A3B8' }}>{REPLICA.direction}</span>
+          <span className="rounded px-1.5 py-0.5 text-[9px] font-bold text-white" style={{ background: '#7C3AED' }}>Graded</span>
+          <span className="rounded px-2 py-0.5 text-sm font-black" style={{ background: '#2563EB', color: '#EFF6FF' }}>{REPLICA.actual.grade}</span>
         </div>
-        {/* Legs — mirrors :421-429. */}
-        <div className="mt-1.5 flex flex-wrap gap-3 font-mono text-[11px] text-text-muted">
-          {EXAMPLE_CARD.legs.map((leg) => (
-            <span key={`${leg.side}-${leg.strike}`}>
+        {/* Legs line — mirrors :421-429. */}
+        <div className="mt-1 flex flex-wrap gap-3 font-mono text-[11px] text-text-muted">
+          {REPLICA.legs.map((leg) => (
+            <span key={`${leg.side}-${leg.type}-${leg.strike}`}>
               <span className={leg.side === 'SELL' ? 'text-brand-red' : 'text-brand-green'}>{leg.side}</span>
               {' '}{leg.type} ${leg.strike} @ ${leg.price.toFixed(2)}
             </span>
           ))}
         </div>
-        {/* PREDICTED vs ACTUAL — mirrors the expanded scorecard :565-639. */}
+        {/* Meta row — mirrors :432-438. */}
+        <p className="mt-1 text-[10px] text-text-faint">{REPLICA.meta}</p>
+        {/* Right-rail numbers as the expanded scorecard — mirrors :565-639. */}
         <div className="mt-3 grid grid-cols-2 gap-4 border-t border-border pt-3 text-xs">
           <div>
             <p className="mb-2 text-[10px] font-bold uppercase tracking-wider text-text-muted">Predicted</p>
             <div className="space-y-1">
-              <div className="flex justify-between"><span className="text-text-muted">Max Profit</span><span className="font-mono font-bold text-brand-green">{EXAMPLE_CARD.predicted.maxProfit}</span></div>
-              <div className="flex justify-between"><span className="text-text-muted">Max Loss</span><span className="font-mono font-bold text-brand-red">{EXAMPLE_CARD.predicted.maxLoss}</span></div>
-              <div className="flex justify-between"><span className="text-text-muted">Est. PoP</span><span className="font-mono font-bold">{EXAMPLE_CARD.predicted.pop}</span></div>
-              <div className="flex justify-between"><span className="text-text-muted">R:R</span><span className="font-mono font-bold">{EXAMPLE_CARD.predicted.rr}</span></div>
-              <div className="flex justify-between"><span className="text-text-muted">Entry Price</span><span className="font-mono font-bold">{EXAMPLE_CARD.predicted.entry}</span></div>
+              <div className="flex justify-between"><span className="text-text-muted">Max Profit</span><span className="font-mono font-bold text-brand-green">{REPLICA.predicted.maxProfit}</span></div>
+              <div className="flex justify-between"><span className="text-text-muted">Max Loss</span><span className="font-mono font-bold text-brand-red">{REPLICA.predicted.maxLoss}</span></div>
+              <div className="flex justify-between"><span className="text-text-muted">Est. PoP</span><span className="font-mono font-bold">{REPLICA.predicted.pop}</span></div>
+              <div className="flex justify-between"><span className="text-text-muted">R:R</span><span className="font-mono font-bold">{REPLICA.predicted.rr}</span></div>
+              <div className="flex justify-between"><span className="text-text-muted">Entry Price</span><span className="font-mono font-bold">{REPLICA.predicted.entry}</span></div>
             </div>
           </div>
           <div>
             <p className="mb-2 text-[10px] font-bold uppercase tracking-wider text-text-muted">Actual</p>
             <div className="space-y-1">
-              <div className="flex justify-between"><span className="text-text-muted">P&amp;L</span><span className="font-mono font-bold text-brand-green">{EXAMPLE_CARD.actual.pl}</span></div>
-              <div className="flex justify-between"><span className="text-text-muted">Entry Price</span><span className="font-mono font-bold">{EXAMPLE_CARD.actual.entry}</span></div>
-              <div className="flex justify-between"><span className="text-text-muted">Exit Price</span><span className="font-mono font-bold">{EXAMPLE_CARD.actual.exit}</span></div>
-              <div className="mt-1 flex items-center justify-between"><span className="text-text-muted">Grade</span><span className="rounded bg-brand-green px-3 py-1 font-black text-white">{EXAMPLE_CARD.actual.grade}</span></div>
+              <div className="flex justify-between"><span className="text-text-muted">P&amp;L</span><span className="font-mono font-bold text-brand-green">{REPLICA.actual.pl}</span></div>
+              <div className="flex justify-between"><span className="text-text-muted">Entry Price</span><span className="font-mono font-bold">{REPLICA.actual.entry}</span></div>
+              <div className="flex justify-between"><span className="text-text-muted">Exit Price</span><span className="font-mono font-bold">{REPLICA.actual.exit}</span></div>
+              <div className="mt-1 flex items-center justify-between"><span className="text-text-muted">Grade</span><span className="rounded px-3 py-1 font-black" style={{ background: '#2563EB', color: '#EFF6FF' }}>{REPLICA.actual.grade}</span></div>
             </div>
           </div>
         </div>
-        {/* Thesis with ✓/✗ grading — mirrors :641-661. */}
+        {/* Thesis ✓/✗ — mirrors :641-661. */}
         <div className="mt-3 border-t border-border pt-3">
           <p className="mb-1.5 text-[10px] font-bold uppercase tracking-wider text-text-muted">Thesis — graded after the outcome</p>
           <div className="space-y-1 text-xs">
-            {EXAMPLE_CARD.thesis.map((t) => (
+            {REPLICA.thesis.map((t) => (
               <div key={t.point} className="flex gap-2">
                 <span className="w-4 shrink-0 text-center">
                   {t.result ? <span className="text-brand-green">✓</span> : <span className="text-brand-red">✗</span>}
@@ -284,111 +306,21 @@ export function GradedCardMirror() {
             ))}
           </div>
         </div>
-        {/* Regime — the ENGINE's own brake declaration (engine-real). */}
+        {/* Regime — mirrors :663-669; the ENGINE's own declaration via the payload. */}
         <div className="mt-3 border-t border-border pt-3">
           <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-text-muted">Regime</p>
-          <p className="font-mono text-xs text-text-secondary">{TRADE_SHOWCASE_BRAKE.declaration}</p>
+          <p className="font-mono text-xs text-text-secondary">{SHOWCASE_DEEP_DIVE.scores.regime.breakdown.survival_brake.declaration}</p>
+        </div>
+        {/* Notes — mirrors :671-677. */}
+        <div className="mt-3 border-t border-border pt-3">
+          <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-text-muted">Notes</p>
+          <p className="text-xs text-text-secondary">{REPLICA.notes}</p>
         </div>
         <p className="mt-3 text-xs text-text-muted">
           Every card writes its claim down BEFORE the trade — max loss, probability, the thesis in
           plain language — then gets linked to the real closed position and graded against what
           happened. A wrong thesis point stays ✗ on the record forever.
         </p>
-      </div>
-    </div>
-  );
-}
-
-// ── 6. DEEP DIVE — engine-real gates + derived FOR/AGAINST ──────────────────
-
-const GATE_META: { key: 'volEdge' | 'quality' | 'regime' | 'infoEdge'; name: string; asks: string }[] = [
-  { key: 'volEdge', name: 'Vol Edge', asks: 'Are these options priced rich vs how the stock actually moves?' },
-  { key: 'quality', name: 'Quality', asks: 'Is the company underneath actually healthy?' },
-  { key: 'regime', name: 'Regime', asks: 'Does today’s macro backdrop favor this trade?' },
-  { key: 'infoEdge', name: 'Info Edge', asks: 'Do the people with better information seem to know something?' },
-];
-
-export function DeepDiveMirror() {
-  // Engine-real: the fixture row the engine sized largest is the deep-dive
-  // subject; the NO-TRADE teaching row is whichever the engine sized at zero.
-  const rows = [...TRADE_SHOWCASE_ROWS].sort((a, b) => b.positionSizePct - a.positionSizePct);
-  const subject = rows[0];
-  const noTrade = TRADE_SHOWCASE_ROWS.find((r) => r.positionSizePct === 0);
-  // FOR vs AGAINST derived from the engine's own gates (>50 = for, else against
-  // — the engine's above-50 convention, composite.ts:141-145).
-  const gates = GATE_META.map((g) => ({ ...g, score: subject[g.key] }));
-  const forGates = gates.filter((g) => g.score != null && g.score > 50);
-  const againstGates = gates.filter((g) => g.score == null || g.score <= 50);
-
-  return (
-    <div className="rounded-lg border border-border bg-white">
-      <SectionTitle title={`The deep dive — why ${subject.ticker}, and why NOT everything else`} tag="Example data" />
-      <div className="space-y-4 p-4 text-xs">
-        {/* WHY THIS TICKER — mirrors TickerChapter (CI:256-257); scores engine-real. */}
-        <div>
-          <p className="mb-1.5 text-[10px] font-bold uppercase tracking-wider text-brand-purple">Why this ticker</p>
-          <p className="text-sm text-text-secondary">
-            {subject.ticker} led this example scan: the engine scored it{' '}
-            <span className="font-mono">&ldquo;{subject.gate}&rdquo;</span> and suggested{' '}
-            <span className="font-semibold text-text-primary">{subject.strategy}</span> at {subject.suggestedDte} DTE.
-            Every number below was computed by the real scoring engine on the declared example inputs.
-          </p>
-          <div className="mt-2 grid gap-2 sm:grid-cols-4">
-            {gates.map((g) => (
-              <div key={g.key} className="rounded border border-border-light bg-bg-row p-2">
-                <div className="flex items-baseline justify-between">
-                  <span className="font-semibold text-text-primary">{g.name}</span>
-                  <span className={`font-mono font-bold ${g.score != null && g.score > 50 ? 'text-brand-green' : 'text-text-muted'}`}>{g.score ?? '—'}</span>
-                </div>
-                <p className="mt-1 text-[11px] leading-snug text-text-muted">{g.asks}</p>
-              </div>
-            ))}
-          </div>
-          <p className="mt-2 text-text-muted">
-            Composite <span className="font-mono font-semibold text-text-primary">{subject.composite ?? '—'}</span> — above 50 means the gate found edge; missing data is excluded and declared, never scored as neutral.
-          </p>
-        </div>
-
-        {/* FOR vs AGAINST — mirrors the card section (CI:465), derived from engine gates. */}
-        <div className="grid gap-3 border-t border-border pt-3 sm:grid-cols-2">
-          <div>
-            <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-brand-green">For</p>
-            <ul className="space-y-1 text-text-secondary">
-              {forGates.map((g) => (
-                <li key={g.key}>• {g.name} {g.score} — {g.asks.replace(/\?$/, '')}: the engine says yes.</li>
-              ))}
-            </ul>
-          </div>
-          <div>
-            <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-brand-red">Against</p>
-            <ul className="space-y-1 text-text-secondary">
-              {againstGates.length > 0 ? (
-                againstGates.map((g) => (
-                  <li key={g.key}>• {g.name} {g.score ?? '—'} — at or below 50: no edge claimed here, and it drags the composite.</li>
-                ))
-              ) : (
-                <li className="text-text-muted">• All four gates cleared 50 in this example.</li>
-              )}
-            </ul>
-          </div>
-        </div>
-
-        {/* Why NOT other strategies — mirrors the rejection_reasons shape (CI:71-76). */}
-        <div className="border-t border-border pt-3">
-          <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-text-muted">Why not the others</p>
-          <p className="text-text-secondary">
-            Strategies that fail a gate are rejected with the failing rule and numbers, e.g.{' '}
-            <span className="font-mono">Short Strangle — rejected: unlimited risk vs your DEFINED_ONLY filter</span>{' '}
-            (example). And when convergence itself fails, the engine says so
-            {noTrade && (
-              <>
-                {' '}— in this example scan {noTrade.ticker} came out{' '}
-                <span className="font-mono">&ldquo;{noTrade.gate}&rdquo;</span>
-              </>
-            )}
-            . It will not manufacture a trade just to have something to sell.
-          </p>
-        </div>
       </div>
     </div>
   );

--- a/src/components/home/tradeShowcasePayload.ts
+++ b/src/components/home/tradeShowcasePayload.ts
@@ -1,0 +1,232 @@
+/**
+ * TRADE-SHOWCASE-REAL-COMPONENTS: the declared example payload the REAL
+ * cockpit components mount on (ScannerResultsTable + TickerChapter).
+ *
+ * WHAT IS ENGINE-REAL vs DECLARED EXAMPLE:
+ *  • TickerDetail.scores — ENGINE-REAL: the complete gate result objects
+ *    (VolEdgeResult/QualityGateResult/RegimeResult/InfoEdgeResult with every
+ *    breakdown and trace) come from the real pure scoreAll() on the declared
+ *    fictional inputs (TRADE_SHOWCASE_FULL, tradeShowcaseRows.ts). Composite
+ *    score/direction/gate strings are the engine's own values verbatim.
+ *  • The GLOBEX Iron Condor card, the chain-fetch table, and the strategy-
+ *    scoring counts — DECLARED EXAMPLE values (chain data needs a live options
+ *    feed), internally coherent and Example-tagged at the mount site.
+ *
+ * IRON CONDOR RECONCILIATION (GLOBEX @ ~$96.80, 30 DTE — the engine's own
+ * suggested DTE for GLOBEX):
+ *   legs  SELL PUT 90 @ 1.15 · BUY PUT 85 @ 0.55 · SELL CALL 105 @ 1.05 · BUY CALL 110 @ 0.45
+ *   COLLECT $120   = ((1.15 − 0.55) + (1.05 − 0.45)) × 100
+ *   MAX LOSS $380  = ($5 wing width − $1.20 credit) × 100
+ *   MAX PROFIT $120 = the credit
+ *   R:R 0.32       = 120 / 380
+ *   B/E $88.80 / $106.20 = 90 − 1.20 and 105 + 1.20
+ *   EV +$10        = 0.78 × 120 − 0.22 × 380 (two-outcome sanity math; the
+ *                    live card's EV uses the engine's three-outcome model) —
+ *                    EV > 0 as it must be: strategy Gate A rejects EV ≤ 0
+ *   EV/RISK 0.026  = 10 / 380
+ *   KELLY          → computed BY THE REAL COMPONENT (quarter-Kelly from
+ *                    hv_pop 0.79 and 120/380, ConvergenceIntelligence.tsx:704-708)
+ *   Greeks: near-zero delta (condor), +theta ($3.10/day), −vega — the correct
+ *   signs for a defined-risk premium-selling structure.
+ *   Strategy-scoring counts reconcile: 14 built = 6 (Gate A) + 3 (Gate B) +
+ *   2 (Gate C) failures + 3 passed; winner Iron Condor at 0.052.
+ *
+ * TRIPWIRE: this file declares data and calls nothing external — zero fetches,
+ * zero paid calls; the engine is only CALLED (via the fixture), never modified.
+ */
+
+import type { TickerDetail } from '@/lib/convergence/filter-engine';
+import type { TradeCardData } from '@/lib/convergence/types';
+import { TRADE_SHOWCASE_FULL } from '@/components/home/tradeShowcaseRows';
+
+// ── the GLOBEX Iron Condor card (declared example, reconciled above) ─────────
+
+const GLOBEX_CONDOR: TradeCardData = {
+  symbol: 'GLOBEX',
+  label: 'Iron Condor · 30 DTE',
+  setup: {
+    strategy_name: 'Iron Condor',
+    legs: [
+      { type: 'put', side: 'sell', strike: 90, price: 1.15 },
+      { type: 'put', side: 'buy', strike: 85, price: 0.55 },
+      { type: 'call', side: 'sell', strike: 105, price: 1.05 },
+      { type: 'call', side: 'buy', strike: 110, price: 0.45 },
+    ],
+    expiration_date: '2026-08-11',
+    dte: 30,
+    net_credit: 1.2,
+    net_debit: null,
+    max_profit: 120,
+    max_loss: 380,
+    breakevens: [88.8, 106.2],
+    probability_of_profit: 0.78,
+    pop_method: 'breakeven_d2',
+    hv_pop: 0.79,
+    risk_reward_ratio: 0.32,
+    greeks: { delta: -0.02, gamma: -0.01, theta: 0.031, vega: -0.09, theta_per_day: 3.1 },
+    ev: 10,
+    ev_per_risk: 0.026,
+    has_wide_spread: false,
+    is_unlimited_risk: false,
+  },
+  why: {
+    composite_score: TRADE_SHOWCASE_FULL.GLOBEX.composite.score,
+    letter_grade: 'C+',
+    direction: TRADE_SHOWCASE_FULL.GLOBEX.composite.direction,
+    convergence_gate: TRADE_SHOWCASE_FULL.GLOBEX.composite.convergence_gate,
+    category_scores: TRADE_SHOWCASE_FULL.GLOBEX.composite.category_scores,
+    plain_english_signals: [
+      'All four gates cleared 50 — a marginal but unanimous signal (example)',
+      'Options modestly rich vs realized movement — premium seller collects the gap (example)',
+      'Direction NEUTRAL — a range-bound structure fits better than a directional bet (example)',
+    ],
+    regime_context: TRADE_SHOWCASE_FULL.GLOBEX.composite.regime_brake.declaration,
+    risk_flags: [],
+  },
+  key_stats: {
+    // Values match the declared GLOBEX fixture inputs (tradeShowcaseRows.ts).
+    current_price: 96.8,
+    iv_rank: 52,
+    iv_percentile: 55,
+    iv30: 30,
+    hv30: 26,
+    iv_hv_spread: 4,
+    vol_cone: { hv10: 24, hv20: 25, hv30: 26, hv60: 27, hv90: 27, current_iv: 30, candles_used: 130, note: 'example vol cone (declared demo candles)' },
+    forward_vol: null,
+    earnings_date: null,
+    days_to_earnings: 52,
+    earnings_pattern: null,
+    market_cap: 22_000_000_000,
+    sector: 'Industrials',
+    beta: 0.9,
+    spy_correlation: 0.7,
+    pe_ratio: 17,
+    dividend_yield: 2.1,
+    liquidity_rating: 3,
+    lendability: 'Easy To Borrow',
+    borrow_rate: 0.3,
+    buzz_ratio: null,
+    sentiment_momentum: null,
+    analyst_consensus: 'Hold',
+  },
+};
+
+// ── TickerDetail rows — gate results ENGINE-REAL, cards/chain declared ───────
+
+function detailFor(sym: 'ACME' | 'GLOBEX' | 'INITECH', cards?: TradeCardData[]): TickerDetail {
+  const full = TRADE_SHOWCASE_FULL[sym];
+  return {
+    symbol: sym,
+    pipeline_runtime_ms: 94_000, // example runtime, matches the funnel footer
+    scores: {
+      vol_edge: full.vol_edge,
+      quality: full.quality,
+      regime: full.regime,
+      info_edge: full.info_edge,
+      composite: {
+        // Non-null for all three demo tickers (all four gates scored).
+        score: full.composite.score as number,
+        direction: full.composite.direction,
+        convergence_gate: full.composite.convergence_gate,
+        categories_above_50: full.composite.categories_above_50,
+        category_scores: full.composite.category_scores as {
+          vol_edge: number; quality: number; regime: number; info_edge: number;
+        },
+      },
+    },
+    trade_cards: cards,
+    data_gaps: [],
+  };
+}
+
+/** Table rows: GLOBEX carries the full condor card; ACME and INITECH are the
+ *  honest no-card cases (strategy gates / convergence said no). */
+export const SHOWCASE_RESULTS: TickerDetail[] = [
+  detailFor('GLOBEX', [GLOBEX_CONDOR]),
+  detailFor('ACME'),
+  detailFor('INITECH'),
+];
+
+/** Per-ticker strategy rejections — the real rejection_reasons shape
+ *  (filter-engine.ts TickerDetail._rejection_reasons / SRT rejectionMap). */
+export const SHOWCASE_REJECTIONS: Record<string, { strategy: string; reason: string; gate: string; details?: { value: number; threshold: number } }[]> = {
+  ACME: [
+    { strategy: 'Bull Put Spread', reason: 'net credit below the minimum', gate: 'Gate C (min credit)', details: { value: 0.27, threshold: 0.3 } },
+    { strategy: 'Iron Condor', reason: 'expected value not positive', gate: 'Gate A (EV ≤ 0)', details: { value: -4, threshold: 0 } },
+  ],
+  INITECH: [
+    { strategy: 'ALL', reason: TRADE_SHOWCASE_FULL.INITECH.composite.convergence_gate, gate: 'Convergence gate' },
+  ],
+};
+
+// ── the pipelineProgress slice TickerChapter reads (steps K, N, P) ───────────
+// Field names match exactly what the real component reads
+// (ConvergenceIntelligence.tsx:225-368): step_k.data.rankings,
+// step_n.data.tickers, step_p.data.tickers.
+
+const rank = (sym: 'ACME' | 'GLOBEX' | 'INITECH', selection: string) => {
+  const c = TRADE_SHOWCASE_FULL[sym].composite;
+  return {
+    symbol: sym,
+    composite: c.score,
+    vol_edge: c.category_scores.vol_edge,
+    quality: c.category_scores.quality,
+    regime: c.category_scores.regime,
+    info_edge: c.category_scores.info_edge,
+    sector: sym === 'GLOBEX' ? 'Industrials' : 'Technology',
+    direction: c.direction,
+    selection_status: selection,
+  };
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const SHOWCASE_PROGRESS: Record<string, any> = {
+  step_k: {
+    data: {
+      // Ranked by the engine's own composites (62.5 > 52 > 36.3).
+      rankings: [
+        rank('ACME', '✓ Selected — ranked #1 (example scan)'),
+        rank('GLOBEX', '✓ Selected — ranked #2 (example scan)'),
+        rank('INITECH', '✗ Not selected — NO TRADE (convergence too weak)'),
+      ],
+    },
+  },
+  step_n: {
+    data: {
+      tickers: [
+        {
+          symbol: 'GLOBEX',
+          expirationsEvaluated: 3,
+          winningExpiration: '2026-08-11',
+          winningDte: 30,
+          strikeCount: 48,
+          priceSource: 'live_quotes',
+          allExpirations: [
+            { expiration: '2026-07-31', dte: 19, strikeCount: 42, strategiesBuilt: 12, bestScore: 0.041 },
+            { expiration: '2026-08-11', dte: 30, strikeCount: 48, strategiesBuilt: 14, bestScore: 0.052 },
+            { expiration: '2026-09-18', dte: 68, strikeCount: 36, strategiesBuilt: 11, bestScore: 0.038 },
+          ],
+        },
+      ],
+    },
+  },
+  step_p: {
+    data: {
+      tickers: [
+        {
+          symbol: 'GLOBEX',
+          // 14 built = 6 + 3 + 2 failures + 3 passed (reconciles).
+          strategiesBuilt: 14,
+          gateAFailed: 6,
+          gateBFailed: 3,
+          gateCFailed: 2,
+          strategiesPassed: 3,
+          winner: 'Iron Condor',
+          winnerScore: 0.052,
+        },
+      ],
+    },
+  },
+};
+
+export const SHOWCASE_DEEP_DIVE: TickerDetail = SHOWCASE_RESULTS[0];

--- a/src/components/home/tradeShowcaseRows.ts
+++ b/src/components/home/tradeShowcaseRows.ts
@@ -24,6 +24,7 @@
  */
 
 import { scoreAll } from '@/lib/convergence/composite';
+import type { FullScoringResult } from '@/lib/convergence/composite';
 import type { ConvergenceInput, FredMacroData, TTScannerData, CandleData } from '@/lib/convergence/types';
 
 // ── declared synthetic inputs ────────────────────────────────────────────────
@@ -334,7 +335,17 @@ function toRow(input: ConvergenceInput): TradeShowcaseRow {
 /** The three demo rows — computed by the real engine on the declared inputs. */
 export const TRADE_SHOWCASE_ROWS: TradeShowcaseRow[] = [ACME, GLOBEX, INITECH].map(toRow);
 
+/** TRADE-SHOWCASE-REAL-COMPONENTS: the COMPLETE engine results (full gate
+ *  result objects with every breakdown/trace), keyed by ticker — so the real
+ *  cockpit components (ScannerResultsTable / TickerChapter) can mount on
+ *  engine-real TickerDetail.scores. Same pure scoreAll, same declared inputs. */
+export const TRADE_SHOWCASE_FULL: Record<string, FullScoringResult> = {
+  ACME: scoreAll(ACME),
+  GLOBEX: scoreAll(GLOBEX),
+  INITECH: scoreAll(INITECH),
+};
+
 /** The engine's survival-brake declaration for the shared demo macro (all rows
  *  see the same market state, like a real scan) — rendered verbatim. */
 export const TRADE_SHOWCASE_BRAKE: { state: 'OFF' | 'ON' | 'UNVERIFIED'; declaration: string } =
-  scoreAll(ACME).composite.regime_brake;
+  TRADE_SHOWCASE_FULL.ACME.composite.regime_brake;


### PR DESCRIPTION
…h example props — kill the simplified mirrors

Phase 1 verdicts (audited before building):
- ScannerResultsTable: MOUNTABLE — zero fetches/effects (grep clean), fully props-driven (ScannerResultsTableProps :58-69), handles card-less rows natively (trade_cards ?? [] at :397, "No strategies" + rejection reason at :666-668).
- TickerChapter deep dive: MOUNTABLE — exported (CI:212), props-driven, AccountSizeContext defaults to 0 (CI:23) = the honest no-dollar-math state, so no provider needed. Sections read pipelineProgress step_k.rankings / step_n.tickers / step_p.tickers (CI:225-368) — payload matches those field names exactly.
- TradeLabPanel: NOT mountable — self-fetches on mount (:118-135), card rows are inline JSX with no props seam. Structural replica survives.

Built on those verdicts:
- New tradeShowcasePayload.ts: one coherent GLOBEX Iron Condor example (engine-NEUTRAL direction, engine-suggested 30 DTE). TickerDetail gate results are ENGINE-REAL full objects (new TRADE_SHOWCASE_FULL export of scoreAll outputs, breakdowns/traces included); composite score/direction/gate strings verbatim. Declared card reconciles: COLLECT $120 = (0.60+0.60)x100; MAX LOSS $380 = (5-1.20)x100; R:R 0.32; B/E 88.80/106.20; EV +$10 = .78x120-.22x380 (>0 as Gate A requires); EV/RISK 0.026; KELLY computed BY the real component (quarter-Kelly, CI:704-708). Strategy counts reconcile: 14 built = 6+3+2 failed + 3 passed. ACME/INITECH ride as honest no-card rows with rejection reasons (INITECH's = the engine's NO-TRADE caption).
- RealCockpitDemo mounts the REAL ScannerResultsTable + REAL TickerChapter on that payload; Queue-Card/save callbacks route to signup (logged-out) or the CTA (locked) — nothing persists.
- TradeCardMirror + DeepDiveMirror deleted: THE TRADE now renders where it really lives, inside the real deep dive's TerminalTradeCard.
- GradedCardMirror rebuilt as a structural replica of TradeLabPanel's JSX (row header :404-419, legs :421-429, meta :432-438, scorecard :565-639, thesis :641-661, regime :663-669, notes :671-677) on the SAME condor: exit 0.35 -> +$85 = (1.20-0.35)x100, grade B, real status/grade colors, green graded tint. Regime line = the engine's brake declaration via the payload.

Page order unchanged: hero -> scanner -> pipeline -> record -> real cockpit -> graded card -> CTA. Zero fetches on the showcase surface (grep clean); engine/gate/route/cockpit-component diff EMPTY. tsc clean (payload satisfies the real components' types); next build "Compiled successfully".


Claude-Session: https://claude.ai/code/session_0166NgTwN2YavGPvPwra9Ycz