### PR TITLE
TRADE-SHOWCASE-BLOOMBERG: Bloomberg-style dark hero + alternating in-…

### DIFF
--- a/src/components/home/TabShowcaseTemplate.tsx
+++ b/src/components/home/TabShowcaseTemplate.tsx
@@ -35,13 +35,50 @@ export interface ShowcaseConceptCard {
   measures: string;
 }
 
-export interface TabShowcaseTemplateProps {
-  /** Small uppercase chip above the headline (e.g. "The Trade tab"). */
-  heroBadge: string;
-  /** Post-ready headline. Keep it honest — real numbers only. */
+export interface ShowcaseDarkHero {
+  /** Small uppercase eyebrow (e.g. "Trade — the scanner"). */
+  eyebrow: string;
   headline: string;
-  /** Teaching subcopy: the real data sources + what the pipe does. */
   subcopy: string;
+  /** The unlock button (routes to the existing signup/checkout flow). */
+  cta: ReactNode;
+  /** The dark terminal panel — REAL payload rows, example-tagged. */
+  panel: ReactNode;
+}
+
+export interface ShowcaseEditorialRow {
+  title: string;
+  copy: string;
+  panel: ReactNode;
+  /** Which side the dark panel sits on (rows alternate, Bloomberg-style). */
+  panelSide: 'left' | 'right';
+}
+
+export interface ShowcaseProductTile {
+  title: string;
+  line: string;
+  /** id of the real section below to scroll to. */
+  anchorId: string;
+}
+
+export interface TabShowcaseTemplateProps {
+  /** Small uppercase chip above the headline (e.g. "The Trade tab").
+   *  Used by the DEFAULT light hero — ignored when darkHero is set. */
+  heroBadge?: string;
+  /** Post-ready headline (default hero). Keep it honest — real numbers only. */
+  headline?: string;
+  /** Teaching subcopy (default hero): real data sources + what the pipe does. */
+  subcopy?: string;
+  /** TRADE-SHOWCASE-BLOOMBERG: the dark cinematic hero (near-black base,
+   *  brand-purple radial glow). When set, it REPLACES the default purple band.
+   *  Optional — tabs not passing it render exactly as before. */
+  darkHero?: ShowcaseDarkHero;
+  /** Centered section header over the editorial rows (e.g. "Go further…"). */
+  editorialTitle?: string;
+  /** Alternating dark-panel + copy rows (Bloomberg Terminal-in-Action). */
+  editorialRows?: ShowcaseEditorialRow[];
+  /** Dark product tiles, each anchoring to a real section below. */
+  productTiles?: ShowcaseProductTile[];
   /** Optional section(s) rendered BETWEEN the hero and the pipe rail — for
    *  content that precedes the pipe in the real product flow (e.g. Trade's
    *  filter panel: you set filters and hit Scan, THEN the pipe runs). */
@@ -77,6 +114,10 @@ export default function TabShowcaseTemplate({
   heroBadge,
   headline,
   subcopy,
+  darkHero,
+  editorialTitle,
+  editorialRows,
+  productTiles,
   preSteps,
   stepsTitle,
   stepsTag,
@@ -90,17 +131,81 @@ export default function TabShowcaseTemplate({
 }: TabShowcaseTemplateProps) {
   return (
     <div className="space-y-6">
-      {/* ── Hero band — the homepage hero's own tokens (purple band, light type) ── */}
-      <div className="rounded-lg bg-brand-purple px-6 py-8 text-white sm:px-8">
-        <div className="flex flex-wrap items-center gap-2">
-          <span className="rounded border border-white/25 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-white/80">
-            {heroBadge}
-          </span>
-          <ExampleTag text="Example data" />
+      {darkHero ? (
+        /* ── TRADE-SHOWCASE-BLOOMBERG hero: near-black base, brand-purple
+              radial glow (rgb(59 45 107) = --ts-purple; rgb(45 27 78) =
+              --ts-purple-deep). No new palette — the brand family, deepened. ── */
+        <div
+          className="overflow-hidden rounded-lg px-6 py-10 text-white sm:px-10"
+          style={{
+            background:
+              'radial-gradient(ellipse 80% 90% at 85% 10%, rgb(59 45 107 / 0.65), transparent 60%), radial-gradient(ellipse 60% 70% at 100% 80%, rgb(45 27 78 / 0.5), transparent 55%), #0b0a14',
+          }}
+        >
+          <div className="grid items-center gap-8 lg:grid-cols-2">
+            <div>
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="rounded border border-white/20 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-white/70">
+                  {darkHero.eyebrow}
+                </span>
+                <ExampleTag text="Example data" />
+              </div>
+              <h3 className="mt-4 text-3xl font-light tracking-tight sm:text-5xl">{darkHero.headline}</h3>
+              <p className="mt-4 max-w-xl text-sm leading-relaxed text-white/65">{darkHero.subcopy}</p>
+              <div className="mt-6">{darkHero.cta}</div>
+            </div>
+            <div>{darkHero.panel}</div>
+          </div>
         </div>
-        <h3 className="mt-3 text-3xl font-light tracking-tight sm:text-4xl">{headline}</h3>
-        <p className="mt-3 max-w-2xl text-sm leading-relaxed text-white/75">{subcopy}</p>
-      </div>
+      ) : (
+        /* ── Default hero band — the homepage hero's own tokens ── */
+        <div className="rounded-lg bg-brand-purple px-6 py-8 text-white sm:px-8">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="rounded border border-white/25 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-white/80">
+              {heroBadge}
+            </span>
+            <ExampleTag text="Example data" />
+          </div>
+          <h3 className="mt-3 text-3xl font-light tracking-tight sm:text-4xl">{headline}</h3>
+          <p className="mt-3 max-w-2xl text-sm leading-relaxed text-white/75">{subcopy}</p>
+        </div>
+      )}
+
+      {/* ── Editorial "in action" rows — alternating dark panel + copy ── */}
+      {editorialRows && editorialRows.length > 0 && (
+        <div className="space-y-6 py-2">
+          {editorialTitle && (
+            <p className="text-center text-[11px] font-bold uppercase tracking-[0.2em] text-text-muted">{editorialTitle}</p>
+          )}
+          {editorialRows.map((row) => (
+            <div key={row.title} className="grid items-center gap-5 lg:grid-cols-2">
+              <div className={row.panelSide === 'left' ? 'lg:order-1' : 'lg:order-2'}>{row.panel}</div>
+              <div className={row.panelSide === 'left' ? 'lg:order-2' : 'lg:order-1'}>
+                <h4 className="text-xl font-light tracking-tight text-text-primary sm:text-2xl">{row.title}</h4>
+                <p className="mt-2 max-w-lg text-sm leading-relaxed text-text-secondary">{row.copy}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* ── Dark product tiles — each anchors to its real section below ── */}
+      {productTiles && productTiles.length > 0 && (
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          {productTiles.map((t) => (
+            <button
+              key={t.title}
+              type="button"
+              onClick={() => document.getElementById(t.anchorId)?.scrollIntoView({ behavior: 'smooth', block: 'start' })}
+              className="rounded-lg border border-panel-border bg-panel p-4 text-left transition-colors hover:bg-panel-hover"
+            >
+              <p className="font-semibold text-white">{t.title}</p>
+              <p className="mt-1 text-xs leading-relaxed text-white/55">{t.line}</p>
+              <p className="mt-2 text-[10px] font-semibold uppercase tracking-wider text-brand-amber">See it below ↓</p>
+            </button>
+          ))}
+        </div>
+      )}
 
       {/* ── Pre-pipe section(s) — the real flow's first act (optional) ── */}
       {preSteps}

--- a/src/components/home/TabShowcases.tsx
+++ b/src/components/home/TabShowcases.tsx
@@ -39,7 +39,12 @@ import {
   RealCockpitDemo,
   TrackRecordMirror,
   GradedCardMirror,
+  UnlockTradeButton,
+  HeroTerminalPanel,
+  PipelinePanelDark,
+  RecordPanelDark,
   TRADE_UNLOCK_CTA_ID,
+  TRADE_SECTION_IDS,
 } from '@/components/home/TradeShowcaseSections';
 
 // ── shared chrome ────────────────────────────────────────────────────────────
@@ -177,9 +182,40 @@ const TRADE_PIPE_STEPS: ShowcaseStep[] = [
 export function TradeShowcase({ currentUserId, onRequireAuth }: ShowcaseProps) {
   return (
     <TabShowcaseTemplate
-      heroBadge="The Trade tab"
-      headline="An entire index in. One decision out."
-      subcopy="Pick your universe — the S&P 500 (475 stocks) or the Nasdaq 100 (101), with more indexes already wired into the engine. Live prices from TastyTrade. Company numbers from Finnhub. Macro from FRED. Filings from SEC EDGAR. The mood from Grok. Twenty steps and four gates later you get a sized suggestion — or an honest NO TRADE."
+      // TRADE-SHOWCASE-BLOOMBERG: dark cinematic hero replaces the purple band;
+      // the terminal panel renders REAL payload rows (condor / no-strategies /
+      // engine NO-TRADE caption / funnel).
+      darkHero={{
+        eyebrow: 'Trade — the scanner',
+        headline: 'An entire index in full focus. One decision out.',
+        subcopy:
+          'Pick your universe — the S&P 500 (475 stocks) or the Nasdaq 100 (101), with more indexes already wired into the engine. Live prices from TastyTrade. Company numbers from Finnhub. Macro from FRED. Filings from SEC EDGAR. The mood from Grok. Twenty steps and four gates later you get a sized suggestion — or an honest NO TRADE.',
+        cta: <UnlockTradeButton currentUserId={currentUserId} onRequireAuth={onRequireAuth} />,
+        panel: <HeroTerminalPanel />,
+      }}
+      editorialTitle="Go further with the Trade tab"
+      editorialRows={[
+        {
+          title: 'Watch every step run.',
+          copy:
+            'A scan is not a spinner — it is 20 named steps you watch happen: what was fetched, what was excluded and why, what survived. Nothing happens off-screen, and the full rail below shows all of it.',
+          panel: <PipelinePanelDark />,
+          panelSide: 'left',
+        },
+        {
+          title: 'A track record that grades itself.',
+          copy:
+            'Denominators first: unlinked positions are counted and declared, a win rate never appears without its n, and any trade that breaks its claimed max loss is named. Example numbers — your record starts at zero and only ever shows what actually happened.',
+          panel: <RecordPanelDark />,
+          panelSide: 'right',
+        },
+      ]}
+      productTiles={[
+        { title: 'The scanner', line: '18 real controls, 16 strategies — the live filter panel, interactive below.', anchorId: TRADE_SECTION_IDS.scanner },
+        { title: 'The deep dive', line: 'Why this ticker — and why NOT everything else, gate by gate.', anchorId: TRADE_SECTION_IDS.deepDive },
+        { title: 'Trade cards', line: 'Priced, sized, then graded against what actually happened.', anchorId: TRADE_SECTION_IDS.gradedCard },
+        { title: 'The survival brake', line: 'Backwardation or a VVIX spike cuts short-vol suggestions automatically.', anchorId: TRADE_SECTION_IDS.deepDive },
+      ]}
       // TRADE-SHOWCASE-ORDER: the scanner renders BEFORE the pipe (preSteps) —
       // in the real product you set filters and hit Scan, THEN the pipe runs.
       preSteps={<ScannerPanelDemo currentUserId={currentUserId} onRequireAuth={onRequireAuth} />}

--- a/src/components/home/TradeShowcaseSections.tsx
+++ b/src/components/home/TradeShowcaseSections.tsx
@@ -47,6 +47,134 @@ import {
 /** id the Scan button scrolls to for logged-in-but-locked viewers. */
 export const TRADE_UNLOCK_CTA_ID = 'trade-unlock-cta';
 
+/** TRADE-SHOWCASE-BLOOMBERG: anchor ids the dark product tiles scroll to. */
+export const TRADE_SECTION_IDS = {
+  scanner: 'trade-scanner',
+  cockpit: 'trade-cockpit',
+  deepDive: 'trade-deep-dive',
+  gradedCard: 'trade-graded-card',
+} as const;
+
+// ── BLOOMBERG-STYLE DARK PIECES ──────────────────────────────────────────────
+// Styling/framing only: every number below comes from the existing payload
+// (tradeShowcasePayload.ts) or the constants already on the pipe rail — no
+// new figures. Dark surfaces use the config's panel token family
+// (tailwind.config.ts:34-40) + the brand purple family for the hero glow.
+
+/** The hero CTA — routes to the existing signup/checkout flow (same recipe as
+ *  the Scan button: logged-out → signup modal; locked → the Unlock CTA). */
+export function UnlockTradeButton({
+  currentUserId,
+  onRequireAuth,
+}: {
+  currentUserId: string;
+  onRequireAuth: () => void;
+}) {
+  const go = () => {
+    if (!currentUserId) {
+      onRequireAuth();
+    } else {
+      document.getElementById(TRADE_UNLOCK_CTA_ID)?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+  };
+  return (
+    <button
+      type="button"
+      onClick={go}
+      className="rounded-lg bg-brand-purple px-6 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-brand-purple-hover"
+    >
+      Unlock Trade
+    </button>
+  );
+}
+
+/** The hero's dark terminal panel — REAL rows from the existing payload:
+ *  the GLOBEX condor card values, ACME's no-strategies rejection, INITECH's
+ *  engine NO-TRADE caption, and the funnel line already on the pipe rail. */
+export function HeroTerminalPanel() {
+  const condor = SHOWCASE_DEEP_DIVE.trade_cards![0].setup;
+  const initechReason = SHOWCASE_REJECTIONS.INITECH[0].reason; // the engine's own caption
+  return (
+    <div className="rounded-lg border border-panel-border bg-panel/90 p-4 font-mono text-[11px] leading-relaxed shadow-2xl">
+      <div className="flex items-center justify-between border-b border-panel-border pb-2">
+        <span className="font-bold uppercase tracking-wider text-white/60">Scan · S&amp;P 500</span>
+        <ExampleTag text="Example scan" />
+      </div>
+      <p className="mt-2 text-white/50">475 → 52 → 40 → 20 → 9 · 128 Finnhub calls · ~94s</p>
+      <div className="mt-2 space-y-1.5">
+        <p>
+          <span className="font-bold text-white">GLOBEX</span>{' '}
+          <span className="text-white/60">{condor.strategy_name} · {condor.dte} DTE</span>
+          <br />
+          <span className="text-brand-green">COLLECT ${((condor.net_credit ?? 0) * 100).toFixed(0)}</span>
+          <span className="text-white/50"> · MAX L </span><span className="text-brand-red">${condor.max_loss}</span>
+          <span className="text-white/50"> · POP </span><span className="text-white/90">{Math.round((condor.probability_of_profit ?? 0) * 100)}%</span>
+        </p>
+        <p>
+          <span className="font-bold text-white">ACME</span>{' '}
+          <span className="text-white/50">No strategies passed — {SHOWCASE_REJECTIONS.ACME[0].gate}</span>
+        </p>
+        <p>
+          <span className="font-bold text-white">INITECH</span>{' '}
+          <span className="text-brand-red">{initechReason}</span>
+        </p>
+      </div>
+      <p className="mt-2 border-t border-panel-border pt-2 text-white/40">
+        The engine says no more often than yes — and shows its work either way.
+      </p>
+    </div>
+  );
+}
+
+/** Editorial row A panel: the pipe, dark — the same step highlights and
+ *  counts the full rail below carries (475/9 real; 128/2,208 example). */
+export function PipelinePanelDark() {
+  const lines: [string, string][] = [
+    ['A', 'TT Scanner — 475 symbols fetched'],
+    ['I', 'Data Enrichment — 128 Finnhub calls (example)'],
+    ['M', 'Final Selection — 9 selected, sector-capped'],
+    ['O', 'Live Greeks — 2,208 events across 9 symbols (example)'],
+    ['T', 'Save & Return — snapshot saved for the self-graded record'],
+  ];
+  return (
+    <div className="rounded-lg border border-panel-border bg-panel p-4 font-mono text-[11px] leading-relaxed">
+      <div className="flex items-center justify-between border-b border-panel-border pb-2">
+        <span className="font-bold uppercase tracking-wider text-white/60">Pipeline — 20 steps, A to T</span>
+        <ExampleTag text="Example scan" />
+      </div>
+      <div className="mt-2 space-y-1">
+        {lines.map(([code, text]) => (
+          <p key={code}>
+            <span className="font-bold text-brand-amber">{code}</span>{' '}
+            <span className="text-white/70">{text}</span>
+          </p>
+        ))}
+        <p className="text-white/40">… all 20, in full, below ↓</p>
+      </div>
+    </div>
+  );
+}
+
+/** Editorial row B panel: the record, dark — the same values the
+ *  track-record mirror below carries. */
+export function RecordPanelDark() {
+  return (
+    <div className="rounded-lg border border-panel-border bg-panel p-4 font-mono text-[11px] leading-relaxed">
+      <div className="flex items-center justify-between border-b border-panel-border pb-2">
+        <span className="font-bold uppercase tracking-wider text-white/60">Track record</span>
+        <ExampleTag text="Example data" />
+      </div>
+      <div className="mt-2 space-y-1 text-white/70">
+        <p><span className="text-white">7</span> linked · <span className="text-white">3</span> unlinked (excluded) · <span className="text-white">2</span> queued</p>
+        <p><span className="font-bold text-brand-green">7W – 0L – 0BE</span> of <span className="text-white">7</span> decided</p>
+        <p>Net P&amp;L <span className="font-bold text-brand-green">$1,284</span> <span className="text-white/40">(linked only)</span></p>
+        <p>Max-loss model: <span className="text-white">7 of 7</span> stayed within the claim</p>
+        <p>Grades A <span className="text-white">3</span> · B <span className="text-white">3</span> · C <span className="text-white">1</span> · D <span className="text-white">0</span> · F <span className="text-white">0</span></p>
+      </div>
+    </div>
+  );
+}
+
 function SectionTitle({ title, tag }: { title: string; tag?: string }) {
   return (
     <div className="flex flex-wrap items-center gap-2 border-b border-border px-4 py-2.5">
@@ -79,7 +207,7 @@ export function ScannerPanelDemo({
   };
 
   return (
-    <div className="rounded-lg border border-border bg-white">
+    <div id={TRADE_SECTION_IDS.scanner} className="scroll-mt-4 rounded-lg border border-border bg-white">
       <SectionTitle title="The scanner — every control is real. Set your filters, hit Scan." />
       <div className="p-4">
         <ScanFilterForm
@@ -121,7 +249,7 @@ export function RealCockpitDemo({
 
   return (
     <div className="space-y-4">
-      <div className="rounded-lg border border-border bg-white">
+      <div id={TRADE_SECTION_IDS.cockpit} className="scroll-mt-4 rounded-lg border border-border bg-white">
         <SectionTitle
           title="The results — the real table, the real deep dive"
           tag="Example scan — engine-real gate scores, declared example chain/card values"
@@ -142,7 +270,7 @@ export function RealCockpitDemo({
           />
         </div>
       </div>
-      <div className="rounded-lg border border-border bg-white">
+      <div id={TRADE_SECTION_IDS.deepDive} className="scroll-mt-4 rounded-lg border border-border bg-white">
         <SectionTitle
           title="Every selected ticker gets this — the full deep dive"
           tag="Example data"
@@ -247,7 +375,7 @@ const REPLICA = {
 
 export function GradedCardMirror() {
   return (
-    <div className="rounded-lg border border-border bg-white">
+    <div id={TRADE_SECTION_IDS.gradedCard} className="scroll-mt-4 rounded-lg border border-border bg-white">
       <SectionTitle title="After the trade — the card grades itself against reality" tag="Example data" />
       {/* Row container: graded + positive P&L → green tint (TradeLabPanel.tsx:394-398). */}
       <div className="bg-green-50 px-4 py-3">


### PR DESCRIPTION
…action sections framing the real cockpit

Styling/framing pass over the real-components showcase (7ba73bbc) — what is shown is unchanged; how it is framed is new.

- DARK HERO (template darkHero slot): near-black #0b0a14 base with a brand-purple radial glow — rgb(59 45 107) = --ts-purple and rgb(45 27 78) = --ts-purple-deep from the config's brand family, no new palette. Left: eyebrow, "An entire index in full focus. One decision out.", the sources subcopy, solid-purple Unlock Trade
  button (same route as Scan: logged-out -> signup modal, locked ->
  the CTA anchor). Right: HeroTerminalPanel, a dark mono terminal rendering REAL payload rows — the GLOBEX condor line (COLLECT $120 / MAX L $380 / POP 78% computed FROM the payload setup), ACME's no-strategies rejection gate, INITECH's engine NO-TRADE caption (from SHOWCASE_REJECTIONS), and the funnel line already on the rail. Example-tagged.
- EDITORIAL ROWS (template editorialRows slot, alternating sides): "Watch every step run." with PipelinePanelDark (step highlights A/I/M/O/T reusing the rail's exact counts — 475/9 real, 128/2,208 example) and "A track record that grades itself." with RecordPanelDark (the same 7W-0L-0BE / $1,284 / 7-of-7 / A3 B3 C1 values the mirror below carries).
- DARK PRODUCT TILES (template productTiles slot): four panel-token cards (Scanner / Deep dive / Trade cards / Survival brake), each scrolling to its real section via new TRADE_SECTION_IDS anchors.
- THE REAL COCKPIT below is untouched: ScanFilterForm, ScannerResultsTable + TickerChapter on the same payload, the graded replica, the LockedTabCard CTA — diff over the payload and the cockpit components is EMPTY.

Reusability: darkHero/editorialTitle/editorialRows/productTiles are all optional template props — tabs 2-9 can adopt the pattern; tabs not passing them render exactly as before (heroBadge/headline/subcopy now optional, used only by the default light hero).

Zero fetches on the showcase surface (grep clean); no gate/route/lib changes. tsc clean; next build "Compiled successfully".


Claude-Session: https://claude.ai/code/session_0166NgTwN2YavGPvPwra9Ycz