### PR TITLE
TRADE-SHOWCASE-FINAL: causal slide order (scanner first), axe rail, f…

### DIFF
--- a/src/components/home/TabShowcaseTemplate.tsx
+++ b/src/components/home/TabShowcaseTemplate.tsx
@@ -83,11 +83,13 @@ export interface TabShowcaseTemplateProps {
    *  content that precedes the pipe in the real product flow (e.g. Trade's
    *  filter panel: you set filters and hit Scan, THEN the pipe runs). */
   preSteps?: ReactNode;
-  /** Title over the pipe rail (e.g. "The pipe — 20 steps, A to T"). */
-  stepsTitle: string;
+  /** Title over the pipe rail (e.g. "The pipe — 20 steps, A to T").
+   *  The rail block is OPTIONAL — a tab may render its pipe inside an
+   *  editorial slide instead (TRADE-SHOWCASE-FINAL) and pass no steps. */
+  stepsTitle?: string;
   /** Rail-level honesty tag (e.g. "Example scan — real steps, sample counts"). */
-  stepsTag: string;
-  steps: ShowcaseStep[];
+  stepsTag?: string;
+  steps?: ShowcaseStep[];
   /** Optional footer inside the pipe card (e.g. the funnel/runtime line). */
   stepsFooter?: ReactNode;
   /** Title over the concept cards (e.g. "The four gates"). Optional — a tab
@@ -210,25 +212,27 @@ export default function TabShowcaseTemplate({
       {/* ── Pre-pipe section(s) — the real flow's first act (optional) ── */}
       {preSteps}
 
-      {/* ── The real pipe, as a compact rail ── */}
-      <div className="rounded-lg border border-border bg-white">
-        <div className="flex flex-wrap items-center justify-between gap-2 border-b border-border px-4 py-2.5">
-          <p className="text-[11px] font-bold uppercase tracking-wider text-text-muted">{stepsTitle}</p>
-          <ExampleTag text={stepsTag} />
+      {/* ── The real pipe, as a compact rail (optional) ── */}
+      {steps && steps.length > 0 && (
+        <div className="rounded-lg border border-border bg-white">
+          <div className="flex flex-wrap items-center justify-between gap-2 border-b border-border px-4 py-2.5">
+            <p className="text-[11px] font-bold uppercase tracking-wider text-text-muted">{stepsTitle}</p>
+            {stepsTag && <ExampleTag text={stepsTag} />}
+          </div>
+          <ol className="grid gap-x-6 px-4 py-3 sm:grid-cols-2">
+            {steps.map((s) => (
+              <li key={s.code} className="flex gap-3 border-b border-border-light py-1.5 last:border-0 sm:[&:nth-last-child(2)]:border-0">
+                <span className="w-5 shrink-0 pt-px text-right font-mono text-xs font-bold text-brand-purple">{s.code}</span>
+                <span className="min-w-0 text-sm">
+                  <span className="font-medium text-text-primary">{s.label}</span>
+                  {s.summary && <span className="text-text-muted"> — {s.summary}</span>}
+                </span>
+              </li>
+            ))}
+          </ol>
+          {stepsFooter && <div className="border-t border-border px-4 py-2.5">{stepsFooter}</div>}
         </div>
-        <ol className="grid gap-x-6 px-4 py-3 sm:grid-cols-2">
-          {steps.map((s) => (
-            <li key={s.code} className="flex gap-3 border-b border-border-light py-1.5 last:border-0 sm:[&:nth-last-child(2)]:border-0">
-              <span className="w-5 shrink-0 pt-px text-right font-mono text-xs font-bold text-brand-purple">{s.code}</span>
-              <span className="min-w-0 text-sm">
-                <span className="font-medium text-text-primary">{s.label}</span>
-                {s.summary && <span className="text-text-muted"> — {s.summary}</span>}
-              </span>
-            </li>
-          ))}
-        </ol>
-        {stepsFooter && <div className="border-t border-border px-4 py-2.5">{stepsFooter}</div>}
-      </div>
+      )}
 
       {/* ── Concept cards (optional — a tab may teach inside richer sections) ── */}
       {cards && cards.length > 0 && (

--- a/src/components/home/TabShowcases.tsx
+++ b/src/components/home/TabShowcases.tsx
@@ -29,7 +29,7 @@ import { useState } from 'react';
 import { Lock } from 'lucide-react';
 // TRADE-SHOWCASE-BUILD: the reusable Plaid-style showcase template (hero band +
 // real pipe rail + optional concept cards + sample/CTA slots) — tabs 2–9 reuse it.
-import TabShowcaseTemplate, { type ShowcaseStep } from '@/components/home/TabShowcaseTemplate';
+import TabShowcaseTemplate from '@/components/home/TabShowcaseTemplate';
 // TRADE-SHOWCASE-FULL: the full-product sections (real interactive filter
 // panel + track-record / graded-card / deep-dive mirrors per the
 // TRADE-FULL-INVENTORY rulings). Engine-real values come from the scoreAll
@@ -161,28 +161,10 @@ interface ShowcaseProps {
 //     engine's convergence_gate caption verbatim (composite.ts:159-170).
 // Static, zero fetches — no scan fires for a logged-out visitor.
 
-const TRADE_PIPE_STEPS: ShowcaseStep[] = [
-  { code: 'A', label: 'TT Scanner', summary: '475 symbols fetched (S&P 500 example run; Nasdaq 100 = 101)' },
-  { code: 'B', label: 'Pre-Filter', summary: 'ranked by IV rank, IV–HV spread, liquidity' },
-  { code: 'C', label: 'Hard Exclusions', summary: 'no premium (IV–HV ≤ 0) or illiquid → eliminated' },
-  { code: 'D', label: 'Top-N Selection', summary: 'top 40 carried forward (scan size 20 × 2)' },
-  { code: 'E', label: 'Hard Filters', summary: 'market cap >$2B, liquidity ≥2/5, IV present, earnings >7 days out, Reg SHO check' },
-  { code: 'F', label: 'Peer Grouping', summary: 'Finnhub peers → industry → sector' },
-  { code: 'G', label: 'Pre-Score', summary: '40 selected for full data enrichment' },
-  { code: 'H', label: 'Macro & Regime Data', summary: 'FRED: VIX, VIX3M, VVIX, yield curve, credit spreads' },
-  { code: 'I', label: 'Data Enrichment', summary: '128 Finnhub calls (example)' },
-  { code: 'J', label: 'Candle Data & Cross-Asset Correlations' },
-  { code: 'K', label: '4-Gate Scoring', summary: 'vol edge · quality · regime · info edge' },
-  { code: 'L', label: 'Re-Score With Technicals' },
-  { code: 'M', label: 'Final Selection', summary: '9 selected, sector-capped (max 2 per sector)' },
-  { code: 'N', label: 'Chain Fetch', summary: 'live TastyTrade option chains' },
-  { code: 'O', label: 'Live Greeks Subscription', summary: '2,208 Greeks events across 9 symbols (example)' },
-  { code: 'P', label: 'Strategy Scoring', summary: 'credit spreads, condors, calendars — built and scored per ticker' },
-  { code: 'Q', label: 'Live Options Flow & GEX' },
-  { code: 'R', label: 'Re-Score With Live Data', summary: 'gates re-checked on live numbers' },
-  { code: 'S', label: 'Trade Cards', summary: 'sized suggestions — or NO TRADE' },
-  { code: 'T', label: 'Save & Return', summary: 'snapshot saved for the self-graded record' },
-];
+// TRADE-SHOWCASE-FINAL: the 20-step data moved into PipelinePanelDark
+// (TradeShowcaseSections.tsx PIPE_STEPS_FULL) — the standalone rail below the
+// slides was redundant and is gone; the template's steps slot is now optional
+// and Trade passes no steps.
 
 export function TradeShowcase({ currentUserId, onRequireAuth }: ShowcaseProps) {
   return (
@@ -199,57 +181,58 @@ export function TradeShowcase({ currentUserId, onRequireAuth }: ShowcaseProps) {
         panel: <HeroTerminalPanel />,
       }}
       editorialTitle="Go further with the Trade tab"
-      // TRADE-SHOWCASE-SLIDES: the full top-down slide sequence — one
-      // self-contained dark panel per product piece, sides alternating,
-      // every value from the payload / real constants / the graded replica.
+      // TRADE-SHOWCASE-FINAL: the slides run in the REAL causal order — the
+      // scanner drives the pipeline, the pipeline produces results, results
+      // become cards, cards get graded, grades accumulate into the record,
+      // and the brake guards all of it. Panel sides alternate 1-8.
       editorialRows={[
-        {
-          title: 'Watch every step run.',
-          copy:
-            'A scan is not a spinner — it is 20 named steps you watch happen: what was fetched, what was excluded and why, what survived. Nothing happens off-screen, and the full rail below shows all of it.',
-          panel: <PipelinePanelDark />,
-          panelSide: 'left',
-        },
-        {
-          title: 'A track record that grades itself.',
-          copy:
-            'Denominators first: unlinked positions are counted and declared, a win rate never appears without its n, and any trade that breaks its claimed max loss is named. Example numbers — your record starts at zero and only ever shows what actually happened.',
-          panel: <RecordPanelDark />,
-          panelSide: 'right',
-        },
         {
           title: 'Eighteen real controls. Sixteen strategies.',
           copy:
-            'Universe, direction, premium, defined risk, DTE and width, four liquidity gates, six edge metrics, sixteen strategy chips — the live panel is below. Set your filters, hit Scan.',
+            'It starts here: universe, direction, premium, defined risk, DTE and width, four liquidity gates, six edge metrics, sixteen strategy chips. Set your filters, hit Scan — and the pipeline below runs.',
           panel: <ScannerPanelDark />,
           panelSide: 'left',
         },
         {
+          title: 'Hit Scan, and this runs.',
+          copy:
+            'A scan is not a spinner — it is 20 named steps you watch happen: what was fetched, what was excluded and why, what survived. Nothing happens off-screen.',
+          panel: <PipelinePanelDark />,
+          panelSide: 'right',
+        },
+        {
           title: 'Every ticker scored. Strategies only where the gates pass.',
           copy:
-            'The table shows all of it: the composite, the built strategy with its price and odds — and, just as loudly, the tickers where no strategy survived and exactly which gate stopped them.',
+            'The pipe ends in a table that shows all of it: the composite, the built strategy with its price and odds — and, just as loudly, the tickers where no strategy survived and exactly which gate stopped them.',
           panel: <ResultsTablePanelDark />,
-          panelSide: 'right',
+          panelSide: 'left',
         },
         {
           title: 'Why — and why not.',
           copy:
             'Each selected ticker gets a deep dive: the four gate scores, the convergence verdict in the engine’s own words, and the rejection reasons for everything that did not make it. No black box.',
           panel: <DeepDivePanelDark />,
-          panelSide: 'left',
+          panelSide: 'right',
         },
         {
           title: 'The whole trade, written down.',
           copy:
             'Legs at live prices, what you collect, the most you can lose, the odds two ways, expected value, breakevens, the Greeks, and how big Kelly says to size it. A priced claim you can hold it to.',
           panel: <TradeCardPanelDark />,
-          panelSide: 'right',
+          panelSide: 'left',
         },
         {
           title: 'Linked to the real position. Graded after the outcome.',
           copy:
             'Predicted sits next to actual, forever. Each thesis point is checked true or false after the trade closes — a wrong call stays ✗ on the record. That is the grade you keep.',
           panel: <GradedPanelDark />,
+          panelSide: 'right',
+        },
+        {
+          title: 'The grades accumulate. Denominators first.',
+          copy:
+            'Every graded card lands in a record that leads with what it excludes: unlinked positions are counted and declared, a win rate never appears without its n, and any trade that breaks its claimed max loss is named. Your record starts at zero.',
+          panel: <RecordPanelDark />,
           panelSide: 'left',
         },
         {
@@ -273,16 +256,8 @@ export function TradeShowcase({ currentUserId, onRequireAuth }: ShowcaseProps) {
           <ScannerPanelDemo currentUserId={currentUserId} onRequireAuth={onRequireAuth} />
         </>
       }
-      stepsTitle="Hit Scan, and this runs — 20 steps, A to T"
-      stepsTag="Example scan — real steps, sample counts"
-      steps={TRADE_PIPE_STEPS}
-      stepsFooter={
-        <p className="text-xs text-text-muted">
-          Example funnel (S&P 500 run): <span className="font-mono text-text-primary">475 → 52 → 40 → 20 → 9</span>{' '}
-          (universe → hard filters → enriched → scored → selected) · 128 Finnhub calls · ~94s runtime.
-          475 is the S&P 500 list size; 40, 20 and 9 are the real defaults; the rest are sample counts.
-        </p>
-      }
+      // TRADE-SHOWCASE-FINAL: no steps rail — the full 20-step pipe lives in
+      // the pipeline slide above (PipelinePanelDark).
       sample={
         <>
           <TrackRecordMirror />

--- a/src/components/home/TradeShowcaseSections.tsx
+++ b/src/components/home/TradeShowcaseSections.tsx
@@ -126,31 +126,53 @@ export function HeroTerminalPanel() {
   );
 }
 
-/** Editorial row A panel: the pipe, dark — the same step highlights and
- *  counts the full rail below carries (475/9 real; 128/2,208 example). */
+/** Editorial pipeline panel — ALL 20 real steps A–T (the pipeline's own
+ *  step_a…step_t labels; TRADE-SHOWCASE-FINAL moved the full list here and
+ *  the standalone rail was removed). Real defaults stated as real (475
+ *  universe, 40 = 2× scan size, 20 scored, 9 selected); illustrative counts
+ *  say "(example)". */
+const PIPE_STEPS_FULL: [string, string, string?][] = [
+  ['A', 'TT Scanner', '475 symbols fetched (S&P 500 example run)'],
+  ['B', 'Pre-Filter', 'ranked by IV rank, IV–HV spread, liquidity'],
+  ['C', 'Hard Exclusions', 'no premium or illiquid → out'],
+  ['D', 'Top-N Selection', 'top 40 carried forward (20 × 2)'],
+  ['E', 'Hard Filters', '>$2B cap, ≥2/5 liquidity, IV present, earnings >7d, Reg SHO'],
+  ['F', 'Peer Grouping', 'Finnhub peers → industry → sector'],
+  ['G', 'Pre-Score', '40 selected for full enrichment'],
+  ['H', 'Macro & Regime Data', 'FRED: VIX, VIX3M, VVIX, yield curve, credit'],
+  ['I', 'Data Enrichment', '128 Finnhub calls (example)'],
+  ['J', 'Candles & Cross-Asset Correlations'],
+  ['K', '4-Gate Scoring', 'vol edge · quality · regime · info edge'],
+  ['L', 'Re-Score With Technicals'],
+  ['M', 'Final Selection', '9 selected, sector-capped (max 2)'],
+  ['N', 'Chain Fetch', 'live TastyTrade option chains'],
+  ['O', 'Live Greeks Subscription', '2,208 events across 9 symbols (example)'],
+  ['P', 'Strategy Scoring', 'spreads, condors, calendars — scored'],
+  ['Q', 'Live Options Flow & GEX'],
+  ['R', 'Re-Score With Live Data'],
+  ['S', 'Trade Cards', 'sized suggestions — or NO TRADE'],
+  ['T', 'Save & Return', 'snapshot saved for the self-graded record'],
+];
+
 export function PipelinePanelDark() {
-  const lines: [string, string][] = [
-    ['A', 'TT Scanner — 475 symbols fetched'],
-    ['I', 'Data Enrichment — 128 Finnhub calls (example)'],
-    ['M', 'Final Selection — 9 selected, sector-capped'],
-    ['O', 'Live Greeks — 2,208 events across 9 symbols (example)'],
-    ['T', 'Save & Return — snapshot saved for the self-graded record'],
-  ];
   return (
     <div className="rounded-lg border border-panel-border bg-panel p-4 font-mono text-[11px] leading-relaxed">
       <div className="flex items-center justify-between border-b border-panel-border pb-2">
-        <span className="font-bold uppercase tracking-wider text-white/60">Pipeline — 20 steps, A to T</span>
+        <span className="font-bold uppercase tracking-wider text-white/60">Hit Scan, and this runs — 20 steps, A to T</span>
         <ExampleTag text="Example scan" />
       </div>
-      <div className="mt-2 space-y-1">
-        {lines.map(([code, text]) => (
+      <div className="mt-2 grid gap-x-5 gap-y-1 sm:grid-cols-2">
+        {PIPE_STEPS_FULL.map(([code, label, summary]) => (
           <p key={code}>
             <span className="font-bold text-brand-amber">{code}</span>{' '}
-            <span className="text-white/70">{text}</span>
+            <span className="text-white/90">{label}</span>
+            {summary && <span className="text-white/50"> — {summary}</span>}
           </p>
         ))}
-        <p className="text-white/40">… all 20, in full, below ↓</p>
       </div>
+      <p className="mt-2 border-t border-panel-border pt-2 text-white/50">
+        Funnel (S&amp;P 500 run): <span className="text-white/90">475 → 52 → 40 → 20 → 9</span> · 128 Finnhub calls · ~94s. 475, 40, 20 and 9 are the real defaults; the rest are sample counts.
+      </p>
     </div>
   );
 }
@@ -479,10 +501,10 @@ export function ScannerPanelDark() {
   return (
     <SlideShell title="Scan filters — the real defaults">
       <div className="space-y-1 text-white/70">
-        <p>Universe <span className="text-white">S&amp;P 500 | Nasdaq 100</span> · Direction <span className="text-white">All/Bull/Bear/Ntrl</span> · Premium <span className="text-white">Sell/Buy/Both</span> · Risk <span className="text-white">Defined/Unlimited</span></p>
+        <p>Universe <span className="text-white">S&amp;P 500 | Nasdaq 100</span> · Direction <span className="text-white">All</span><span className="text-white/40">/Bull/Bear/Ntrl</span> · Premium <span className="text-white">Both</span><span className="text-white/40">/Sell/Buy</span> · Risk <span className="text-white">Defined</span><span className="text-white/40">/Unlimited</span></p>
         <p>DTE <span className="text-white">{f.risk.minDte}–{f.risk.maxDte}</span> · Width <span className="text-white">${f.risk.minSpreadWidth}–${f.risk.maxSpreadWidth}</span></p>
-        <p className="text-white/50">Liquidity gates: min OI <span className="text-white/80">{f.liquidity.minOpenInterest}</span> · max spread <span className="text-white/80">{f.liquidity.maxBidAskSpreadPct}%</span> · min volume <span className="text-white/80">500K</span> · min rating <span className="text-white/80">{f.liquidity.minLiquidityRating}★</span></p>
-        <p className="text-white/50">Edge metrics: min PoP <span className="text-white/80">{f.edge.minPop}%</span> · min EV <span className="text-white/80">${f.edge.minEv}</span> · min EV/Risk <span className="text-white/80">{f.edge.minEvPerRisk}</span> · vol edge <span className="text-white/80">Any</span> · min IV rank <span className="text-white/80">{f.edge.minIvRank}</span> · sentiment <span className="text-white/80">{(f.edge.minSentiment / 100).toFixed(1)}</span></p>
+        <p className="text-white/50">Liquidity gates (4): min OI <span className="text-white/80">{f.liquidity.minOpenInterest}</span> · max bid-ask spread <span className="text-white/80">{f.liquidity.maxBidAskSpreadPct}%</span> · min volume <span className="text-white/80">{(f.liquidity.minUnderlyingVolume / 1000).toFixed(0)}K</span> · min TT rating <span className="text-white/80">{f.liquidity.minLiquidityRating}★</span></p>
+        <p className="text-white/50">Edge metrics (6): min PoP <span className="text-white/80">{f.edge.minPop}%</span> · min EV <span className="text-white/80">${f.edge.minEv}</span> · min EV/Risk <span className="text-white/80">{f.edge.minEvPerRisk.toFixed(2)}</span> · vol edge <span className="text-white/80">Any</span> · min IV rank <span className="text-white/80">{f.edge.minIvRank}%</span> · min sentiment <span className="text-white/80">{(f.edge.minSentiment / 100).toFixed(1)}</span></p>
         <p className="mt-1.5 flex flex-wrap gap-1">
           {AVAILABLE_STRATEGIES.map((s) => (
             <span key={s} className="rounded border border-panel-border bg-panel-hover px-1.5 py-0.5 text-[10px] text-white/70">{s}</span>
@@ -502,22 +524,37 @@ export function ResultsTablePanelDark() {
   const initech = SHOWCASE_RESULTS[2];
   return (
     <SlideShell title="Results — every ticker scored" tag="Example scan">
-      <div className="space-y-1.5">
+      <div className="space-y-2">
+        <div>
+          <p>
+            <span className="font-bold text-white">GLOBEX</span> <span className="text-white/50">score</span> <span className="text-white">{globex.scores.composite.score}</span>
+            <span className="text-white/50"> · </span><span className="text-white/80">{globex.scores.composite.direction}</span>
+            <span className="text-white/50"> · </span><span className="text-white/90">{condor.strategy_name}</span>
+            <span className="text-white/50"> · {condor.dte} DTE</span>
+          </p>
+          <p className="text-white/60">
+            {condor.legs.map((l) => `${l.side.toUpperCase()} ${l.type.toUpperCase()} $${l.strike}`).join(' / ')}
+          </p>
+          <p>
+            <span className="text-brand-green">COLLECT ${((condor.net_credit ?? 0) * 100).toFixed(0)}</span>
+            <span className="text-white/50"> · MAX P </span><span className="text-brand-green">${condor.max_profit}</span>
+            <span className="text-white/50"> · MAX L </span><span className="text-brand-red">${condor.max_loss}</span>
+            <span className="text-white/50"> · POP </span><span className="text-white/90">{Math.round((condor.probability_of_profit ?? 0) * 100)}%</span>
+            <span className="text-white/50"> · EV </span><span className="text-brand-green">+${condor.ev}</span>
+            <span className="text-white/50"> · EV/RISK </span><span className="text-white/90">{condor.ev_per_risk.toFixed(3)}</span>
+            <span className="text-white/50"> · R:R </span><span className="text-white/90">{condor.risk_reward_ratio?.toFixed(2)}</span>
+          </p>
+        </div>
         <p>
-          <span className="font-bold text-white">GLOBEX</span> <span className="text-white/50">score</span> <span className="text-white">{globex.scores.composite.score}</span>{' '}
-          <span className="text-white/70">{condor.strategy_name}</span>
+          <span className="font-bold text-white">ACME</span> <span className="text-white/50">score</span> <span className="text-white">{acme.scores.composite.score}</span>
+          <span className="text-white/50"> · </span><span className="text-white/80">{acme.scores.composite.direction}</span>
           <br />
-          <span className="text-brand-green">COLLECT ${((condor.net_credit ?? 0) * 100).toFixed(0)}</span>
-          <span className="text-white/50"> · MAX L </span><span className="text-brand-red">${condor.max_loss}</span>
-          <span className="text-white/50"> · POP </span><span className="text-white/90">{Math.round((condor.probability_of_profit ?? 0) * 100)}%</span>
-          <span className="text-white/50"> · EV </span><span className="text-brand-green">+${condor.ev}</span>
+          <span className="text-white/50">No strategies — {SHOWCASE_REJECTIONS.ACME[0].strategy}: {SHOWCASE_REJECTIONS.ACME[0].gate}; {SHOWCASE_REJECTIONS.ACME[1].strategy}: {SHOWCASE_REJECTIONS.ACME[1].gate}</span>
         </p>
         <p>
-          <span className="font-bold text-white">ACME</span> <span className="text-white/50">score</span> <span className="text-white">{acme.scores.composite.score}</span>{' '}
-          <span className="text-white/50">No strategies — {SHOWCASE_REJECTIONS.ACME[0].gate}</span>
-        </p>
-        <p>
-          <span className="font-bold text-white">INITECH</span> <span className="text-white/50">score</span> <span className="text-white">{initech.scores.composite.score}</span>{' '}
+          <span className="font-bold text-white">INITECH</span> <span className="text-white/50">score</span> <span className="text-white">{initech.scores.composite.score}</span>
+          <span className="text-white/50"> · </span><span className="text-white/80">{initech.scores.composite.direction}</span>
+          <br />
           <span className="text-brand-red">{SHOWCASE_REJECTIONS.INITECH[0].reason}</span>
         </p>
       </div>
@@ -530,12 +567,48 @@ export function ResultsTablePanelDark() {
 export function DeepDivePanelDark() {
   const c = SHOWCASE_DEEP_DIVE.scores.composite;
   const g = c.category_scores;
+  // The rank/sector the deep dive really shows (SHOWCASE_PROGRESS step_k —
+  // the same rankings the mounted TickerChapter below reads).
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const rankings: any[] = SHOWCASE_PROGRESS.step_k.data.rankings;
+  const rankIdx = rankings.findIndex((r) => r.symbol === 'GLOBEX');
+  const rankRow = rankings[rankIdx];
+  // The real terminal card's 10-char bar (termBar, ConvergenceIntelligence.tsx:394-395).
+  const bar = (score: number) => '█'.repeat(Math.round((score / 100) * 10)).padEnd(10, '░');
+  const gates: [string, number][] = [
+    ['Vol Edge', g.vol_edge],
+    ['Quality', g.quality],
+    ['Regime', g.regime],
+    ['Info Edge', g.info_edge],
+  ];
+  const forGates = gates.filter(([, s]) => s > 50);
+  const againstGates = gates.filter(([, s]) => s <= 50);
   return (
     <SlideShell title="Deep dive — GLOBEX" tag="Example data">
       <div className="space-y-1 text-white/70">
         <p className="text-white/50">WHY THIS TICKER</p>
-        <p>Gates: <span className="text-brand-green">{g.vol_edge}</span> Vol Edge · <span className="text-brand-green">{g.quality}</span> Quality · <span className="text-brand-green">{g.regime}</span> Regime · <span className="text-brand-green">{g.info_edge}</span> Info Edge</p>
-        <p>Composite <span className="text-white">{c.score}</span> — <span className="text-white/90">&ldquo;{c.convergence_gate}&rdquo;</span></p>
+        <p>Composite <span className="text-white">{c.score}</span> — ranked <span className="text-white">#{rankIdx + 1}</span> of all scored · Sector <span className="text-white/90">{rankRow.sector}</span> · Direction <span className="text-white/90">{c.direction}</span></p>
+        <div className="space-y-0.5">
+          {gates.map(([name, score]) => (
+            <p key={name}>
+              <span className={score > 50 ? 'text-brand-green' : 'text-brand-red'}>{bar(score)}</span>{' '}
+              <span className="text-white/90">{score}</span> <span className="text-white/60">{name}</span>
+            </p>
+          ))}
+        </div>
+        <p><span className="text-white/90">&ldquo;{c.convergence_gate}&rdquo;</span></p>
+        <p className="mt-1.5 text-white/50">FOR</p>
+        {forGates.map(([name, score]) => (
+          <p key={name}>• <span className="text-brand-green">{name} {score}</span> — above 50: the gate found edge.</p>
+        ))}
+        <p className="mt-1.5 text-white/50">AGAINST</p>
+        {againstGates.length > 0 ? (
+          againstGates.map(([name, score]) => (
+            <p key={name}>• <span className="text-brand-red">{name} {score}</span> — at or below 50: no edge claimed.</p>
+          ))
+        ) : (
+          <p className="text-white/50">• None — all four gates cleared 50 in this example (a marginal but unanimous 4/4).</p>
+        )}
         <p className="mt-1.5 text-white/50">AND WHY NOT THE OTHERS</p>
         <p><span className="text-white">ACME</span> — {SHOWCASE_REJECTIONS.ACME[0].strategy}: {SHOWCASE_REJECTIONS.ACME[0].reason} ({SHOWCASE_REJECTIONS.ACME[0].gate})</p>
         <p><span className="text-white">INITECH</span> — <span className="text-brand-red">{SHOWCASE_REJECTIONS.INITECH[0].reason}</span></p>
@@ -556,6 +629,7 @@ export function TradeCardPanelDark() {
   return (
     <SlideShell title="The trade card — GLOBEX Iron Condor" tag="Example data">
       <div className="space-y-0.5">
+        <p className="text-white/50">Exp <span className="text-white/80">{s.expiration_date}</span> · <span className="text-white/80">{s.dte} DTE</span></p>
         {s.legs.map((leg) => (
           <p key={`${leg.side}-${leg.type}-${leg.strike}`}>
             <span className={leg.side === 'sell' ? 'font-bold text-brand-red' : 'font-bold text-brand-green'}>{leg.side.toUpperCase().padEnd(4)}</span>
@@ -591,11 +665,13 @@ export function GradedPanelDark() {
           <p className="text-white/70">Max Profit <span className="text-brand-green">{REPLICA.predicted.maxProfit}</span></p>
           <p className="text-white/70">Max Loss <span className="text-brand-red">{REPLICA.predicted.maxLoss}</span></p>
           <p className="text-white/70">Est. PoP <span className="text-white">{REPLICA.predicted.pop}</span></p>
+          <p className="text-white/70">R:R <span className="text-white">{REPLICA.predicted.rr}</span></p>
           <p className="text-white/70">Entry <span className="text-white">{REPLICA.predicted.entry}</span></p>
         </div>
         <div className="space-y-0.5">
           <p className="text-white/50">ACTUAL</p>
           <p className="text-white/70">P&amp;L <span className="font-bold text-brand-green">{REPLICA.actual.pl}</span></p>
+          <p className="text-white/70">Entry <span className="text-white">{REPLICA.actual.entry}</span></p>
           <p className="text-white/70">Exit <span className="text-white">{REPLICA.actual.exit}</span></p>
           <p className="text-white/70">Grade <span className="rounded px-1.5 py-0.5 font-black" style={{ background: '#2563EB', color: '#EFF6FF' }}>{REPLICA.actual.grade}</span></p>
         </div>
@@ -608,6 +684,10 @@ export function GradedPanelDark() {
           </p>
         ))}
       </div>
+      {/* Regime — the engine's own brake declaration (payload), as on the real card. */}
+      <p className="mt-2 border-t border-panel-border pt-2 text-white/50">
+        Regime: <span className="text-brand-green">{SHOWCASE_DEEP_DIVE.scores.regime.breakdown.survival_brake.declaration}</span>
+      </p>
     </SlideShell>
   );
 }


### PR DESCRIPTION
…ull data per panel

(1) REORDER — the slides now run in the real causal flow, panel sides re-alternating L/R 1-8: scanner ("Set your filters, hit Scan — and the pipeline below runs") -> pipeline ("Hit Scan, and this runs") -> results -> deep dive -> trade card -> graded -> track record ("The grades accumulate. Denominators first.") -> survival brake. The old order had pipeline before scanner (backwards causality) and the record second.

(2) AXE THE RAIL — the standalone 20-step rail + funnel footer below the slides was redundant with the pipeline slide. Removed from Trade's composition; the template's steps slot is now optional (steps? /stepsTitle?/stepsTag?, rail renders only when steps present) so other tabs can still use it. The pipeline slide's dangling "all 20, in full, below" pointer died with it; TRADE_PIPE_STEPS moved into PipelinePanelDark as PIPE_STEPS_FULL.

(3) FULL DATA per panel, each screengrab self-contained:
- Scanner: every control with its DEFAULT_FILTERS value at render (selected defaults highlighted: All/Both/Defined; volume formatted from the constant, EV/Risk + IV-rank units) + all 16 strategy chips.
- Pipeline: ALL 20 steps A-T with labels + counts in a two-column grid, funnel + ~94s runtime in the panel footer, real-vs-sample counts stated.
- Results: full condor columns (score, direction, strategy, all 4 legs, COLLECT/MAX P/MAX L/POP/EV/EV-RISK/R:R/DTE) + directions and BOTH rejection captions for ACME, engine NO-TRADE caption for INITECH — all read from the payload at render.
- Deep dive: composite + rank #2 + sector from the step_k rankings the real TickerChapter reads, four 10-char gate bars using the real termBar formula (CI:394-395), full FOR/AGAINST lists derived from the engine's above-50 convention, the convergence-gate string, why-not lines.
- Trade card: added Exp + DTE header (was the one missing field).
- Graded: full PREDICTED (incl. R:R) + ACTUAL (incl. entry) columns, all 3 thesis points, grade, and the engine's regime declaration.
- Record + brake: already complete (verified).

Framing only: zero fetches (grep clean); engine/gates/cockpit/payload diff EMPTY; other tabs unaffected (optional template props). tsc clean; next build "Compiled successfully".


Claude-Session: https://claude.ai/code/session_0166NgTwN2YavGPvPwra9Ycz