### PR TITLE
TRADE-SHOWCASE-SLIDES: full top-down editorial slides — every product…

### DIFF
--- a/src/components/home/TabShowcases.tsx
+++ b/src/components/home/TabShowcases.tsx
@@ -43,8 +43,13 @@ import {
   HeroTerminalPanel,
   PipelinePanelDark,
   RecordPanelDark,
+  ScannerPanelDark,
+  ResultsTablePanelDark,
+  DeepDivePanelDark,
+  TradeCardPanelDark,
+  GradedPanelDark,
+  BrakePanelDark,
   TRADE_UNLOCK_CTA_ID,
-  TRADE_SECTION_IDS,
 } from '@/components/home/TradeShowcaseSections';
 
 // ── shared chrome ────────────────────────────────────────────────────────────
@@ -194,6 +199,9 @@ export function TradeShowcase({ currentUserId, onRequireAuth }: ShowcaseProps) {
         panel: <HeroTerminalPanel />,
       }}
       editorialTitle="Go further with the Trade tab"
+      // TRADE-SHOWCASE-SLIDES: the full top-down slide sequence — one
+      // self-contained dark panel per product piece, sides alternating,
+      // every value from the payload / real constants / the graded replica.
       editorialRows={[
         {
           title: 'Watch every step run.',
@@ -209,16 +217,62 @@ export function TradeShowcase({ currentUserId, onRequireAuth }: ShowcaseProps) {
           panel: <RecordPanelDark />,
           panelSide: 'right',
         },
-      ]}
-      productTiles={[
-        { title: 'The scanner', line: '18 real controls, 16 strategies — the live filter panel, interactive below.', anchorId: TRADE_SECTION_IDS.scanner },
-        { title: 'The deep dive', line: 'Why this ticker — and why NOT everything else, gate by gate.', anchorId: TRADE_SECTION_IDS.deepDive },
-        { title: 'Trade cards', line: 'Priced, sized, then graded against what actually happened.', anchorId: TRADE_SECTION_IDS.gradedCard },
-        { title: 'The survival brake', line: 'Backwardation or a VVIX spike cuts short-vol suggestions automatically.', anchorId: TRADE_SECTION_IDS.deepDive },
+        {
+          title: 'Eighteen real controls. Sixteen strategies.',
+          copy:
+            'Universe, direction, premium, defined risk, DTE and width, four liquidity gates, six edge metrics, sixteen strategy chips — the live panel is below. Set your filters, hit Scan.',
+          panel: <ScannerPanelDark />,
+          panelSide: 'left',
+        },
+        {
+          title: 'Every ticker scored. Strategies only where the gates pass.',
+          copy:
+            'The table shows all of it: the composite, the built strategy with its price and odds — and, just as loudly, the tickers where no strategy survived and exactly which gate stopped them.',
+          panel: <ResultsTablePanelDark />,
+          panelSide: 'right',
+        },
+        {
+          title: 'Why — and why not.',
+          copy:
+            'Each selected ticker gets a deep dive: the four gate scores, the convergence verdict in the engine’s own words, and the rejection reasons for everything that did not make it. No black box.',
+          panel: <DeepDivePanelDark />,
+          panelSide: 'left',
+        },
+        {
+          title: 'The whole trade, written down.',
+          copy:
+            'Legs at live prices, what you collect, the most you can lose, the odds two ways, expected value, breakevens, the Greeks, and how big Kelly says to size it. A priced claim you can hold it to.',
+          panel: <TradeCardPanelDark />,
+          panelSide: 'right',
+        },
+        {
+          title: 'Linked to the real position. Graded after the outcome.',
+          copy:
+            'Predicted sits next to actual, forever. Each thesis point is checked true or false after the trade closes — a wrong call stays ✗ on the record. That is the grade you keep.',
+          panel: <GradedPanelDark />,
+          panelSide: 'left',
+        },
+        {
+          title: 'The brake that says no for you.',
+          copy:
+            'Backwardation or a VVIX spike cuts short-vol suggestions automatically — and if the brake’s inputs are missing, it reads UNVERIFIED and acts as if it were on. It never assumes safety.',
+          panel: <BrakePanelDark />,
+          panelSide: 'right',
+        },
       ]}
       // TRADE-SHOWCASE-ORDER: the scanner renders BEFORE the pipe (preSteps) —
       // in the real product you set filters and hit Scan, THEN the pipe runs.
-      preSteps={<ScannerPanelDemo currentUserId={currentUserId} onRequireAuth={onRequireAuth} />}
+      // TRADE-SHOWCASE-SLIDES: one connective line bridges the slides above
+      // into the live cockpit below.
+      preSteps={
+        <>
+          <p className="text-center text-sm text-text-secondary">
+            Everything you just saw in the slides is live below — the real components, rendered
+            from the same declared example scan. Try the controls.
+          </p>
+          <ScannerPanelDemo currentUserId={currentUserId} onRequireAuth={onRequireAuth} />
+        </>
+      }
       stepsTitle="Hit Scan, and this runs — 20 steps, A to T"
       stepsTag="Example scan — real steps, sample counts"
       steps={TRADE_PIPE_STEPS}

--- a/src/components/home/TradeShowcaseSections.tsx
+++ b/src/components/home/TradeShowcaseSections.tsx
@@ -35,7 +35,7 @@ import ScanFilterForm from '@/components/trading/ScanFilterForm';
 import ScannerResultsTable from '@/components/convergence/ScannerResultsTable';
 import { TickerChapter } from '@/components/convergence/ConvergenceIntelligence';
 import type { ScannerFilters } from '@/lib/convergence/filter-types';
-import { DEFAULT_FILTERS } from '@/lib/convergence/filter-types';
+import { DEFAULT_FILTERS, AVAILABLE_STRATEGIES } from '@/lib/convergence/filter-types';
 import { ExampleTag } from '@/components/home/TabShowcaseTemplate';
 import {
   SHOWCASE_RESULTS,
@@ -451,5 +451,178 @@ export function GradedCardMirror() {
         </p>
       </div>
     </div>
+  );
+}
+
+// ── TRADE-SHOWCASE-SLIDES: the six product-piece slide panels ────────────────
+// Each is a dark, self-contained "slide" panel (screengrab-ready). Values come
+// ONLY from the existing payload (tradeShowcasePayload.ts), the real constants
+// (DEFAULT_FILTERS / AVAILABLE_STRATEGIES, filter-types.ts), the graded
+// REPLICA above, and the engine's own strings — nothing newly invented.
+
+function SlideShell({ title, tag, children }: { title: string; tag?: string; children: React.ReactNode }) {
+  return (
+    <div className="rounded-lg border border-panel-border bg-panel p-4 font-mono text-[11px] leading-relaxed">
+      <div className="flex items-center justify-between gap-2 border-b border-panel-border pb-2">
+        <span className="font-bold uppercase tracking-wider text-white/60">{title}</span>
+        {tag && <ExampleTag text={tag} />}
+      </div>
+      <div className="mt-2">{children}</div>
+    </div>
+  );
+}
+
+/** Slide a — the scanner's real controls, from DEFAULT_FILTERS (filter-types.ts:53-78)
+ *  and AVAILABLE_STRATEGIES (:85-102). The interactive real panel lives below. */
+export function ScannerPanelDark() {
+  const f = DEFAULT_FILTERS;
+  return (
+    <SlideShell title="Scan filters — the real defaults">
+      <div className="space-y-1 text-white/70">
+        <p>Universe <span className="text-white">S&amp;P 500 | Nasdaq 100</span> · Direction <span className="text-white">All/Bull/Bear/Ntrl</span> · Premium <span className="text-white">Sell/Buy/Both</span> · Risk <span className="text-white">Defined/Unlimited</span></p>
+        <p>DTE <span className="text-white">{f.risk.minDte}–{f.risk.maxDte}</span> · Width <span className="text-white">${f.risk.minSpreadWidth}–${f.risk.maxSpreadWidth}</span></p>
+        <p className="text-white/50">Liquidity gates: min OI <span className="text-white/80">{f.liquidity.minOpenInterest}</span> · max spread <span className="text-white/80">{f.liquidity.maxBidAskSpreadPct}%</span> · min volume <span className="text-white/80">500K</span> · min rating <span className="text-white/80">{f.liquidity.minLiquidityRating}★</span></p>
+        <p className="text-white/50">Edge metrics: min PoP <span className="text-white/80">{f.edge.minPop}%</span> · min EV <span className="text-white/80">${f.edge.minEv}</span> · min EV/Risk <span className="text-white/80">{f.edge.minEvPerRisk}</span> · vol edge <span className="text-white/80">Any</span> · min IV rank <span className="text-white/80">{f.edge.minIvRank}</span> · sentiment <span className="text-white/80">{(f.edge.minSentiment / 100).toFixed(1)}</span></p>
+        <p className="mt-1.5 flex flex-wrap gap-1">
+          {AVAILABLE_STRATEGIES.map((s) => (
+            <span key={s} className="rounded border border-panel-border bg-panel-hover px-1.5 py-0.5 text-[10px] text-white/70">{s}</span>
+          ))}
+        </p>
+      </div>
+    </SlideShell>
+  );
+}
+
+/** Slide b — the results table, from the payload rows (engine composites,
+ *  the condor card values, the rejection gates, the engine NO-TRADE caption). */
+export function ResultsTablePanelDark() {
+  const globex = SHOWCASE_RESULTS[0];
+  const condor = globex.trade_cards![0].setup;
+  const acme = SHOWCASE_RESULTS[1];
+  const initech = SHOWCASE_RESULTS[2];
+  return (
+    <SlideShell title="Results — every ticker scored" tag="Example scan">
+      <div className="space-y-1.5">
+        <p>
+          <span className="font-bold text-white">GLOBEX</span> <span className="text-white/50">score</span> <span className="text-white">{globex.scores.composite.score}</span>{' '}
+          <span className="text-white/70">{condor.strategy_name}</span>
+          <br />
+          <span className="text-brand-green">COLLECT ${((condor.net_credit ?? 0) * 100).toFixed(0)}</span>
+          <span className="text-white/50"> · MAX L </span><span className="text-brand-red">${condor.max_loss}</span>
+          <span className="text-white/50"> · POP </span><span className="text-white/90">{Math.round((condor.probability_of_profit ?? 0) * 100)}%</span>
+          <span className="text-white/50"> · EV </span><span className="text-brand-green">+${condor.ev}</span>
+        </p>
+        <p>
+          <span className="font-bold text-white">ACME</span> <span className="text-white/50">score</span> <span className="text-white">{acme.scores.composite.score}</span>{' '}
+          <span className="text-white/50">No strategies — {SHOWCASE_REJECTIONS.ACME[0].gate}</span>
+        </p>
+        <p>
+          <span className="font-bold text-white">INITECH</span> <span className="text-white/50">score</span> <span className="text-white">{initech.scores.composite.score}</span>{' '}
+          <span className="text-brand-red">{SHOWCASE_REJECTIONS.INITECH[0].reason}</span>
+        </p>
+      </div>
+    </SlideShell>
+  );
+}
+
+/** Slide c — the deep dive, from the payload's engine-real GLOBEX gate scores
+ *  + the engine's convergence-gate string + the rejection reasons. */
+export function DeepDivePanelDark() {
+  const c = SHOWCASE_DEEP_DIVE.scores.composite;
+  const g = c.category_scores;
+  return (
+    <SlideShell title="Deep dive — GLOBEX" tag="Example data">
+      <div className="space-y-1 text-white/70">
+        <p className="text-white/50">WHY THIS TICKER</p>
+        <p>Gates: <span className="text-brand-green">{g.vol_edge}</span> Vol Edge · <span className="text-brand-green">{g.quality}</span> Quality · <span className="text-brand-green">{g.regime}</span> Regime · <span className="text-brand-green">{g.info_edge}</span> Info Edge</p>
+        <p>Composite <span className="text-white">{c.score}</span> — <span className="text-white/90">&ldquo;{c.convergence_gate}&rdquo;</span></p>
+        <p className="mt-1.5 text-white/50">AND WHY NOT THE OTHERS</p>
+        <p><span className="text-white">ACME</span> — {SHOWCASE_REJECTIONS.ACME[0].strategy}: {SHOWCASE_REJECTIONS.ACME[0].reason} ({SHOWCASE_REJECTIONS.ACME[0].gate})</p>
+        <p><span className="text-white">INITECH</span> — <span className="text-brand-red">{SHOWCASE_REJECTIONS.INITECH[0].reason}</span></p>
+      </div>
+    </SlideShell>
+  );
+}
+
+/** Slide d — the full priced trade card, from the payload condor setup.
+ *  KELLY is computed here with the SAME quarter-Kelly formula the live card
+ *  uses (ConvergenceIntelligence.tsx:704-708): winRate = hv_pop, ratio =
+ *  max_profit/max_loss → max(0, (w·r − (1−w))/r × 0.25). */
+export function TradeCardPanelDark() {
+  const s = SHOWCASE_DEEP_DIVE.trade_cards![0].setup;
+  const w = s.hv_pop ?? s.probability_of_profit ?? 0;
+  const ratio = s.max_profit != null && s.max_loss ? s.max_profit / s.max_loss : 0;
+  const kellyPct = ratio > 0 ? Math.round(Math.max(0, ((w * ratio - (1 - w)) / ratio) * 0.25) * 1000) / 10 : 0;
+  return (
+    <SlideShell title="The trade card — GLOBEX Iron Condor" tag="Example data">
+      <div className="space-y-0.5">
+        {s.legs.map((leg) => (
+          <p key={`${leg.side}-${leg.type}-${leg.strike}`}>
+            <span className={leg.side === 'sell' ? 'font-bold text-brand-red' : 'font-bold text-brand-green'}>{leg.side.toUpperCase().padEnd(4)}</span>
+            <span className="text-white/50"> {leg.type.toUpperCase().padEnd(4)} </span>
+            <span className="text-white">${leg.strike}</span>
+            <span className="text-white/40">  ${leg.price.toFixed(2)}</span>
+          </p>
+        ))}
+        <p className="pt-1.5">
+          <span className="font-bold text-brand-green">COLLECT ${((s.net_credit ?? 0) * 100).toFixed(0)}</span>
+          <span className="text-white/50"> · MAX LOSS </span><span className="text-brand-red">${s.max_loss}</span>
+          <span className="text-white/50"> · POP </span><span className="text-white/90">{Math.round((s.probability_of_profit ?? 0) * 100)}%</span><span className="text-white/40"> (N(d2))</span>
+          <span className="text-white/50"> · EV </span><span className="text-brand-green">+${s.ev}</span>
+          <span className="text-white/50"> · EV/RISK </span><span className="text-white/90">{s.ev_per_risk.toFixed(3)}</span>
+          <span className="text-white/50"> · R:R </span><span className="text-white/90">{s.risk_reward_ratio?.toFixed(2)}</span>
+        </p>
+        <p className="text-white/50">
+          B/E <span className="text-white/80">{s.breakevens.map((b) => `$${b.toFixed(2)}`).join(' / ')}</span> · HV POP <span className="text-white/80">{Math.round((s.hv_pop ?? 0) * 100)}%</span> · THETA <span className="text-brand-green">+${s.greeks.theta_per_day.toFixed(2)}/day</span> · VEGA/pt <span className="text-brand-red">-${Math.abs(s.greeks.vega * 100).toFixed(2)}</span> · KELLY <span className="text-white/80">{kellyPct.toFixed(1)}%</span>
+        </p>
+      </div>
+    </SlideShell>
+  );
+}
+
+/** Slide e — graded against reality, from the REPLICA values (the same
+ *  condor: entry 1.20, exit 0.35 → +$85, grade B, thesis 2✓ 1✗). */
+export function GradedPanelDark() {
+  return (
+    <SlideShell title="Graded against reality — GLOBEX" tag="Example data">
+      <div className="grid grid-cols-2 gap-4">
+        <div className="space-y-0.5">
+          <p className="text-white/50">PREDICTED</p>
+          <p className="text-white/70">Max Profit <span className="text-brand-green">{REPLICA.predicted.maxProfit}</span></p>
+          <p className="text-white/70">Max Loss <span className="text-brand-red">{REPLICA.predicted.maxLoss}</span></p>
+          <p className="text-white/70">Est. PoP <span className="text-white">{REPLICA.predicted.pop}</span></p>
+          <p className="text-white/70">Entry <span className="text-white">{REPLICA.predicted.entry}</span></p>
+        </div>
+        <div className="space-y-0.5">
+          <p className="text-white/50">ACTUAL</p>
+          <p className="text-white/70">P&amp;L <span className="font-bold text-brand-green">{REPLICA.actual.pl}</span></p>
+          <p className="text-white/70">Exit <span className="text-white">{REPLICA.actual.exit}</span></p>
+          <p className="text-white/70">Grade <span className="rounded px-1.5 py-0.5 font-black" style={{ background: '#2563EB', color: '#EFF6FF' }}>{REPLICA.actual.grade}</span></p>
+        </div>
+      </div>
+      <div className="mt-2 space-y-0.5 border-t border-panel-border pt-2">
+        {REPLICA.thesis.map((t) => (
+          <p key={t.point}>
+            {t.result ? <span className="text-brand-green">✓</span> : <span className="text-brand-red">✗</span>}{' '}
+            <span className="text-white/70">{t.point}</span>
+          </p>
+        ))}
+      </div>
+    </SlideShell>
+  );
+}
+
+/** Slide f — the survival brake: the engine's own declaration (payload) and
+ *  the real rule constants (regime.ts:72-73; fail-safe UNVERIFIED :104-115). */
+export function BrakePanelDark() {
+  const brake = SHOWCASE_DEEP_DIVE.scores.regime.breakdown.survival_brake;
+  return (
+    <SlideShell title="The survival brake" tag="Example data">
+      <div className="space-y-1.5 text-white/70">
+        <p>Rule: <span className="text-white">VIX/VIX3M &gt; 1.0</span> (backwardation) <span className="text-white/50">or</span> <span className="text-white">VVIX ≥ 110</span> → short-vol suggestions cut automatically.</p>
+        <p className="text-white/50">Missing inputs → <span className="text-brand-amber">UNVERIFIED</span> — treated like ON. It never assumes safety.</p>
+        <p className="border-t border-panel-border pt-1.5 text-brand-green">{brake.declaration}</p>
+      </div>
+    </SlideShell>
   );
 }


### PR DESCRIPTION
… piece shown beside its teaching copy

Replaces the four "see it below" product tiles with six additional full editorial rows, so the page is a complete top-down slide sequence (each row = self-contained dark panel + copy, panel sides alternating L/R — screengrab-ready):

  1. Watch every step run (pipeline highlights — existing)
  2. A track record that grades itself (existing)
  3. Eighteen real controls. Sixteen strategies. — ScannerPanelDark renders the REAL defaults from DEFAULT_FILTERS (DTE 30-60, width $1-$10, OI 100, spread 10%, volume 500K, rating 2, PoP 50%...) and all 16 AVAILABLE_STRATEGIES chips (filter-types.ts:53-102).
  4. Every ticker scored — ResultsTablePanelDark reads the payload rows at render: engine composites (52 / 62.5 / 36.3), the condor COLLECT/MAX L/POP/EV, ACME's rejection gate, INITECH's engine NO-TRADE caption.
  5. Why — and why not — DeepDivePanelDark: the four engine gate scores + the engine's convergence-gate string + both rejection lines, all from the payload.
  6. The whole trade, written down — TradeCardPanelDark: the payload condor's legs/COLLECT/MAX LOSS/POP/EV/EV-RISK/R:R/B/E/HV POP/ THETA/VEGA, with KELLY computed inline by the SAME quarter-Kelly formula the live card uses (CI:704-708).
  7. Linked and graded — GradedPanelDark: PREDICTED vs ACTUAL + thesis 2✓1✗ + grade B from the existing REPLICA values.
  8. The brake that says no for you — BrakePanelDark: the engine's own brake declaration (payload) + the REAL rule constants (VIX/VIX3M
     > 1.0, VVIX >= 110, regime.ts:72-73; missing inputs -> UNVERIFIED
     fail-safe :104-115).

One connective line bridges the slides into the live cockpit ("the real components, rendered from the same declared example scan"). The real interactive cockpit + CTA below are unchanged. Slides ride the existing editorialRows template slot — reusable for tabs 2-9; other tabs unaffected.

Framing only: zero fetches (grep clean); engine/gates/cockpit/payload diff EMPTY. tsc clean; next build "Compiled successfully".


Claude-Session: https://claude.ai/code/session_0166NgTwN2YavGPvPwra9Ycz