### PR TITLE
PR-Cancel-1: in-app LiteAPI booking cancellation with truthful policy…

### DIFF
--- a/src/app/api/reservations/[id]/cancel/route.ts
+++ b/src/app/api/reservations/[id]/cancel/route.ts
@@ -1,0 +1,136 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { cancelBooking } from '@/lib/liteapiClient';
+import { MissingLiteApiKeyError, LiteApiError } from '@/lib/travelErrors';
+
+// POST /api/reservations/[id]/cancel — PR-Cancel-1: in-app LiteAPI cancellation.
+//
+// Auth chain mirrors the T4 PATCH exactly (../route.ts:40-74, the SEC-2
+// defensive-404 convention):
+//   1. getVerifiedEmail → 401.
+//   2. user lookup → 404.
+//   3. reservations.findFirst({ id, userId: user.id, provider: 'liteapi' }) →
+//      404. The userId scope is ALSO the guest fence: guest rows (userId null)
+//      can never match — guest cancellation stays a SUPPORT path until the
+//      claim flow exists. The provider scope keeps this hotel-only v1: Duffel
+//      flight cancellation is FLIP-B scope, deliberately excluded here.
+//   4. status must be 'confirmed' → 409 otherwise (already-cancelled, pending
+//      and failed rows have nothing to cancel).
+//
+// Money truth: the provider call is the ONLY authority. On its success the row
+// flips status → 'cancelled' (the ONLY field written — the reservation is NEVER
+// deleted; the financial record lives forever) and the provider's fee/refund/
+// currency return VERBATIM (null where the provider didn't state a field —
+// never defaulted, never invented). On provider failure (policy-rejected NRFN,
+// past-deadline, network) the row is untouched and the provider's message
+// surfaces as 502 — mirroring liteapi/book's LiteApiError convention (:142-147).
+//
+// NOT in middleware PUBLIC_PATHS — this is an authed account route by design.
+// No rate limit: mirrors the authed reservations/[id] PATCH convention
+// (rateLimit is this codebase's PUBLIC-paid-route guard). Stated, not omitted.
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    const user = await prisma.users.findFirst({
+      where: { email: { equals: userEmail, mode: 'insensitive' } },
+      select: { id: true },
+    });
+    if (!user) {
+      return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    }
+
+    // Ownership + scope gate (defensive 404 — never confirms a foreign or
+    // guest row exists; provider scope excludes flights, FLIP-B).
+    const owned = await prisma.reservations.findFirst({
+      where: { id, userId: user.id, provider: 'liteapi' },
+      select: { id: true, status: true, providerBookingId: true },
+    });
+    if (!owned) {
+      return NextResponse.json({ error: 'Reservation not found' }, { status: 404 });
+    }
+    if (owned.status !== 'confirmed') {
+      return NextResponse.json(
+        { error: `Only a confirmed booking can be cancelled — this one is ${owned.status}.` },
+        { status: 409 }
+      );
+    }
+
+    // ─── The provider cancel — the only money authority ──────────────────────
+    let cancelled;
+    try {
+      cancelled = await cancelBooking(owned.providerBookingId);
+    } catch (err) {
+      if (err instanceof MissingLiteApiKeyError) {
+        return NextResponse.json(
+          { error: err.message, source: 'liteapi', kind: 'missing_key', mode: err.mode },
+          { status: 500 }
+        );
+      }
+      if (err instanceof LiteApiError) {
+        // Policy-rejected (NRFN / past deadline) or provider-side failure: the
+        // booking stands, our row is untouched, the provider's message surfaces.
+        return NextResponse.json(
+          { error: err.message, source: 'liteapi', kind: 'api_error', status: err.status },
+          { status: 502 }
+        );
+      }
+      console.error('[Reservation cancel] unexpected provider error:', err);
+      return NextResponse.json(
+        { error: err instanceof Error ? err.message : 'Cancellation failed' },
+        { status: 500 }
+      );
+    }
+
+    // ─── Persist the flip (status is the ONLY field written) ─────────────────
+    let row;
+    try {
+      row = await prisma.reservations.update({
+        where: { id: owned.id },
+        data: { status: 'cancelled' },
+      });
+    } catch (dbErr) {
+      // The provider ALREADY cancelled — the money truth exists upstream but our
+      // row still says confirmed. Surface loudly (mirrors the book routes'
+      // DB-fail-after convention); include the provider outcome so it isn't lost.
+      console.error('[Reservation cancel] DB update failed AFTER provider cancel:', {
+        reservationId: owned.id, providerBookingId: owned.providerBookingId, error: dbErr,
+      });
+      return NextResponse.json(
+        {
+          error:
+            'The booking was cancelled at the provider, but we could not update the local record — refresh, and contact support if it still shows confirmed.',
+          cancellation: {
+            providerStatus: cancelled.status,
+            cancellationFee: cancelled.cancellationFee,
+            refundAmount: cancelled.refundAmount,
+            currency: cancelled.currency,
+          },
+        },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json({
+      reservation: { id: row.id, status: row.status },
+      // Provider verbatim — null means "not stated by provider", never zero.
+      cancellation: {
+        providerStatus: cancelled.status,
+        cancellationFee: cancelled.cancellationFee,
+        refundAmount: cancelled.refundAmount,
+        currency: cancelled.currency,
+      },
+    });
+  } catch (error) {
+    console.error('[Reservation cancel] request error:', error);
+    return NextResponse.json({ error: 'Failed to cancel the reservation' }, { status: 500 });
+  }
+}

--- a/src/app/api/reservations/unattached/route.ts
+++ b/src/app/api/reservations/unattached/route.ts
@@ -46,6 +46,9 @@ export async function GET() {
       status: r.status,
       bookingType: r.bookingType,
       confirmationCode: r.providerConfirmationCode,
+      // PR-Cancel-1: the STORED policy (written at book time) — the pre-cancel
+      // dialog renders exactly this, never a fabricated policy.
+      cancellationPolicyJson: r.cancellationPolicyJson ?? null,
     }));
 
     return NextResponse.json({ reservations });

--- a/src/app/api/trips/[id]/reservations/route.ts
+++ b/src/app/api/trips/[id]/reservations/route.ts
@@ -60,6 +60,9 @@ export async function GET(
       status: r.status,
       bookingType: r.bookingType,
       confirmationCode: r.providerConfirmationCode,
+      // PR-Cancel-1: the STORED policy (written at book time) — the pre-cancel
+      // dialog renders exactly this, never a fabricated policy.
+      cancellationPolicyJson: r.cancellationPolicyJson ?? null,
     }));
 
     return NextResponse.json({ reservations });

--- a/src/components/trips/CancelBookingDialog.tsx
+++ b/src/components/trips/CancelBookingDialog.tsx
@@ -1,0 +1,132 @@
+'use client';
+
+/**
+ * CancelBookingDialog (PR-Cancel-1) — the pre-confirm step of in-app hotel
+ * cancellation, shared by TripBookings and UnattachedBookings.
+ *
+ * It renders the STORED cancellationPolicyJson (written at book time by
+ * liteapi/book:187) truthfully: only the fields that actually exist —
+ * refundableTag ('RFN'/'NRFN', same vocabulary CheckoutPanel renders pre-
+ * purchase), the cancelPolicyInfos deadline rows, and hotelRemarks. When the
+ * stored policy is null or unparseable, the one honest line renders instead —
+ * NEVER a fabricated policy. The dialog only collects the explicit confirm /
+ * abort; the parent owns the POST and the result rendering (the outcome line
+ * lives inline in the row, which REMAINS after cancellation — record-keeping).
+ */
+
+import TripFormModal from './TripFormModal';
+
+// The stored shape (see CheckoutPanel's CancellationData twin, :117-121):
+// { refundableTag?: 'RFN'|'NRFN', cancelPolicyInfos?: [...], hotelRemarks?: [...] }
+interface PolicyShape {
+  refundableTag?: string;
+  cancelPolicyInfos?: unknown[];
+  hotelRemarks?: unknown[];
+}
+
+interface Props {
+  /** Row display context — name + dates, so the user confirms the RIGHT booking. */
+  bookingName: string;
+  checkIn: string | null;
+  checkOut: string | null;
+  /** The reservation row's stored cancellationPolicyJson, verbatim. */
+  policy: unknown;
+  /** True while the cancel POST is in flight — locks both buttons. */
+  busy: boolean;
+  onConfirm: () => void;
+  onClose: () => void;
+}
+
+/** One cancelPolicyInfos row → a truthful line from ONLY its present fields. */
+function policyInfoLine(info: unknown): string | null {
+  if (typeof info !== 'object' || info === null) return null;
+  const o = info as Record<string, unknown>;
+  const parts: string[] = [];
+  if (typeof o.cancelTime === 'string' && o.cancelTime) parts.push(`from ${o.cancelTime}`);
+  if (typeof o.amount === 'number') {
+    const cur = typeof o.currency === 'string' && o.currency ? `${o.currency} ` : '';
+    parts.push(`fee ${cur}${o.amount.toFixed(2)}`);
+  }
+  if (typeof o.type === 'string' && o.type) parts.push(`(${o.type})`);
+  return parts.length > 0 ? parts.join(' ') : null;
+}
+
+export default function CancelBookingDialog({ bookingName, checkIn, checkOut, policy, busy, onConfirm, onClose }: Props) {
+  const p: PolicyShape | null =
+    policy && typeof policy === 'object' && !Array.isArray(policy) ? (policy as PolicyShape) : null;
+  const isNonRefundable = p?.refundableTag === 'NRFN';
+  const isRefundable = p?.refundableTag === 'RFN';
+  const infoLines = (Array.isArray(p?.cancelPolicyInfos) ? p!.cancelPolicyInfos! : [])
+    .map(policyInfoLine)
+    .filter((l): l is string => l !== null);
+  const remarks = (Array.isArray(p?.hotelRemarks) ? p!.hotelRemarks! : [])
+    .filter((r): r is string => typeof r === 'string' && r.trim().length > 0);
+  const hasAnyPolicy = isNonRefundable || isRefundable || infoLines.length > 0 || remarks.length > 0;
+
+  const dates =
+    checkIn && checkOut ? `${String(checkIn).slice(0, 10)} → ${String(checkOut).slice(0, 10)}` : null;
+
+  return (
+    <TripFormModal
+      title="Cancel this booking?"
+      subtitle={`${bookingName}${dates ? ` · ${dates}` : ''}`}
+      onClose={onClose}
+    >
+      <div className="space-y-3">
+        {/* ── The stored policy, truthfully — or the one honest absence line ── */}
+        {hasAnyPolicy ? (
+          <div className="rounded border border-border p-3 text-sm">
+            {isNonRefundable && (
+              <p className="font-semibold text-brand-red">
+                Non-refundable — the rate&apos;s terms say this booking can&apos;t be refunded.
+              </p>
+            )}
+            {isRefundable && <p className="font-semibold text-brand-green">Refundable rate</p>}
+            {infoLines.length > 0 && (
+              <ul className="mt-1 space-y-0.5 text-xs text-text-muted">
+                {infoLines.map((l, i) => (
+                  <li key={i}>{l}</li>
+                ))}
+              </ul>
+            )}
+            {remarks.length > 0 && (
+              <ul className="mt-1 space-y-0.5 text-xs text-text-muted">
+                {remarks.slice(0, 4).map((r, i) => (
+                  <li key={i}>{r}</li>
+                ))}
+              </ul>
+            )}
+          </div>
+        ) : (
+          <p className="rounded border border-border bg-bg-row px-3 py-2 text-sm text-text-muted">
+            Cancellation terms unavailable here — fees may apply per the rate&apos;s terms.
+          </p>
+        )}
+
+        <p className="text-sm text-text-secondary">
+          The hotel decides the refund per these terms — the actual refund and any fee show here
+          after cancellation. This can&apos;t be undone.
+        </p>
+
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={onConfirm}
+            disabled={busy}
+            className="flex-1 rounded bg-brand-red px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-brand-red/90 disabled:opacity-50"
+          >
+            {busy ? 'Cancelling…' : 'Cancel booking'}
+          </button>
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={busy}
+            className="flex-1 rounded border border-border px-4 py-2 text-sm font-semibold text-text-secondary transition-colors hover:bg-bg-row disabled:opacity-50"
+          >
+            Keep booking
+          </button>
+        </div>
+      </div>
+    </TripFormModal>
+  );
+}

--- a/src/components/trips/TripBookings.tsx
+++ b/src/components/trips/TripBookings.tsx
@@ -20,7 +20,8 @@
  * them to an account user (reservations/route.ts:12-13).
  */
 
-import { useCallback, useEffect, useState } from 'react';
+import { Fragment, useCallback, useEffect, useState } from 'react';
+import CancelBookingDialog from './CancelBookingDialog';
 
 interface BookingRow {
   id: string;
@@ -34,6 +35,19 @@ interface BookingRow {
   status: string;
   bookingType: string;
   confirmationCode: string | null;
+  /** PR-Cancel-1: the stored policy from book time — the pre-cancel dialog
+   *  renders exactly this. */
+  cancellationPolicyJson?: unknown;
+}
+
+/** PR-Cancel-1: the per-row cancellation outcome — the provider's verbatim
+ *  numbers on success (null = not stated by provider), or the failure message. */
+type CancelOutcome =
+  | { ok: true; providerStatus: string | null; refundAmount: number | null; cancellationFee: number | null; currency: string | null }
+  | { ok: false; message: string };
+
+function moneyOrUnstated(v: number | null, cur: string | null): string {
+  return v === null ? 'not stated by provider' : `${cur ? `${cur} ` : ''}${v.toFixed(2)}`;
 }
 
 interface Props {
@@ -55,6 +69,14 @@ export default function TripBookings({ tripId, onChanged }: Props) {
   const [rows, setRows] = useState<BookingRow[]>([]);
   const [busyId, setBusyId] = useState<string | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
+  // PR-Cancel-1: the row whose pre-cancel dialog is open, and per-row outcomes.
+  // Outcomes render INLINE under the row, which REMAINS after cancellation
+  // (record-keeping) — so a cancel updates rows LOCALLY instead of bumping the
+  // shared tripsRefresh (a remount would erase the inline outcome; the flip is
+  // already persisted server-side, so any later refetch agrees).
+  const [cancelTarget, setCancelTarget] = useState<BookingRow | null>(null);
+  const [cancelBusy, setCancelBusy] = useState(false);
+  const [cancelOutcomes, setCancelOutcomes] = useState<Record<string, CancelOutcome>>({});
 
   const load = useCallback(() => {
     let cancelled = false;
@@ -92,6 +114,38 @@ export default function TripBookings({ tripId, onChanged }: Props) {
       setActionError(err instanceof Error ? err.message : 'Could not remove the booking from the trip.');
     } finally {
       setBusyId(null);
+    }
+  };
+
+  // PR-Cancel-1: the confirmed cancel — POST the authed cancel route; on
+  // success flip THIS row's status locally + show the provider's verbatim
+  // outcome inline; on failure show the provider's message inline. Either way
+  // the dialog closes and the row remains.
+  const doCancel = async (row: BookingRow) => {
+    setCancelBusy(true);
+    try {
+      const res = await fetch(`/api/reservations/${row.id}/cancel`, { method: 'POST' });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(data.error || 'Could not cancel the booking.');
+      setRows((prev) => prev.map((r) => (r.id === row.id ? { ...r, status: data.reservation?.status ?? 'cancelled' } : r)));
+      setCancelOutcomes((prev) => ({
+        ...prev,
+        [row.id]: {
+          ok: true,
+          providerStatus: data.cancellation?.providerStatus ?? null,
+          refundAmount: data.cancellation?.refundAmount ?? null,
+          cancellationFee: data.cancellation?.cancellationFee ?? null,
+          currency: data.cancellation?.currency ?? null,
+        },
+      }));
+    } catch (err) {
+      setCancelOutcomes((prev) => ({
+        ...prev,
+        [row.id]: { ok: false, message: err instanceof Error ? err.message : 'Could not cancel the booking.' },
+      }));
+    } finally {
+      setCancelBusy(false);
+      setCancelTarget(null);
     }
   };
 
@@ -140,8 +194,11 @@ export default function TripBookings({ tripId, onChanged }: Props) {
                 </tr>
               </thead>
               <tbody>
-                {rows.map((r) => (
-                  <tr key={r.id} className="border-b border-border last:border-0">
+                {rows.map((r) => {
+                  const outcome = cancelOutcomes[r.id];
+                  return (
+                  <Fragment key={r.id}>
+                  <tr className="border-b border-border last:border-0">
                     <td className="px-3 py-2 capitalize text-text-secondary">{r.type}</td>
                     <td className="px-3 py-2 font-medium text-text-primary">{r.name}</td>
                     <td className="px-3 py-2 text-text-secondary">
@@ -157,6 +214,19 @@ export default function TripBookings({ tripId, onChanged }: Props) {
                       {r.confirmationCode ?? ''}
                     </td>
                     <td className="px-3 py-2 text-right">
+                      {/* PR-Cancel-1: hotel-only v1 (liteapi rows), and ONLY while
+                          confirmed — after the flip the action disappears, the
+                          row stays (record-keeping). */}
+                      {r.provider === 'liteapi' && r.status === 'confirmed' && (
+                        <button
+                          type="button"
+                          disabled={busyId === r.id || cancelBusy}
+                          onClick={() => setCancelTarget(r)}
+                          className="mr-2 rounded border border-brand-red/40 px-2 py-1 text-xs font-medium text-brand-red hover:bg-brand-red/10 disabled:opacity-50"
+                        >
+                          Cancel booking
+                        </button>
+                      )}
                       <button
                         type="button"
                         disabled={busyId === r.id}
@@ -167,7 +237,30 @@ export default function TripBookings({ tripId, onChanged }: Props) {
                       </button>
                     </td>
                   </tr>
-                ))}
+                  {/* PR-Cancel-1: the provider's actual outcome, inline under the
+                      row — verbatim numbers on success, the provider's message on
+                      failure. Absent fields say so; nothing is invented. */}
+                  {outcome && (
+                    <tr className="border-b border-border last:border-0">
+                      <td colSpan={7} className="px-3 py-2">
+                        {outcome.ok ? (
+                          <p className="text-xs text-text-secondary">
+                            <span className="font-semibold text-brand-green">Cancelled</span>
+                            {outcome.providerStatus ? ` (provider status: ${outcome.providerStatus})` : ''}
+                            {' — refund: '}
+                            <span className="font-medium">{moneyOrUnstated(outcome.refundAmount, outcome.currency)}</span>
+                            {' · cancellation fee: '}
+                            <span className="font-medium">{moneyOrUnstated(outcome.cancellationFee, outcome.currency)}</span>
+                          </p>
+                        ) : (
+                          <p className="text-xs text-brand-red">{outcome.message}</p>
+                        )}
+                      </td>
+                    </tr>
+                  )}
+                  </Fragment>
+                  );
+                })}
               </tbody>
             </table>
           </div>
@@ -175,6 +268,18 @@ export default function TripBookings({ tripId, onChanged }: Props) {
             Total booked: <span className="text-brand-green">${sumUsd(rows)}</span>
           </p>
         </>
+      )}
+
+      {cancelTarget && (
+        <CancelBookingDialog
+          bookingName={cancelTarget.name}
+          checkIn={cancelTarget.checkIn}
+          checkOut={cancelTarget.checkOut}
+          policy={cancelTarget.cancellationPolicyJson ?? null}
+          busy={cancelBusy}
+          onConfirm={() => doCancel(cancelTarget)}
+          onClose={() => { if (!cancelBusy) setCancelTarget(null); }}
+        />
       )}
     </div>
   );

--- a/src/components/trips/UnattachedBookings.tsx
+++ b/src/components/trips/UnattachedBookings.tsx
@@ -11,17 +11,34 @@
  * null) never appear here by design — ownership is unprovable (T0 §5).
  */
 
-import { useCallback, useEffect, useState } from 'react';
+import { Fragment, useCallback, useEffect, useState } from 'react';
+import CancelBookingDialog from './CancelBookingDialog';
 
 interface BookingRow {
   id: string;
   name: string;
+  /** 'liteapi' | 'viator' | 'duffel' — the route always returned this; declared
+   *  now because the Cancel action is liteapi-only (PR-Cancel-1). */
+  provider: string;
   type: string;
   amountUsd: number;
   checkIn: string | null;
   checkOut: string | null;
   status: string;
   confirmationCode: string | null;
+  /** PR-Cancel-1: the stored policy from book time — the pre-cancel dialog
+   *  renders exactly this. */
+  cancellationPolicyJson?: unknown;
+}
+
+/** PR-Cancel-1: the per-row cancellation outcome — the provider's verbatim
+ *  numbers on success (null = not stated by provider), or the failure message. */
+type CancelOutcome =
+  | { ok: true; providerStatus: string | null; refundAmount: number | null; cancellationFee: number | null; currency: string | null }
+  | { ok: false; message: string };
+
+function moneyOrUnstated(v: number | null, cur: string | null): string {
+  return v === null ? 'not stated by provider' : `${cur ? `${cur} ` : ''}${v.toFixed(2)}`;
 }
 
 interface Props {
@@ -36,6 +53,12 @@ export default function UnattachedBookings({ selectedTrip, onChanged }: Props) {
   const [rows, setRows] = useState<BookingRow[]>([]);
   const [busyId, setBusyId] = useState<string | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
+  // PR-Cancel-1: same local-update convention as TripBookings — the cancelled
+  // row REMAINS with its inline outcome (a tripsRefresh bump would remount this
+  // block and erase it; the flip is persisted server-side regardless).
+  const [cancelTarget, setCancelTarget] = useState<BookingRow | null>(null);
+  const [cancelBusy, setCancelBusy] = useState(false);
+  const [cancelOutcomes, setCancelOutcomes] = useState<Record<string, CancelOutcome>>({});
 
   const load = useCallback(() => {
     let cancelled = false;
@@ -73,6 +96,36 @@ export default function UnattachedBookings({ selectedTrip, onChanged }: Props) {
       setActionError(err instanceof Error ? err.message : 'Could not attach the booking.');
     } finally {
       setBusyId(null);
+    }
+  };
+
+  // PR-Cancel-1: identical flow to TripBookings.doCancel — POST, local flip,
+  // inline provider-verbatim outcome (or failure message), dialog closes.
+  const doCancel = async (row: BookingRow) => {
+    setCancelBusy(true);
+    try {
+      const res = await fetch(`/api/reservations/${row.id}/cancel`, { method: 'POST' });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(data.error || 'Could not cancel the booking.');
+      setRows((prev) => prev.map((r) => (r.id === row.id ? { ...r, status: data.reservation?.status ?? 'cancelled' } : r)));
+      setCancelOutcomes((prev) => ({
+        ...prev,
+        [row.id]: {
+          ok: true,
+          providerStatus: data.cancellation?.providerStatus ?? null,
+          refundAmount: data.cancellation?.refundAmount ?? null,
+          cancellationFee: data.cancellation?.cancellationFee ?? null,
+          currency: data.cancellation?.currency ?? null,
+        },
+      }));
+    } catch (err) {
+      setCancelOutcomes((prev) => ({
+        ...prev,
+        [row.id]: { ok: false, message: err instanceof Error ? err.message : 'Could not cancel the booking.' },
+      }));
+    } finally {
+      setCancelBusy(false);
+      setCancelTarget(null);
     }
   };
 
@@ -124,8 +177,11 @@ export default function UnattachedBookings({ selectedTrip, onChanged }: Props) {
                 </tr>
               </thead>
               <tbody>
-                {rows.map((r) => (
-                  <tr key={r.id} className="border-b border-border last:border-0">
+                {rows.map((r) => {
+                  const outcome = cancelOutcomes[r.id];
+                  return (
+                  <Fragment key={r.id}>
+                  <tr className="border-b border-border last:border-0">
                     <td className="px-3 py-2 capitalize text-text-secondary">{r.type}</td>
                     <td className="px-3 py-2 font-medium text-text-primary">{r.name}</td>
                     <td className="px-3 py-2 text-text-secondary">
@@ -138,6 +194,19 @@ export default function UnattachedBookings({ selectedTrip, onChanged }: Props) {
                     </td>
                     <td className="px-3 py-2 text-text-secondary">{r.status}</td>
                     <td className="px-3 py-2 text-right">
+                      {/* PR-Cancel-1: hotel-only v1 (liteapi rows), only while
+                          confirmed — after the flip the action disappears, the
+                          row stays (record-keeping). */}
+                      {r.provider === 'liteapi' && r.status === 'confirmed' && (
+                        <button
+                          type="button"
+                          disabled={busyId === r.id || cancelBusy}
+                          onClick={() => setCancelTarget(r)}
+                          className="mr-2 rounded border border-brand-red/40 px-2 py-1 text-xs font-medium text-brand-red hover:bg-brand-red/10 disabled:opacity-50"
+                        >
+                          Cancel booking
+                        </button>
+                      )}
                       {selectedTrip ? (
                         <button
                           type="button"
@@ -150,11 +219,45 @@ export default function UnattachedBookings({ selectedTrip, onChanged }: Props) {
                       ) : null}
                     </td>
                   </tr>
-                ))}
+                  {/* PR-Cancel-1: the provider's actual outcome, inline — verbatim
+                      numbers on success, the provider's message on failure. */}
+                  {outcome && (
+                    <tr className="border-b border-border last:border-0">
+                      <td colSpan={6} className="px-3 py-2">
+                        {outcome.ok ? (
+                          <p className="text-xs text-text-secondary">
+                            <span className="font-semibold text-brand-green">Cancelled</span>
+                            {outcome.providerStatus ? ` (provider status: ${outcome.providerStatus})` : ''}
+                            {' — refund: '}
+                            <span className="font-medium">{moneyOrUnstated(outcome.refundAmount, outcome.currency)}</span>
+                            {' · cancellation fee: '}
+                            <span className="font-medium">{moneyOrUnstated(outcome.cancellationFee, outcome.currency)}</span>
+                          </p>
+                        ) : (
+                          <p className="text-xs text-brand-red">{outcome.message}</p>
+                        )}
+                      </td>
+                    </tr>
+                  )}
+                  </Fragment>
+                  );
+                })}
               </tbody>
             </table>
           </div>
         </>
+      )}
+
+      {cancelTarget && (
+        <CancelBookingDialog
+          bookingName={cancelTarget.name}
+          checkIn={cancelTarget.checkIn}
+          checkOut={cancelTarget.checkOut}
+          policy={cancelTarget.cancellationPolicyJson ?? null}
+          busy={cancelBusy}
+          onConfirm={() => doCancel(cancelTarget)}
+          onClose={() => { if (!cancelBusy) setCancelTarget(null); }}
+        />
       )}
     </div>
   );

--- a/src/lib/liteapiClient.ts
+++ b/src/lib/liteapiClient.ts
@@ -908,3 +908,84 @@ export async function getCities(countryCode: string): Promise<LiteApiCity[]> {
   const json = await res.json();
   return Array.isArray(json?.data) ? json.data : [];
 }
+
+// ─── Booking management (PR-Cancel-1) ────────────────────────────────────────
+// Contract discovered from LiteAPI's OFFICIAL nodejs-sdk v4.3.2 (github.com/
+// liteapi-travel/nodejs-sdk, index.js — the v3.0-generation SDK; the npm
+// `liteapi-travel` latest is a stale v2.0 SDK and was NOT mirrored):
+//   index.js:5    bookServiceURL = "https://book.liteapi.travel/v3.0"
+//   index.js:206  retrieveBooking → GET  {book}/bookings/{bookingId}
+//   index.js:244  cancelBooking   → PUT  {book}/bookings/{bookingId} (NO body)
+// Both authenticate with the same X-API-Key header this client already uses.
+// Cancel response (README "Booking cancel" return type): bookingId, status,
+// cancellation_fee, refund_amount, currency. The provider's response is the
+// ONLY money truth — absent fields map to null, NEVER defaulted or invented.
+
+export interface BookingStatus {
+  bookingId: string | null;
+  status: string | null;
+  hotelConfirmationCode: string | null;
+  checkin: string | null;
+  checkout: string | null;
+  price: number | null;
+  currency: string | null;
+  cancellationPolicies: unknown;
+}
+
+/** Hit `GET /v3.0/bookings/{bookingId}` on the BOOK host. Throws
+ *  MissingLiteApiKeyError on no key, LiteApiError on non-2xx. */
+export async function getBookingStatus(bookingId: string): Promise<BookingStatus> {
+  const res = await fetch(`${LITEAPI_BOOK_BASE}/bookings/${encodeURIComponent(bookingId)}`, {
+    method: 'GET',
+    headers: headers(),
+  });
+  if (!res.ok) {
+    throw new LiteApiError('/v3.0/bookings/{id}', res.status, await res.text());
+  }
+  const json = await res.json();
+  const d = json.data ?? json;
+  return {
+    bookingId: typeof d.bookingId === 'string' ? d.bookingId : null,
+    status: typeof d.status === 'string' ? d.status : null,
+    hotelConfirmationCode: typeof d.hotelConfirmationCode === 'string' ? d.hotelConfirmationCode : null,
+    checkin: typeof d.checkin === 'string' ? d.checkin : null,
+    checkout: typeof d.checkout === 'string' ? d.checkout : null,
+    price: typeof d.price === 'number' ? d.price : null,
+    currency: typeof d.currency === 'string' ? d.currency : null,
+    cancellationPolicies: d.cancellationPolicies ?? null,
+  };
+}
+
+export interface CancelBookingResult {
+  bookingId: string | null;
+  /** Provider's post-cancel booking status, verbatim. */
+  status: string | null;
+  /** Provider `cancellation_fee`, verbatim — null when not stated. */
+  cancellationFee: number | null;
+  /** Provider `refund_amount`, verbatim — null when not stated. */
+  refundAmount: number | null;
+  currency: string | null;
+}
+
+/** Hit `PUT /v3.0/bookings/{bookingId}` (the cancel call — no body) on the BOOK
+ *  host. Throws MissingLiteApiKeyError on no key, LiteApiError on non-2xx (a
+ *  policy-rejected cancellation — e.g. NRFN or past the deadline — comes back
+ *  non-2xx and therefore THROWS; the caller surfaces the provider's message). */
+export async function cancelBooking(bookingId: string): Promise<CancelBookingResult> {
+  const res = await fetch(`${LITEAPI_BOOK_BASE}/bookings/${encodeURIComponent(bookingId)}`, {
+    method: 'PUT',
+    headers: headers(),
+  });
+  if (!res.ok) {
+    throw new LiteApiError('/v3.0/bookings/{id} (cancel)', res.status, await res.text());
+  }
+  const json = await res.json();
+  const d = json.data ?? json;
+  return {
+    bookingId: typeof d.bookingId === 'string' ? d.bookingId : null,
+    status: typeof d.status === 'string' ? d.status : null,
+    cancellationFee: typeof d.cancellation_fee === 'number' ? d.cancellation_fee : null,
+    refundAmount: typeof d.refund_amount === 'number' ? d.refund_amount : null,
+    currency: typeof d.currency === 'string' ? d.currency : null,
+  };
+}


### PR DESCRIPTION
… + provider-verbatim refund

Claude-Session: https://claude.ai/code/session_012SwyczkSr1yj48xAU79XXu