### PR TITLE
fix(auth): set issuer on GitHubProvider for RFC 9207 iss validation

### DIFF
--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -22,6 +22,7 @@ const handler = NextAuth({
     GitHubProvider({
       clientId: process.env.GITHUB_CLIENT_ID!,
       clientSecret: process.env.GITHUB_CLIENT_SECRET!,
+      issuer: "https://github.com/login/oauth",
     }),
   ],
   callbacks: {


### PR DESCRIPTION
## What

One line: add `issuer: "https://github.com/login/oauth"` to `GitHubProvider({...})` in `src/app/api/auth/[...nextauth]/route.ts`. Nothing else changed — Google provider, callbacks, pages, secret, and env are untouched.

## Why

GitHub's OAuth authorization responses now carry the RFC 9207 `iss` parameter. Our locked `openid-client@5.7.1` (`oauthCallback`, `lib/client.js:584`) sees `iss` in the callback params and calls `assertIssuerConfiguration(this.issuer, 'issuer')` — with no issuer configured it throws `TypeError: issuer must be configured on the issuer` (`lib/helpers/assert.js:17`). NextAuth v4 catches that as `OAUTH_CALLBACK_ERROR` and redirects to `/?error=OAuthCallback`, which is why every GitHub login suddenly broke with no deploy-side cause (the SSRF fix in #1560 was ruled out — `safeFetch` is not imported anywhere in the auth path).

With `issuer` set, next-auth passes it into the openid-client `Issuer` (`next-auth/core/lib/oauth/client.js:17`), so the callback's `iss` is validated against `https://github.com/login/oauth` and login proceeds. GitHub has no `wellKnown` URL in the provider defaults, so this adds metadata only — no discovery request, no endpoint changes.

Failure mode if GitHub's `iss` value ever differs: openid-client throws `RPError: iss mismatch, expected https://github.com/login/oauth, got: <actual>` — the log line itself names the correct value.

## Verification

- `npx tsc --noEmit` — clean
- `npx eslint 'src/app/api/auth/[...nextauth]/route.ts'` — clean
- Confirmed in the locked deps: the throwing assert in `openid-client@5.7.1` and the `issuer: provider.issuer` plumbing in `next-auth@4.24.13`

Real login can only be verified in production after merge (needs GitHub's live callback). Do not merge from automation — Alex merges (SOC 2 gate).

---
_Generated by [Claude Code](https://claude.ai/code/session_01TV6iR5RzqQGCA1RwA82DkT)_