### PR TITLE
Repaint 4c: trade lane goes light — literals housed, charts re-inked

### DIFF
--- a/src/app/trading/page.tsx
+++ b/src/app/trading/page.tsx
@@ -761,25 +761,25 @@ export default function TradingPage() {
 
           {/* Performance — the 7-metric row (was ROW 2 in the sticky zone). */}
           {(() => { const m = filteredMetrics; return (
-          <div className="rounded-lg overflow-hidden border border-panel-border shadow-sm mb-3">
+          <div className="rounded-lg overflow-hidden border border-border shadow-sm mb-3">
             <div className={SECTION_HEADER}>
               <span>Performance</span>
               <span className="flex items-center gap-1.5 text-xs font-normal ml-auto">
-                <span className="text-white/60 uppercase text-[10px]">Period</span>
-                <input type="date" value={dateFrom} onChange={e => setDateFrom(e.target.value)} className="bg-white/20 border border-white/30 rounded px-1.5 py-0.5 text-white text-[11px] font-mono w-[110px] outline-none" />
-                <span className="text-white/50">—</span>
-                <input type="date" value={dateTo} onChange={e => setDateTo(e.target.value)} className="bg-white/20 border border-white/30 rounded px-1.5 py-0.5 text-white text-[11px] font-mono w-[110px] outline-none" />
-                {(dateFrom || dateTo) && <button onClick={() => { setDateFrom(''); setDateTo(''); }} className="text-white/60 hover:text-white text-xs">x</button>}
+                <span className="text-text-muted uppercase text-[10px]">Period</span>
+                <input type="date" value={dateFrom} onChange={e => setDateFrom(e.target.value)} className="bg-bg-row border border-border rounded px-1.5 py-0.5 text-text-primary text-[11px] font-mono w-[110px] outline-none" />
+                <span className="text-text-faint">—</span>
+                <input type="date" value={dateTo} onChange={e => setDateTo(e.target.value)} className="bg-bg-row border border-border rounded px-1.5 py-0.5 text-text-primary text-[11px] font-mono w-[110px] outline-none" />
+                {(dateFrom || dateTo) && <button onClick={() => { setDateFrom(''); setDateTo(''); }} className="text-text-muted hover:text-text-primary text-xs">x</button>}
               </span>
             </div>
-            <div className="bg-panel-surface px-3 py-3 grid grid-cols-3 sm:grid-cols-4 lg:grid-cols-7 gap-2 text-center">
-              <div className="px-2"><div className="text-[9px] text-white/60 uppercase">P&amp;L</div><div className={`text-sm font-bold font-mono truncate ${m.totalRealizedPL >= 0 ? 'text-status-success' : 'text-status-danger'}`}>{fmtPL(m.totalRealizedPL)}</div></div>
-              <div className="px-2"><div className="text-[9px] text-white/60 uppercase">WR</div><div className="text-sm font-bold font-mono text-white truncate">{m.winRate}%</div></div>
-              <div className="px-2"><div className="text-[9px] text-white/60 uppercase">PF</div><div className="text-sm font-bold font-mono text-white truncate">{m.profitFactor >= 999 ? '∞' : m.profitFactor.toFixed(2)}</div></div>
-              <div className="px-2"><div className="text-[9px] text-white/60 uppercase">Max W</div><div className="text-sm font-bold font-mono text-status-success truncate">{fmt(m.largestWin)}</div></div>
-              <div className="px-2"><div className="text-[9px] text-white/60 uppercase">Max L</div><div className="text-sm font-bold font-mono text-status-danger truncate">{fmt(Math.abs(m.largestLoss))}</div></div>
-              <div className="px-2"><div className="text-[9px] text-white/60 uppercase">Avg W</div><div className="text-sm font-bold font-mono text-status-success truncate">{fmt(m.avgWin)}</div></div>
-              <div className="px-2"><div className="text-[9px] text-white/60 uppercase">Avg L</div><div className="text-sm font-bold font-mono text-status-danger truncate">{fmt(m.avgLoss)}</div></div>
+            <div className="bg-white px-3 py-3 grid grid-cols-3 sm:grid-cols-4 lg:grid-cols-7 gap-2 text-center">
+              <div className="px-2"><div className="text-[9px] text-text-muted uppercase">P&amp;L</div><div className={`text-sm font-bold font-mono truncate ${m.totalRealizedPL >= 0 ? 'text-status-success' : 'text-status-danger'}`}>{fmtPL(m.totalRealizedPL)}</div></div>
+              <div className="px-2"><div className="text-[9px] text-text-muted uppercase">WR</div><div className="text-sm font-bold font-mono text-text-primary truncate">{m.winRate}%</div></div>
+              <div className="px-2"><div className="text-[9px] text-text-muted uppercase">PF</div><div className="text-sm font-bold font-mono text-text-primary truncate">{m.profitFactor >= 999 ? '∞' : m.profitFactor.toFixed(2)}</div></div>
+              <div className="px-2"><div className="text-[9px] text-text-muted uppercase">Max W</div><div className="text-sm font-bold font-mono text-status-success truncate">{fmt(m.largestWin)}</div></div>
+              <div className="px-2"><div className="text-[9px] text-text-muted uppercase">Max L</div><div className="text-sm font-bold font-mono text-status-danger truncate">{fmt(Math.abs(m.largestLoss))}</div></div>
+              <div className="px-2"><div className="text-[9px] text-text-muted uppercase">Avg W</div><div className="text-sm font-bold font-mono text-status-success truncate">{fmt(m.avgWin)}</div></div>
+              <div className="px-2"><div className="text-[9px] text-text-muted uppercase">Avg L</div><div className="text-sm font-bold font-mono text-status-danger truncate">{fmt(m.avgLoss)}</div></div>
             </div>
           </div>
           ); })()}
@@ -788,9 +788,9 @@ export default function TradingPage() {
           <div className="space-y-3 mt-4">
             {/* Chart of Accounts */}
             {tradingEntityId && (
-              <div className="overflow-hidden border-x border-b border-panel-border">
+              <div className="overflow-hidden border-x border-b border-border">
                 <div className={SECTION_HEADER}>Chart of Accounts</div>
-                <div className="bg-panel-surface p-3">
+                <div className="bg-white p-3">
                   <COAManagementTable
                     entityId={tradingEntityId}
                     entityName="Trading"
@@ -802,14 +802,14 @@ export default function TradingPage() {
 
             {/* Commit Trades to Ledger */}
             {uncommittedTrades.length > 0 && (
-              <div className="overflow-hidden border-x border-b border-panel-border">
+              <div className="overflow-hidden border-x border-b border-border">
                 <div className={SECTION_HEADER}>Commit Trades to Ledger</div>
-                <div className="bg-panel-surface px-4 py-3 flex items-center justify-between">
+                <div className="bg-white px-4 py-3 flex items-center justify-between">
                   <div>
-                    <span className="text-sm text-white font-medium">
+                    <span className="text-sm text-text-primary font-medium">
                       {uncommittedTrades.length} closed trade{uncommittedTrades.length !== 1 ? 's' : ''} not yet in ledger
                     </span>
-                    <span className="text-xs text-white/50 ml-2">
+                    <span className="text-xs text-text-faint ml-2">
                       (Net P&L: {fmtCurrency(uncommittedTrades.reduce((s, t) => s + t.realizedPL, 0))})
                     </span>
                   </div>
@@ -834,9 +834,9 @@ export default function TradingPage() {
             )}
 
             {/* P&L Calendar */}
-            <div className="overflow-hidden border-x border-b border-panel-border">
+            <div className="overflow-hidden border-x border-b border-border">
               <div className={SECTION_HEADER}>P&L Calendar</div>
-              <div className="bg-panel-surface">
+              <div className="bg-white">
                 <CalendarGrid
                   events={plCalendarEvents}
                   sourceConfig={PL_SOURCE_CONFIG}
@@ -854,7 +854,7 @@ export default function TradingPage() {
             {isOwner && ttConnected && (
               <div className="mb-4">
                 {ttLoading ? (
-                  <div className={`overflow-hidden border-x border-b border-panel-border bg-panel-surface ${STATE.loading}`}>Loading account data...</div>
+                  <div className={`overflow-hidden border-x border-b border-border bg-white ${STATE.loading}`}>Loading account data...</div>
                 ) : ttDataError ? (
                   <div className={STATE.errorCard}>
                     <div className="text-sm text-status-danger mb-3">{ttDataError}</div>
@@ -887,28 +887,28 @@ export default function TradingPage() {
 
 
                 {/* Trade Journal */}
-                <div className="overflow-hidden border-x border-b border-panel-border">
+                <div className="overflow-hidden border-x border-b border-border">
                   <div className={SECTION_HEADER}>
                     <span>Trade Journal</span>
-                    <span className="text-xs text-white/40">{filteredTrades.length} trades · {journalEntries.length} entries</span>
+                    <span className="text-xs text-text-faint">{filteredTrades.length} trades · {journalEntries.length} entries</span>
                   </div>
                   <div className="overflow-x-auto">
                     <table className="w-full text-xs">
-                      <thead className="bg-white/5">
+                      <thead className="bg-bg-row">
                         <tr>
-                          <th className="px-2 py-2 text-left font-mono text-[10px] uppercase tracking-wider text-white/50">Trade #</th>
-                          <th className="px-2 py-2 text-left font-mono text-[10px] uppercase tracking-wider text-white/50">Date</th>
-                          <th className="px-2 py-2 text-left font-mono text-[10px] uppercase tracking-wider text-white/50">Ticker</th>
-                          <th className="px-2 py-2 text-left font-mono text-[10px] uppercase tracking-wider text-white/50">Strategy</th>
-                          <th className="px-2 py-2 text-center font-mono text-[10px] uppercase tracking-wider text-white/50">Type</th>
-                          <th className="px-2 py-2 text-center font-mono text-[10px] uppercase tracking-wider text-white/50">Status</th>
-                          <th className="px-2 py-2 text-right font-mono text-[10px] uppercase tracking-wider text-white/50">P&L</th>
-                          <th className="px-2 py-2 text-center font-mono text-[10px] uppercase tracking-wider text-white/50">Rating</th>
-                          <th className="px-2 py-2 text-center font-mono text-[10px] uppercase tracking-wider text-white/50">Journal</th>
-                          <th className="px-2 py-2 text-center font-mono text-[10px] uppercase tracking-wider text-white/50"></th>
+                          <th className="px-2 py-2 text-left font-mono text-[10px] uppercase tracking-wider text-text-faint">Trade #</th>
+                          <th className="px-2 py-2 text-left font-mono text-[10px] uppercase tracking-wider text-text-faint">Date</th>
+                          <th className="px-2 py-2 text-left font-mono text-[10px] uppercase tracking-wider text-text-faint">Ticker</th>
+                          <th className="px-2 py-2 text-left font-mono text-[10px] uppercase tracking-wider text-text-faint">Strategy</th>
+                          <th className="px-2 py-2 text-center font-mono text-[10px] uppercase tracking-wider text-text-faint">Type</th>
+                          <th className="px-2 py-2 text-center font-mono text-[10px] uppercase tracking-wider text-text-faint">Status</th>
+                          <th className="px-2 py-2 text-right font-mono text-[10px] uppercase tracking-wider text-text-faint">P&L</th>
+                          <th className="px-2 py-2 text-center font-mono text-[10px] uppercase tracking-wider text-text-faint">Rating</th>
+                          <th className="px-2 py-2 text-center font-mono text-[10px] uppercase tracking-wider text-text-faint">Journal</th>
+                          <th className="px-2 py-2 text-center font-mono text-[10px] uppercase tracking-wider text-text-faint"></th>
                         </tr>
                       </thead>
-                      <tbody className="divide-y divide-panel-border">
+                      <tbody className="divide-y divide-border">
                         {filteredTrades.map(trade => {
                           const journal = getJournalEntry(trade.tradeNum);
                           const isExpanded = expandedTrade === trade.tradeNum;
@@ -916,8 +916,8 @@ export default function TradingPage() {
                           return (
                             <>
                               <tr key={trade.tradeNum} className={`transition-colors hover:bg-white/5 ${isExpanded ? 'bg-brand-purple-pop/10' : ''}`}>
-                                <td className="px-2 py-2 font-mono text-white/60">#{trade.tradeNum}</td>
-                                <td className="px-2 py-2 text-white/60">{new Date(trade.openDate).toLocaleDateString()}</td>
+                                <td className="px-2 py-2 font-mono text-text-muted">#{trade.tradeNum}</td>
+                                <td className="px-2 py-2 text-text-muted">{new Date(trade.openDate).toLocaleDateString()}</td>
                                 <td className="px-2 py-2 font-mono font-semibold">{trade.underlying}</td>
                                 <td className="px-2 py-2">
                                   <span className={chip('accent')}>{trade.strategy}</span>
@@ -933,14 +933,14 @@ export default function TradingPage() {
                                   )}>{trade.status}</span>
                                 </td>
                                 <td className={`px-2 py-2 text-right font-mono font-semibold ${
-                                  trade.status === 'CLOSED' ? (trade.realizedPL >= 0 ? 'text-status-success' : 'text-status-danger') : 'text-white/40'
+                                  trade.status === 'CLOSED' ? (trade.realizedPL >= 0 ? 'text-status-success' : 'text-status-danger') : 'text-text-faint'
                                 }`}>
                                   {trade.status === 'CLOSED' ? fmtPL(trade.realizedPL) : '—'}
                                 </td>
                                 <td className="px-2 py-2 text-center">
                                   {journal?.rating ? (
                                     <span className="text-status-warning">{'★'.repeat(journal.rating)}{'☆'.repeat(5 - journal.rating)}</span>
-                                  ) : <span className="text-white/40">—</span>}
+                                  ) : <span className="text-text-faint">—</span>}
                                 </td>
                                 <td className="px-2 py-2 text-center">
                                   {journal ? (
@@ -950,7 +950,7 @@ export default function TradingPage() {
                                       journal.emotion === 'fomo' || journal.emotion === 'revenge' || journal.emotion === 'greedy' ? 'danger' :
                                       'neutral'
                                     )}>{journal.emotion}</span>
-                                  ) : <span className="text-white/40">—</span>}
+                                  ) : <span className="text-text-faint">—</span>}
                                 </td>
                                 <td className="px-2 py-2 text-center">
                                   <div className="flex items-center gap-1 justify-center">
@@ -959,7 +959,7 @@ export default function TradingPage() {
                                       {journal ? 'Edit' : 'Add'}
                                     </button>
                                     <button onClick={() => setExpandedTrade(isExpanded ? null : trade.tradeNum)}
-                                      className="px-2 py-1 text-[10px] bg-white/5 text-white/60 hover:bg-panel-border">
+                                      className="px-2 py-1 text-[10px] bg-bg-row text-text-muted hover:bg-border">
                                       {isExpanded ? '▲' : '▼'}
                                     </button>
                                   </div>
@@ -967,11 +967,11 @@ export default function TradingPage() {
                               </tr>
                               {isExpanded && (
                                 <tr key={`${trade.tradeNum}-detail`}>
-                                  <td colSpan={10} className="px-4 py-3 bg-white/5">
+                                  <td colSpan={10} className="px-4 py-3 bg-bg-row">
                                     <div className="grid lg:grid-cols-2 gap-4 text-xs">
                                       <div>
-                                        <div className="font-semibold text-white/60 mb-2">Trade Details</div>
-                                        <div className="space-y-1 text-white/60">
+                                        <div className="font-semibold text-text-muted mb-2">Trade Details</div>
+                                        <div className="space-y-1 text-text-muted">
                                           <div>Opened: {new Date(trade.openDate).toLocaleString()}</div>
                                           {trade.closeDate && <div>Closed: {new Date(trade.closeDate).toLocaleString()}</div>}
                                           <div>Legs: {trade.legs}</div>
@@ -986,8 +986,8 @@ export default function TradingPage() {
                                       </div>
                                       {journal && (
                                         <div>
-                                          <div className="font-semibold text-white/60 mb-2">Journal Notes</div>
-                                          <div className="space-y-1 text-white/60">
+                                          <div className="font-semibold text-text-muted mb-2">Journal Notes</div>
+                                          <div className="space-y-1 text-text-muted">
                                             {journal.thesis && <div><span className="font-medium">Thesis:</span> {journal.thesis}</div>}
                                             {journal.setup && <div><span className="font-medium">Setup:</span> {journal.setup}</div>}
                                             {journal.mistakes && <div><span className="font-medium text-status-danger">Mistakes:</span> {journal.mistakes}</div>}
@@ -1033,20 +1033,20 @@ export default function TradingPage() {
       {/* Journal Entry Modal */}
       {journalModal && (
         <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" onClick={() => setJournalModal(null)}>
-          <div className="bg-panel-surface w-full max-w-lg max-h-[90vh] overflow-y-auto" onClick={e => e.stopPropagation()}>
+          <div className="bg-white w-full max-w-lg max-h-[90vh] overflow-y-auto" onClick={e => e.stopPropagation()}>
             <div className={`${SECTION_HEADER} sticky top-0`}>
               <div>
                 <div className="font-semibold">Trade Journal</div>
-                <div className="text-xs text-white/40">#{journalModal.trade.tradeNum} · {journalModal.trade.underlying}</div>
+                <div className="text-xs text-text-faint">#{journalModal.trade.tradeNum} · {journalModal.trade.underlying}</div>
               </div>
-              <button onClick={() => setJournalModal(null)} className="text-white/60 hover:text-white text-sm">×</button>
+              <button onClick={() => setJournalModal(null)} className="text-text-muted hover:text-text-primary text-sm">×</button>
             </div>
             
             <div className="p-4 space-y-4">
               <div>
-                <label className="block text-xs font-medium text-white/60 mb-1">Entry Type</label>
+                <label className="block text-xs font-medium text-text-muted mb-1">Entry Type</label>
                 <select value={journalForm.entryType} onChange={e => setJournalForm(p => ({ ...p, entryType: e.target.value }))}
-                  className="w-full border border-panel-border px-3 py-2 text-sm">
+                  className="w-full border border-border px-3 py-2 text-sm">
                   <option value="pre-trade">Pre-Trade (Planning)</option>
                   <option value="during">During Trade</option>
                   <option value="post-trade">Post-Trade (Review)</option>
@@ -1054,47 +1054,47 @@ export default function TradingPage() {
               </div>
               
               <div>
-                <label className="block text-xs font-medium text-white/60 mb-1">Thesis / Reason</label>
+                <label className="block text-xs font-medium text-text-muted mb-1">Thesis / Reason</label>
                 <textarea value={journalForm.thesis} onChange={e => setJournalForm(p => ({ ...p, thesis: e.target.value }))}
-                  className="w-full border border-panel-border px-3 py-2 text-sm h-20" placeholder="Why did you take this trade?" />
+                  className="w-full border border-border px-3 py-2 text-sm h-20" placeholder="Why did you take this trade?" />
               </div>
               
               <div className="grid grid-cols-2 gap-3">
                 <div>
-                  <label className="block text-xs font-medium text-white/60 mb-1">Setup</label>
+                  <label className="block text-xs font-medium text-text-muted mb-1">Setup</label>
                   <select value={journalForm.setup} onChange={e => setJournalForm(p => ({ ...p, setup: e.target.value }))}
-                    className="w-full border border-panel-border px-3 py-2 text-sm">
+                    className="w-full border border-border px-3 py-2 text-sm">
                     <option value="">Select...</option>
                     {SETUPS.map(s => <option key={s} value={s}>{s}</option>)}
                   </select>
                 </div>
                 <div>
-                  <label className="block text-xs font-medium text-white/60 mb-1">Emotion</label>
+                  <label className="block text-xs font-medium text-text-muted mb-1">Emotion</label>
                   <select value={journalForm.emotion} onChange={e => setJournalForm(p => ({ ...p, emotion: e.target.value }))}
-                    className="w-full border border-panel-border px-3 py-2 text-sm">
+                    className="w-full border border-border px-3 py-2 text-sm">
                     {EMOTIONS.map(e => <option key={e} value={e}>{e}</option>)}
                   </select>
                 </div>
               </div>
               
               <div>
-                <label className="block text-xs font-medium text-white/60 mb-1">Mistakes</label>
+                <label className="block text-xs font-medium text-text-muted mb-1">Mistakes</label>
                 <textarea value={journalForm.mistakes} onChange={e => setJournalForm(p => ({ ...p, mistakes: e.target.value }))}
-                  className="w-full border border-panel-border px-3 py-2 text-sm h-16" placeholder="What went wrong?" />
+                  className="w-full border border-border px-3 py-2 text-sm h-16" placeholder="What went wrong?" />
               </div>
               
               <div>
-                <label className="block text-xs font-medium text-white/60 mb-1">Lessons Learned</label>
+                <label className="block text-xs font-medium text-text-muted mb-1">Lessons Learned</label>
                 <textarea value={journalForm.lessons} onChange={e => setJournalForm(p => ({ ...p, lessons: e.target.value }))}
-                  className="w-full border border-panel-border px-3 py-2 text-sm h-16" placeholder="What will you do differently?" />
+                  className="w-full border border-border px-3 py-2 text-sm h-16" placeholder="What will you do differently?" />
               </div>
               
               <div>
-                <label className="block text-xs font-medium text-white/60 mb-1">Rating (1-5)</label>
+                <label className="block text-xs font-medium text-text-muted mb-1">Rating (1-5)</label>
                 <div className="flex gap-2">
                   {[1, 2, 3, 4, 5].map(n => (
                     <button key={n} onClick={() => setJournalForm(p => ({ ...p, rating: n }))}
-                      className={`w-10 h-10 text-terminal-lg ${journalForm.rating >= n ? 'text-status-warning' : 'text-white/40'}`}>
+                      className={`w-10 h-10 text-terminal-lg ${journalForm.rating >= n ? 'text-status-warning' : 'text-text-faint'}`}>
                       {journalForm.rating >= n ? '★' : '☆'}
                     </button>
                   ))}
@@ -1102,14 +1102,14 @@ export default function TradingPage() {
               </div>
               
               <div>
-                <label className="block text-xs font-medium text-white/60 mb-1">Tags (comma separated)</label>
+                <label className="block text-xs font-medium text-text-muted mb-1">Tags (comma separated)</label>
                 <input type="text" value={journalForm.tags} onChange={e => setJournalForm(p => ({ ...p, tags: e.target.value }))}
-                  className="w-full border border-panel-border px-3 py-2 text-sm" placeholder="e.g., earnings, scalp, swing" />
+                  className="w-full border border-border px-3 py-2 text-sm" placeholder="e.g., earnings, scalp, swing" />
               </div>
             </div>
             
-            <div className="bg-white/5 px-4 py-3 flex justify-end gap-2 sticky bottom-0 border-t">
-              <button onClick={() => setJournalModal(null)} className="px-4 py-2 text-sm text-white/60 hover:text-white">
+            <div className="bg-bg-row px-4 py-3 flex justify-end gap-2 sticky bottom-0 border-t">
+              <button onClick={() => setJournalModal(null)} className="px-4 py-2 text-sm text-text-muted hover:text-text-primary">
                 Cancel
               </button>
               <button onClick={saveJournalEntry} disabled={saving}

--- a/src/components/BacktestPanel.tsx
+++ b/src/components/BacktestPanel.tsx
@@ -29,20 +29,20 @@ interface BacktestState {
 function HeroStats({ result }: { result: BacktestResult }) {
   const s = result.summary;
   const stats = [
-    { label: 'Est. PoP', value: `${Math.round(s.winRate * 100)}%`, color: s.winRate >= 0.5 ? '#10B981' : '#EF4444' },
-    { label: 'Total P&L', value: `$${s.totalPnl.toLocaleString()}`, color: s.totalPnl >= 0 ? '#10B981' : '#EF4444' },
-    { label: 'Avg P&L', value: `$${s.avgPnl.toFixed(0)}`, color: s.avgPnl >= 0 ? '#10B981' : '#EF4444' },
-    { label: 'Max Drawdown', value: `$${s.maxDrawdown.toFixed(0)}`, color: '#EF4444' },
-    { label: 'Sharpe', value: s.sharpeRatio.toFixed(2), color: s.sharpeRatio >= 1 ? '#10B981' : s.sharpeRatio >= 0.5 ? '#F59E0B' : '#EF4444' },
-    { label: 'Profit Factor', value: s.profitFactor === Infinity ? '∞' : s.profitFactor.toFixed(2), color: s.profitFactor >= 1.5 ? '#10B981' : '#F59E0B' },
-    { label: 'Total Trades', value: String(s.totalTrades), color: '#9CA3AF' },
-    { label: 'Avg Days Held', value: String(s.avgHoldingDays), color: '#9CA3AF' },
+    { label: 'Est. PoP', value: `${Math.round(s.winRate * 100)}%`, color: s.winRate >= 0.5 ? '#16a34a' : '#c53030' },
+    { label: 'Total P&L', value: `$${s.totalPnl.toLocaleString()}`, color: s.totalPnl >= 0 ? '#16a34a' : '#c53030' },
+    { label: 'Avg P&L', value: `$${s.avgPnl.toFixed(0)}`, color: s.avgPnl >= 0 ? '#16a34a' : '#c53030' },
+    { label: 'Max Drawdown', value: `$${s.maxDrawdown.toFixed(0)}`, color: '#c53030' },
+    { label: 'Sharpe', value: s.sharpeRatio.toFixed(2), color: s.sharpeRatio >= 1 ? '#16a34a' : s.sharpeRatio >= 0.5 ? '#f59e0b' : '#c53030' },
+    { label: 'Profit Factor', value: s.profitFactor === Infinity ? '∞' : s.profitFactor.toFixed(2), color: s.profitFactor >= 1.5 ? '#16a34a' : '#f59e0b' },
+    { label: 'Total Trades', value: String(s.totalTrades), color: '#7a7488' },
+    { label: 'Avg Days Held', value: String(s.avgHoldingDays), color: '#7a7488' },
   ];
 
   return (
     <div className="grid grid-cols-4 gap-2 mb-4">
       {stats.map((st, i) => (
-        <div key={i} className="bg-panel-surface border border-panel-border rounded p-2 text-center">
+        <div key={i} className="bg-white border border-border rounded p-2 text-center">
           <div className="text-[10px] text-text-muted uppercase tracking-wide">{st.label}</div>
           <div className="text-sm font-bold font-mono" style={{ color: st.color }}>{st.value}</div>
         </div>
@@ -63,30 +63,30 @@ function EquityCurve({ result }: { result: BacktestResult }) {
   return (
     <div className="mb-4">
       <div className="text-xs font-semibold text-text-faint mb-2">Equity Curve</div>
-      <div className="bg-panel-surface border border-panel-border rounded p-3">
+      <div className="bg-white border border-border rounded p-3">
         <ResponsiveContainer width="100%" height={200}>
           <LineChart data={data}>
-            <CartesianGrid strokeDasharray="3 3" stroke="#21262d" />
+            <CartesianGrid strokeDasharray="3 3" stroke="#DDD6E8" />
             <XAxis
               dataKey="date"
-              tick={{ fontSize: 9, fill: '#6B7280' }}
+              tick={{ fontSize: 9, fill: '#4a4a5a' }}
               tickFormatter={(d: string) => d.slice(0, 7)}
               interval="preserveStartEnd"
             />
             <YAxis
-              tick={{ fontSize: 9, fill: '#6B7280' }}
+              tick={{ fontSize: 9, fill: '#4a4a5a' }}
               tickFormatter={(v: number) => `$${v.toFixed(0)}`}
             />
             <Tooltip
-              contentStyle={{ background: '#0d1117', border: '1px solid #30363d', fontSize: 11, color: '#c9d1d9' }}
+              contentStyle={{ background: '#FFFDF9', border: '1px solid #DDD6E8', fontSize: 11, color: '#1a1a2e' }}
               formatter={(value: any) => [`$${Number(value).toFixed(2)}`, 'Equity']}
               labelFormatter={(label: any) => `Date: ${label}`}
             />
-            <ReferenceLine y={0} stroke="#30363d" />
+            <ReferenceLine y={0} stroke="#DDD6E8" />
             <Line
               type="monotone"
               dataKey="equity"
-              stroke="#58a6ff"
+              stroke="#3b2d6b"
               strokeWidth={1.5}
               dot={false}
               activeDot={{ r: 3 }}
@@ -114,10 +114,10 @@ function MonthlyHeatmap({ result }: { result: BacktestResult }) {
   const maxAbs = Math.max(1, ...result.monthlyReturns.map(m => Math.abs(m.pnl)));
 
   function cellColor(pnl: number | undefined): string {
-    if (pnl === undefined) return '#0d1117';
+    if (pnl === undefined) return '#F3EFE6';
     const intensity = Math.min(1, Math.abs(pnl) / maxAbs);
-    if (pnl >= 0) return `rgba(16, 185, 129, ${0.15 + intensity * 0.6})`;
-    return `rgba(239, 68, 68, ${0.15 + intensity * 0.6})`;
+    if (pnl >= 0) return `rgba(22, 163, 74, ${0.15 + intensity * 0.6})`;
+    return `rgba(197, 48, 48, ${0.15 + intensity * 0.6})`;
   }
 
   if (years.length === 0) return null;
@@ -125,7 +125,7 @@ function MonthlyHeatmap({ result }: { result: BacktestResult }) {
   return (
     <div className="mb-4">
       <div className="text-xs font-semibold text-text-faint mb-2">Monthly Returns</div>
-      <div className="bg-panel-surface border border-panel-border rounded p-3 overflow-x-auto">
+      <div className="bg-white border border-border rounded p-3 overflow-x-auto">
         <table className="w-full text-[10px]">
           <thead>
             <tr>
@@ -152,7 +152,7 @@ function MonthlyHeatmap({ result }: { result: BacktestResult }) {
                         className="text-center px-1 font-mono"
                         style={{
                           backgroundColor: cellColor(pnl),
-                          color: pnl !== undefined ? (pnl >= 0 ? '#6ee7b7' : '#fca5a5') : '#374151',
+                          color: pnl !== undefined ? (pnl >= 0 ? '#16a34a' : '#c53030') : '#a8a2b0',
                         }}
                       >
                         {pnl !== undefined ? `$${Math.round(pnl)}` : '-'}
@@ -161,7 +161,7 @@ function MonthlyHeatmap({ result }: { result: BacktestResult }) {
                   })}
                   <td
                     className="text-center px-1 font-mono font-bold"
-                    style={{ color: yearTotal >= 0 ? '#10B981' : '#EF4444' }}
+                    style={{ color: yearTotal >= 0 ? '#16a34a' : '#c53030' }}
                   >
                     ${Math.round(yearTotal)}
                   </td>
@@ -201,19 +201,19 @@ function PnlDistribution({ result }: { result: BacktestResult }) {
   return (
     <div className="mb-4">
       <div className="text-xs font-semibold text-text-faint mb-2">P&L Distribution</div>
-      <div className="bg-panel-surface border border-panel-border rounded p-3">
+      <div className="bg-white border border-border rounded p-3">
         <ResponsiveContainer width="100%" height={150}>
           <BarChart data={bins}>
-            <CartesianGrid strokeDasharray="3 3" stroke="#21262d" />
-            <XAxis dataKey="range" tick={{ fontSize: 8, fill: '#6B7280' }} interval="preserveStartEnd" />
-            <YAxis tick={{ fontSize: 9, fill: '#6B7280' }} />
+            <CartesianGrid strokeDasharray="3 3" stroke="#DDD6E8" />
+            <XAxis dataKey="range" tick={{ fontSize: 8, fill: '#4a4a5a' }} interval="preserveStartEnd" />
+            <YAxis tick={{ fontSize: 9, fill: '#4a4a5a' }} />
             <Tooltip
-              contentStyle={{ background: '#0d1117', border: '1px solid #30363d', fontSize: 11, color: '#c9d1d9' }}
+              contentStyle={{ background: '#FFFDF9', border: '1px solid #DDD6E8', fontSize: 11, color: '#1a1a2e' }}
               formatter={(value: any) => [value, 'Trades']}
             />
             <Bar dataKey="count">
               {bins.map((b, i) => (
-                <Cell key={i} fill={b.midPnl >= 0 ? '#10B981' : '#EF4444'} />
+                <Cell key={i} fill={b.midPnl >= 0 ? '#16a34a' : '#c53030'} />
               ))}
             </Bar>
           </BarChart>
@@ -234,11 +234,11 @@ function TradeLog({ result }: { result: BacktestResult }) {
       <div className="text-xs font-semibold text-text-faint mb-2">
         Trade Log ({result.trades.length} trades)
       </div>
-      <div className="bg-panel-surface border border-panel-border rounded overflow-hidden">
+      <div className="bg-white border border-border rounded overflow-hidden">
         <div className="max-h-[300px] overflow-y-auto">
           <table className="w-full text-[10px]">
-            <thead className="sticky top-0 bg-panel-surface">
-              <tr className="border-b border-panel-border">
+            <thead className="sticky top-0 bg-white">
+              <tr className="border-b border-border">
                 <th className="text-left px-2 py-1 text-text-muted">#</th>
                 <th className="text-left px-2 py-1 text-text-muted">Entry</th>
                 <th className="text-left px-2 py-1 text-text-muted">Exit</th>
@@ -250,15 +250,15 @@ function TradeLog({ result }: { result: BacktestResult }) {
             </thead>
             <tbody>
               {trades.map((t, i) => (
-                <tr key={i} className="border-b border-panel-hover hover:bg-panel-hover">
+                <tr key={i} className="border-b border-panel-hover hover:bg-bg-row">
                   <td className="px-2 py-1 text-text-muted font-mono">{i + 1}</td>
                   <td className="px-2 py-1 text-text-faint font-mono">{t.entryDate}</td>
                   <td className="px-2 py-1 text-text-faint font-mono">{t.exitDate}</td>
                   <td className="px-2 py-1 text-text-faint font-mono text-right">{t.holdingDays}</td>
-                  <td className="px-2 py-1 font-mono text-right" style={{ color: t.pnl >= 0 ? '#10B981' : '#EF4444' }}>
+                  <td className="px-2 py-1 font-mono text-right" style={{ color: t.pnl >= 0 ? '#16a34a' : '#c53030' }}>
                     {t.pnl >= 0 ? '+' : ''}${t.pnl.toFixed(0)}
                   </td>
-                  <td className="px-2 py-1 font-mono text-right" style={{ color: t.pnlPercent >= 0 ? '#10B981' : '#EF4444' }}>
+                  <td className="px-2 py-1 font-mono text-right" style={{ color: t.pnlPercent >= 0 ? '#16a34a' : '#c53030' }}>
                     {t.pnlPercent >= 0 ? '+' : ''}{(t.pnlPercent * 100).toFixed(1)}%
                   </td>
                   <td className="px-2 py-1 text-text-muted">
@@ -272,7 +272,7 @@ function TradeLog({ result }: { result: BacktestResult }) {
         {result.trades.length > 20 && (
           <button
             onClick={() => setExpanded(!expanded)}
-            className="w-full text-[10px] text-blue-400 hover:text-blue-300 py-1 border-t border-panel-border"
+            className="w-full text-[10px] text-blue-400 hover:text-blue-300 py-1 border-t border-border"
           >
             {expanded ? 'Show less' : `Show all ${result.trades.length} trades`}
           </button>
@@ -300,14 +300,14 @@ function ConfigPanel({
   return (
     <div className="mb-4">
       <div className="text-xs font-semibold text-text-faint mb-2">Configuration</div>
-      <div className="bg-panel-surface border border-panel-border rounded p-3 grid grid-cols-2 gap-3">
+      <div className="bg-white border border-border rounded p-3 grid grid-cols-2 gap-3">
         <div>
           <label className="text-[10px] text-text-muted block mb-1">Target DTE</label>
           <input
             type="number"
             value={dte}
             onChange={e => onChange({ dte: parseInt(e.target.value) || 45 })}
-            className="w-full bg-panel border border-panel-border rounded px-2 py-1 text-xs text-text-faint font-mono"
+            className="w-full bg-white border border-border rounded px-2 py-1 text-xs text-text-faint font-mono"
           />
         </div>
         <div>
@@ -316,7 +316,7 @@ function ConfigPanel({
             type="number"
             value={management.profitTargetPercent}
             onChange={e => onChange({ management: { profitTargetPercent: parseInt(e.target.value) || 50 } })}
-            className="w-full bg-panel border border-panel-border rounded px-2 py-1 text-xs text-text-faint font-mono"
+            className="w-full bg-white border border-border rounded px-2 py-1 text-xs text-text-faint font-mono"
           />
         </div>
         <div>
@@ -325,7 +325,7 @@ function ConfigPanel({
             type="number"
             value={management.stopLossPercent}
             onChange={e => onChange({ management: { stopLossPercent: parseInt(e.target.value) || 200 } })}
-            className="w-full bg-panel border border-panel-border rounded px-2 py-1 text-xs text-text-faint font-mono"
+            className="w-full bg-white border border-border rounded px-2 py-1 text-xs text-text-faint font-mono"
           />
         </div>
         <div>
@@ -334,7 +334,7 @@ function ConfigPanel({
             type="number"
             value={management.exitDte}
             onChange={e => onChange({ management: { exitDte: parseInt(e.target.value) || 21 } })}
-            className="w-full bg-panel border border-panel-border rounded px-2 py-1 text-xs text-text-faint font-mono"
+            className="w-full bg-white border border-border rounded px-2 py-1 text-xs text-text-faint font-mono"
           />
         </div>
         <div>
@@ -343,7 +343,7 @@ function ConfigPanel({
             type="date"
             value={startDate}
             onChange={e => onChange({ startDate: e.target.value })}
-            className="w-full bg-panel border border-panel-border rounded px-2 py-1 text-xs text-text-faint font-mono"
+            className="w-full bg-white border border-border rounded px-2 py-1 text-xs text-text-faint font-mono"
           />
         </div>
         <div>
@@ -352,7 +352,7 @@ function ConfigPanel({
             type="date"
             value={endDate}
             onChange={e => onChange({ endDate: e.target.value })}
-            className="w-full bg-panel border border-panel-border rounded px-2 py-1 text-xs text-text-faint font-mono"
+            className="w-full bg-white border border-border rounded px-2 py-1 text-xs text-text-faint font-mono"
           />
         </div>
       </div>
@@ -449,13 +449,13 @@ export default function BacktestPanel({ symbol, card, onClose }: BacktestPanelPr
   return (
     <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 p-4" onClick={onClose}>
       <div
-        className="bg-panel border border-panel-border rounded w-full max-w-4xl max-h-[90vh] overflow-hidden flex flex-col"
+        className="bg-white border border-border rounded w-full max-w-4xl max-h-[90vh] overflow-hidden flex flex-col"
         onClick={e => e.stopPropagation()}
       >
         {/* Header */}
-        <div className="bg-panel-surface border-b border-panel-border px-4 py-3 flex justify-between items-center">
+        <div className="bg-white border-b border-border px-4 py-3 flex justify-between items-center">
           <div>
-            <div className="text-sm font-bold text-white">
+            <div className="text-sm font-bold text-text-primary">
               Backtest: {symbol} — {card.name}
             </div>
             <div className="text-[10px] text-text-muted">
@@ -463,7 +463,7 @@ export default function BacktestPanel({ symbol, card, onClose }: BacktestPanelPr
               {' '} | {card.dte} DTE
             </div>
           </div>
-          <button onClick={onClose} className="text-text-faint hover:text-white text-sm leading-none">
+          <button onClick={onClose} className="text-text-faint hover:text-text-primary text-sm leading-none">
             &times;
           </button>
         </div>
@@ -511,7 +511,7 @@ export default function BacktestPanel({ symbol, card, onClose }: BacktestPanelPr
               {/* Leg summary */}
               <div className="mb-4">
                 <div className="text-xs font-semibold text-text-faint mb-2">Strategy Legs (delta targets)</div>
-                <div className="bg-panel-surface border border-panel-border rounded p-3 flex gap-4">
+                <div className="bg-white border border-border rounded p-3 flex gap-4">
                   {card.legs.map((leg, i) => (
                     <div key={i} className="text-[11px] font-mono">
                       <span className={leg.side === 'sell' ? 'text-emerald-400' : 'text-blue-400'}>
@@ -533,7 +533,7 @@ export default function BacktestPanel({ symbol, card, onClose }: BacktestPanelPr
                 </button>
                 <button
                   onClick={onClose}
-                  className="px-4 py-2 text-text-faint hover:text-text-faint text-sm border border-panel-border rounded"
+                  className="px-4 py-2 text-text-faint hover:text-text-faint text-sm border border-border rounded"
                 >
                   Cancel
                 </button>
@@ -564,7 +564,7 @@ export default function BacktestPanel({ symbol, card, onClose }: BacktestPanelPr
               <TradeLog result={state.result} />
 
               {/* Re-run with different params */}
-              <div className="border-t border-panel-border pt-4 mt-4">
+              <div className="border-t border-border pt-4 mt-4">
                 <ConfigPanel
                   management={management}
                   dte={dte}
@@ -588,7 +588,7 @@ export default function BacktestPanel({ symbol, card, onClose }: BacktestPanelPr
               <div className="text-red-400 text-sm mb-2">{state.error}</div>
               <button
                 onClick={checkAvailability}
-                className="px-4 py-2 text-text-faint hover:text-text-faint text-sm border border-panel-border rounded"
+                className="px-4 py-2 text-text-faint hover:text-text-faint text-sm border border-border rounded"
               >
                 Try Again
               </button>

--- a/src/components/convergence/ConvergenceIntelligence.tsx
+++ b/src/components/convergence/ConvergenceIntelligence.tsx
@@ -877,7 +877,7 @@ export function TickerCard({ dk = false, detail, sentiment, savedCards, savingCa
       {/* A) HEADER ROW */}
       <div className="px-5 py-2 flex items-center justify-between flex-wrap gap-2 bg-brand-purple-hover">
         <div className="flex items-center gap-3">
-          <span className="text-sm font-black font-mono text-white">{detail.symbol}</span>
+          <span className="text-sm font-black font-mono text-text-primary">{detail.symbol}</span>
           <span className="text-sm font-black font-mono" style={{ color: gradeColorHex(comp.score) }}><MetricInfo surface={dk ? 'dark' : 'light'} metricKey="composite_score" values={{ score: comp.score }}>{comp.score.toFixed(1)}</MetricInfo></span>
           <span className="text-terminal-lg font-black" style={{ color: gradeColorHex(comp.score) }}><MetricInfo surface={dk ? 'dark' : 'light'} metricKey="letter_grade" values={{ score: comp.score, grade: letterGrade(comp.score) }}>{letterGrade(comp.score)}</MetricInfo></span>
         </div>
@@ -1639,7 +1639,7 @@ function PipelineFlowPanel({ dk = false, result, progress, universe }: { dk?: bo
 
       {/* Step A */}
       <div className={themed('border-b border-panel-border', dk)}>
-        <div className={`${SECTION_HEADER} cursor-pointer hover:bg-white/10`} onClick={() => toggle('step_a')}>
+        <div className={`${SECTION_HEADER} cursor-pointer hover:bg-bg-row`} onClick={() => toggle('step_a')}>
           <div className="flex items-center gap-3">
             <span className={chip('accent')}>STEP A</span>
             <span className={themed('text-white/70', dk)}>TT Scanner — Universe Scan</span>
@@ -1664,12 +1664,12 @@ function PipelineFlowPanel({ dk = false, result, progress, universe }: { dk?: bo
                 <table className={themed('w-full border-collapse border border-panel-border', dk)}>
                   <thead>
                     <tr>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>DATA POINT</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>SOURCE</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>WHEN APPLIED</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>WHERE APPLIED</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>WHY</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>HOW / VALUE</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>DATA POINT</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>SOURCE</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>WHEN APPLIED</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>WHERE APPLIED</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>WHY</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>HOW / VALUE</th>
                     </tr>
                   </thead>
                   <tbody>
@@ -1684,12 +1684,12 @@ function PipelineFlowPanel({ dk = false, result, progress, universe }: { dk?: bo
                       ['Beta / SPY Correlation', 'TastyTrade market-metrics', 'Step A fetch', 'Step K Regime gate (SPY correlation modifier)', 'Tells us how closely this stock follows the market. High correlation amplifies regime signals', 'SPY correlation multiplied against base regime score in Step K'],
                     ].map(([dp, src, when, where, why, how], i) => (
                       <tr key={i}>
-                        <td className={"text-xs p-2 text-white/80 font-medium border border-panel-border"}>{dp}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{src}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{when}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{where}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{why}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{how}</td>
+                        <td className={"text-xs p-2 text-text-secondary font-medium border border-border"}>{dp}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{src}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{when}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{where}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{why}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{how}</td>
                       </tr>
                     ))}
                   </tbody>
@@ -1722,7 +1722,7 @@ function PipelineFlowPanel({ dk = false, result, progress, universe }: { dk?: bo
                 <div className="overflow-y-auto" style={{maxHeight: '320px'}}>
                   <table className="w-full text-xs">
                     <thead>
-                      <tr className={"font-mono text-[10px] uppercase tracking-wider text-white/50 border-b border-panel-border"}>
+                      <tr className={"font-mono text-[10px] uppercase tracking-wider text-text-faint border-b border-border"}>
                         <th className="text-left py-1 pr-1 w-4"></th>
                         <th className="text-left py-1 pr-2">#</th>
                         <th className="text-left py-1 pr-2">SYMBOL</th>
@@ -1753,18 +1753,18 @@ function PipelineFlowPanel({ dk = false, result, progress, universe }: { dk?: bo
                             <tr className={themed('border-b border-panel-border cursor-pointer hover:bg-white/5', dk)} onClick={() => toggle(detailKey)}>
                               <td className={themed('py-1 pr-1 text-white/50 text-center', dk)}>{isOpen ? '▼' : '▶'}</td>
                               <td className={themed('py-1 pr-2 text-white/50', dk)}>{i+1}</td>
-                              <td className="py-1 pr-2 font-bold text-white/80">{s.symbol}</td>
-                              <td className="py-1 pr-2 text-right text-white/80">{fmtPct(s.ivRank)}</td>
-                              <td className="py-1 pr-2 text-right text-white/80">{fmtPct(s.ivPercentile)}</td>
-                              <td className="py-1 pr-2 text-right text-white/80">{fmt1(s.iv30)}</td>
-                              <td className="py-1 pr-2 text-right text-white/80">{fmtSpread(s.ivHvSpread)}</td>
-                              <td className="py-1 pr-2 text-right text-white/80">{s.liquidityRating != null ? s.liquidityRating + '/5' : '—'}</td>
-                              <td className="py-1 pr-2 text-right text-white/80">{fmtCap(s.marketCap)}</td>
-                              <td className="py-1 pr-2 text-right text-white/80">{fmt2(s.beta)}</td>
-                              <td className="py-1 pr-2 text-right text-white/80">{fmt2(s.corrSpy)}</td>
-                              <td className="py-1 pr-2 text-right text-white/80">{s.borrowRate != null ? s.borrowRate + '%' : '—'}</td>
+                              <td className="py-1 pr-2 font-bold text-text-secondary">{s.symbol}</td>
+                              <td className="py-1 pr-2 text-right text-text-secondary">{fmtPct(s.ivRank)}</td>
+                              <td className="py-1 pr-2 text-right text-text-secondary">{fmtPct(s.ivPercentile)}</td>
+                              <td className="py-1 pr-2 text-right text-text-secondary">{fmt1(s.iv30)}</td>
+                              <td className="py-1 pr-2 text-right text-text-secondary">{fmtSpread(s.ivHvSpread)}</td>
+                              <td className="py-1 pr-2 text-right text-text-secondary">{s.liquidityRating != null ? s.liquidityRating + '/5' : '—'}</td>
+                              <td className="py-1 pr-2 text-right text-text-secondary">{fmtCap(s.marketCap)}</td>
+                              <td className="py-1 pr-2 text-right text-text-secondary">{fmt2(s.beta)}</td>
+                              <td className="py-1 pr-2 text-right text-text-secondary">{fmt2(s.corrSpy)}</td>
+                              <td className="py-1 pr-2 text-right text-text-secondary">{s.borrowRate != null ? s.borrowRate + '%' : '—'}</td>
                               <td className="py-1 pr-2 text-left">{s.earningsDate ?? '—'}</td>
-                              <td className="py-1 pr-2 text-right text-white/80">{s.daysTillEarnings != null ? s.daysTillEarnings + 'd' : '—'}</td>
+                              <td className="py-1 pr-2 text-right text-text-secondary">{s.daysTillEarnings != null ? s.daysTillEarnings + 'd' : '—'}</td>
                               <td className={themed('py-1 pr-2 text-white/50 text-[10px]', dk)}>TastyTrade</td>
                               <td className={themed('py-1 pr-2 text-white/50 text-[10px]', dk)}>market-metrics</td>
                               <td className={themed('py-1 pr-2 text-white/50 text-[10px]', dk)}>{fetchedAt ? new Date(fetchedAt).toISOString().slice(11, 19) + ' UTC' : '—'}</td>
@@ -1827,7 +1827,7 @@ function PipelineFlowPanel({ dk = false, result, progress, universe }: { dk?: bo
 
       {/* Step A2 */}
       <div className={themed('border-b border-panel-border', dk)}>
-        <div className={`${SECTION_HEADER} cursor-pointer hover:bg-white/10`} onClick={() => toggle('step_b')}>
+        <div className={`${SECTION_HEADER} cursor-pointer hover:bg-bg-row`} onClick={() => toggle('step_b')}>
           <div className="flex items-center gap-3">
             <span className={chip('accent')}>STEP B</span>
             <span className={themed('text-white/70', dk)}>Pre-Filter</span>
@@ -1852,12 +1852,12 @@ function PipelineFlowPanel({ dk = false, result, progress, universe }: { dk?: bo
                 <table className={themed('w-full border-collapse border border-panel-border', dk)}>
                   <thead>
                     <tr>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>DATA POINT</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>SOURCE</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>WHEN APPLIED</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>WHERE APPLIED</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>WHY</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>HOW / VALUE</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>DATA POINT</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>SOURCE</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>WHEN APPLIED</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>WHERE APPLIED</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>WHY</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>HOW / VALUE</th>
                     </tr>
                   </thead>
                   <tbody>
@@ -1868,12 +1868,12 @@ function PipelineFlowPanel({ dk = false, result, progress, universe }: { dk?: bo
                       ['Pre-Score', 'Computed', 'Step B output', 'Step D Top-N cutoff', 'Single number summarizing vol selling opportunity per ticker', 'Top scorers advance to Step E. Everyone else is ranked out'],
                     ].map(([dp, src, when, where, why, how], i) => (
                       <tr key={i}>
-                        <td className={"text-xs p-2 text-white/80 font-medium border border-panel-border"}>{dp}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{src}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{when}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{where}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{why}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{how}</td>
+                        <td className={"text-xs p-2 text-text-secondary font-medium border border-border"}>{dp}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{src}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{when}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{where}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{why}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{how}</td>
                       </tr>
                     ))}
                   </tbody>
@@ -1886,7 +1886,7 @@ function PipelineFlowPanel({ dk = false, result, progress, universe }: { dk?: bo
             <div className="overflow-x-auto overflow-y-auto" style={{maxHeight: '240px'}}>
               <table className="w-full text-xs">
                 <thead>
-                  <tr className={"font-mono text-[10px] uppercase tracking-wider text-white/50 border-b border-panel-border"}>
+                  <tr className={"font-mono text-[10px] uppercase tracking-wider text-text-faint border-b border-border"}>
                     <th className="text-left py-1 pr-3">#</th>
                     <th className="text-left py-1 pr-3">SYMBOL</th>
                     <th className="text-right py-1 pr-3">IV RANK</th>
@@ -1949,7 +1949,7 @@ function PipelineFlowPanel({ dk = false, result, progress, universe }: { dk?: bo
 
       {/* Step C — Hard Exclusions */}
       <div className={themed('border-b border-panel-border', dk)}>
-        <div className={`${SECTION_HEADER} cursor-pointer hover:bg-white/10`} onClick={() => toggle('step_c')}>
+        <div className={`${SECTION_HEADER} cursor-pointer hover:bg-bg-row`} onClick={() => toggle('step_c')}>
           <div className="flex items-center gap-3">
             <span className={chip('accent')}>STEP C</span>
             <span className={themed('text-white/70', dk)}>Hard Exclusions</span>
@@ -1973,12 +1973,12 @@ function PipelineFlowPanel({ dk = false, result, progress, universe }: { dk?: bo
                 <table className={themed('w-full border-collapse border border-panel-border', dk)}>
                   <thead>
                     <tr>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>DATA POINT</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>SOURCE</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>WHEN APPLIED</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>WHERE APPLIED</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>WHY</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>HOW / VALUE</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>DATA POINT</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>SOURCE</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>WHEN APPLIED</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>WHERE APPLIED</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>WHY</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>HOW / VALUE</th>
                     </tr>
                   </thead>
                   <tbody>
@@ -1988,12 +1988,12 @@ function PipelineFlowPanel({ dk = false, result, progress, universe }: { dk?: bo
                       ['Earnings proximity', 'Step A', 'Step C flag', 'Warning passed to Step E', 'Earnings within 3 days flagged for visibility — Step E enforces the hard 7-day rule', 'Not eliminated here — passed forward with warning'],
                     ].map(([dp, src, when, where, why, how], i) => (
                       <tr key={i}>
-                        <td className={"text-xs p-2 text-white/80 font-medium border border-panel-border"}>{dp}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{src}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{when}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{where}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{why}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{how}</td>
+                        <td className={"text-xs p-2 text-text-secondary font-medium border border-border"}>{dp}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{src}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{when}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{where}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{why}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{how}</td>
                       </tr>
                     ))}
                   </tbody>
@@ -2010,7 +2010,7 @@ function PipelineFlowPanel({ dk = false, result, progress, universe }: { dk?: bo
                 {(progress?.step_c?.data?.exclusions ?? []).length > 0 ? (
                   <div style={{ maxHeight: 200, overflowY: 'auto' }}>
                     <table className="w-full text-[10px]">
-                      <thead><tr className={"font-mono text-[10px] uppercase tracking-wider text-white/50 border-b border-panel-border"}>
+                      <thead><tr className={"font-mono text-[10px] uppercase tracking-wider text-text-faint border-b border-border"}>
                         <th className="text-left py-1 px-1">#</th>
                         <th className="text-left py-1 px-1">SYMBOL</th>
                         <th className="text-left py-1 px-1">REASON</th>
@@ -2039,7 +2039,7 @@ function PipelineFlowPanel({ dk = false, result, progress, universe }: { dk?: bo
                 {(progress?.step_c?.data?.earnings_warnings ?? []).length > 0 ? (
                   <div style={{ maxHeight: 200, overflowY: 'auto' }}>
                     <table className="w-full text-[10px]">
-                      <thead><tr className={"font-mono text-[10px] uppercase tracking-wider text-white/50 border-b border-panel-border"}>
+                      <thead><tr className={"font-mono text-[10px] uppercase tracking-wider text-text-faint border-b border-border"}>
                         <th className="text-left py-1 px-1">#</th>
                         <th className="text-left py-1 px-1">SYMBOL</th>
                         <th className="text-right py-1 px-1">DAYS TO EARNINGS</th>
@@ -2073,7 +2073,7 @@ function PipelineFlowPanel({ dk = false, result, progress, universe }: { dk?: bo
 
       {/* Step D — Top-N Selection */}
       <div className={themed('border-b border-panel-border', dk)}>
-        <div className={`${SECTION_HEADER} cursor-pointer hover:bg-white/10`} onClick={() => toggle('step_d')}>
+        <div className={`${SECTION_HEADER} cursor-pointer hover:bg-bg-row`} onClick={() => toggle('step_d')}>
           <div className="flex items-center gap-3">
             <span className={chip('accent')}>STEP D</span>
             <span className={themed('text-white/70', dk)}>Top-N Selection</span>
@@ -2095,12 +2095,12 @@ function PipelineFlowPanel({ dk = false, result, progress, universe }: { dk?: bo
                 <table className={themed('w-full border-collapse border border-panel-border', dk)}>
                   <thead>
                     <tr>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>DATA POINT</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>SOURCE</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>WHEN APPLIED</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>WHERE APPLIED</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>WHY</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>HOW / VALUE</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>DATA POINT</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>SOURCE</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>WHEN APPLIED</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>WHERE APPLIED</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>WHY</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>HOW / VALUE</th>
                     </tr>
                   </thead>
                   <tbody>
@@ -2109,12 +2109,12 @@ function PipelineFlowPanel({ dk = false, result, progress, universe }: { dk?: bo
                       ['Rank', 'Computed', 'Step D output', 'Step E input', 'Ordered list of highest-conviction candidates before hard filters run', 'Rank determines who gets checked in Step E'],
                     ].map(([dp, src, when, where, why, how], i) => (
                       <tr key={i}>
-                        <td className={"text-xs p-2 text-white/80 font-medium border border-panel-border"}>{dp}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{src}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{when}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{where}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{why}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{how}</td>
+                        <td className={"text-xs p-2 text-text-secondary font-medium border border-border"}>{dp}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{src}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{when}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{where}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{why}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{how}</td>
                       </tr>
                     ))}
                   </tbody>
@@ -2128,7 +2128,7 @@ function PipelineFlowPanel({ dk = false, result, progress, universe }: { dk?: bo
             <div className="overflow-y-auto" style={{maxHeight: '240px'}}>
               <table className="w-full text-xs">
                 <thead>
-                  <tr className={"font-mono text-[10px] uppercase tracking-wider text-white/50 border-b border-panel-border"}>
+                  <tr className={"font-mono text-[10px] uppercase tracking-wider text-text-faint border-b border-border"}>
                     <th className="text-left py-1 pr-3">#</th>
                     <th className="text-left py-1 pr-3">SYMBOL</th>
                     <th className="text-right py-1 pr-3">PRE-SCORE</th>
@@ -2187,7 +2187,7 @@ function PipelineFlowPanel({ dk = false, result, progress, universe }: { dk?: bo
 
       {/* Step E — Hard Filters */}
       <div className={themed('border-b border-panel-border', dk)}>
-        <div className={`${SECTION_HEADER} cursor-pointer hover:bg-white/10`} onClick={() => toggle('step_e')}>
+        <div className={`${SECTION_HEADER} cursor-pointer hover:bg-bg-row`} onClick={() => toggle('step_e')}>
           <div className="flex items-center gap-3">
             <span className={chip('accent')}>STEP E</span>
             <span className={themed('text-white/70', dk)}>Hard Filters</span>
@@ -2209,12 +2209,12 @@ function PipelineFlowPanel({ dk = false, result, progress, universe }: { dk?: bo
                 <table className={themed('w-full border-collapse border border-panel-border', dk)}>
                   <thead>
                     <tr>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>DATA POINT</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>SOURCE</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>WHEN APPLIED</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>WHERE APPLIED</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>WHY</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>HOW / VALUE</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>DATA POINT</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>SOURCE</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>WHEN APPLIED</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>WHERE APPLIED</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>WHY</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>HOW / VALUE</th>
                     </tr>
                   </thead>
                   <tbody>
@@ -2227,12 +2227,12 @@ function PipelineFlowPanel({ dk = false, result, progress, universe }: { dk?: bo
                       ['Reg SHO Status', 'SEC FINRA daily list', 'Step E filter', 'Rule 6 — must not be on list', 'Stocks with persistent delivery failures carry elevated short squeeze risk', 'On list = eliminated'],
                     ].map(([dp, src, when, where, why, how], i) => (
                       <tr key={i}>
-                        <td className={"text-xs p-2 text-white/80 font-medium border border-panel-border"}>{dp}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{src}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{when}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{where}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{why}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{how}</td>
+                        <td className={"text-xs p-2 text-text-secondary font-medium border border-border"}>{dp}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{src}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{when}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{where}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{why}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{how}</td>
                       </tr>
                     ))}
                   </tbody>
@@ -2331,7 +2331,7 @@ function PipelineFlowPanel({ dk = false, result, progress, universe }: { dk?: bo
 
       {/* Step F — Peer Grouping */}
       <div className={themed('border-b border-panel-border', dk)}>
-        <div className={`${SECTION_HEADER} cursor-pointer hover:bg-white/10`} onClick={() => toggle('step_f')}>
+        <div className={`${SECTION_HEADER} cursor-pointer hover:bg-bg-row`} onClick={() => toggle('step_f')}>
           <div className="flex items-center gap-3">
             <span className={chip('accent')}>STEP F</span>
             <span className={themed('text-white/70', dk)}>Peer Grouping</span>
@@ -2353,12 +2353,12 @@ function PipelineFlowPanel({ dk = false, result, progress, universe }: { dk?: bo
                 <table className={themed('w-full border-collapse border border-panel-border', dk)}>
                   <thead>
                     <tr>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>DATA POINT</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>SOURCE</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>WHEN APPLIED</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>WHERE APPLIED</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>WHY</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>HOW / VALUE</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>DATA POINT</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>SOURCE</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>WHEN APPLIED</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>WHERE APPLIED</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>WHY</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>HOW / VALUE</th>
                     </tr>
                   </thead>
                   <tbody>
@@ -2370,12 +2370,12 @@ function PipelineFlowPanel({ dk = false, result, progress, universe }: { dk?: bo
                       ['GICS sector fallback', 'TastyTrade sector data', 'Step F fallback', 'Peer grouping when Finnhub peers unavailable', 'Some tickers have no Finnhub peers. Sector grouping ensures every ticker gets a peer comparison', 'Flagged with ⚠ in the TYPE column'],
                     ].map(([dp, src, when, where, why, how], i) => (
                       <tr key={i}>
-                        <td className={"text-xs p-2 text-white/80 font-medium border border-panel-border"}>{dp}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{src}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{when}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{where}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{why}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{how}</td>
+                        <td className={"text-xs p-2 text-text-secondary font-medium border border-border"}>{dp}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{src}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{when}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{where}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{why}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{how}</td>
                       </tr>
                     ))}
                   </tbody>
@@ -2416,12 +2416,12 @@ function PipelineFlowPanel({ dk = false, result, progress, universe }: { dk?: bo
                     const ageSec = fetchedAt ? Math.round((Date.now() - new Date(fetchedAt).getTime()) / 1000) + 's' : '—';
                     return (progress?.step_f?.data?.groups ?? []).map((g: any, i: number) => {
                     const zColor = (z: string | null) => {
-                      if (z == null) return 'text-white/50';
+                      if (z == null) return 'text-text-faint';
                       const n = parseFloat(z);
                       if (n >= 1.5) return 'text-brand-green font-bold';
                       if (n >= 0.5) return 'text-brand-gold';
                       if (n <= -1.5) return 'text-brand-red';
-                      return 'text-white/50';
+                      return 'text-text-faint';
                     };
                     return (
                       <tr key={g.symbol} className={themed('border-b border-panel-border', dk)}>
@@ -2480,7 +2480,7 @@ function PipelineFlowPanel({ dk = false, result, progress, universe }: { dk?: bo
 
       {/* Step G — Pre-Score */}
       <div className={themed('border-b border-panel-border', dk)}>
-        <div className={`${SECTION_HEADER} cursor-pointer hover:bg-white/10`} onClick={() => toggle('step_g')}>
+        <div className={`${SECTION_HEADER} cursor-pointer hover:bg-bg-row`} onClick={() => toggle('step_g')}>
           <div className="flex items-center gap-3">
             <span className={chip('accent')}>STEP G</span>
             <span className={themed('text-white/70', dk)}>Pre-Score</span>
@@ -2502,12 +2502,12 @@ function PipelineFlowPanel({ dk = false, result, progress, universe }: { dk?: bo
                 <table className={themed('w-full border-collapse border border-panel-border', dk)}>
                   <thead>
                     <tr>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>DATA POINT</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>SOURCE</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>WHEN APPLIED</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>WHERE APPLIED</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>WHY</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>HOW / VALUE</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>DATA POINT</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>SOURCE</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>WHEN APPLIED</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>WHERE APPLIED</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>WHY</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>HOW / VALUE</th>
                     </tr>
                   </thead>
                   <tbody>
@@ -2518,12 +2518,12 @@ function PipelineFlowPanel({ dk = false, result, progress, universe }: { dk?: bo
                       ['Step G Score', 'Computed', 'Step G output', 'Steps H I J enrichment order', 'Determines which tickers get expensive data fetches first', 'All survivors advance but ranking matters for tie-breaking'],
                     ].map(([dp, src, when, where, why, how], i) => (
                       <tr key={i}>
-                        <td className={"text-xs p-2 text-white/80 font-medium border border-panel-border"}>{dp}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{src}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{when}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{where}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{why}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{how}</td>
+                        <td className={"text-xs p-2 text-text-secondary font-medium border border-border"}>{dp}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{src}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{when}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{where}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{why}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{how}</td>
                       </tr>
                     ))}
                   </tbody>
@@ -2595,7 +2595,7 @@ function PipelineFlowPanel({ dk = false, result, progress, universe }: { dk?: bo
 
       {/* Step H — Macro & Regime Data */}
       <div className={themed('border-b border-panel-border', dk)}>
-        <div className={`${SECTION_HEADER} cursor-pointer hover:bg-white/10`} onClick={() => toggle('step_h')}>
+        <div className={`${SECTION_HEADER} cursor-pointer hover:bg-bg-row`} onClick={() => toggle('step_h')}>
           <div className="flex items-center gap-3">
             <span className={chip('accent')}>STEP H</span>
             <span className={themed('text-white/70', dk)}>Macro &amp; Regime Data</span>
@@ -2619,12 +2619,12 @@ function PipelineFlowPanel({ dk = false, result, progress, universe }: { dk?: bo
                 <table className={themed('w-full border-collapse border border-panel-border', dk)}>
                   <thead>
                     <tr>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>DATA POINT</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>SOURCE</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>WHEN APPLIED</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>WHERE APPLIED</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>WHY</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>HOW / VALUE</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>DATA POINT</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>SOURCE</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>WHEN APPLIED</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>WHERE APPLIED</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>WHY</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>HOW / VALUE</th>
                     </tr>
                   </thead>
                   <tbody>
@@ -2640,12 +2640,12 @@ function PipelineFlowPanel({ dk = false, result, progress, universe }: { dk?: bo
                       ['GDP / Unemployment / NFP', 'FRED GDPC1 / UNRATE / PAYEMS', 'Step H fetch', 'Step K Regime gate', 'Core growth signals. Determine whether we are in expansion or contraction', 'Low growth + high unemployment = Deflation or Stagflation classification'],
                     ].map(([dp, src, when, where, why, how], i) => (
                       <tr key={i}>
-                        <td className={"text-xs p-2 text-white/80 font-medium border border-panel-border"}>{dp}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{src}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{when}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{where}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{why}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{how}</td>
+                        <td className={"text-xs p-2 text-text-secondary font-medium border border-border"}>{dp}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{src}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{when}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{where}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{why}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{how}</td>
                       </tr>
                     ))}
                   </tbody>
@@ -2764,7 +2764,7 @@ function PipelineFlowPanel({ dk = false, result, progress, universe }: { dk?: bo
 
       {/* Step I — Data Enrichment */}
       <div className={themed('border-b border-panel-border', dk)}>
-        <div className={`${SECTION_HEADER} cursor-pointer hover:bg-white/10`} onClick={() => toggle('step_i')}>
+        <div className={`${SECTION_HEADER} cursor-pointer hover:bg-bg-row`} onClick={() => toggle('step_i')}>
           <div className="flex items-center gap-3">
             <span className={chip('accent')}>STEP I</span>
             <span className={themed('text-white/70', dk)}>Data Enrichment</span>
@@ -2791,12 +2791,12 @@ function PipelineFlowPanel({ dk = false, result, progress, universe }: { dk?: bo
                 <table className={themed('w-full border-collapse border border-panel-border', dk)}>
                   <thead>
                     <tr>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>DATA POINT</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>SOURCE</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>WHEN APPLIED</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>WHERE APPLIED</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>WHY</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>HOW / VALUE</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>DATA POINT</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>SOURCE</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>WHEN APPLIED</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>WHERE APPLIED</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>WHY</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>HOW / VALUE</th>
                     </tr>
                   </thead>
                   <tbody>
@@ -2816,19 +2816,19 @@ function PipelineFlowPanel({ dk = false, result, progress, universe }: { dk?: bo
                       ['SEC 8-K scan', 'SEC EDGAR EFTS', 'Step I fetch', 'Step K Info Edge gate (material event flag)', 'Recent 8-Ks flag M&A, leadership changes, restatements — events that explain elevated IV', 'High 8-K count = material event risk flag on trade card'],
                     ].map(([dp, src, when, where, why, how], i) => (
                       <tr key={i}>
-                        <td className={"text-xs p-2 text-white/80 font-medium border border-panel-border"}>{dp}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{src}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{when}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{where}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{why}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{how}</td>
+                        <td className={"text-xs p-2 text-text-secondary font-medium border border-border"}>{dp}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{src}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{when}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{where}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{why}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{how}</td>
                       </tr>
                     ))}
                   </tbody>
                 </table>
               </div>
               {progress?.step_i?.data?.data_gaps?.length > 0 && (
-                <div className="p-2 bg-white/5 rounded border border-brand-red/30">
+                <div className="p-2 bg-bg-row rounded border border-brand-red/30">
                   <p className="text-brand-red font-bold text-xs mb-1">DATA GAPS DETECTED</p>
                   {(progress?.step_i?.data?.data_gaps ?? []).map((gap: string, i: number) => (
                     <p key={i} className="text-brand-red text-xs">⚠ {gap}</p>
@@ -2881,9 +2881,9 @@ function PipelineFlowPanel({ dk = false, result, progress, universe }: { dk?: bo
                       </thead>
                       <tbody>
                         {tickers.map((t: any, i: number) => {
-                          const beatColor = t.beat_rate == null ? 'text-white/50' : t.beat_rate >= 60 ? 'text-brand-green' : t.beat_rate >= 40 ? 'text-brand-gold' : 'text-brand-red';
-                          const insiderColor = t.insider_sentiment == null ? 'text-white/50' : t.insider_sentiment > 10 ? 'text-brand-green' : t.insider_sentiment < -10 ? 'text-brand-red' : 'text-brand-gold';
-                          const newsColor = t.news_sentiment == null ? 'text-white/50' : t.news_sentiment > 55 ? 'text-brand-green' : t.news_sentiment < 45 ? 'text-brand-red' : 'text-brand-gold';
+                          const beatColor = t.beat_rate == null ? 'text-text-faint' : t.beat_rate >= 60 ? 'text-brand-green' : t.beat_rate >= 40 ? 'text-brand-gold' : 'text-brand-red';
+                          const insiderColor = t.insider_sentiment == null ? 'text-text-faint' : t.insider_sentiment > 10 ? 'text-brand-green' : t.insider_sentiment < -10 ? 'text-brand-red' : 'text-brand-gold';
+                          const newsColor = t.news_sentiment == null ? 'text-text-faint' : t.news_sentiment > 55 ? 'text-brand-green' : t.news_sentiment < 45 ? 'text-brand-red' : 'text-brand-gold';
                           return (
                             <tr key={t.symbol} className={themed('border-b border-panel-border', dk)}>
                               <td className={themed('py-1 pr-3 text-white/50', dk)}>{i+1}</td>
@@ -2905,7 +2905,7 @@ function PipelineFlowPanel({ dk = false, result, progress, universe }: { dk?: bo
                                   ? 'text-brand-gold'
                                   : t.earnings_quality_letter != null
                                   ? 'text-brand-red'
-                                  : 'text-white/50'
+                                  : 'text-text-faint'
                               }`, dk)}>
                                 {t.earnings_quality_letter != null && t.earnings_quality_score != null
                                   ? `${t.earnings_quality_letter} (${t.earnings_quality_score.toFixed(2)})`
@@ -2966,7 +2966,7 @@ function PipelineFlowPanel({ dk = false, result, progress, universe }: { dk?: bo
 
       {/* Step J — Candle Data & Cross-Asset Correlations */}
       <div className={themed('border-b border-panel-border', dk)}>
-        <div className={`${SECTION_HEADER} cursor-pointer hover:bg-white/10`} onClick={() => toggle('step_j')}>
+        <div className={`${SECTION_HEADER} cursor-pointer hover:bg-bg-row`} onClick={() => toggle('step_j')}>
           <div className="flex items-center gap-3">
             <span className={chip('accent')}>STEP J</span>
             <span className={themed('text-white/70', dk)}>Candle Data &amp; Cross-Asset Correlations</span>
@@ -2988,12 +2988,12 @@ function PipelineFlowPanel({ dk = false, result, progress, universe }: { dk?: bo
                 <table className={themed('w-full border-collapse border border-panel-border', dk)}>
                   <thead>
                     <tr>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>DATA POINT</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>SOURCE</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>WHEN APPLIED</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>WHERE APPLIED</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>WHY</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>HOW / VALUE</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>DATA POINT</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>SOURCE</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>WHEN APPLIED</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>WHERE APPLIED</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>WHY</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>HOW / VALUE</th>
                     </tr>
                   </thead>
                   <tbody>
@@ -3002,12 +3002,12 @@ function PipelineFlowPanel({ dk = false, result, progress, universe }: { dk?: bo
                       ['Cross-asset correlations', 'FRED daily series', 'Step J computation', 'Step K Regime gate cluster modifier', 'Correlation cluster tells us whether markets are risk-on or risk-off right now', 'Adjusts Regime gate score up or down based on cluster signal'],
                     ].map(([dp, src, when, where, why, how], i) => (
                       <tr key={i}>
-                        <td className={"text-xs p-2 text-white/80 font-medium border border-panel-border"}>{dp}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{src}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{when}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{where}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{why}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{how}</td>
+                        <td className={"text-xs p-2 text-text-secondary font-medium border border-border"}>{dp}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{src}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{when}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{where}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{why}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{how}</td>
                       </tr>
                     ))}
                   </tbody>
@@ -3082,7 +3082,7 @@ function PipelineFlowPanel({ dk = false, result, progress, universe }: { dk?: bo
 
       {/* Step K — 4-Gate Scoring */}
       <div className={themed('border-b border-panel-border', dk)}>
-        <div className={`${SECTION_HEADER} cursor-pointer hover:bg-white/10`} onClick={() => toggle('step_k')}>
+        <div className={`${SECTION_HEADER} cursor-pointer hover:bg-bg-row`} onClick={() => toggle('step_k')}>
           <div className="flex items-center gap-3">
             <span className={chip('accent')}>STEP K</span>
             <span className={themed('text-white/70', dk)}>4-Gate Scoring</span>
@@ -3104,12 +3104,12 @@ function PipelineFlowPanel({ dk = false, result, progress, universe }: { dk?: bo
                 <table className={themed('w-full border-collapse border border-panel-border', dk)}>
                   <thead>
                     <tr>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>DATA POINT</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>SOURCE</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>WHEN APPLIED</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>WHERE APPLIED</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>WHY</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>HOW / VALUE</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>DATA POINT</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>SOURCE</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>WHEN APPLIED</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>WHERE APPLIED</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>WHY</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>HOW / VALUE</th>
                     </tr>
                   </thead>
                   <tbody>
@@ -3122,12 +3122,12 @@ function PipelineFlowPanel({ dk = false, result, progress, universe }: { dk?: bo
                       ['Convergence requirement', 'Computed', 'Step K output', 'Step M final selection', '3 of 4 gates must score above 50. One strong gate is not enough', 'Enforces multi-dimensional agreement before any trade signal is produced'],
                     ].map(([dp, src, when, where, why, how], i) => (
                       <tr key={i}>
-                        <td className={"text-xs p-2 text-white/80 font-medium border border-panel-border"}>{dp}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{src}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{when}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{where}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{why}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{how}</td>
+                        <td className={"text-xs p-2 text-text-secondary font-medium border border-border"}>{dp}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{src}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{when}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{where}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{why}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{how}</td>
                       </tr>
                     ))}
                   </tbody>
@@ -3206,7 +3206,7 @@ function PipelineFlowPanel({ dk = false, result, progress, universe }: { dk?: bo
                                 <p className="text-brand-purple-pop font-bold mb-1">VOL EDGE {r.vol_edge}<span className={themed('text-white/50 font-normal ml-1', dk)}>— TastyTrade + Candles</span></p>
                                 {r.vol_edge_detail && (
                                   <table className="w-full text-[10px]">
-                                    <thead><tr className={"font-mono text-[10px] uppercase tracking-wider text-white/50 border-b border-panel-border"}><th className="text-left py-0.5">COMPONENT</th><th className="text-right py-0.5">SCORE</th><th className="text-right py-0.5">WEIGHT</th><th className="text-right py-0.5">CONTRIB</th></tr></thead>
+                                    <thead><tr className={"font-mono text-[10px] uppercase tracking-wider text-text-faint border-b border-border"}><th className="text-left py-0.5">COMPONENT</th><th className="text-right py-0.5">SCORE</th><th className="text-right py-0.5">WEIGHT</th><th className="text-right py-0.5">CONTRIB</th></tr></thead>
                                     <tbody>
                                       {[
                                         ['Mispricing', r.vol_edge_detail.mispricing],
@@ -3232,7 +3232,7 @@ function PipelineFlowPanel({ dk = false, result, progress, universe }: { dk?: bo
                                 <p className="text-brand-purple-pop font-bold mb-1">QUALITY {r.quality}<span className={themed('text-white/50 font-normal ml-1', dk)}>— Finnhub</span></p>
                                 {r.quality_detail && (
                                   <table className="w-full text-[10px]">
-                                    <thead><tr className={"font-mono text-[10px] uppercase tracking-wider text-white/50 border-b border-panel-border"}><th className="text-left py-0.5">COMPONENT</th><th className="text-right py-0.5">SCORE</th><th className="text-right py-0.5">WEIGHT</th><th className="text-right py-0.5">CONTRIB</th></tr></thead>
+                                    <thead><tr className={"font-mono text-[10px] uppercase tracking-wider text-text-faint border-b border-border"}><th className="text-left py-0.5">COMPONENT</th><th className="text-right py-0.5">SCORE</th><th className="text-right py-0.5">WEIGHT</th><th className="text-right py-0.5">CONTRIB</th></tr></thead>
                                     <tbody>
                                       {[
                                         ['Safety', r.quality_detail.safety],
@@ -3294,7 +3294,7 @@ function PipelineFlowPanel({ dk = false, result, progress, universe }: { dk?: bo
                                 <p className="text-brand-purple-pop font-bold mb-1">INFO EDGE {r.info_edge}<span className={themed('text-white/50 font-normal ml-1', dk)}>— Finnhub</span></p>
                                 {r.info_edge_detail && (
                                   <table className="w-full text-[10px]">
-                                    <thead><tr className={"font-mono text-[10px] uppercase tracking-wider text-white/50 border-b border-panel-border"}><th className="text-left py-0.5">COMPONENT</th><th className="text-right py-0.5">SCORE</th><th className="text-right py-0.5">WEIGHT</th><th className="text-right py-0.5">CONTRIB</th></tr></thead>
+                                    <thead><tr className={"font-mono text-[10px] uppercase tracking-wider text-text-faint border-b border-border"}><th className="text-left py-0.5">COMPONENT</th><th className="text-right py-0.5">SCORE</th><th className="text-right py-0.5">WEIGHT</th><th className="text-right py-0.5">CONTRIB</th></tr></thead>
                                     <tbody>
                                       {[
                                         ['Analyst', r.info_edge_detail.analyst_consensus],
@@ -3354,7 +3354,7 @@ function PipelineFlowPanel({ dk = false, result, progress, universe }: { dk?: bo
 
       {/* Step L — Re-Score With Technicals */}
       <div className={themed('border-b border-panel-border', dk)}>
-        <div className={`${SECTION_HEADER} cursor-pointer hover:bg-white/10`} onClick={() => toggle('step_l')}>
+        <div className={`${SECTION_HEADER} cursor-pointer hover:bg-bg-row`} onClick={() => toggle('step_l')}>
           <div className="flex items-center gap-3">
             <span className={chip('accent')}>STEP L</span>
             <span className={themed('text-white/70', dk)}>Re-Score With Technicals</span>
@@ -3376,12 +3376,12 @@ function PipelineFlowPanel({ dk = false, result, progress, universe }: { dk?: bo
                 <table className={themed('w-full border-collapse border border-panel-border', dk)}>
                   <thead>
                     <tr>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>DATA POINT</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>SOURCE</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>WHEN APPLIED</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>WHERE APPLIED</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>WHY</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>HOW / VALUE</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>DATA POINT</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>SOURCE</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>WHEN APPLIED</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>WHERE APPLIED</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>WHY</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>HOW / VALUE</th>
                     </tr>
                   </thead>
                   <tbody>
@@ -3393,12 +3393,12 @@ function PipelineFlowPanel({ dk = false, result, progress, universe }: { dk?: bo
                       ['52-week high ratio', 'Step A / Step I fundamentals', 'Step L computation', 'Vol Edge technicals sub-score (15% of technicals)', 'Price proximity to 52-week high is a documented momentum signal', 'Near 52-week high = elevated score'],
                     ].map(([dp, src, when, where, why, how], i) => (
                       <tr key={i}>
-                        <td className={"text-xs p-2 text-white/80 font-medium border border-panel-border"}>{dp}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{src}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{when}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{where}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{why}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{how}</td>
+                        <td className={"text-xs p-2 text-text-secondary font-medium border border-border"}>{dp}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{src}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{when}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{where}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{why}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{how}</td>
                       </tr>
                     ))}
                   </tbody>
@@ -3469,7 +3469,7 @@ function PipelineFlowPanel({ dk = false, result, progress, universe }: { dk?: bo
 
       {/* Step M — Final Selection */}
       <div className={themed('border-b border-panel-border', dk)}>
-        <div className={`${SECTION_HEADER} cursor-pointer hover:bg-white/10`} onClick={() => toggle('step_m')}>
+        <div className={`${SECTION_HEADER} cursor-pointer hover:bg-bg-row`} onClick={() => toggle('step_m')}>
           <div className="flex items-center gap-3">
             <span className={chip('accent')}>STEP M</span>
             <span className={themed('text-white/70', dk)}>Final Selection</span>
@@ -3491,12 +3491,12 @@ function PipelineFlowPanel({ dk = false, result, progress, universe }: { dk?: bo
                 <table className={themed('w-full border-collapse border border-panel-border', dk)}>
                   <thead>
                     <tr>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>DATA POINT</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>SOURCE</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>WHEN APPLIED</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>WHERE APPLIED</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>WHY</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>HOW / VALUE</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>DATA POINT</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>SOURCE</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>WHEN APPLIED</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>WHERE APPLIED</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>WHY</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>HOW / VALUE</th>
                     </tr>
                   </thead>
                   <tbody>
@@ -3508,12 +3508,12 @@ function PipelineFlowPanel({ dk = false, result, progress, universe }: { dk?: bo
                       ['Adjustments log', 'Computed', 'Step M output', 'Displayed in UI', 'Full audit trail of every promotion demotion and cap relaxation', 'Every decision documented with symbol rank composite and reason'],
                     ].map(([dp, src, when, where, why, how], i) => (
                       <tr key={i}>
-                        <td className={"text-xs p-2 text-white/80 font-medium border border-panel-border"}>{dp}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{src}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{when}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{where}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{why}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{how}</td>
+                        <td className={"text-xs p-2 text-text-secondary font-medium border border-border"}>{dp}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{src}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{when}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{where}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{why}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{how}</td>
                       </tr>
                     ))}
                   </tbody>
@@ -3631,7 +3631,7 @@ function PipelineFlowPanel({ dk = false, result, progress, universe }: { dk?: bo
 
       {/* Step N — Chain Fetch */}
       <div className={themed('border-b border-panel-border', dk)}>
-        <div className={`${SECTION_HEADER} cursor-pointer hover:bg-white/10`} onClick={() => toggle('step_n')}>
+        <div className={`${SECTION_HEADER} cursor-pointer hover:bg-bg-row`} onClick={() => toggle('step_n')}>
           <div className="flex items-center gap-3">
             <span className={chip('accent')}>STEP N</span>
             <span className={themed('text-white/70', dk)}>Chain Fetch</span>
@@ -3653,12 +3653,12 @@ function PipelineFlowPanel({ dk = false, result, progress, universe }: { dk?: bo
                 <table className={themed('w-full border-collapse border border-panel-border', dk)}>
                   <thead>
                     <tr>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>DATA POINT</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>SOURCE</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>WHEN APPLIED</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>WHERE APPLIED</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>WHY</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>HOW / VALUE</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>DATA POINT</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>SOURCE</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>WHEN APPLIED</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>WHERE APPLIED</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>WHY</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>HOW / VALUE</th>
                     </tr>
                   </thead>
                   <tbody>
@@ -3668,12 +3668,12 @@ function PipelineFlowPanel({ dk = false, result, progress, universe }: { dk?: bo
                       ['Streamer symbols', 'Converted from chain data', 'Step N output', 'Step O WebSocket subscription', 'Greeks subscription requires DXFeed format symbol strings', 'All symbols collected and passed to Step O WebSocket'],
                     ].map(([dp, src, when, where, why, how], i) => (
                       <tr key={i}>
-                        <td className={"text-xs p-2 text-white/80 font-medium border border-panel-border"}>{dp}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{src}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{when}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{where}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{why}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{how}</td>
+                        <td className={"text-xs p-2 text-text-secondary font-medium border border-border"}>{dp}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{src}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{when}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{where}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{why}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{how}</td>
                       </tr>
                     ))}
                   </tbody>
@@ -3687,7 +3687,7 @@ function PipelineFlowPanel({ dk = false, result, progress, universe }: { dk?: bo
               return (
               <div style={{ maxHeight: 240, overflowY: 'auto' }}>
                 <table className="w-full text-[10px]">
-                  <thead><tr className={"font-mono text-[10px] uppercase tracking-wider text-white/50 border-b border-panel-border"}>
+                  <thead><tr className={"font-mono text-[10px] uppercase tracking-wider text-text-faint border-b border-border"}>
                     <th className="text-left py-1 px-1">SYMBOL</th>
                     <th className="text-left py-1 px-1">EXPIRATION</th>
                     <th className="text-right py-1 px-1">DTE</th>
@@ -3732,7 +3732,7 @@ function PipelineFlowPanel({ dk = false, result, progress, universe }: { dk?: bo
 
       {/* Step O — Live Greeks Subscription */}
       <div className={themed('border-b border-panel-border', dk)}>
-        <div className={`${SECTION_HEADER} cursor-pointer hover:bg-white/10`} onClick={() => toggle('step_o')}>
+        <div className={`${SECTION_HEADER} cursor-pointer hover:bg-bg-row`} onClick={() => toggle('step_o')}>
           <div className="flex items-center gap-3">
             <span className={chip('accent')}>STEP O</span>
             <span className={themed('text-white/70', dk)}>Live Greeks Subscription</span>
@@ -3760,12 +3760,12 @@ function PipelineFlowPanel({ dk = false, result, progress, universe }: { dk?: bo
                   <table className={themed('w-full border-collapse border border-panel-border', dk)}>
                     <thead>
                       <tr>
-                        <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>DATA POINT</th>
-                        <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>SOURCE</th>
-                        <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>WHEN APPLIED</th>
-                        <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>WHERE APPLIED</th>
-                        <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>WHY</th>
-                        <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>HOW / VALUE</th>
+                        <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>DATA POINT</th>
+                        <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>SOURCE</th>
+                        <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>WHEN APPLIED</th>
+                        <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>WHERE APPLIED</th>
+                        <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>WHY</th>
+                        <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>HOW / VALUE</th>
                       </tr>
                     </thead>
                     <tbody>
@@ -3776,12 +3776,12 @@ function PipelineFlowPanel({ dk = false, result, progress, universe }: { dk?: bo
                         ['Market open / closed status', 'TastyTrade API', 'Step O check', 'Trade card pricing label', 'Closed market means theoretical pricing instead of live quotes', 'Market Closed label shown on trade card. Price source flagged as theo'],
                       ].map(([dp, src, when, where, why, how], i) => (
                         <tr key={i}>
-                          <td className={"text-xs p-2 text-white/80 font-medium border border-panel-border"}>{dp}</td>
-                          <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{src}</td>
-                          <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{when}</td>
-                          <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{where}</td>
-                          <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{why}</td>
-                          <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{how}</td>
+                          <td className={"text-xs p-2 text-text-secondary font-medium border border-border"}>{dp}</td>
+                          <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{src}</td>
+                          <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{when}</td>
+                          <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{where}</td>
+                          <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{why}</td>
+                          <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{how}</td>
                         </tr>
                       ))}
                     </tbody>
@@ -3797,7 +3797,7 @@ function PipelineFlowPanel({ dk = false, result, progress, universe }: { dk?: bo
               {tickers.length > 0 && (
                 <div style={{ maxHeight: 240, overflowY: 'auto' }}>
                   <table className="w-full text-[10px]">
-                    <thead><tr className={"font-mono text-[10px] uppercase tracking-wider text-white/50 border-b border-panel-border"}>
+                    <thead><tr className={"font-mono text-[10px] uppercase tracking-wider text-text-faint border-b border-border"}>
                       <th className="text-right py-1 px-1">#</th>
                       <th className="text-left py-1 px-1">SYMBOL</th>
                       <th className="text-right py-1 px-1">STRIKES</th>
@@ -3833,7 +3833,7 @@ function PipelineFlowPanel({ dk = false, result, progress, universe }: { dk?: bo
 
       {/* Step P — Strategy Scoring */}
       <div className={themed('border-b border-panel-border', dk)}>
-        <div className={`${SECTION_HEADER} cursor-pointer hover:bg-white/10`} onClick={() => toggle('step_p')}>
+        <div className={`${SECTION_HEADER} cursor-pointer hover:bg-bg-row`} onClick={() => toggle('step_p')}>
           <div className="flex items-center gap-3">
             <span className={chip('accent')}>STEP P</span>
             <span className={themed('text-white/70', dk)}>Strategy Scoring</span>
@@ -3855,12 +3855,12 @@ function PipelineFlowPanel({ dk = false, result, progress, universe }: { dk?: bo
                 <table className={themed('w-full border-collapse border border-panel-border', dk)}>
                   <thead>
                     <tr>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>DATA POINT</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>SOURCE</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>WHEN APPLIED</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>WHERE APPLIED</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>WHY</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>HOW / VALUE</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>DATA POINT</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>SOURCE</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>WHEN APPLIED</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>WHERE APPLIED</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>WHY</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>HOW / VALUE</th>
                     </tr>
                   </thead>
                   <tbody>
@@ -3872,12 +3872,12 @@ function PipelineFlowPanel({ dk = false, result, progress, universe }: { dk?: bo
                       ['xAI social sentiment', 'xAI Grok API', 'Step P fetch (parallel)', 'Trade card For/Against section', 'Real-time social signal from Reddit Twitter and financial forums', 'Bullish sentiment adds to For column. Bearish adds to Against'],
                     ].map(([dp, src, when, where, why, how], i) => (
                       <tr key={i}>
-                        <td className={"text-xs p-2 text-white/80 font-medium border border-panel-border"}>{dp}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{src}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{when}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{where}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{why}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{how}</td>
+                        <td className={"text-xs p-2 text-text-secondary font-medium border border-border"}>{dp}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{src}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{when}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{where}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{why}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{how}</td>
                       </tr>
                     ))}
                   </tbody>
@@ -3892,7 +3892,7 @@ function PipelineFlowPanel({ dk = false, result, progress, universe }: { dk?: bo
               return (
               <div style={{ maxHeight: 240, overflowY: 'auto' }}>
                 <table className="w-full text-[10px]">
-                  <thead><tr className={"font-mono text-[10px] uppercase tracking-wider text-white/50 border-b border-panel-border"}>
+                  <thead><tr className={"font-mono text-[10px] uppercase tracking-wider text-text-faint border-b border-border"}>
                     <th className="text-left py-1 px-1">SYMBOL</th>
                     <th className="text-right py-1 px-1">BUILT</th>
                     <th className="text-right py-1 px-1">GATE A ✗</th>
@@ -3935,7 +3935,7 @@ function PipelineFlowPanel({ dk = false, result, progress, universe }: { dk?: bo
       {/* Step Q — Live Options Flow & GEX */}
       {(() => { const qData: any = progress?.step_q?.data ?? null; return (
       <div className={themed('border-b border-panel-border', dk)}>
-        <div className={`${SECTION_HEADER} cursor-pointer hover:bg-white/10`} onClick={() => toggle('step_q')}>
+        <div className={`${SECTION_HEADER} cursor-pointer hover:bg-bg-row`} onClick={() => toggle('step_q')}>
           <div className="flex items-center gap-3">
             <span className={chip('accent')}>STEP Q</span>
             <span className={themed('text-white/70', dk)}>Live Options Flow &amp; GEX</span>
@@ -3957,12 +3957,12 @@ function PipelineFlowPanel({ dk = false, result, progress, universe }: { dk?: bo
                 <table className={themed('w-full border-collapse border border-panel-border', dk)}>
                   <thead>
                     <tr>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>DATA POINT</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>SOURCE</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>WHEN APPLIED</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>WHERE APPLIED</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>WHY</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>HOW / VALUE</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>DATA POINT</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>SOURCE</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>WHEN APPLIED</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>WHERE APPLIED</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>WHY</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>HOW / VALUE</th>
                     </tr>
                   </thead>
                   <tbody>
@@ -3974,12 +3974,12 @@ function PipelineFlowPanel({ dk = false, result, progress, universe }: { dk?: bo
                       ['Zero-gamma flip point', 'Step Q GEX computation', 'Step Q output', 'Trade card risk flags', 'Price level where dealer hedging flips from stabilizing to destabilizing', 'Distance to flip shown on trade card'],
                     ].map(([dp, src, when, where, why, how], i) => (
                       <tr key={i}>
-                        <td className={"text-xs p-2 text-white/80 font-medium border border-panel-border"}>{dp}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{src}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{when}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{where}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{why}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{how}</td>
+                        <td className={"text-xs p-2 text-text-secondary font-medium border border-border"}>{dp}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{src}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{when}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{where}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{why}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{how}</td>
                       </tr>
                     ))}
                   </tbody>
@@ -3993,7 +3993,7 @@ function PipelineFlowPanel({ dk = false, result, progress, universe }: { dk?: bo
               return (
               <div style={{ maxHeight: 240, overflowY: 'auto' }}>
                 <table className="w-full text-[10px]">
-                  <thead><tr className={"font-mono text-[10px] uppercase tracking-wider text-white/50 border-b border-panel-border"}>
+                  <thead><tr className={"font-mono text-[10px] uppercase tracking-wider text-text-faint border-b border-border"}>
                     <th className="text-right py-1 px-1">#</th>
                     <th className="text-left py-1 px-1">SYMBOL</th>
                     <th className="text-right py-1 px-1">PCR</th>
@@ -4041,7 +4041,7 @@ function PipelineFlowPanel({ dk = false, result, progress, universe }: { dk?: bo
       {/* Step R — Re-Score With Live Data */}
       {(() => { const rData: any = progress?.step_r?.data ?? null; return (
       <div className={themed('border-b border-panel-border', dk)}>
-        <div className={`${SECTION_HEADER} cursor-pointer hover:bg-white/10`} onClick={() => toggle('step_r')}>
+        <div className={`${SECTION_HEADER} cursor-pointer hover:bg-bg-row`} onClick={() => toggle('step_r')}>
           <div className="flex items-center gap-3">
             <span className={chip('accent')}>STEP R</span>
             <span className={themed('text-white/70', dk)}>Re-Score With Live Data</span>
@@ -4063,12 +4063,12 @@ function PipelineFlowPanel({ dk = false, result, progress, universe }: { dk?: bo
                 <table className={themed('w-full border-collapse border border-panel-border', dk)}>
                   <thead>
                     <tr>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>DATA POINT</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>SOURCE</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>WHEN APPLIED</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>WHERE APPLIED</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>WHY</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>HOW / VALUE</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>DATA POINT</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>SOURCE</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>WHEN APPLIED</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>WHERE APPLIED</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>WHY</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>HOW / VALUE</th>
                     </tr>
                   </thead>
                   <tbody>
@@ -4078,12 +4078,12 @@ function PipelineFlowPanel({ dk = false, result, progress, universe }: { dk?: bo
                       ['Updated composite score', 'Recomputed from all four gates', 'Step R output', 'Trade card, Step S eligibility', 'Final score the trade card is built on', 'Tickers without flow data keep their Step L score unchanged'],
                     ].map(([dp, src, when, where, why, how], i) => (
                       <tr key={i}>
-                        <td className={"text-xs p-2 text-white/80 font-medium border border-panel-border"}>{dp}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{src}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{when}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{where}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{why}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{how}</td>
+                        <td className={"text-xs p-2 text-text-secondary font-medium border border-border"}>{dp}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{src}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{when}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{where}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{why}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{how}</td>
                       </tr>
                     ))}
                   </tbody>
@@ -4097,7 +4097,7 @@ function PipelineFlowPanel({ dk = false, result, progress, universe }: { dk?: bo
               return (
               <div style={{ maxHeight: 240, overflowY: 'auto' }}>
                 <table className="w-full text-[10px]">
-                  <thead><tr className={"font-mono text-[10px] uppercase tracking-wider text-white/50 border-b border-panel-border"}>
+                  <thead><tr className={"font-mono text-[10px] uppercase tracking-wider text-text-faint border-b border-border"}>
                     <th className="text-right py-1 px-1">#</th>
                     <th className="text-left py-1 px-1">SYMBOL</th>
                     <th className="text-right py-1 px-1">COMPOSITE</th>
@@ -4136,7 +4136,7 @@ function PipelineFlowPanel({ dk = false, result, progress, universe }: { dk?: bo
 
       {/* Step S — Trade Cards */}
       <div className={themed('border-b border-panel-border', dk)}>
-        <div className={`${SECTION_HEADER} cursor-pointer hover:bg-white/10`} onClick={() => toggle('step_s')}>
+        <div className={`${SECTION_HEADER} cursor-pointer hover:bg-bg-row`} onClick={() => toggle('step_s')}>
           <div className="flex items-center gap-3">
             <span className={chip('accent')}>STEP S</span>
             <span className={themed('text-white/70', dk)}>Trade Cards</span>
@@ -4158,12 +4158,12 @@ function PipelineFlowPanel({ dk = false, result, progress, universe }: { dk?: bo
                 <table className={themed('w-full border-collapse border border-panel-border', dk)}>
                   <thead>
                     <tr>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>DATA POINT</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>SOURCE</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>WHEN APPLIED</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>WHERE APPLIED</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>WHY</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>HOW / VALUE</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>DATA POINT</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>SOURCE</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>WHEN APPLIED</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>WHERE APPLIED</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>WHY</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>HOW / VALUE</th>
                     </tr>
                   </thead>
                   <tbody>
@@ -4174,12 +4174,12 @@ function PipelineFlowPanel({ dk = false, result, progress, universe }: { dk?: bo
                       ['Trade card assembly', 'All prior steps', 'Step S output', 'User-facing card', 'Packages all signals scores strategy and risk flags into one structured card', 'Strategy legs strikes credit max loss PoP EV Greeks For/Against risk flags'],
                     ].map(([dp, src, when, where, why, how], i) => (
                       <tr key={i}>
-                        <td className={"text-xs p-2 text-white/80 font-medium border border-panel-border"}>{dp}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{src}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{when}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{where}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{why}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{how}</td>
+                        <td className={"text-xs p-2 text-text-secondary font-medium border border-border"}>{dp}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{src}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{when}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{where}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{why}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{how}</td>
                       </tr>
                     ))}
                   </tbody>
@@ -4195,7 +4195,7 @@ function PipelineFlowPanel({ dk = false, result, progress, universe }: { dk?: bo
               return (
             <div style={{ maxHeight: 300, overflowY: 'auto' }}>
               <table className="w-full text-[10px]">
-                <thead><tr className={"font-mono text-[10px] uppercase tracking-wider text-white/50 border-b border-panel-border"}>
+                <thead><tr className={"font-mono text-[10px] uppercase tracking-wider text-text-faint border-b border-border"}>
                   <th className="text-left py-1 px-1">RANK</th>
                   <th className="text-left py-1 px-1">SYMBOL</th>
                   <th className="text-right py-1 px-1">COMPOSITE</th>
@@ -4284,7 +4284,7 @@ function PipelineFlowPanel({ dk = false, result, progress, universe }: { dk?: bo
         const tAgeSec = tFetchedAt ? Math.round((Date.now() - tFetchedAt.getTime()) / 1000) : null;
         return (
       <div className={themed('border-b border-panel-border', dk)}>
-        <div className={`${SECTION_HEADER} cursor-pointer hover:bg-white/10`} onClick={() => toggle('step_t')}>
+        <div className={`${SECTION_HEADER} cursor-pointer hover:bg-bg-row`} onClick={() => toggle('step_t')}>
           <div className="flex items-center gap-3">
             <span className={chip('accent')}>STEP T</span>
             <span className={themed('text-white/70', dk)}>Save &amp; Return</span>
@@ -4310,12 +4310,12 @@ function PipelineFlowPanel({ dk = false, result, progress, universe }: { dk?: bo
                 <table className={themed('w-full border-collapse border border-panel-border', dk)}>
                   <thead>
                     <tr>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>DATA POINT</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>SOURCE</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>WHEN APPLIED</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>WHERE APPLIED</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>WHY</th>
-                      <th className={"p-2 bg-white/5 border border-panel-border font-mono text-[10px] uppercase tracking-wider text-white/50"}>HOW / VALUE</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>DATA POINT</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>SOURCE</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>WHEN APPLIED</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>WHERE APPLIED</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>WHY</th>
+                      <th className={"p-2 bg-bg-row border border-border font-mono text-[10px] uppercase tracking-wider text-text-faint"}>HOW / VALUE</th>
                     </tr>
                   </thead>
                   <tbody>
@@ -4327,12 +4327,12 @@ function PipelineFlowPanel({ dk = false, result, progress, universe }: { dk?: bo
                       ['Pipeline runtime', 'Computed', 'Step T output', 'UI summary bar', 'Operational metric', 'Tracks scan performance over time'],
                     ].map(([dp, src, when, where, why, how], i) => (
                       <tr key={i}>
-                        <td className={"text-xs p-2 text-white/80 font-medium border border-panel-border"}>{dp}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{src}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{when}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{where}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{why}</td>
-                        <td className={"text-xs p-2 text-white/70 leading-relaxed border border-panel-border"}>{how}</td>
+                        <td className={"text-xs p-2 text-text-secondary font-medium border border-border"}>{dp}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{src}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{when}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{where}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{why}</td>
+                        <td className={"text-xs p-2 text-text-secondary leading-relaxed border border-border"}>{how}</td>
                       </tr>
                     ))}
                   </tbody>
@@ -4818,9 +4818,9 @@ export default function ConvergenceIntelligence({
     <div className={themed('bg-white rounded border border-border shadow-sm overflow-hidden', dk)}>
 
       {/* RISK-1: user-entered account-size input for capital context (labeled not-synced). */}
-      <div className="border-b border-panel-border bg-white/5 px-4 py-2 flex flex-wrap items-center gap-2 font-mono text-[11px]">
-        <label htmlFor="ci-account-size" className="text-white/60">Account size <span className="text-white/40">(user-entered, not synced)</span>:</label>
-        <span className="text-white/40">$</span>
+      <div className="border-b border-border bg-bg-row px-4 py-2 flex flex-wrap items-center gap-2 font-mono text-[11px]">
+        <label htmlFor="ci-account-size" className="text-text-muted">Account size <span className="text-text-faint">(user-entered, not synced)</span>:</label>
+        <span className="text-text-faint">$</span>
         <input
           id="ci-account-size"
           type="number"
@@ -4829,7 +4829,7 @@ export default function ConvergenceIntelligence({
           value={accountSize > 0 ? accountSize : ''}
           onChange={(e) => handleAccountSizeChange(e.target.value)}
           placeholder="Set account size for capital context"
-          className="w-64 rounded border border-panel-border bg-panel px-2 py-1 text-xs font-mono text-white"
+          className="w-64 rounded border border-border bg-white px-2 py-1 text-xs font-mono text-text-primary"
         />
       </div>
 
@@ -4864,7 +4864,7 @@ export default function ConvergenceIntelligence({
             </div>
           </div>
           {batchData && (
-            <div className="px-4 pb-1.5 text-[10px] text-white/60 font-mono">
+            <div className="px-4 pb-1.5 text-[10px] text-text-muted font-mono">
               {batchData.pipeline_summary.total_universe} scanned
               {' \u2192 '}{batchData.pipeline_summary.after_hard_filters} filtered
               {' \u2192 '}{batchData.pipeline_summary.scored} scored

--- a/src/components/convergence/ScannerResultsTable.tsx
+++ b/src/components/convergence/ScannerResultsTable.tsx
@@ -545,7 +545,7 @@ export default function ScannerResultsTable({
 
   // TRADE-TABLES: DATA.columnHeader layered onto the sort affordances —
   // token-native, so the themed() wrap dropped (identity on dark).
-  const thBase = 'px-2 py-2 font-mono text-[10px] uppercase tracking-wider text-white/50 cursor-pointer hover:text-white/60 select-none whitespace-nowrap';
+  const thBase = 'px-2 py-2 font-mono text-[10px] uppercase tracking-wider text-text-faint cursor-pointer hover:text-text-muted select-none whitespace-nowrap';
 
   return (
     <div className="px-4 py-3">
@@ -578,7 +578,7 @@ export default function ScannerResultsTable({
       <div className={themed('overflow-x-auto rounded border border-border overflow-y-auto', dk)}>
         <table className="w-full text-xs" style={{ minWidth: 900 }}>
           <thead className="sticky top-0 z-10">
-            <tr className="bg-white/5">
+            <tr className="bg-bg-row">
               <th className="px-2 py-2 w-8">{/* checkbox col */}</th>
               <th className={thBase + ' text-left'} onClick={() => toggleSort('symbol')}>Symbol{sortIndicator('symbol')}</th>
               <th className={thBase + ' text-center w-6'} title="Social Sentiment from X/Twitter (via xAI Grok)">X</th>
@@ -596,7 +596,7 @@ export default function ScannerResultsTable({
               <th className={thBase + ' text-right'} onClick={() => toggleSort('dte')}>DTE{sortIndicator('dte')}</th>
             </tr>
           </thead>
-          <tbody className="divide-y divide-panel-border">
+          <tbody className="divide-y divide-border">
             {sortedRows.map((row, idx) => {
               const isExpanded = expandedRow === row.id;
               const isQueued = row.card ? savedCards.has(row.cardKey) : false;

--- a/src/components/trading/CoverageDeclaration.tsx
+++ b/src/components/trading/CoverageDeclaration.tsx
@@ -59,7 +59,7 @@ export default function CoverageDeclaration() {
 
   if (state === 'loading') {
     return (
-      <div className="rounded-lg border border-panel-border bg-white/5 px-3 py-2 font-mono text-[11px] text-white/50">
+      <div className="rounded-lg border border-border bg-bg-row px-3 py-2 font-mono text-[11px] text-text-faint">
         Checking synced coverage…
       </div>
     );
@@ -83,7 +83,7 @@ export default function CoverageDeclaration() {
   if (!data) return null; // unreachable in 'ok', keeps types honest
 
   return (
-    <div className="rounded-lg border border-panel-border bg-white/5 font-mono text-[11px] text-white/50">
+    <div className="rounded-lg border border-border bg-bg-row font-mono text-[11px] text-text-faint">
       {/* DISCLOSURE-COMPACT: the collapsed row — counts from the SAME data
           the full copy renders (investment_txn_count / unlinked_closed_count);
           the ▼/▲ chevron is the house bar toggle (FlightPickerView). */}
@@ -96,10 +96,10 @@ export default function CoverageDeclaration() {
         <span>
           Sync coverage: {data.investment_txn_count} transactions · {data.unlinked_closed_count} unlinked — details
         </span>
-        <span aria-hidden="true" className="shrink-0 text-white/40">{expanded ? '▲' : '▼'}</span>
+        <span aria-hidden="true" className="shrink-0 text-text-faint">{expanded ? '▲' : '▼'}</span>
       </button>
       {expanded && (
-        <div className="border-t border-panel-border px-3 py-2">
+        <div className="border-t border-border px-3 py-2">
           This tab reflects <span className={themed('font-semibold text-text-primary', dk)}>{data.investment_txn_count}</span> synced
           transactions from <span className="font-mono">{fmtDate(data.earliest_txn_date)}</span> to{' '}
           <span className="font-mono">{fmtDate(data.latest_txn_date)}</span>.{' '}

--- a/src/components/trading/ScanFilterForm.tsx
+++ b/src/components/trading/ScanFilterForm.tsx
@@ -43,11 +43,11 @@ const UNIVERSES = [{ val: 'sp500', label: 'S&P 500' }, { val: 'nasdaq100', label
 // Light/secondary group label — the Travel one-purple + secondary-white inner rule.
 function GroupLabel({ children }: { children: React.ReactNode }) {
   // TRADE-INK: group eyebrows → white/60 (the brand-purple ink was illegible on dark).
-  return <div className="text-[10px] uppercase tracking-wider font-semibold text-white/60 mb-1.5">{children}</div>;
+  return <div className="text-[10px] uppercase tracking-wider font-semibold text-text-muted mb-1.5">{children}</div>;
 }
 function FieldLabel({ dk = false, children }: { dk?: boolean; children: React.ReactNode }) {
   // HOME-STYLE-PR-1: field sub-labels → readable secondary text, weight 500.
-  return <span className="text-[11px] text-white/70 font-medium w-[88px] shrink-0">{children}</span>;
+  return <span className="text-[11px] text-text-secondary font-medium w-[88px] shrink-0">{children}</span>;
 }
 
 export default function ScanFilterForm({
@@ -110,20 +110,20 @@ export default function ScanFilterForm({
           <GroupLabel>DTE</GroupLabel>
           <div className="flex items-center gap-1">
             <input type="number" min={0} max={365} value={f.risk.minDte} onChange={e => onFiltersChange({ ...f, risk: { ...f.risk, minDte: +e.target.value } })}
-              className="w-14 rounded border border-panel-border bg-panel px-2 py-1 text-xs font-mono text-white text-center focus:outline-none focus:border-brand-purple-pop focus:ring-2 focus:ring-brand-purple-pop/20" />
+              className="w-14 rounded border border-border bg-white px-2 py-1 text-xs font-mono text-text-primary text-center focus:outline-none focus:border-brand-purple-pop focus:ring-2 focus:ring-brand-purple-pop/20" />
             <span className={themed('text-gray-400 text-xs', dk)}>—</span>
             <input type="number" min={0} max={365} value={f.risk.maxDte} onChange={e => onFiltersChange({ ...f, risk: { ...f.risk, maxDte: +e.target.value } })}
-              className="w-14 rounded border border-panel-border bg-panel px-2 py-1 text-xs font-mono text-white text-center focus:outline-none focus:border-brand-purple-pop focus:ring-2 focus:ring-brand-purple-pop/20" />
+              className="w-14 rounded border border-border bg-white px-2 py-1 text-xs font-mono text-text-primary text-center focus:outline-none focus:border-brand-purple-pop focus:ring-2 focus:ring-brand-purple-pop/20" />
           </div>
         </div>
         <div className="flex flex-col gap-1">
           <GroupLabel>Width $</GroupLabel>
           <div className="flex items-center gap-1">
             <input type="number" min={0} max={100} value={f.risk.minSpreadWidth} onChange={e => onFiltersChange({ ...f, risk: { ...f.risk, minSpreadWidth: +e.target.value } })}
-              className="w-14 rounded border border-panel-border bg-panel px-2 py-1 text-xs font-mono text-white text-center focus:outline-none focus:border-brand-purple-pop focus:ring-2 focus:ring-brand-purple-pop/20" />
+              className="w-14 rounded border border-border bg-white px-2 py-1 text-xs font-mono text-text-primary text-center focus:outline-none focus:border-brand-purple-pop focus:ring-2 focus:ring-brand-purple-pop/20" />
             <span className={themed('text-gray-400 text-xs', dk)}>—</span>
             <input type="number" min={0} max={100} value={f.risk.maxSpreadWidth} onChange={e => onFiltersChange({ ...f, risk: { ...f.risk, maxSpreadWidth: +e.target.value } })}
-              className="w-14 rounded border border-panel-border bg-panel px-2 py-1 text-xs font-mono text-white text-center focus:outline-none focus:border-brand-purple-pop focus:ring-2 focus:ring-brand-purple-pop/20" />
+              className="w-14 rounded border border-border bg-white px-2 py-1 text-xs font-mono text-text-primary text-center focus:outline-none focus:border-brand-purple-pop focus:ring-2 focus:ring-brand-purple-pop/20" />
           </div>
         </div>
       </div>
@@ -183,7 +183,7 @@ export default function ScanFilterForm({
       {/* Scan CTA */}
       <div className={themed('flex justify-end border-t border-gray-100 pt-3', dk)}>
         <button type="button" onClick={runScan}
-          className="px-8 py-2 ts-cta-gradient text-white font-bold text-sm rounded transition-colors hover:brightness-110 whitespace-nowrap">
+          className="px-8 py-2 bg-brand-purple text-white font-bold text-sm rounded transition-colors hover:bg-brand-purple-hover whitespace-nowrap">
           Scan
         </button>
       </div>
@@ -192,7 +192,7 @@ export default function ScanFilterForm({
 
   if (!showHeader) return formBody;
   return (
-    <div className="rounded-lg overflow-hidden border border-panel-border shadow-sm mb-3">
+    <div className="rounded-lg overflow-hidden border border-border shadow-sm mb-3">
       <div className={SECTION_HEADER}>
         <span>Scan filters</span>
         {ttConnected != null && (
@@ -203,7 +203,7 @@ export default function ScanFilterForm({
           </span>
         )}
       </div>
-      <div className="bg-panel-surface p-4">{formBody}</div>
+      <div className="bg-white p-4">{formBody}</div>
     </div>
   );
 }

--- a/src/components/trading/TradeLabPanel.tsx
+++ b/src/components/trading/TradeLabPanel.tsx
@@ -355,7 +355,7 @@ export default function TradeLabPanel({ onCardsChange, surface = 'light' }: { on
           <select
             value={filter}
             onChange={e => setFilter(e.target.value)}
-            className="rounded border border-panel-border bg-panel px-2 py-1 text-xs text-white"
+            className="rounded border border-border bg-white px-2 py-1 text-xs text-text-primary"
           >
             <option value="all">All</option>
             <option value="queued">Queued</option>
@@ -363,7 +363,7 @@ export default function TradeLabPanel({ onCardsChange, surface = 'light' }: { on
             <option value="linked">Linked</option>
             <option value="graded">Graded</option>
           </select>
-          <button onClick={loadCards} className="rounded border border-white/30 px-3 py-1 text-xs hover:bg-white/10">
+          <button onClick={loadCards} className="rounded border border-border px-3 py-1 text-xs hover:bg-bg-row">
             Refresh
           </button>
         </div>
@@ -388,7 +388,7 @@ export default function TradeLabPanel({ onCardsChange, surface = 'light' }: { on
               type="date"
               value={startDateInput}
               onChange={e => setStartDateInput(e.target.value)}
-              className="rounded border border-panel-border bg-panel px-1 py-0.5 text-xs text-white"
+              className="rounded border border-border bg-white px-1 py-0.5 text-xs text-text-primary"
             />
             <button
               onClick={() => saveScannerStartDate(startDateInput)}
@@ -398,7 +398,7 @@ export default function TradeLabPanel({ onCardsChange, surface = 'light' }: { on
             </button>
             <button
               onClick={() => setEditingStartDate(false)}
-              className="text-xs text-white/50 hover:text-white/70"
+              className="text-xs text-text-faint hover:text-text-secondary"
             >
               Cancel
             </button>
@@ -509,7 +509,7 @@ export default function TradeLabPanel({ onCardsChange, surface = 'light' }: { on
                       {/* Actual P&L for graded cards */}
                       {card.link?.actual_pl != null && (
                         <div className="mb-1">
-                          <div className="text-[9px] text-white/60 uppercase">Actual P&L</div>
+                          <div className="text-[9px] text-text-muted uppercase">Actual P&L</div>
                           <div className={`text-terminal-lg font-mono font-black ${moneyColorClass(Number(card.link.actual_pl), 'pnl')}`}>
                             {formatMoney(Number(card.link.actual_pl), { kind: 'pnl', fractionDigits: 0 })}
                           </div>
@@ -517,16 +517,16 @@ export default function TradeLabPanel({ onCardsChange, surface = 'light' }: { on
                       )}
 
                       <div className="grid grid-cols-2 gap-x-4 gap-y-0.5 text-[11px]">
-                        <div className="text-white/60">Max Profit</div>
+                        <div className="text-text-muted">Max Profit</div>
                         <div className="font-mono font-bold text-brand-green">{fmtDollar(card.max_profit)}</div>
-                        <div className="text-white/60">Max Loss</div>
+                        <div className="text-text-muted">Max Loss</div>
                         <div className="font-mono font-bold text-brand-red">{fmtDollar(card.max_loss)}</div>
-                        <div className="text-white/60" title="Estimated Probability of Profit based on delta approximation">Est. PoP</div>
+                        <div className="text-text-muted" title="Estimated Probability of Profit based on delta approximation">Est. PoP</div>
                         {/* TRADE-UX-1: the anchor leads the queue row \u2014 size +
                             weight within the grid idiom. Same field/format. */}
-                        <div className="font-mono font-black text-sm text-white/80">{card.win_rate != null ? `${Number(card.win_rate).toFixed(1)}%` : '\u2014'}</div>
-                        <div className="text-white/60">R:R</div>
-                        <div className="font-mono font-bold text-white/80">{card.risk_reward != null ? Number(card.risk_reward).toFixed(2) : '\u2014'}</div>
+                        <div className="font-mono font-black text-sm text-text-secondary">{card.win_rate != null ? `${Number(card.win_rate).toFixed(1)}%` : '\u2014'}</div>
+                        <div className="text-text-muted">R:R</div>
+                        <div className="font-mono font-bold text-text-secondary">{card.risk_reward != null ? Number(card.risk_reward).toFixed(2) : '\u2014'}</div>
                       </div>
 
                       {/* Actions by status */}
@@ -542,7 +542,7 @@ export default function TradeLabPanel({ onCardsChange, surface = 'light' }: { on
                             </button>
                             <button
                               onClick={() => deleteCard(card.id)}
-                              className="text-[10px] text-white/40 hover:text-status-danger transition-colors"
+                              className="text-[10px] text-text-faint hover:text-status-danger transition-colors"
                             >
                               Remove
                             </button>
@@ -561,7 +561,7 @@ export default function TradeLabPanel({ onCardsChange, surface = 'light' }: { on
                             </button>
                             <button
                               onClick={() => unlinkCard(card.link!.id)}
-                              className="text-[10px] text-white/40 hover:text-status-danger transition-colors"
+                              className="text-[10px] text-text-faint hover:text-status-danger transition-colors"
                             >
                               Unlink
                             </button>
@@ -572,7 +572,7 @@ export default function TradeLabPanel({ onCardsChange, surface = 'light' }: { on
                         {card.status === 'graded' && card.link && (
                           <button
                             onClick={() => unlinkCard(card.link!.id)}
-                            className="text-[10px] text-white/40 hover:text-status-danger transition-colors"
+                            className="text-[10px] text-text-faint hover:text-status-danger transition-colors"
                           >
                             Unlink
                           </button>
@@ -584,17 +584,17 @@ export default function TradeLabPanel({ onCardsChange, surface = 'light' }: { on
 
                 {/* Linking dropdown */}
                 {isLinking && (
-                  <div className="px-4 py-3 bg-white/5 border-t border-panel-border" onClick={e => e.stopPropagation()}>
-                    <div className="text-xs font-medium text-white/70 mb-2">
+                  <div className="px-4 py-3 bg-bg-row border-t border-border" onClick={e => e.stopPropagation()}>
+                    <div className="text-xs font-medium text-text-secondary mb-2">
                       Select a position to link to:
                     </div>
                     {linkError && (
                       <div className="text-xs text-brand-red mb-2">{linkError}</div>
                     )}
                     {loadingPositions ? (
-                      <div className="text-xs text-white/60">Loading positions...</div>
+                      <div className="text-xs text-text-muted">Loading positions...</div>
                     ) : matchablePositions.length === 0 ? (
-                      <div className="text-xs text-white/60">
+                      <div className="text-xs text-text-muted">
                         No matching positions yet &mdash; execute the trade and commit it in Books first.
                       </div>
                     ) : (
@@ -603,20 +603,20 @@ export default function TradeLabPanel({ onCardsChange, surface = 'light' }: { on
                           <button
                             key={pos.trade_num}
                             onClick={() => linkToPosition(card.id, pos.trade_num)}
-                            className="w-full text-left px-3 py-2 rounded border border-panel-border bg-panel hover:border-brand-purple-pop hover:bg-white/10 transition-colors"
+                            className="w-full text-left px-3 py-2 rounded border border-border bg-white hover:border-brand-purple-pop hover:bg-bg-row transition-colors"
                           >
                             <div className="flex items-center justify-between">
                               <div className="flex items-center gap-2 text-xs">
-                                <span className="font-mono font-bold text-white/90">#{pos.trade_num}</span>
-                                <span className="font-medium text-white/70">{pos.symbol}</span>
-                                {pos.strategy && <span className="text-white/60">{pos.strategy}</span>}
+                                <span className="font-mono font-bold text-text-primary">#{pos.trade_num}</span>
+                                <span className="font-medium text-text-secondary">{pos.symbol}</span>
+                                {pos.strategy && <span className="text-text-muted">{pos.strategy}</span>}
                                 {pos.option_type && (
-                                  <span className="text-white/40">
+                                  <span className="text-text-faint">
                                     {pos.option_type} {pos.strike_price ? `$${pos.strike_price}` : ''}
                                   </span>
                                 )}
                               </div>
-                              <div className="flex items-center gap-2 text-[10px] text-white/40">
+                              <div className="flex items-center gap-2 text-[10px] text-text-faint">
                                 <span>{fmtDateShort(pos.open_date)}</span>
                                 <span className={chip(pos.status === 'OPEN' ? 'success' : 'neutral')}>
                                   {pos.status}
@@ -639,25 +639,25 @@ export default function TradeLabPanel({ onCardsChange, surface = 'light' }: { on
                         <div className={themed('text-[10px] text-text-muted uppercase tracking-wider font-bold mb-2', dk)}>Predicted</div>
                         <div className="space-y-1 text-xs">
                           <div className="flex justify-between">
-                            <span className="text-white/60">Max Profit</span>
+                            <span className="text-text-muted">Max Profit</span>
                             <span className="font-mono font-bold text-brand-green">{fmtDollar(card.max_profit)}</span>
                           </div>
                           <div className="flex justify-between">
-                            <span className="text-white/60">Max Loss</span>
+                            <span className="text-text-muted">Max Loss</span>
                             <span className="font-mono font-bold text-brand-red">{fmtDollar(card.max_loss)}</span>
                           </div>
                           <div className="flex justify-between">
-                            <span className="text-white/60" title="Estimated Probability of Profit based on delta approximation">Est. PoP</span>
-                            <span className="font-mono font-bold text-white/80">{card.win_rate != null ? `${Number(card.win_rate).toFixed(1)}%` : '\u2014'}</span>
+                            <span className="text-text-muted" title="Estimated Probability of Profit based on delta approximation">Est. PoP</span>
+                            <span className="font-mono font-bold text-text-secondary">{card.win_rate != null ? `${Number(card.win_rate).toFixed(1)}%` : '\u2014'}</span>
                           </div>
                           <div className="flex justify-between">
-                            <span className="text-white/60">R:R</span>
-                            <span className="font-mono font-bold text-white/80">{card.risk_reward != null ? Number(card.risk_reward).toFixed(2) : '\u2014'}</span>
+                            <span className="text-text-muted">R:R</span>
+                            <span className="font-mono font-bold text-text-secondary">{card.risk_reward != null ? Number(card.risk_reward).toFixed(2) : '\u2014'}</span>
                           </div>
                           {card.entry_price != null && (
                             <div className="flex justify-between">
-                              <span className="text-white/60">Entry Price</span>
-                              <span className="font-mono font-bold text-white/80">${Number(card.entry_price).toFixed(2)}</span>
+                              <span className="text-text-muted">Entry Price</span>
+                              <span className="font-mono font-bold text-text-secondary">${Number(card.entry_price).toFixed(2)}</span>
                             </div>
                           )}
                         </div>
@@ -670,26 +670,26 @@ export default function TradeLabPanel({ onCardsChange, surface = 'light' }: { on
                             <div className={themed('text-[10px] text-text-muted uppercase tracking-wider font-bold mb-2', dk)}>Actual</div>
                             <div className="space-y-1 text-xs">
                               <div className="flex justify-between">
-                                <span className="text-white/60">P&L</span>
+                                <span className="text-text-muted">P&L</span>
                                 <span className={themed(`font-mono font-bold ${card.link.actual_pl != null ? moneyColorClass(Number(card.link.actual_pl), 'pnl') : 'text-text-secondary'}`, dk)}>
                                   {card.link.actual_pl != null ? formatMoney(Number(card.link.actual_pl), { kind: 'pnl', fractionDigits: 0 }) : 'Open'}
                                 </span>
                               </div>
                               {card.link.actual_entry_price != null && (
                                 <div className="flex justify-between">
-                                  <span className="text-white/60">Entry Price</span>
-                                  <span className="font-mono font-bold text-white/80">${Number(card.link.actual_entry_price).toFixed(2)}</span>
+                                  <span className="text-text-muted">Entry Price</span>
+                                  <span className="font-mono font-bold text-text-secondary">${Number(card.link.actual_entry_price).toFixed(2)}</span>
                                 </div>
                               )}
                               {card.link.actual_exit_price != null && (
                                 <div className="flex justify-between">
-                                  <span className="text-white/60">Exit Price</span>
-                                  <span className="font-mono font-bold text-white/80">${Number(card.link.actual_exit_price).toFixed(2)}</span>
+                                  <span className="text-text-muted">Exit Price</span>
+                                  <span className="font-mono font-bold text-text-secondary">${Number(card.link.actual_exit_price).toFixed(2)}</span>
                                 </div>
                               )}
                               {card.link.grade && (
                                 <div className="flex justify-between items-center mt-2">
-                                  <span className="text-white/60">Grade</span>
+                                  <span className="text-text-muted">Grade</span>
                                   {/* TRADE-CHIPS: hero grade keeps its scale,
                                       wears the chip variant colors (one map). */}
                                   <span className={`rounded px-3 py-1 text-terminal-lg font-black ${CHIP_VARIANTS[gradeVariant(card.link.grade)]}`}>
@@ -702,7 +702,7 @@ export default function TradeLabPanel({ onCardsChange, surface = 'light' }: { on
                         ) : (
                           <div>
                             <div className={themed('text-[10px] text-text-muted uppercase tracking-wider font-bold mb-2', dk)}>Actual</div>
-                            <div className="text-xs text-white/40">Not yet linked to a position</div>
+                            <div className="text-xs text-text-faint">Not yet linked to a position</div>
                           </div>
                         )}
                       </div>
@@ -755,10 +755,10 @@ export default function TradeLabPanel({ onCardsChange, surface = 'light' }: { on
                         type="button"
                         onClick={() => setIntelOpen((v) => !v)}
                         aria-expanded={intelOpen}
-                        className="flex w-full items-center justify-between gap-3 rounded-lg border border-panel-border bg-white/5 px-3 py-2 text-left font-mono text-[11px] text-white/50"
+                        className="flex w-full items-center justify-between gap-3 rounded-lg border border-border bg-bg-row px-3 py-2 text-left font-mono text-[11px] text-text-faint"
                       >
                         <span>Full scanner intel — details</span>
-                        <span aria-hidden="true" className="shrink-0 text-white/40">{intelOpen ? '▲' : '▼'}</span>
+                        <span aria-hidden="true" className="shrink-0 text-text-faint">{intelOpen ? '▲' : '▼'}</span>
                       </button>
                       {intelOpen && (() => {
                         const setup = card.full_card_json?.setup ?? {};
@@ -772,8 +772,8 @@ export default function TradeLabPanel({ onCardsChange, surface = 'light' }: { on
                         const fmtCap = (v: number | null | undefined) => v == null ? '\u2014' : v >= 1e12 ? `$${(v / 1e12).toFixed(1)}T` : `$${(v / 1e9).toFixed(1)}B`;
                         const row = (label: string, value: string) => (
                           <div key={label} className="flex justify-between text-xs">
-                            <span className="text-white/60">{label}</span>
-                            <span className="text-right font-mono text-white/80">{value}</span>
+                            <span className="text-text-muted">{label}</span>
+                            <span className="text-right font-mono text-text-secondary">{value}</span>
                           </div>
                         );
                         const eyebrow = (label: string) => (
@@ -836,7 +836,7 @@ export default function TradeLabPanel({ onCardsChange, surface = 'light' }: { on
                                   <div className="mt-2 overflow-x-auto">
                                     <table className="w-full text-xs">
                                       <thead>
-                                        <tr className="font-mono text-[10px] uppercase tracking-wider text-white/50 border-b border-panel-border">
+                                        <tr className="font-mono text-[10px] uppercase tracking-wider text-text-faint border-b border-border">
                                           <th className="px-2 py-1 text-right">HV10</th>
                                           <th className="px-2 py-1 text-right">HV20</th>
                                           <th className="px-2 py-1 text-right">HV30</th>
@@ -847,16 +847,16 @@ export default function TradeLabPanel({ onCardsChange, surface = 'light' }: { on
                                       </thead>
                                       <tbody>
                                         <tr>
-                                          <td className="px-2 py-1 text-right font-mono text-white/80">{pct(cone.hv10)}</td>
-                                          <td className="px-2 py-1 text-right font-mono text-white/80">{pct(cone.hv20)}</td>
-                                          <td className="px-2 py-1 text-right font-mono text-white/80">{pct(cone.hv30)}</td>
-                                          <td className="px-2 py-1 text-right font-mono text-white/80">{pct(cone.hv60)}</td>
-                                          <td className="px-2 py-1 text-right font-mono text-white/80">{pct(cone.hv90)}</td>
-                                          <td className="px-2 py-1 text-right font-mono text-white/80">{pct(cone.current_iv)}</td>
+                                          <td className="px-2 py-1 text-right font-mono text-text-secondary">{pct(cone.hv10)}</td>
+                                          <td className="px-2 py-1 text-right font-mono text-text-secondary">{pct(cone.hv20)}</td>
+                                          <td className="px-2 py-1 text-right font-mono text-text-secondary">{pct(cone.hv30)}</td>
+                                          <td className="px-2 py-1 text-right font-mono text-text-secondary">{pct(cone.hv60)}</td>
+                                          <td className="px-2 py-1 text-right font-mono text-text-secondary">{pct(cone.hv90)}</td>
+                                          <td className="px-2 py-1 text-right font-mono text-text-secondary">{pct(cone.current_iv)}</td>
                                         </tr>
                                       </tbody>
                                     </table>
-                                    {cone.candles_used != null && <div className="mt-1 text-[10px] text-white/40">{cone.candles_used} candles used</div>}
+                                    {cone.candles_used != null && <div className="mt-1 text-[10px] text-text-faint">{cone.candles_used} candles used</div>}
                                   </div>
                                 )}
                                 {fwd && <div className="mt-2">{row('Forward vol', `${fwd.from_expiry ?? '?'} \u2192 ${fwd.to_expiry ?? '?'} \u00b7 fwd IV ${pct(fwd.forward_iv)}`)}</div>}
@@ -916,7 +916,7 @@ export default function TradeLabPanel({ onCardsChange, surface = 'light' }: { on
                                 <div className="space-y-1.5">
                                   {card.headlines!.map((h, i) => (
                                     <div key={i} className="flex items-start justify-between gap-2 text-xs">
-                                      <span className="text-white/80">{h.title} <span className="text-white/50">\u2014 {h.source}</span></span>
+                                      <span className="text-text-secondary">{h.title} <span className="text-text-faint">\u2014 {h.source}</span></span>
                                       <span className={chip(h.sentiment?.toLowerCase().includes('bull') || h.sentiment?.toLowerCase().includes('pos') ? 'success' : h.sentiment?.toLowerCase().includes('bear') || h.sentiment?.toLowerCase().includes('neg') ? 'danger' : 'neutral')}>{h.sentiment}</span>
                                     </div>
                                   ))}
@@ -929,20 +929,20 @@ export default function TradeLabPanel({ onCardsChange, surface = 'light' }: { on
                                 {freshSignals.length > 0 && (
                                   <div className="space-y-1 mb-2">
                                     {freshSignals.map((s, i) => (
-                                      <div key={i} className="flex gap-2 text-xs"><span className="shrink-0 text-white/40">\u2022</span><span className="text-white/70">{s}</span></div>
+                                      <div key={i} className="flex gap-2 text-xs"><span className="shrink-0 text-text-faint">\u2022</span><span className="text-text-secondary">{s}</span></div>
                                     ))}
                                   </div>
                                 )}
                                 {card.sentiment && (
                                   <div className="mb-2">
                                     {eyebrow('Sentiment')}
-                                    <div className="text-xs text-white/70">{card.sentiment}</div>
+                                    <div className="text-xs text-text-secondary">{card.sentiment}</div>
                                   </div>
                                 )}
                                 {card.insider_activity && (
                                   <div>
                                     {eyebrow('Insider activity')}
-                                    <div className="text-xs text-white/70">{card.insider_activity}</div>
+                                    <div className="text-xs text-text-secondary">{card.insider_activity}</div>
                                   </div>
                                 )}
                               </div>

--- a/src/components/trading/TradeRecord.tsx
+++ b/src/components/trading/TradeRecord.tsx
@@ -128,47 +128,47 @@ export default function TradeRecord() {
   });
 
   return (
-    <div className="rounded-lg border border-panel-border bg-panel-surface text-xs text-white/60">
+    <div className="rounded-lg border border-border bg-white text-xs text-text-muted">
       <div className={`${SECTION_HEADER} rounded-t-lg`}>Track record</div>
 
       {/* RECORD-BOOM: the HERO VERDICT — rows (b)/(c)/(d) at stat scale,
           every string byte-identical (the big stats compose the same
           dynamic values; qualifiers/sentences render beneath). */}
       {linked.length > 0 && (
-        <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 p-3 border-b border-panel-border">
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 p-3 border-b border-border">
           {/* (b) HONEST WIN RATE — RECORD-POLISH: label-above pattern; the
               win bar is a pure presentation division of two already-
               rendered numbers (wins / decided.length), omitted at 0. */}
-          <div className="rounded-lg bg-white/5 p-3">
-            <div className="font-mono text-[10px] uppercase tracking-wider text-white/50">RECORD</div>
-            <div className="font-mono text-3xl font-bold text-white">{wins}W – {losses}L – {breakevens}BE</div>
+          <div className="rounded-lg bg-bg-row p-3">
+            <div className="font-mono text-[10px] uppercase tracking-wider text-text-faint">RECORD</div>
+            <div className="font-mono text-3xl font-bold text-text-primary">{wins}W – {losses}L – {breakevens}BE</div>
             {decided.length > 0 && (
-              <div className="mt-1.5 h-1 rounded bg-white/10">
+              <div className="mt-1.5 h-1 rounded bg-bg-row">
                 <div className="h-1 rounded bg-status-success" style={{ width: `${(wins / decided.length) * 100}%` }} />
               </div>
             )}
-            <div className="mt-1 text-white/50">
-              of <span className="font-mono font-semibold text-white/90">{decided.length}</span> decided
-              {openLinked > 0 && <span className="text-white/40"> ({openLinked} still open, outcome unknown)</span>}
+            <div className="mt-1 text-text-faint">
+              of <span className="font-mono font-semibold text-text-primary">{decided.length}</span> decided
+              {openLinked > 0 && <span className="text-text-faint"> ({openLinked} still open, outcome unknown)</span>}
             </div>
           </div>
           {/* (c) NET P&L — RECORD-POLISH: the quoted eyebrow supersedes the
               inline "Net P&L:" label; the qualifier string is byte-identical.
               Accent: border-l in the value's own status family. */}
-          <div className={`rounded-lg bg-white/5 p-3 border-l-2 ${netPl >= 0 ? 'border-status-success/60' : 'border-status-danger/60'}`}>
-            <div className="font-mono text-[10px] uppercase tracking-wider text-white/50">NET P&amp;L</div>
+          <div className={`rounded-lg bg-bg-row p-3 border-l-2 ${netPl >= 0 ? 'border-status-success/60' : 'border-status-danger/60'}`}>
+            <div className="font-mono text-[10px] uppercase tracking-wider text-text-faint">NET P&amp;L</div>
             <div className={`font-mono text-3xl font-bold ${netPl >= 0 ? 'text-brand-green' : 'text-brand-red'}`}>{fmtMoney(netPl)}</div>
-            <div className="text-white/50"><span className="text-white/40"> (linked trades only)</span></div>
+            <div className="text-text-faint"><span className="text-text-faint"> (linked trades only)</span></div>
           </div>
           {/* (d) INTEGRITY — RECORD-POLISH: accent conditional on the
               EXISTING exceeded list (presentation only): green when 0
               breaches, danger otherwise. */}
-          <div className={`rounded-lg bg-white/5 p-3 border-l-2 ${exceeded.length > 0 ? 'border-status-danger/60' : 'border-status-success/60'}`}>
-            <div className="font-mono text-[10px] uppercase tracking-wider text-white/50">MAX-LOSS INTEGRITY</div>
-            <div className="font-mono text-3xl font-bold text-white">{withinClaim} of {withMaxLoss.length}</div>
-            <div className="text-white/50">
-              Max-loss model: <span className="font-mono font-semibold text-white/90">{withinClaim}</span> of{' '}
-              <span className="font-mono font-semibold text-white/90">{withMaxLoss.length}</span> linked trades stayed within their card&rsquo;s stated max loss.
+          <div className={`rounded-lg bg-bg-row p-3 border-l-2 ${exceeded.length > 0 ? 'border-status-danger/60' : 'border-status-success/60'}`}>
+            <div className="font-mono text-[10px] uppercase tracking-wider text-text-faint">MAX-LOSS INTEGRITY</div>
+            <div className="font-mono text-3xl font-bold text-text-primary">{withinClaim} of {withMaxLoss.length}</div>
+            <div className="text-text-faint">
+              Max-loss model: <span className="font-mono font-semibold text-text-primary">{withinClaim}</span> of{' '}
+              <span className="font-mono font-semibold text-text-primary">{withMaxLoss.length}</span> linked trades stayed within their card&rsquo;s stated max loss.
             </div>
             {exceeded.length > 0 && (
               <ul className="mt-1 space-y-0.5">
@@ -187,12 +187,12 @@ export default function TradeRecord() {
           back to ONE quiet line with the exact original strings and ' · '
           separators; the grade chips STAY (semantic, not phrases). Renders
           always — denominator honesty survives the zero state. */}
-      <div className="px-3 py-2 border-b border-panel-border font-mono text-[11px] text-white/50">
+      <div className="px-3 py-2 border-b border-border font-mono text-[11px] text-text-faint">
         <span className="inline-flex flex-wrap items-center gap-1">
           <span>
-            Record: <span className="font-semibold text-white/90">{linked.length}</span> linked trades
-            {' · '}<span className="font-semibold text-white/90">{unlinkedClosed}</span> closed positions unlinked (excluded)
-            {' · '}<span className="font-semibold text-white/90">{queuedNotLinked}</span> cards queued, not yet linked
+            Record: <span className="font-semibold text-text-primary">{linked.length}</span> linked trades
+            {' · '}<span className="font-semibold text-text-primary">{unlinkedClosed}</span> closed positions unlinked (excluded)
+            {' · '}<span className="font-semibold text-text-primary">{queuedNotLinked}</span> cards queued, not yet linked
           </span>
           {linked.length > 0 && (
             <>
@@ -209,7 +209,7 @@ export default function TradeRecord() {
 
       {linked.length === 0 ? (
         // Honest zero-state — no fabricated stats.
-        <div className="px-3 py-3 text-white/50">
+        <div className="px-3 py-3 text-text-faint">
           No linked trades yet — link queued cards to closed positions in Trade Lab to build your record.
         </div>
       ) : (
@@ -226,7 +226,7 @@ export default function TradeRecord() {
             {showTable && (
               <div className="mt-2 overflow-x-auto">
                 <table className="w-full text-[11px]">
-                  <thead className="text-white/50">
+                  <thead className="text-text-faint">
                     <tr>
                       <th className="px-2 py-1 text-left font-mono text-[10px] uppercase tracking-wider">Symbol</th>
                       <th className="px-2 py-1 text-left font-mono text-[10px] uppercase tracking-wider">Generated</th>
@@ -235,15 +235,15 @@ export default function TradeRecord() {
                       <th className="px-2 py-1 text-center font-mono text-[10px] uppercase tracking-wider">Grade</th>
                     </tr>
                   </thead>
-                  <tbody className="divide-y divide-panel-border">
+                  <tbody className="divide-y divide-border">
                     {tableRows.map((c) => {
                       const pl = c.link!.actual_pl;
                       return (
                         <tr key={c.id}>
-                          <td className="px-2 py-1 font-mono font-medium text-white/90">{c.symbol}</td>
-                          <td className="px-2 py-1 font-mono text-white/50">{fmtDate(c.generated_at)}</td>
+                          <td className="px-2 py-1 font-mono font-medium text-text-primary">{c.symbol}</td>
+                          <td className="px-2 py-1 font-mono text-text-faint">{fmtDate(c.generated_at)}</td>
                           <td className="px-2 py-1 text-right font-mono">{c.max_loss != null ? fmtMoney(-Number(c.max_loss)) : '—'}</td>
-                          <td className={`px-2 py-1 text-right font-mono font-semibold ${pl == null ? 'text-white/40' : Number(pl) >= 0 ? 'text-brand-green' : 'text-brand-red'}`}>
+                          <td className={`px-2 py-1 text-right font-mono font-semibold ${pl == null ? 'text-text-faint' : Number(pl) >= 0 ? 'text-brand-green' : 'text-brand-red'}`}>
                             {pl == null ? 'Open' : fmtMoney(Number(pl))}
                           </td>
                           <td className="px-2 py-1 text-center">{c.link!.grade ? <span className={chip(c.link!.grade === 'A' || c.link!.grade === 'B' ? 'success' : c.link!.grade === 'C' ? 'warning' : 'danger')}>{c.link!.grade}</span> : '—'}</td>

--- a/src/components/trading/TradingDataDisclaimer.tsx
+++ b/src/components/trading/TradingDataDisclaimer.tsx
@@ -11,7 +11,7 @@ export default function TradingDataDisclaimer({ surface = 'light' }: { surface?:
   return (
     <p
       role="note"
-      className="rounded-lg border border-panel-border bg-white/5 px-3 py-2 font-mono text-[11px] text-white/50"
+      className="rounded-lg border border-border bg-bg-row px-3 py-2 font-mono text-[11px] text-text-faint"
     >
       Data and analytics only — not investment advice or a recommendation. All metrics are
       computed from market data; you make all trading decisions. Options involve substantial


### PR DESCRIPTION
Claude-Session: https://claude.ai/code/session_016notmnG23sKzhQibZrMoHm