### PR TITLE
feat(landing): add headline to done-for-you section

### DIFF
--- a/src/components/landing/Landing.tsx
+++ b/src/components/landing/Landing.tsx
@@ -760,6 +760,25 @@ export default function Landing({ onRequireAuth, onRequireLogin, logoAvailabilit
           <p className="font-mono text-xs lg:text-[10px] font-semibold uppercase tracking-wider text-text-faint">
             DONE-FOR-YOU
           </p>
+          {/* HEADLINE: the travel act's h2 treatment, class for class —
+              mt-3 text-2xl sm:text-3xl font-medium tracking-tight
+              text-brand-purple. The two revenue acts under the hero are a
+              pair and now read as one: eyebrow, headline, then the surface.
+              WEIGHT AND BREAKPOINT, BOTH DELIBERATE. font-medium is 500, and
+              the sm: prefix is not the lg:-only idiom the numbered slides
+              keep — both are correct HERE because this act sits above the
+              teaching run and matches its sibling instead. sm: is already
+              this section's own idiom (the services grid below is
+              sm:grid-cols-2), so nothing new is introduced; swapping it for
+              lg: would leave this headline a size behind travel's between
+              640 and 1023px, which is the one thing the match exists to
+              prevent.
+              NO MARGIN BELOW, also matching: the travel h2 carries only mt-3
+              and lets the element after it supply the gap. The services card
+              below keeps its own mt-4, untouched. */}
+          <h2 className="mt-3 text-2xl sm:text-3xl font-medium tracking-tight text-brand-purple">
+            Need help setting it up? Send a proposal.
+          </h2>
           <div className="mt-4 rounded-lg border border-border bg-white p-5">
             <div className="mt-4">
               <span className="rounded border border-border px-2 py-0.5 font-mono text-xs lg:text-[10px] font-semibold uppercase tracking-wider text-text-secondary">


### PR DESCRIPTION
The two revenue acts under the hero are a pair, but only travel carried a headline between its eyebrow and its surface. This adds the matching one: "Need help setting it up? Send a proposal."

Class for class the travel act's h2 - same element, mt-3 text-2xl sm:text-3xl font-medium tracking-tight text-brand-purple - and no margin below, because the travel h2 has none either and lets the element after it supply the gap. The services card keeps its own mt-4, untouched.

DELIBERATE DEVIATION FROM THE lg:-ONLY RULE, flagged rather than silently resolved: the travel headline's second size is sm:text-3xl, so matching it exactly means carrying sm: here too. Two things make that the right read. The instruction was to match the sibling exactly at both breakpoints, and sm: is already this section's own idiom - the services grid below is sm:grid-cols-2 - so nothing new is introduced. And lg: would actively break the match: measured at 800px, both headlines render 30px; with lg:text-3xl this one would sit at 24px through the whole 640-1023 band, which is the one thing the match exists to prevent.

font-medium (500) is likewise intentional, per the ruling that the 400-weight rule governing slides 01-03 does not reach this act.

Pure insertion - zero deleted lines - so the eyebrow, cards, button and "Scoped by proposal" line are untouched by construction.

Verified: tsc clean, eslint clean, no raw hex. Both h2s measured on the real rendered page at 1280, 800 and true 375 are identical on tag, fontSize, fontWeight, color, marginTop, marginBottom, letterSpacing, lineHeight and fontFamily. Container order is eyebrow, headline, card; eyebrow-to-headline gap is 12px in both acts. Seams unchanged at [1,0,1,1,1,1,1,1], none needing attention, no horizontal scroll.


Claude-Session: https://claude.ai/code/session_01BUyergqkiGC4TonRRFEwfG