### PR TITLE
security: fix SSRF bypass in fetch-og url-guard + harden citation verify

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "assert:showroom": "node scripts/assert-showroom-fetch-free.mjs",
     "build": "node scripts/assert-showroom-fetch-free.mjs && prisma generate && prisma migrate deploy && next build",
     "start": "next start",
+    "test": "tsx --test src/lib/__tests__/*.test.ts",
     "lint": "eslint .",
     "lint:strict": "eslint . --max-warnings 0",
     "postinstall": "prisma generate",

--- a/src/app/api/fetch-og/route.ts
+++ b/src/app/api/fetch-og/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
-import { assertPublicHttpUrl } from '@/lib/url-guard';
+import { safeFetch, SsrfBlockedError } from '@/lib/url-guard';
 
 export async function POST(request: NextRequest) {
   try {
@@ -22,20 +22,25 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'URL required' }, { status: 400 });
     }
 
-    // SEC-5: SSRF guard — reject non-http(s) schemes and any host that resolves
-    // to a private/loopback/link-local/metadata address BEFORE the server-side
-    // fetch. Public listing URLs (the feature's real input) pass unchanged.
-    const blockReason = await assertPublicHttpUrl(url);
-    if (blockReason) {
-      return NextResponse.json({ error: blockReason }, { status: 400 });
+    // SEC-5: SSRF-safe fetch — validates the URL (rejecting non-http(s) schemes
+    // and any host that resolves to a private/loopback/link-local/metadata
+    // address) BEFORE the server-side request, and re-validates every redirect
+    // Location so a public URL cannot 302 into an internal target. Public
+    // listing URLs (the feature's real input) pass unchanged.
+    let res: Response;
+    try {
+      res = await safeFetch(url, {
+        headers: {
+          'User-Agent': 'Mozilla/5.0 (compatible; TripPlanner/1.0)'
+        }
+      });
+    } catch (err) {
+      if (err instanceof SsrfBlockedError) {
+        return NextResponse.json({ error: err.reason }, { status: 400 });
+      }
+      throw err;
     }
 
-    const res = await fetch(url, {
-      headers: {
-        'User-Agent': 'Mozilla/5.0 (compatible; TripPlanner/1.0)'
-      }
-    });
-    
     if (!res.ok) {
       return NextResponse.json({ error: 'Could not fetch URL' }, { status: 400 });
     }

--- a/src/lib/__tests__/url-guard.test.ts
+++ b/src/lib/__tests__/url-guard.test.ts
@@ -1,0 +1,173 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import { assertPublicHttpUrl, safeFetch, SsrfBlockedError } from '../url-guard';
+
+// SEC-5 SSRF regression suite. Proves the guard blocks the disclosed
+// IPv4-mapped-IPv6 (hex) bypass and its whole obfuscation family, that
+// legitimate public URLs still pass, and that redirects are re-validated so a
+// public URL cannot 302 into an internal target. Hermetic: every ALLOW case is
+// an IP literal (no DNS) and the redirect tests use local servers only.
+
+const MUST_BLOCK: string[] = [
+  // Disclosed bug: IPv4-mapped IPv6 in hex form (Node normalizes the dotted
+  // spelling to this) — loopback and cloud-metadata via ::ffff:
+  'http://[::ffff:127.0.0.1]:8080/',
+  'http://[::ffff:7f00:1]/',
+  'http://[::ffff:169.254.169.254]/',
+  'http://[::ffff:a9fe:a9fe]/',
+  // Direct private / loopback / link-local / CGNAT (v4 + v6)
+  'http://127.0.0.1/',
+  'http://169.254.169.254/',
+  'http://[::1]/',
+  'http://[fd00::1]/',
+  'http://[febf::1]/',
+  'http://10.0.0.5/',
+  'http://192.168.1.1/',
+  'http://100.64.0.1/',
+  // IPv4-embedded-in-IPv6 transition ranges (NAT64, 6to4)
+  'http://[64:ff9b::7f00:1]/',
+  'http://[2002:7f00:1::]/',
+  // Alternate IPv4 encodings (URL normalizes these to 127.0.0.1)
+  'http://2130706433/',
+  'http://0x7f000001/',
+  'http://0177.0.0.1/',
+  // Non-http(s) schemes
+  'file:///etc/passwd',
+  'gopher://127.0.0.1/',
+];
+
+const MUST_ALLOW: string[] = [
+  'http://8.8.8.8/',
+  'https://1.1.1.1/',
+  'http://[2606:4700:4700::1111]/',
+];
+
+for (const url of MUST_BLOCK) {
+  test(`assertPublicHttpUrl BLOCKS ${url}`, async () => {
+    const reason = await assertPublicHttpUrl(url);
+    assert.notEqual(reason, null, `expected ${url} to be blocked, but it was allowed`);
+  });
+}
+
+for (const url of MUST_ALLOW) {
+  test(`assertPublicHttpUrl ALLOWS ${url}`, async () => {
+    const reason = await assertPublicHttpUrl(url);
+    assert.equal(reason, null, `expected ${url} to be allowed, but it was blocked: ${reason}`);
+  });
+}
+
+// --- Redirect re-validation ------------------------------------------------
+function listen(server: http.Server): Promise<number> {
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address();
+      resolve(typeof addr === 'object' && addr ? addr.port : 0);
+    });
+  });
+}
+
+test('safeFetch refuses an internal initial URL before any request', async () => {
+  // The disclosed hole #2 baseline: a loopback target is rejected by the initial
+  // guard and never fetched.
+  let internalHits = 0;
+  const internal = http.createServer((_req, res) => {
+    internalHits++;
+    res.end('INTERNAL-SECRET-BODY');
+  });
+  const internalPort = await listen(internal);
+  try {
+    await assert.rejects(
+      () => safeFetch(`http://127.0.0.1:${internalPort}/`),
+      (err: unknown) => err instanceof SsrfBlockedError,
+    );
+    assert.equal(internalHits, 0, 'a blocked initial URL must never be fetched');
+  } finally {
+    internal.close();
+  }
+});
+
+test('safeFetch re-validates redirects and refuses an internal 302 target', async () => {
+  // Hole #2: a public entry that 302s to a loopback URL must be blocked ON THE
+  // REDIRECT HOP and never read the internal body. Both servers are on loopback,
+  // so we inject a validator that permits ONLY the entry origin and delegates
+  // every other URL to the REAL guard — the redirect target (a different loopback
+  // port) is then blocked by the real assertPublicHttpUrl on the redirect hop.
+  // This drives the real safeFetch loop through its per-hop re-validation.
+  let internalHits = 0;
+  const internal = http.createServer((_req, res) => {
+    internalHits++;
+    res.writeHead(200, { 'Content-Type': 'text/plain' });
+    res.end('INTERNAL-SECRET-BODY');
+  });
+  const internalPort = await listen(internal);
+
+  const entry = http.createServer((req, res) => {
+    if (req.url === '/redir') {
+      res.writeHead(302, { Location: `http://127.0.0.1:${internalPort}/internal` });
+      res.end();
+      return;
+    }
+    res.writeHead(404);
+    res.end();
+  });
+  const entryPort = await listen(entry);
+  const entryOrigin = `http://127.0.0.1:${entryPort}`;
+
+  const validate = async (u: string): Promise<string | null> =>
+    u === entryOrigin || u.startsWith(entryOrigin + '/') ? null : assertPublicHttpUrl(u);
+
+  try {
+    await assert.rejects(
+      () => safeFetch(`${entryOrigin}/redir`, undefined, { validate }),
+      (err: unknown) => {
+        assert.ok(err instanceof SsrfBlockedError, `expected SsrfBlockedError, got ${err}`);
+        return /private or reserved/.test((err as SsrfBlockedError).reason);
+      },
+    );
+    assert.equal(internalHits, 0, 'internal endpoint must never be requested');
+  } finally {
+    entry.close();
+    internal.close();
+  }
+});
+
+test('safeFetch follows a public redirect chain to the final response', async () => {
+  // Legitimate redirects still work: a 302 to another allowed host is followed
+  // and the final 200 body is returned. Both hops are on loopback, so both are
+  // permitted via the validator seam to exercise the FOLLOW path of the real
+  // safeFetch (production callers use the default public-only guard).
+  let finalHits = 0;
+  const finalServer = http.createServer((_req, res) => {
+    finalHits++;
+    res.writeHead(200, { 'Content-Type': 'text/plain' });
+    res.end('FINAL-OK');
+  });
+  const finalPort = await listen(finalServer);
+
+  const entry = http.createServer((req, res) => {
+    if (req.url === '/start') {
+      res.writeHead(302, { Location: `http://127.0.0.1:${finalPort}/final` });
+      res.end();
+      return;
+    }
+    res.writeHead(404);
+    res.end();
+  });
+  const entryPort = await listen(entry);
+  const entryOrigin = `http://127.0.0.1:${entryPort}`;
+  const finalOrigin = `http://127.0.0.1:${finalPort}`;
+
+  const validate = async (u: string): Promise<string | null> =>
+    u.startsWith(entryOrigin) || u.startsWith(finalOrigin) ? null : 'blocked';
+
+  try {
+    const res = await safeFetch(`${entryOrigin}/start`, undefined, { validate });
+    assert.equal(res.status, 200);
+    assert.equal(await res.text(), 'FINAL-OK');
+    assert.equal(finalHits, 1, 'final endpoint should be reached exactly once');
+  } finally {
+    entry.close();
+    finalServer.close();
+  }
+});

--- a/src/lib/citations/verifyCitation.ts
+++ b/src/lib/citations/verifyCitation.ts
@@ -1,6 +1,7 @@
 import { createHash } from 'crypto';
 import { citations, VerificationCheckResult } from '@prisma/client';
 import { prisma } from '@/lib/prisma';
+import { safeFetch, SsrfBlockedError } from '@/lib/url-guard';
 
 export interface VerificationResult {
   citation_id: string;
@@ -25,7 +26,10 @@ async function checkExistence(url: string): Promise<{ result: VerificationCheckR
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), HTTP_TIMEOUT_MS);
   try {
-    const res = await fetch(url, { method: 'HEAD', signal: controller.signal, redirect: 'follow' });
+    // SEC-5: safeFetch validates the (AI/web-search-supplied) host and every
+    // redirect Location before requesting, so an internal address can never be
+    // probed here. A blocked target fails the check loudly — it never fetches.
+    const res = await safeFetch(url, { method: 'HEAD', signal: controller.signal });
     if (res.status === 200 || res.status === 301 || res.status === 302) {
       return { result: 'passed' };
     }
@@ -34,6 +38,9 @@ async function checkExistence(url: string): Promise<{ result: VerificationCheckR
     }
     return { result: 'error', note: `Existence check: unexpected HTTP ${res.status}` };
   } catch (err) {
+    if (err instanceof SsrfBlockedError) {
+      return { result: 'error', note: `Existence check: blocked non-public URL (${err.reason})` };
+    }
     return { result: 'error', note: `Existence check: ${err instanceof Error ? err.message : 'network error'}` };
   } finally {
     clearTimeout(timeout);
@@ -79,7 +86,10 @@ async function checkContentHash(url: string, expectedHash: string): Promise<{ re
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), HTTP_TIMEOUT_MS);
   try {
-    const res = await fetch(url, { method: 'GET', signal: controller.signal, redirect: 'follow' });
+    // SEC-5: safeFetch validates the (AI/web-search-supplied) host and every
+    // redirect Location before requesting, so this body-reading GET can never be
+    // pointed at an internal endpoint. A blocked target fails the check loudly.
+    const res = await safeFetch(url, { method: 'GET', signal: controller.signal });
     if (!res.ok) {
       return { result: 'error', note: `Content hash check: HTTP ${res.status}` };
     }
@@ -90,6 +100,9 @@ async function checkContentHash(url: string, expectedHash: string): Promise<{ re
     }
     return { result: 'failed', note: 'Content hash check: hash mismatch — content may have changed' };
   } catch (err) {
+    if (err instanceof SsrfBlockedError) {
+      return { result: 'error', note: `Content hash check: blocked non-public URL (${err.reason})` };
+    }
     return { result: 'error', note: `Content hash check: ${err instanceof Error ? err.message : 'network error'}` };
   } finally {
     clearTimeout(timeout);

--- a/src/lib/url-guard.ts
+++ b/src/lib/url-guard.ts
@@ -7,36 +7,59 @@ import net from 'net';
 // schemes and any host that resolves to a private / loopback / link-local /
 // cloud-metadata address. Deny-by-default — a malformed or unresolvable host is
 // blocked, never fetched.
+//
+// IP-range math is delegated to Node's net.BlockList instead of hand-rolled
+// string checks. BlockList does correct subnet arithmetic and, crucially,
+// evaluates an IPv4-mapped IPv6 address (e.g. ::ffff:7f00:1) against the IPv4
+// rules automatically — closing the IPv4-mapped-hex bypass that dotted-string
+// matching missed. The IPv4-embedded-in-IPv6 transition ranges (::/96,
+// 64:ff9b::/96, 2002::/16) are added as explicit v6 subnets so those forms are
+// blocked structurally regardless of the embedded payload.
 
-function isBlockedIpv4(ip: string): boolean {
-  const p = ip.split('.').map(Number);
-  if (p.length !== 4 || p.some((n) => !Number.isInteger(n) || n < 0 || n > 255)) return true; // malformed → block
-  const [a, b] = p;
-  if (a === 0) return true;                            // 0.0.0.0/8 "this host"
-  if (a === 10) return true;                           // 10.0.0.0/8 private
-  if (a === 127) return true;                          // 127.0.0.0/8 loopback
-  if (a === 169 && b === 254) return true;             // 169.254.0.0/16 link-local (incl. 169.254.169.254 metadata)
-  if (a === 172 && b >= 16 && b <= 31) return true;    // 172.16.0.0/12 private
-  if (a === 192 && b === 168) return true;             // 192.168.0.0/16 private
-  if (a === 100 && b >= 64 && b <= 127) return true;   // 100.64.0.0/10 CGNAT
-  if (a >= 224) return true;                           // 224.0.0.0/4 multicast + 240/4 reserved
-  return false;
+// Private / reserved ranges that must never be reached from a user-supplied URL.
+// Kept as data so the set is auditable at a glance.
+const BLOCKED_V4: Array<[string, number]> = [
+  ['0.0.0.0', 8],       // 0.0.0.0/8 "this host" / current network
+  ['10.0.0.0', 8],      // RFC1918 private
+  ['100.64.0.0', 10],   // RFC6598 CGNAT
+  ['127.0.0.0', 8],     // loopback
+  ['169.254.0.0', 16],  // link-local (incl. 169.254.169.254 cloud metadata)
+  ['172.16.0.0', 12],   // RFC1918 private
+  ['192.168.0.0', 16],  // RFC1918 private
+  ['224.0.0.0', 4],     // multicast
+  ['240.0.0.0', 4],     // reserved / future use (incl. 255.255.255.255 broadcast)
+];
+
+const BLOCKED_V6: Array<[string, number]> = [
+  ['::', 128],          // unspecified
+  ['::1', 128],         // loopback
+  ['::', 96],           // IPv4-compatible ::a.b.c.d (deprecated; embeds a v4 address)
+  ['64:ff9b::', 96],    // NAT64 well-known prefix (embeds a v4 address)
+  ['2002::', 16],       // 6to4 (embeds a v4 address in the next 32 bits)
+  ['fc00::', 7],        // unique-local (fc00::/7 covers fc.. and fd..)
+  ['fe80::', 10],       // link-local (fe80::/10 covers fe80.. through febf..)
+  ['ff00::', 8],        // multicast
+];
+
+function buildBlockList(): net.BlockList {
+  const bl = new net.BlockList();
+  for (const [addr, prefix] of BLOCKED_V4) bl.addSubnet(addr, prefix, 'ipv4');
+  for (const [addr, prefix] of BLOCKED_V6) bl.addSubnet(addr, prefix, 'ipv6');
+  return bl;
 }
 
-function isBlockedIpv6(ip: string): boolean {
-  const lower = ip.toLowerCase();
-  if (lower === '::1' || lower === '::') return true;  // loopback / unspecified
-  if (lower.startsWith('fe80')) return true;           // link-local
-  if (lower.startsWith('fc') || lower.startsWith('fd')) return true; // unique-local fc00::/7
-  const mapped = lower.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/);        // IPv4-mapped
-  if (mapped) return isBlockedIpv4(mapped[1]);
-  return false;
-}
+const BLOCK_LIST = buildBlockList();
 
+/**
+ * True when `ip` (an IPv4 or IPv6 literal) falls in any private / reserved
+ * range, or is not a recognizable IP literal at all (fail closed). BlockList
+ * evaluates IPv4-mapped IPv6 (::ffff:a.b.c.d, in any hex/dotted spelling)
+ * against the IPv4 rules automatically.
+ */
 function isBlockedIp(ip: string): boolean {
   const fam = net.isIP(ip);
-  if (fam === 4) return isBlockedIpv4(ip);
-  if (fam === 6) return isBlockedIpv6(ip);
+  if (fam === 4) return BLOCK_LIST.check(ip, 'ipv4');
+  if (fam === 6) return BLOCK_LIST.check(ip, 'ipv6');
   return true; // not a valid IP literal → block
 }
 
@@ -45,7 +68,7 @@ function isBlockedIp(ip: string): boolean {
  * when it must be blocked (non-http(s) scheme, or the host is / resolves to a
  * private/reserved address). Resolves the hostname and blocks if ANY returned
  * address is private — closing the direct SSRF path to internal services and
- * the cloud metadata endpoint.
+ * the cloud metadata endpoint. Fails closed on any parse/resolve failure.
  */
 export async function assertPublicHttpUrl(rawUrl: string): Promise<string | null> {
   let parsed: URL;
@@ -76,4 +99,80 @@ export async function assertPublicHttpUrl(rawUrl: string): Promise<string | null
   if (addresses.length === 0) return 'Could not resolve host';
   if (addresses.some(isBlockedIp)) return 'URL resolves to a private or reserved address';
   return null;
+}
+
+/**
+ * Thrown when a request target (the initial URL or any redirect Location) fails
+ * the SSRF guard. Routes map this to a 400. `reason` carries the guard's message.
+ */
+export class SsrfBlockedError extends Error {
+  readonly reason: string;
+  constructor(reason: string) {
+    super(reason);
+    this.name = 'SsrfBlockedError';
+    this.reason = reason;
+  }
+}
+
+const MAX_REDIRECTS = 4;
+
+export interface SafeFetchOptions {
+  /**
+   * Validator run against the initial URL and every redirect Location. Defaults
+   * to assertPublicHttpUrl. Exposed as a seam so per-call policies (and hermetic
+   * redirect tests against loopback) can override it; production callers omit it
+   * and get the standard public-only guard.
+   */
+  validate?: (url: string) => Promise<string | null>;
+}
+
+/**
+ * SSRF-safe replacement for `fetch` on USER-INFLUENCED URLs. It re-validates
+ * the target with assertPublicHttpUrl BEFORE every hop, follows redirects
+ * manually (under `redirect: 'manual'` Node returns the real 3xx response with a
+ * readable Location, unlike the browser's opaque redirect), re-checks each
+ * Location resolved against the current URL, and caps the redirect depth.
+ *
+ * Fails closed: any block reason throws SsrfBlockedError and NO request to an
+ * internal target is ever issued — there is no fallback path that fetches when a
+ * check is uncertain.
+ */
+export async function safeFetch(
+  rawUrl: string,
+  init?: RequestInit,
+  opts?: SafeFetchOptions,
+): Promise<Response> {
+  const validate = opts?.validate ?? assertPublicHttpUrl;
+  let currentUrl = rawUrl;
+
+  for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
+    const blockReason = await validate(currentUrl);
+    if (blockReason) throw new SsrfBlockedError(blockReason);
+
+    const res = await fetch(currentUrl, { ...init, redirect: 'manual' });
+
+    // Non-redirect response — hand it back to the caller.
+    if (res.status < 300 || res.status >= 400) return res;
+
+    const location = res.headers.get('location');
+    if (!location) return res; // 3xx without a Location: nothing to follow.
+
+    // Drain the redirect body so the socket can be reused, then resolve the
+    // (possibly relative) Location against the current URL and loop to re-check.
+    try {
+      await res.arrayBuffer();
+    } catch {
+      /* body already consumed / empty — ignore */
+    }
+
+    let nextUrl: string;
+    try {
+      nextUrl = new URL(location, currentUrl).toString();
+    } catch {
+      throw new SsrfBlockedError('Invalid redirect target');
+    }
+    currentUrl = nextUrl;
+  }
+
+  throw new SsrfBlockedError('Too many redirects');
 }


### PR DESCRIPTION
IP checks now delegate to Node's net.BlockList instead of hand-rolled string matching. This fixes the disclosed IPv4-mapped IPv6 (hex) bypass: Node's URL normalizes ::ffff:127.0.0.1 to ::ffff:7f00:1 (and 169.254.169.254 to ::ffff:a9fe:a9fe), which the old dotted-only regex never matched, so those resolved as "public". BlockList evaluates IPv4-mapped IPv6 against the IPv4 rules automatically, and the IPv4-in-IPv6 transition ranges (::/96, NAT64 64:ff9b::/96, 6to4 2002::/16), the full link-local fe80::/10, and multicast ff00::/8 are now covered.

Redirects are re-validated per hop via a new redirect-safe safeFetch (redirect: 'manual', re-runs the guard on every Location, depth-capped at 4, throws SsrfBlockedError), so a public URL can no longer 302 into an internal target. safeFetch replaces the raw fetch in fetch-og, and the same guard was applied to verifyCitation's two outbound fetches (HEAD existence check and body-reading GET hash check), whose host comes from untrusted AI/web-search output.

Added a 25-test node:test regression suite covering the disclosed vectors, the obfuscation families, redirect re-validation, and that legitimate public URLs still pass. Fail-closed throughout: no fetch happens on validation uncertainty. No schema/migration changes.


Claude-Session: https://claude.ai/code/session_01R13tPYPCBC8okWrKEfMh9w