### PR TITLE
fix: section 04 SVGs load as standalone documents

### DIFF
--- a/public/demo/books.svg
+++ b/public/demo/books.svg
@@ -6,10 +6,16 @@
        Code = CAT -> JE -> LDG (double-entry), Reports = TB -> STMT.
        Trial-balance truth = /api/trial-balance totals
        (isBalanced / hasActivity). -->
-  <!-- Canvas: --ts-bg cream. Cards: --ts-white on --ts-border hairline.
-       Active step: --ts-purple fill, --ts-white ink. Accent: --ts-gold.
-       Text ladder: --ts-text #1a1a2e / --ts-text-secondary #4a4a5a /
-       --ts-text-muted #7a7488 / --ts-text-faint #a8a2b0. -->
+  <!-- Canvas: ts-bg cream. Cards: ts-white on ts-border hairline.
+       Active step: ts-purple fill, ts-white ink. Accent: ts-gold.
+       Text ladder: ts-text #1a1a2e / ts-text-secondary #4a4a5a /
+       ts-text-muted #7a7488 / ts-text-faint #a8a2b0.
+       (Token names drop their CSS custom-property prefix on purpose: this
+       file is parsed as a STANDALONE XML document when it is served to an
+       img tag, and XML forbids a double hyphen inside a comment. Spelling
+       the prefix out made all nine files fail to parse - every frame
+       rendered as alt text on the Preview.)
+       -->
   <rect width="1200" height="750" fill="#FAF8F3"/>
   <text x="60" y="76" font-size="20" font-weight="600" letter-spacing="6" fill="#7a7488">BOOKS</text>
 

--- a/public/demo/compliance.svg
+++ b/public/demo/compliance.svg
@@ -5,10 +5,16 @@
        locally and reports any mismatch'; the prev_hash / content_hash
        row shape :23-24, :167-168; GET /api/audit-log and
        POST /api/audit-log/verify-chain :59, :81). -->
-  <!-- Canvas: --ts-bg cream. Cards: --ts-white on --ts-border hairline.
-       Active step: --ts-purple fill, --ts-white ink. Accent: --ts-gold.
-       Text ladder: --ts-text #1a1a2e / --ts-text-secondary #4a4a5a /
-       --ts-text-muted #7a7488 / --ts-text-faint #a8a2b0. -->
+  <!-- Canvas: ts-bg cream. Cards: ts-white on ts-border hairline.
+       Active step: ts-purple fill, ts-white ink. Accent: ts-gold.
+       Text ladder: ts-text #1a1a2e / ts-text-secondary #4a4a5a /
+       ts-text-muted #7a7488 / ts-text-faint #a8a2b0.
+       (Token names drop their CSS custom-property prefix on purpose: this
+       file is parsed as a STANDALONE XML document when it is served to an
+       img tag, and XML forbids a double hyphen inside a comment. Spelling
+       the prefix out made all nine files fail to parse - every frame
+       rendered as alt text on the Preview.)
+       -->
   <rect width="1200" height="750" fill="#FAF8F3"/>
   <text x="60" y="76" font-size="20" font-weight="600" letter-spacing="6" fill="#7a7488">COMPLIANCE</text>
 

--- a/public/demo/content.svg
+++ b/public/demo/content.svg
@@ -4,10 +4,16 @@
        (workbench/operations/content/ContentPipeline.tsx:85
        'calendar' | 'log' | 'script', the three keep-mounted surfaces
        :350, :352, :514 - DayCalendar, the day log, ScriptGenerator). -->
-  <!-- Canvas: --ts-bg cream. Cards: --ts-white on --ts-border hairline.
-       Active step: --ts-purple fill, --ts-white ink. Accent: --ts-gold.
-       Text ladder: --ts-text #1a1a2e / --ts-text-secondary #4a4a5a /
-       --ts-text-muted #7a7488 / --ts-text-faint #a8a2b0. -->
+  <!-- Canvas: ts-bg cream. Cards: ts-white on ts-border hairline.
+       Active step: ts-purple fill, ts-white ink. Accent: ts-gold.
+       Text ladder: ts-text #1a1a2e / ts-text-secondary #4a4a5a /
+       ts-text-muted #7a7488 / ts-text-faint #a8a2b0.
+       (Token names drop their CSS custom-property prefix on purpose: this
+       file is parsed as a STANDALONE XML document when it is served to an
+       img tag, and XML forbids a double hyphen inside a comment. Spelling
+       the prefix out made all nine files fail to parse - every frame
+       rendered as alt text on the Preview.)
+       -->
   <rect width="1200" height="750" fill="#FAF8F3"/>
   <text x="60" y="76" font-size="20" font-weight="600" letter-spacing="6" fill="#7a7488">CONTENT</text>
 

--- a/public/demo/projects.svg
+++ b/public/demo/projects.svg
@@ -5,10 +5,16 @@
        'inputs -> research -> audit -> fusion -> tasks'), its per-run
        costSummary.cost_usd (:43), and the human-accept task gate
        (tasksPreview -> AITaskPreview, :12-13, :40). -->
-  <!-- Canvas: --ts-bg cream. Cards: --ts-white on --ts-border hairline.
-       Active step: --ts-purple fill, --ts-white ink. Accent: --ts-gold.
-       Text ladder: --ts-text #1a1a2e / --ts-text-secondary #4a4a5a /
-       --ts-text-muted #7a7488 / --ts-text-faint #a8a2b0. -->
+  <!-- Canvas: ts-bg cream. Cards: ts-white on ts-border hairline.
+       Active step: ts-purple fill, ts-white ink. Accent: ts-gold.
+       Text ladder: ts-text #1a1a2e / ts-text-secondary #4a4a5a /
+       ts-text-muted #7a7488 / ts-text-faint #a8a2b0.
+       (Token names drop their CSS custom-property prefix on purpose: this
+       file is parsed as a STANDALONE XML document when it is served to an
+       img tag, and XML forbids a double hyphen inside a comment. Spelling
+       the prefix out made all nine files fail to parse - every frame
+       rendered as alt text on the Preview.)
+       -->
   <rect width="1200" height="750" fill="#FAF8F3"/>
   <text x="60" y="76" font-size="20" font-weight="600" letter-spacing="6" fill="#7a7488">PROJECTS</text>
 

--- a/public/demo/routines.svg
+++ b/public/demo/routines.svg
@@ -5,10 +5,16 @@
        create form's budget fields that make it planned spend
        (home/RoutineCreateForm.tsx:120 budget_amount, :129 coa_code,
        rendered as '$amount - coa' :258). -->
-  <!-- Canvas: --ts-bg cream. Cards: --ts-white on --ts-border hairline.
-       Active step: --ts-purple fill, --ts-white ink. Accent: --ts-gold.
-       Text ladder: --ts-text #1a1a2e / --ts-text-secondary #4a4a5a /
-       --ts-text-muted #7a7488 / --ts-text-faint #a8a2b0. -->
+  <!-- Canvas: ts-bg cream. Cards: ts-white on ts-border hairline.
+       Active step: ts-purple fill, ts-white ink. Accent: ts-gold.
+       Text ladder: ts-text #1a1a2e / ts-text-secondary #4a4a5a /
+       ts-text-muted #7a7488 / ts-text-faint #a8a2b0.
+       (Token names drop their CSS custom-property prefix on purpose: this
+       file is parsed as a STANDALONE XML document when it is served to an
+       img tag, and XML forbids a double hyphen inside a comment. Spelling
+       the prefix out made all nine files fail to parse - every frame
+       rendered as alt text on the Preview.)
+       -->
   <rect width="1200" height="750" fill="#FAF8F3"/>
   <text x="60" y="76" font-size="20" font-weight="600" letter-spacing="6" fill="#7a7488">ROUTINES</text>
 

--- a/public/demo/runway.svg
+++ b/public/demo/runway.svg
@@ -4,10 +4,16 @@
        month/year) + its RunwayWindow months field (:24-25) and the
        'Net burn' / 'Runway' / zero-date cells (:71-74); planned spend
        vs ledger actuals by the day. -->
-  <!-- Canvas: --ts-bg cream. Cards: --ts-white on --ts-border hairline.
-       Active step: --ts-purple fill, --ts-white ink. Accent: --ts-gold.
-       Text ladder: --ts-text #1a1a2e / --ts-text-secondary #4a4a5a /
-       --ts-text-muted #7a7488 / --ts-text-faint #a8a2b0. -->
+  <!-- Canvas: ts-bg cream. Cards: ts-white on ts-border hairline.
+       Active step: ts-purple fill, ts-white ink. Accent: ts-gold.
+       Text ladder: ts-text #1a1a2e / ts-text-secondary #4a4a5a /
+       ts-text-muted #7a7488 / ts-text-faint #a8a2b0.
+       (Token names drop their CSS custom-property prefix on purpose: this
+       file is parsed as a STANDALONE XML document when it is served to an
+       img tag, and XML forbids a double hyphen inside a comment. Spelling
+       the prefix out made all nine files fail to parse - every frame
+       rendered as alt text on the Preview.)
+       -->
   <rect width="1200" height="750" fill="#FAF8F3"/>
   <text x="60" y="76" font-size="20" font-weight="600" letter-spacing="6" fill="#7a7488">RUNWAY</text>
 

--- a/public/demo/tax.svg
+++ b/public/demo/tax.svg
@@ -5,10 +5,16 @@
        closed) and the wizard's own STEPS list
        (tax-filing/TaxFilingWizard.tsx:58-105 - Life events, Documents,
        Income, Deductions, Trading, Review, File = 7 steps). -->
-  <!-- Canvas: --ts-bg cream. Cards: --ts-white on --ts-border hairline.
-       Active step: --ts-purple fill, --ts-white ink. Accent: --ts-gold.
-       Text ladder: --ts-text #1a1a2e / --ts-text-secondary #4a4a5a /
-       --ts-text-muted #7a7488 / --ts-text-faint #a8a2b0. -->
+  <!-- Canvas: ts-bg cream. Cards: ts-white on ts-border hairline.
+       Active step: ts-purple fill, ts-white ink. Accent: ts-gold.
+       Text ladder: ts-text #1a1a2e / ts-text-secondary #4a4a5a /
+       ts-text-muted #7a7488 / ts-text-faint #a8a2b0.
+       (Token names drop their CSS custom-property prefix on purpose: this
+       file is parsed as a STANDALONE XML document when it is served to an
+       img tag, and XML forbids a double hyphen inside a comment. Spelling
+       the prefix out made all nine files fail to parse - every frame
+       rendered as alt text on the Preview.)
+       -->
   <rect width="1200" height="750" fill="#FAF8F3"/>
   <text x="60" y="76" font-size="20" font-weight="600" letter-spacing="6" fill="#7a7488">TAX</text>
 

--- a/public/demo/trade.svg
+++ b/public/demo/trade.svg
@@ -6,10 +6,16 @@
        the TRADE/SKIP verdict rows (ScannerResultsTable.tsx verdict +
        stored RejectionReason), and the strip's COMMIT link chip
        ('IN BOOKS ->', selectTab('books')). -->
-  <!-- Canvas: --ts-bg cream. Cards: --ts-white on --ts-border hairline.
-       Active step: --ts-purple fill, --ts-white ink. Accent: --ts-gold.
-       Text ladder: --ts-text #1a1a2e / --ts-text-secondary #4a4a5a /
-       --ts-text-muted #7a7488 / --ts-text-faint #a8a2b0. -->
+  <!-- Canvas: ts-bg cream. Cards: ts-white on ts-border hairline.
+       Active step: ts-purple fill, ts-white ink. Accent: ts-gold.
+       Text ladder: ts-text #1a1a2e / ts-text-secondary #4a4a5a /
+       ts-text-muted #7a7488 / ts-text-faint #a8a2b0.
+       (Token names drop their CSS custom-property prefix on purpose: this
+       file is parsed as a STANDALONE XML document when it is served to an
+       img tag, and XML forbids a double hyphen inside a comment. Spelling
+       the prefix out made all nine files fail to parse - every frame
+       rendered as alt text on the Preview.)
+       -->
   <rect width="1200" height="750" fill="#FAF8F3"/>
   <text x="60" y="76" font-size="20" font-weight="600" letter-spacing="6" fill="#7a7488">TRADE</text>
 

--- a/public/demo/travel.svg
+++ b/public/demo/travel.svg
@@ -5,10 +5,16 @@
        (TRAVEL_TRUST_CHIPS 'Book on this page', travelStripModes.tsx:92-102)
        -> the trip budget ledger's planned-vs-actual lens
        (TripBudgetActual.tsx:4-34, GET /api/trips/[id]/actuals). -->
-  <!-- Canvas: --ts-bg cream. Cards: --ts-white on --ts-border hairline.
-       Active step: --ts-purple fill, --ts-white ink. Accent: --ts-gold.
-       Text ladder: --ts-text #1a1a2e / --ts-text-secondary #4a4a5a /
-       --ts-text-muted #7a7488 / --ts-text-faint #a8a2b0. -->
+  <!-- Canvas: ts-bg cream. Cards: ts-white on ts-border hairline.
+       Active step: ts-purple fill, ts-white ink. Accent: ts-gold.
+       Text ladder: ts-text #1a1a2e / ts-text-secondary #4a4a5a /
+       ts-text-muted #7a7488 / ts-text-faint #a8a2b0.
+       (Token names drop their CSS custom-property prefix on purpose: this
+       file is parsed as a STANDALONE XML document when it is served to an
+       img tag, and XML forbids a double hyphen inside a comment. Spelling
+       the prefix out made all nine files fail to parse - every frame
+       rendered as alt text on the Preview.)
+       -->
   <rect width="1200" height="750" fill="#FAF8F3"/>
   <text x="60" y="76" font-size="20" font-weight="600" letter-spacing="6" fill="#7a7488">TRAVEL</text>
 


### PR DESCRIPTION
XML forbids a double hyphen inside a comment; the DS token names in each file's palette legend were spelled with their CSS custom-property prefix, so every file failed to parse when served to an img tag and rendered as alt text. Token names now drop the prefix.


Claude-Session: https://claude.ai/code/session_0142nEDQpqCZJr9NFU7y9wfU