### PR TITLE
feat: section 04 frames v2 — runway, routines

### DIFF
--- a/public/demo/routines.svg
+++ b/public/demo/routines.svg
@@ -1,49 +1,104 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 750" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">
-  <!-- LANDING-04-ILLOS: the Routines pipeline, as it actually runs.
-       Stages read from: the routine's cadence grouping
-       (RoutineList.tsx:2-7, classifyCadence(schedule_rrule)) and the
-       create form's budget fields that make it planned spend
-       (home/RoutineCreateForm.tsx:120 budget_amount, :129 coa_code,
-       rendered as '$amount - coa' :258). -->
-  <!-- Canvas: ts-bg cream. Cards: ts-white on ts-border hairline.
-       Active step: ts-purple fill, ts-white ink. Accent: ts-gold.
-       Text ladder: ts-text #1a1a2e / ts-text-secondary #4a4a5a /
-       ts-text-muted #7a7488 / ts-text-faint #a8a2b0.
-       (Token names drop their CSS custom-property prefix on purpose: this
-       file is parsed as a STANDALONE XML document when it is served to an
-       img tag, and XML forbids a double hyphen inside a comment. Spelling
-       the prefix out made all nine files fail to parse - every frame
-       rendered as alt text on the Preview.)
-       -->
-  <rect width="1200" height="750" fill="#FAF8F3"/>
-  <text x="60" y="76" font-size="20" font-weight="600" letter-spacing="6" fill="#7a7488">ROUTINES</text>
-
-  <!-- 01 SET IT -->
-  <rect x="60" y="150" width="304" height="470" rx="14" fill="#FFFDF9" stroke="#DDD6E8" stroke-width="2"/>
-  <text x="88" y="202" font-size="16" letter-spacing="4" fill="#a8a2b0">01</text>
-  <text x="88" y="330" font-size="34" font-weight="700" letter-spacing="1" fill="#1a1a2e">SET IT</text>
-  <text x="88" y="374" font-size="34" font-weight="700" letter-spacing="1" fill="#1a1a2e">ONCE</text>
-  <rect x="88" y="442" width="164" height="40" rx="8" fill="#F3EFE6"/>
-  <text x="103" y="468" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" letter-spacing="1.5" fill="#4a4a5a">EVERY MONDAY</text>
-  <line x1="380" y1="385" x2="426" y2="385" stroke="#a8a2b0" stroke-width="3"/>
-  <path d="M 426 374 L 442 385 L 426 396 Z" fill="#a8a2b0"/>
-
-  <!-- 02 CALENDAR -->
-  <rect x="448" y="150" width="304" height="470" rx="14" fill="#3b2d6b"/>
-  <text x="476" y="202" font-size="16" letter-spacing="4" fill="#FFFDF9" opacity="0.6">02</text>
-  <text x="476" y="315" font-size="34" font-weight="700" letter-spacing="1" fill="#FFFDF9">CALENDAR</text>
-  <text x="476" y="359" font-size="34" font-weight="700" letter-spacing="1" fill="#FFFDF9">+ BUDGET</text>
-  <text x="476" y="407" font-size="15" letter-spacing="3" fill="#FFFDF9" opacity="0.75">&#9679; YOU ARE HERE</text>
-  <rect x="476" y="457" width="220" height="40" rx="8" fill="#ffffff"/>
-  <text x="491" y="483" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" letter-spacing="1.5" fill="#3b2d6b">AMOUNT + CATEGORY</text>
-  <line x1="768" y1="385" x2="814" y2="385" stroke="#a8a2b0" stroke-width="3"/>
-  <path d="M 814 374 L 830 385 L 814 396 Z" fill="#a8a2b0"/>
-
-  <!-- 03 NO -->
-  <rect x="836" y="150" width="304" height="470" rx="14" fill="#FFFDF9" stroke="#DDD6E8" stroke-width="2"/>
-  <text x="864" y="202" font-size="16" letter-spacing="4" fill="#a8a2b0">03</text>
-  <text x="864" y="330" font-size="34" font-weight="700" letter-spacing="1" fill="#1a1a2e">NO</text>
-  <text x="864" y="374" font-size="34" font-weight="700" letter-spacing="1" fill="#1a1a2e">SURPRISES</text>
-  <rect x="864" y="442" width="231" height="40" rx="8" fill="#F3EFE6"/>
-  <text x="879" y="468" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" letter-spacing="1.5" fill="#4a4a5a">PLANNED THIS MONTH</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 750">
+  <!-- LANDING-04-FRAMES-V2: ROUTINES, step 02 of 03 (CALENDAR + BUDGET).
+       The panel is that step's own screen: the routine list plus the
+       month it lands on.
+       Every value is read from src/components/home/RoutinesShowcaseSections.tsx
+       (:86-88): 'Pay the rent' COA 6100 monthly day 1 at $400.00,
+       'Restock supplies' COA 6120 monthly day 15 at $300.00, 'Service the
+       truck' COA 6010 monthly day 20 at $150.00; planned total 850.00
+       (:90). Calendar hits are those same days of the month.
+       No live indicator is drawn: the real surface has none (ruling 5).
+       Tokens: bg cream, white cards, bg-row bands, purple active step
+       and calendar hits, gold money, border hairlines, text ladder. -->
+  <rect x="0.0" y="0.0" width="1200.0" height="750.0" fill="#FAF8F3"/>
+  <text id="t46" x="36.0" y="53.0" font-family="'IBM Plex Mono', monospace" font-size="22" fill="#7a7488" font-weight="500" letter-spacing="6.60">ROUTINES</text>
+  <text id="t47" x="1164.0" y="53.0" font-family="'IBM Plex Mono', monospace" font-size="20" fill="#a8a2b0" letter-spacing="3.20" text-anchor="end">STEP 02 OF 03</text>
+  <rect x="37.0" y="75.0" width="351.3" height="102.0" fill="#FFFDF9" stroke="#DDD6E8" stroke-width="2"/>
+  <text id="t48" x="56.0" y="105.6" font-family="'IBM Plex Mono', monospace" font-size="20" fill="#a8a2b0" letter-spacing="4.00">01</text>
+  <text id="t49" x="56.0" y="134.8" font-family="'Helvetica Neue', Helvetica, Arial, sans-serif" font-size="28" fill="#1a1a2e" font-weight="600">SET IT ONCE</text>
+  <text id="t50" x="56.0" y="158.0" font-family="'IBM Plex Mono', monospace" font-size="18" fill="#a8a2b0" letter-spacing="2.16">COST + CADENCE</text>
+  <text id="t51" x="406.3" y="136.0" font-family="'IBM Plex Mono', monospace" font-size="30" fill="#a8a2b0" text-anchor="middle">›</text>
+  <rect x="423.3" y="74.0" width="353.3" height="104.0" fill="#3b2d6b"/>
+  <rect x="423.3" y="173.0" width="353.3" height="5.0" fill="#B8860B"/>
+  <text id="t52" x="443.3" y="105.6" font-family="'IBM Plex Mono', monospace" font-size="20" fill="#FFFDF9" letter-spacing="4.00" opacity="0.6">02</text>
+  <text id="t53" x="443.3" y="134.8" font-family="'Helvetica Neue', Helvetica, Arial, sans-serif" font-size="28" fill="#FFFDF9" font-weight="600">CALENDAR + BUDGET</text>
+  <text id="t54" x="443.3" y="158.0" font-family="'IBM Plex Mono', monospace" font-size="18" fill="#FFFDF9" letter-spacing="2.52" opacity="0.78">▪ YOU ARE HERE</text>
+  <text id="t55" x="793.7" y="136.0" font-family="'IBM Plex Mono', monospace" font-size="30" fill="#a8a2b0" text-anchor="middle">›</text>
+  <rect x="811.7" y="75.0" width="351.3" height="102.0" fill="#FFFDF9" stroke="#DDD6E8" stroke-width="2"/>
+  <text id="t56" x="830.7" y="105.6" font-family="'IBM Plex Mono', monospace" font-size="20" fill="#a8a2b0" letter-spacing="4.00">03</text>
+  <text id="t57" x="830.7" y="134.8" font-family="'Helvetica Neue', Helvetica, Arial, sans-serif" font-size="28" fill="#1a1a2e" font-weight="600">NO SURPRISES</text>
+  <text id="t58" x="830.7" y="158.0" font-family="'IBM Plex Mono', monospace" font-size="18" fill="#a8a2b0" letter-spacing="2.16">DONE OR MISSED</text>
+  <rect x="597.5" y="178.0" width="5.0" height="20.0" fill="#B8860B"/>
+  <rect x="37.0" y="199.0" width="1126.0" height="518.0" fill="#FFFDF9" stroke="#DDD6E8" stroke-width="2"/>
+  <text id="t59" x="60.0" y="228.0" font-family="'IBM Plex Mono', monospace" font-size="22" fill="#4a4a5a" letter-spacing="2.64">YOUR ROUTINES</text>
+  <line x1="36.0" y1="244.0" x2="1164.0" y2="244.0" stroke="#DDD6E8" stroke-width="2"/>
+  <line x1="792.0" y1="244.0" x2="792.0" y2="674.0" stroke="#DDD6E8" stroke-width="2"/>
+  <rect x="37.0" y="244.0" width="755.0" height="38.0" fill="#F3EFE6"/>
+  <text id="t60" x="60.0" y="270.0" font-family="'IBM Plex Mono', monospace" font-size="20" fill="#7a7488" letter-spacing="2.40">ROUTINE</text>
+  <text id="t61" x="346.0" y="270.0" font-family="'IBM Plex Mono', monospace" font-size="20" fill="#7a7488" letter-spacing="2.40">CADENCE</text>
+  <text id="t62" x="768.0" y="270.0" font-family="'IBM Plex Mono', monospace" font-size="20" fill="#7a7488" letter-spacing="2.40" text-anchor="end">EACH TIME</text>
+  <text id="t63" x="60.0" y="356.3" font-family="'Helvetica Neue', Helvetica, Arial, sans-serif" font-size="27" fill="#1a1a2e">Pay the rent</text>
+  <text id="t64" x="346.0" y="356.3" font-family="'IBM Plex Mono', monospace" font-size="24" fill="#4a4a5a">MONTHLY · DAY 1</text>
+  <rect x="636.4" y="328.3" width="131.6" height="38.0" fill="#F3EFE6"/>
+  <text id="t65" x="754.0" y="356.3" font-family="'IBM Plex Mono', monospace" font-size="24" fill="#B8860B" font-weight="500" text-anchor="end">$400.00</text>
+  <line x1="60.0" y1="412.7" x2="768.0" y2="412.7" stroke="#EBE4F7" stroke-width="1"/>
+  <text id="t66" x="60.0" y="487.0" font-family="'Helvetica Neue', Helvetica, Arial, sans-serif" font-size="27" fill="#1a1a2e">Restock supplies</text>
+  <text id="t67" x="346.0" y="487.0" font-family="'IBM Plex Mono', monospace" font-size="24" fill="#4a4a5a">MONTHLY · DAY 15</text>
+  <rect x="636.4" y="459.0" width="131.6" height="38.0" fill="#F3EFE6"/>
+  <text id="t68" x="754.0" y="487.0" font-family="'IBM Plex Mono', monospace" font-size="24" fill="#B8860B" font-weight="500" text-anchor="end">$300.00</text>
+  <line x1="60.0" y1="543.3" x2="768.0" y2="543.3" stroke="#EBE4F7" stroke-width="1"/>
+  <text id="t69" x="60.0" y="617.7" font-family="'Helvetica Neue', Helvetica, Arial, sans-serif" font-size="27" fill="#1a1a2e">Service the truck</text>
+  <text id="t70" x="346.0" y="617.7" font-family="'IBM Plex Mono', monospace" font-size="24" fill="#4a4a5a">MONTHLY · DAY 20</text>
+  <rect x="636.4" y="589.7" width="131.6" height="38.0" fill="#F3EFE6"/>
+  <text id="t71" x="754.0" y="617.7" font-family="'IBM Plex Mono', monospace" font-size="24" fill="#B8860B" font-weight="500" text-anchor="end">$150.00</text>
+  <text id="t72" x="818.0" y="286.0" font-family="'IBM Plex Mono', monospace" font-size="20" fill="#7a7488" letter-spacing="2.80">AUGUST</text>
+  <rect x="818.0" y="298.0" width="40.6" height="38.0" fill="#3b2d6b"/>
+  <text id="t73" x="838.3" y="323.0" font-family="'IBM Plex Mono', monospace" font-size="19" fill="#FFFDF9" font-weight="500" text-anchor="middle">1</text>
+  <rect x="865.1" y="298.5" width="39.6" height="37.0" fill="#FFFDF9" stroke="#EBE4F7" stroke-width="1"/>
+  <text id="t74" x="884.9" y="323.0" font-family="'IBM Plex Mono', monospace" font-size="19" fill="#4a4a5a" text-anchor="middle">2</text>
+  <rect x="911.6" y="298.5" width="39.6" height="37.0" fill="#FFFDF9" stroke="#EBE4F7" stroke-width="1"/>
+  <text id="t75" x="931.4" y="323.0" font-family="'IBM Plex Mono', monospace" font-size="19" fill="#4a4a5a" text-anchor="middle">3</text>
+  <rect x="958.2" y="298.5" width="39.6" height="37.0" fill="#FFFDF9" stroke="#EBE4F7" stroke-width="1"/>
+  <text id="t76" x="978.0" y="323.0" font-family="'IBM Plex Mono', monospace" font-size="19" fill="#4a4a5a" text-anchor="middle">4</text>
+  <rect x="1004.8" y="298.5" width="39.6" height="37.0" fill="#FFFDF9" stroke="#EBE4F7" stroke-width="1"/>
+  <text id="t77" x="1024.6" y="323.0" font-family="'IBM Plex Mono', monospace" font-size="19" fill="#4a4a5a" text-anchor="middle">5</text>
+  <rect x="1051.4" y="298.5" width="39.6" height="37.0" fill="#FFFDF9" stroke="#EBE4F7" stroke-width="1"/>
+  <text id="t78" x="1071.1" y="323.0" font-family="'IBM Plex Mono', monospace" font-size="19" fill="#4a4a5a" text-anchor="middle">6</text>
+  <rect x="1097.9" y="298.5" width="39.6" height="37.0" fill="#FFFDF9" stroke="#EBE4F7" stroke-width="1"/>
+  <text id="t79" x="1117.7" y="323.0" font-family="'IBM Plex Mono', monospace" font-size="19" fill="#4a4a5a" text-anchor="middle">7</text>
+  <rect x="818.5" y="342.5" width="39.6" height="37.0" fill="#FFFDF9" stroke="#EBE4F7" stroke-width="1"/>
+  <text id="t80" x="838.3" y="367.0" font-family="'IBM Plex Mono', monospace" font-size="19" fill="#4a4a5a" text-anchor="middle">8</text>
+  <rect x="865.1" y="342.5" width="39.6" height="37.0" fill="#FFFDF9" stroke="#EBE4F7" stroke-width="1"/>
+  <text id="t81" x="884.9" y="367.0" font-family="'IBM Plex Mono', monospace" font-size="19" fill="#4a4a5a" text-anchor="middle">9</text>
+  <rect x="911.6" y="342.5" width="39.6" height="37.0" fill="#FFFDF9" stroke="#EBE4F7" stroke-width="1"/>
+  <text id="t82" x="931.4" y="367.0" font-family="'IBM Plex Mono', monospace" font-size="19" fill="#4a4a5a" text-anchor="middle">10</text>
+  <rect x="958.2" y="342.5" width="39.6" height="37.0" fill="#FFFDF9" stroke="#EBE4F7" stroke-width="1"/>
+  <text id="t83" x="978.0" y="367.0" font-family="'IBM Plex Mono', monospace" font-size="19" fill="#4a4a5a" text-anchor="middle">11</text>
+  <rect x="1004.8" y="342.5" width="39.6" height="37.0" fill="#FFFDF9" stroke="#EBE4F7" stroke-width="1"/>
+  <text id="t84" x="1024.6" y="367.0" font-family="'IBM Plex Mono', monospace" font-size="19" fill="#4a4a5a" text-anchor="middle">12</text>
+  <rect x="1051.4" y="342.5" width="39.6" height="37.0" fill="#FFFDF9" stroke="#EBE4F7" stroke-width="1"/>
+  <text id="t85" x="1071.1" y="367.0" font-family="'IBM Plex Mono', monospace" font-size="19" fill="#4a4a5a" text-anchor="middle">13</text>
+  <rect x="1097.9" y="342.5" width="39.6" height="37.0" fill="#FFFDF9" stroke="#EBE4F7" stroke-width="1"/>
+  <text id="t86" x="1117.7" y="367.0" font-family="'IBM Plex Mono', monospace" font-size="19" fill="#4a4a5a" text-anchor="middle">14</text>
+  <rect x="818.0" y="386.0" width="40.6" height="38.0" fill="#3b2d6b"/>
+  <text id="t87" x="838.3" y="411.0" font-family="'IBM Plex Mono', monospace" font-size="19" fill="#FFFDF9" font-weight="500" text-anchor="middle">15</text>
+  <rect x="865.1" y="386.5" width="39.6" height="37.0" fill="#FFFDF9" stroke="#EBE4F7" stroke-width="1"/>
+  <text id="t88" x="884.9" y="411.0" font-family="'IBM Plex Mono', monospace" font-size="19" fill="#4a4a5a" text-anchor="middle">16</text>
+  <rect x="911.6" y="386.5" width="39.6" height="37.0" fill="#FFFDF9" stroke="#EBE4F7" stroke-width="1"/>
+  <text id="t89" x="931.4" y="411.0" font-family="'IBM Plex Mono', monospace" font-size="19" fill="#4a4a5a" text-anchor="middle">17</text>
+  <rect x="958.2" y="386.5" width="39.6" height="37.0" fill="#FFFDF9" stroke="#EBE4F7" stroke-width="1"/>
+  <text id="t90" x="978.0" y="411.0" font-family="'IBM Plex Mono', monospace" font-size="19" fill="#4a4a5a" text-anchor="middle">18</text>
+  <rect x="1004.8" y="386.5" width="39.6" height="37.0" fill="#FFFDF9" stroke="#EBE4F7" stroke-width="1"/>
+  <text id="t91" x="1024.6" y="411.0" font-family="'IBM Plex Mono', monospace" font-size="19" fill="#4a4a5a" text-anchor="middle">19</text>
+  <rect x="1050.9" y="386.0" width="40.6" height="38.0" fill="#3b2d6b"/>
+  <text id="t92" x="1071.1" y="411.0" font-family="'IBM Plex Mono', monospace" font-size="19" fill="#FFFDF9" font-weight="500" text-anchor="middle">20</text>
+  <rect x="1097.9" y="386.5" width="39.6" height="37.0" fill="#FFFDF9" stroke="#EBE4F7" stroke-width="1"/>
+  <text id="t93" x="1117.7" y="411.0" font-family="'IBM Plex Mono', monospace" font-size="19" fill="#4a4a5a" text-anchor="middle">21</text>
+  <line x1="818.0" y1="540.0" x2="1138.0" y2="540.0" stroke="#DDD6E8" stroke-width="2"/>
+  <text id="t94" x="818.0" y="574.0" font-family="'IBM Plex Mono', monospace" font-size="20" fill="#7a7488" letter-spacing="2.80">PLANNED THIS MONTH</text>
+  <text id="t95" x="818.0" y="630.0" font-family="'Helvetica Neue', Helvetica, Arial, sans-serif" font-size="48" fill="#B8860B" font-weight="500" letter-spacing="-0.96">$850.00</text>
+  <rect x="37.0" y="674.0" width="1126.0" height="43.0" fill="#F3EFE6"/>
+  <line x1="36.0" y1="674.0" x2="1164.0" y2="674.0" stroke="#DDD6E8" stroke-width="2"/>
+  <text id="t96" x="60.0" y="703.0" font-family="'IBM Plex Mono', monospace" font-size="22" fill="#1a1a2e" letter-spacing="2.20">$400 + $300 + $150 = $850.00</text>
+  <text id="t97" x="1140.0" y="703.0" font-family="'IBM Plex Mono', monospace" font-size="22" fill="#7a7488" letter-spacing="2.20" text-anchor="end">YOUR ROUTINES ARE THE BUDGET</text>
 </svg>

--- a/public/demo/runway.svg
+++ b/public/demo/runway.svg
@@ -1,46 +1,78 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 750" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">
-  <!-- LANDING-04-ILLOS: the Runway pipeline, as it actually runs.
-       Stages read from: RunwayBudgetPanel.tsx:5-13 (one budget panel,
-       month/year) + its RunwayWindow months field (:24-25) and the
-       'Net burn' / 'Runway' / zero-date cells (:71-74); planned spend
-       vs ledger actuals by the day. -->
-  <!-- Canvas: ts-bg cream. Cards: ts-white on ts-border hairline.
-       Active step: ts-purple fill, ts-white ink. Accent: ts-gold.
-       Text ladder: ts-text #1a1a2e / ts-text-secondary #4a4a5a /
-       ts-text-muted #7a7488 / ts-text-faint #a8a2b0.
-       (Token names drop their CSS custom-property prefix on purpose: this
-       file is parsed as a STANDALONE XML document when it is served to an
-       img tag, and XML forbids a double hyphen inside a comment. Spelling
-       the prefix out made all nine files fail to parse - every frame
-       rendered as alt text on the Preview.)
-       -->
-  <rect width="1200" height="750" fill="#FAF8F3"/>
-  <text x="60" y="76" font-size="20" font-weight="600" letter-spacing="6" fill="#7a7488">RUNWAY</text>
-
-  <!-- 01 MONEY IN -->
-  <rect x="60" y="150" width="304" height="470" rx="14" fill="#FFFDF9" stroke="#DDD6E8" stroke-width="2"/>
-  <text x="88" y="202" font-size="16" letter-spacing="4" fill="#a8a2b0">01</text>
-  <text x="88" y="352" font-size="34" font-weight="700" letter-spacing="1" fill="#1a1a2e">MONEY IN</text>
-  <rect x="88" y="420" width="175" height="40" rx="8" fill="#F3EFE6"/>
-  <text x="103" y="446" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" letter-spacing="1.5" fill="#4a4a5a">BANK + LEDGER</text>
-  <line x1="380" y1="385" x2="426" y2="385" stroke="#a8a2b0" stroke-width="3"/>
-  <path d="M 426 374 L 442 385 L 426 396 Z" fill="#a8a2b0"/>
-
-  <!-- 02 PLANNED -->
-  <rect x="448" y="150" width="304" height="470" rx="14" fill="#3b2d6b"/>
-  <text x="476" y="202" font-size="16" letter-spacing="4" fill="#FFFDF9" opacity="0.6">02</text>
-  <text x="476" y="315" font-size="34" font-weight="700" letter-spacing="1" fill="#FFFDF9">PLANNED</text>
-  <text x="476" y="359" font-size="34" font-weight="700" letter-spacing="1" fill="#FFFDF9">VS ACTUAL</text>
-  <text x="476" y="407" font-size="15" letter-spacing="3" fill="#FFFDF9" opacity="0.75">&#9679; YOU ARE HERE</text>
-  <rect x="476" y="457" width="142" height="40" rx="8" fill="#ffffff"/>
-  <text x="491" y="483" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" letter-spacing="1.5" fill="#3b2d6b">BY THE DAY</text>
-  <line x1="768" y1="385" x2="814" y2="385" stroke="#a8a2b0" stroke-width="3"/>
-  <path d="M 814 374 L 830 385 L 814 396 Z" fill="#a8a2b0"/>
-
-  <!-- 03 MONTHS LEFT -->
-  <rect x="836" y="150" width="304" height="470" rx="14" fill="#FFFDF9" stroke="#DDD6E8" stroke-width="2"/>
-  <text x="864" y="202" font-size="16" letter-spacing="4" fill="#a8a2b0">03</text>
-  <text x="864" y="352" font-size="34" font-weight="700" letter-spacing="1" fill="#1a1a2e">MONTHS LEFT</text>
-  <rect x="864" y="420" width="231" height="40" rx="8" fill="#F3EFE6"/>
-  <text x="879" y="446" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="16" letter-spacing="1.5" fill="#4a4a5a">FROM YOUR NET BURN</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 750">
+  <!-- LANDING-04-FRAMES-V2: RUNWAY, step 02 of 03 (PLANNED VS ACTUAL).
+       The panel is that step's own screen: the June budget table plus
+       the months-left rail.
+       Every number is read from src/components/home/RunwayShowcaseSections.tsx:
+       window3 (:82) expenses 3,000 minus income 1,200 = 600/mo net burn,
+       runway '25.0', zeroDate 'Aug 14, 2028'; cash 9,400 + 2,500 + 3,100
+       = 15,000 (:14); budget rows (:86-88) 6100 Rent (Business) 400/400.00
+       0.0%, 6120 Supplies 300/312.45 +4.2%, 6010 Car and Truck Expenses
+       150/138.20 -7.9%; totals (:90-91, :266) 850.00 / 850.65 / +0.1%.
+       Variance ink follows that file's own rule (:264): over budget red,
+       under budget green, exactly on budget muted.
+       No live indicator is drawn: the real surface has none (ruling 5).
+       Tokens: bg cream, white cards, bg-row bands, purple active step,
+       gold money, border hairlines, text ladder. -->
+  <rect x="0.0" y="0.0" width="1200.0" height="750.0" fill="#FAF8F3"/>
+  <text id="t1" x="36.0" y="53.0" font-family="'IBM Plex Mono', monospace" font-size="22" fill="#7a7488" font-weight="500" letter-spacing="6.60">RUNWAY</text>
+  <text id="t2" x="1164.0" y="53.0" font-family="'IBM Plex Mono', monospace" font-size="20" fill="#a8a2b0" letter-spacing="3.20" text-anchor="end">STEP 02 OF 03</text>
+  <rect x="37.0" y="75.0" width="351.3" height="102.0" fill="#FFFDF9" stroke="#DDD6E8" stroke-width="2"/>
+  <text id="t3" x="56.0" y="105.6" font-family="'IBM Plex Mono', monospace" font-size="20" fill="#a8a2b0" letter-spacing="4.00">01</text>
+  <text id="t4" x="56.0" y="134.8" font-family="'Helvetica Neue', Helvetica, Arial, sans-serif" font-size="28" fill="#1a1a2e" font-weight="600">MONEY IN</text>
+  <text id="t5" x="56.0" y="158.0" font-family="'IBM Plex Mono', monospace" font-size="18" fill="#a8a2b0" letter-spacing="2.16">YOUR BANKS</text>
+  <text id="t6" x="406.3" y="136.0" font-family="'IBM Plex Mono', monospace" font-size="30" fill="#a8a2b0" text-anchor="middle">›</text>
+  <rect x="423.3" y="74.0" width="353.3" height="104.0" fill="#3b2d6b"/>
+  <rect x="423.3" y="173.0" width="353.3" height="5.0" fill="#B8860B"/>
+  <text id="t7" x="443.3" y="105.6" font-family="'IBM Plex Mono', monospace" font-size="20" fill="#FFFDF9" letter-spacing="4.00" opacity="0.6">02</text>
+  <text id="t8" x="443.3" y="134.8" font-family="'Helvetica Neue', Helvetica, Arial, sans-serif" font-size="28" fill="#FFFDF9" font-weight="600">PLANNED VS ACTUAL</text>
+  <text id="t9" x="443.3" y="158.0" font-family="'IBM Plex Mono', monospace" font-size="18" fill="#FFFDF9" letter-spacing="2.52" opacity="0.78">▪ YOU ARE HERE</text>
+  <text id="t10" x="793.7" y="136.0" font-family="'IBM Plex Mono', monospace" font-size="30" fill="#a8a2b0" text-anchor="middle">›</text>
+  <rect x="811.7" y="75.0" width="351.3" height="102.0" fill="#FFFDF9" stroke="#DDD6E8" stroke-width="2"/>
+  <text id="t11" x="830.7" y="105.6" font-family="'IBM Plex Mono', monospace" font-size="20" fill="#a8a2b0" letter-spacing="4.00">03</text>
+  <text id="t12" x="830.7" y="134.8" font-family="'Helvetica Neue', Helvetica, Arial, sans-serif" font-size="28" fill="#1a1a2e" font-weight="600">MONTHS LEFT</text>
+  <text id="t13" x="830.7" y="158.0" font-family="'IBM Plex Mono', monospace" font-size="18" fill="#a8a2b0" letter-spacing="2.16">CASH ÷ BURN</text>
+  <rect x="597.5" y="178.0" width="5.0" height="20.0" fill="#B8860B"/>
+  <rect x="37.0" y="199.0" width="1126.0" height="518.0" fill="#FFFDF9" stroke="#DDD6E8" stroke-width="2"/>
+  <text id="t14" x="60.0" y="228.0" font-family="'IBM Plex Mono', monospace" font-size="22" fill="#4a4a5a" letter-spacing="2.64">BUDGET — JUNE</text>
+  <line x1="36.0" y1="244.0" x2="1164.0" y2="244.0" stroke="#DDD6E8" stroke-width="2"/>
+  <line x1="792.0" y1="244.0" x2="792.0" y2="674.0" stroke="#DDD6E8" stroke-width="2"/>
+  <rect x="37.0" y="244.0" width="755.0" height="38.0" fill="#F3EFE6"/>
+  <text id="t15" x="60.0" y="270.0" font-family="'IBM Plex Mono', monospace" font-size="20" fill="#7a7488" letter-spacing="2.40">CATEGORY</text>
+  <text id="t16" x="512.0" y="270.0" font-family="'IBM Plex Mono', monospace" font-size="20" fill="#7a7488" letter-spacing="2.40" text-anchor="end">PLANNED</text>
+  <text id="t17" x="652.0" y="270.0" font-family="'IBM Plex Mono', monospace" font-size="20" fill="#7a7488" letter-spacing="2.40" text-anchor="end">ACTUAL</text>
+  <text id="t18" x="768.0" y="270.0" font-family="'IBM Plex Mono', monospace" font-size="20" fill="#7a7488" letter-spacing="2.40" text-anchor="end">VAR</text>
+  <text id="t19" x="60.0" y="345.7" font-family="'Helvetica Neue', Helvetica, Arial, sans-serif" font-size="27" fill="#1a1a2e">Rent (Business)</text>
+  <text id="t20" x="512.0" y="345.7" font-family="'IBM Plex Mono', monospace" font-size="26" fill="#4a4a5a" text-anchor="end">400.00</text>
+  <text id="t21" x="652.0" y="345.7" font-family="'IBM Plex Mono', monospace" font-size="26" fill="#1a1a2e" text-anchor="end">400.00</text>
+  <text id="t22" x="768.0" y="345.7" font-family="'IBM Plex Mono', monospace" font-size="26" fill="#7a7488" text-anchor="end">0.0%</text>
+  <line x1="60.0" y1="391.3" x2="768.0" y2="391.3" stroke="#EBE4F7" stroke-width="1"/>
+  <text id="t23" x="60.0" y="455.0" font-family="'Helvetica Neue', Helvetica, Arial, sans-serif" font-size="27" fill="#1a1a2e">Supplies</text>
+  <text id="t24" x="512.0" y="455.0" font-family="'IBM Plex Mono', monospace" font-size="26" fill="#4a4a5a" text-anchor="end">300.00</text>
+  <text id="t25" x="652.0" y="455.0" font-family="'IBM Plex Mono', monospace" font-size="26" fill="#1a1a2e" text-anchor="end">312.45</text>
+  <text id="t26" x="768.0" y="455.0" font-family="'IBM Plex Mono', monospace" font-size="26" fill="#c53030" text-anchor="end">+4.2%</text>
+  <line x1="60.0" y1="500.7" x2="768.0" y2="500.7" stroke="#EBE4F7" stroke-width="1"/>
+  <text id="t27" x="60.0" y="564.3" font-family="'Helvetica Neue', Helvetica, Arial, sans-serif" font-size="27" fill="#1a1a2e">Car &amp; Truck Expenses</text>
+  <text id="t28" x="512.0" y="564.3" font-family="'IBM Plex Mono', monospace" font-size="26" fill="#4a4a5a" text-anchor="end">150.00</text>
+  <text id="t29" x="652.0" y="564.3" font-family="'IBM Plex Mono', monospace" font-size="26" fill="#1a1a2e" text-anchor="end">138.20</text>
+  <text id="t30" x="768.0" y="564.3" font-family="'IBM Plex Mono', monospace" font-size="26" fill="#16a34a" text-anchor="end">-7.9%</text>
+  <rect x="37.0" y="610.0" width="755.0" height="64.0" fill="#F3EFE6"/>
+  <line x1="36.0" y1="610.0" x2="792.0" y2="610.0" stroke="#DDD6E8" stroke-width="2"/>
+  <text id="t31" x="60.0" y="650.0" font-family="'IBM Plex Mono', monospace" font-size="22" fill="#7a7488" letter-spacing="2.64">TOTAL</text>
+  <text id="t32" x="512.0" y="650.0" font-family="'IBM Plex Mono', monospace" font-size="26" fill="#4a4a5a" text-anchor="end">850.00</text>
+  <text id="t33" x="652.0" y="650.0" font-family="'IBM Plex Mono', monospace" font-size="26" fill="#1a1a2e" font-weight="500" text-anchor="end">850.65</text>
+  <text id="t34" x="768.0" y="650.0" font-family="'IBM Plex Mono', monospace" font-size="26" fill="#c53030" font-weight="500" text-anchor="end">+0.1%</text>
+  <text id="t35" x="820.0" y="290.0" font-family="'IBM Plex Mono', monospace" font-size="20" fill="#7a7488" letter-spacing="3.20">MONTHS LEFT</text>
+  <text id="t36" x="820.0" y="380.0" font-family="'Helvetica Neue', Helvetica, Arial, sans-serif" font-size="104" fill="#3b2d6b" font-weight="500" letter-spacing="-3.12">25.0</text>
+  <text id="t37" x="1020.0" y="380.0" font-family="'IBM Plex Mono', monospace" font-size="28" fill="#7a7488" letter-spacing="2.80">MO</text>
+  <text id="t38" x="820.0" y="452.0" font-family="'IBM Plex Mono', monospace" font-size="20" fill="#7a7488" letter-spacing="3.20">ZERO DATE</text>
+  <text id="t39" x="820.0" y="490.0" font-family="'IBM Plex Mono', monospace" font-size="30" fill="#B8860B" font-weight="500">AUG 14, 2028</text>
+  <line x1="820.0" y1="548.0" x2="1136.0" y2="548.0" stroke="#DDD6E8" stroke-width="2"/>
+  <text id="t40" x="820.0" y="584.0" font-family="'IBM Plex Mono', monospace" font-size="22" fill="#7a7488" letter-spacing="1.76">CASH</text>
+  <text id="t41" x="1136.0" y="584.0" font-family="'IBM Plex Mono', monospace" font-size="22" fill="#1a1a2e" text-anchor="end">$15,000</text>
+  <text id="t42" x="820.0" y="618.0" font-family="'IBM Plex Mono', monospace" font-size="22" fill="#7a7488" letter-spacing="1.76">BURN</text>
+  <text id="t43" x="1136.0" y="618.0" font-family="'IBM Plex Mono', monospace" font-size="22" fill="#c53030" text-anchor="end">$600/MO</text>
+  <rect x="37.0" y="674.0" width="1126.0" height="43.0" fill="#F3EFE6"/>
+  <line x1="36.0" y1="674.0" x2="1164.0" y2="674.0" stroke="#DDD6E8" stroke-width="2"/>
+  <text id="t44" x="60.0" y="703.0" font-family="'IBM Plex Mono', monospace" font-size="22" fill="#1a1a2e" letter-spacing="2.20">$15,000 ÷ $600 = 25.0 MONTHS</text>
+  <text id="t45" x="1140.0" y="703.0" font-family="'IBM Plex Mono', monospace" font-size="22" fill="#7a7488" letter-spacing="2.20" text-anchor="end">NOT A NUMBER YOU TYPED</text>
 </svg>


### PR DESCRIPTION
Trade is held: the handoff's SKIP reason strings are not the strings the app stores, and the real ones do not fit the 330px verdict cell at any size at or above the 18px floor. Reported for a ruling.


Claude-Session: https://claude.ai/code/session_0142nEDQpqCZJr9NFU7y9wfU