### PR TITLE
feat: trade phase sub-labels

### DIFF
--- a/src/components/home/ModuleLauncher.tsx
+++ b/src/components/home/ModuleLauncher.tsx
@@ -1035,17 +1035,28 @@ export default function ModuleLauncher({ onRequireAuth, onTabChange }: Props) {
                   <div className="mt-4">{TRADE_TRUST_CHIPS}</div>
                 </div>
                 <div className={MODULE_SHELL_CARD}>
+                  {/* R2 sub-labels — each derived FROM its surface's real
+                      machinery (cites in the R2 PR report): SETUP = universe
+                      + filter groups (ScanFilterForm); SCAN = fires the
+                      convergence pipeline (scanTriggerRef → scanMarket,
+                      steps A–T); REVIEW = pick candidates / queue cards
+                      (results table + Queue Card — the mock's one truthful
+                      candidate); LAB = link to position + check grade
+                      (TradeLabPanel's real actions — the mock's "PAPER-TEST"
+                      is fiction, replaced); RECORD = the graded results
+                      (TradeRecord's W–L/P&L hero — the mock's "GRADE IT"
+                      happens in LAB, replaced). */}
                   <StageStrip
                     phases={([
-                      { key: 'setup', num: '01', label: 'SETUP',
+                      { key: 'setup', num: '01', label: 'SETUP', subLabel: 'UNIVERSE + FILTERS',
                         state: tradePhase === 'setup' ? 'active' : tradeFiltersTouched ? 'done' : 'pending' },
-                      { key: 'scan', num: '02', label: 'SCAN',
+                      { key: 'scan', num: '02', label: 'SCAN', subLabel: 'RUN THE PIPELINE',
                         state: tradePhase === 'scan' ? 'active' : tradeScanMeta ? 'done' : 'pending' },
-                      { key: 'review', num: '03', label: 'REVIEW',
+                      { key: 'review', num: '03', label: 'REVIEW', subLabel: 'PICK CANDIDATES',
                         state: tradePhase === 'review' ? 'active' : 'pending' },
-                      { key: 'lab', num: '04', label: 'LAB',
+                      { key: 'lab', num: '04', label: 'LAB', subLabel: 'LINK + GRADE',
                         state: tradePhase === 'lab' ? 'active' : (tradeRecordStats?.linkedCount ?? 0) > 0 ? 'done' : 'pending' },
-                      { key: 'record', num: '05', label: 'RECORD',
+                      { key: 'record', num: '05', label: 'RECORD', subLabel: 'GRADED RESULTS',
                         state: tradePhase === 'record' ? 'active' : (tradeRecordStats?.decidedCount ?? 0) > 0 ? 'done' : 'pending' },
                     ] as StagePhase[])}
                     onSelect={(k) => setTradePhase(k as typeof tradePhase)}

--- a/src/components/ui/StageStrip.tsx
+++ b/src/components/ui/StageStrip.tsx
@@ -32,6 +32,12 @@ export interface StagePhase {
   state: StagePhaseState;
   /** blocked only: the danger sub-line's text. */
   blockedNote?: string;
+  /** R2: the descriptive micro-label under the phase name — truth-backed
+   *  copy supplied by the consumer. STATE SUB-LINES KEEP PRECEDENCE: when a
+   *  state marker occupies the sub slot (● YOU ARE HERE / ✓ DONE / a
+   *  blockedNote), the subLabel yields; it renders only on plain cells.
+   *  Idiom = the strip's own faint mono micro tier (the num line's class). */
+  subLabel?: string;
 }
 
 interface Props {
@@ -82,6 +88,9 @@ export default function StageStrip({ phases, onSelect, link }: Props) {
               )}
               {p.state === 'blocked' && p.blockedNote && (
                 <span className="font-mono text-[9px] tracking-widest text-status-danger">{p.blockedNote}</span>
+              )}
+              {p.subLabel && !active && p.state !== 'done' && !(p.state === 'blocked' && p.blockedNote) && (
+                <span className="font-mono text-[9px] tracking-widest text-text-faint">{p.subLabel}</span>
               )}
             </button>
           );


### PR DESCRIPTION
Claude-Session: https://claude.ai/code/session_0142nEDQpqCZJr9NFU7y9wfU