### PR TITLE
PR-D1: slide 01 (THE PROBLEM) reconciled to pipeline deck copy

### DIFF
--- a/src/components/landing/Landing.tsx
+++ b/src/components/landing/Landing.tsx
@@ -215,16 +215,18 @@ const PROBLEM_SHEET_SM = [
   { top: 410, cols: PROBLEM_SHEET.slice(3) },
 ] as const;
 
-// PROBLEM-CAPTION: the two lines that sit under the sheet. They are rendered
-// TWICE — on desktop INSIDE the sheet column, so they inherit the table's left
-// edge, and on mobile under the stacked grids — so the strings live here once
-// rather than being typed twice (the no-drift law). CAPTION-ANCHOR: the note
-// used to be a lone <p> child of the section with no left offset at all, so it
-// began at the page margin while A SPREADSHEET faked its alignment with a
-// pl-[560px] hand-copied from the sheet's rect x. Both magic numbers are gone:
-// on desktop the pair are simply children of the column the table fills.
-const PROBLEM_SHEET_CAPTION = 'A spreadsheet';
-const PROBLEM_SHEET_NOTE = 'As current as the last time you typed into it.';
+// PROBLEM-CAPTION: the line that sits under the sheet. It is rendered TWICE —
+// on desktop INSIDE the sheet column, so it inherits the table's left edge,
+// and on mobile under the stacked grids — so the string lives here once
+// rather than being typed twice (the no-drift law). PR-D1: the deck's caption
+// is ONE sentence joined by an em dash, not the earlier A SPREADSHEET kicker +
+// note pair, so the two consts collapsed into this one. CAPTION-ANCHOR: the
+// caption used to be a lone <p> child of the section with no left offset at
+// all, so it began at the page margin while A SPREADSHEET faked its alignment
+// with a pl-[560px] hand-copied from the sheet's rect x. Both magic numbers
+// are gone: on desktop the caption is simply a child of the column the table
+// fills.
+const PROBLEM_SHEET_CAPTION = 'A spreadsheet — as current as the last time you typed into it.';
 
 // IMPORT-COLUMNS: the eleven columns of the raw import table, for the
 // 02 / THE IMPORT slide. Four bands, each a heading plus its rows; a row is
@@ -1081,13 +1083,10 @@ FLUID, NOT 1:1. Design measured a 1728px artboard; scaled
                 ))}
               </tbody>
             </table>
-            {/* CAPTION-ANCHOR: children of the sheet column, so both lines start
-                at the table's left edge with no offset of their own. */}
-            <p className="mt-5 font-mono text-[10px] font-semibold uppercase tracking-[0.08em] text-brand-purple">
+            {/* CAPTION-ANCHOR: a child of the sheet column, so the line starts
+                at the table's left edge with no offset of its own. */}
+            <p className="mt-5 text-[15px] leading-[1.6] text-text-secondary">
               {PROBLEM_SHEET_CAPTION}
-            </p>
-            <p className="mt-[10px] text-[15px] leading-[1.6] text-text-secondary">
-              {PROBLEM_SHEET_NOTE}
             </p>
           </div>
         </div>
@@ -1108,7 +1107,7 @@ FLUID, NOT 1:1. Design measured a 1728px artboard; scaled
             is 240 / 3 = 80px a column (dividers at x=100/180, text at
             24 + c*80), with the same header band, the same six 20px data rows
             and the same rule weights as desktop. Both grids share x=20, so the
-            A SPREADSHEET caption's pl-[20px] still aligns to both and does not
+            spreadsheet caption's pl-[20px] still aligns to both and does not
             move. Every coordinate derives from each grid's `top` — the split
             and its geometry live together in PROBLEM_SHEET_SM. */}
         <div className="relative mt-6 lg:hidden">
@@ -1161,11 +1160,8 @@ FLUID, NOT 1:1. Design measured a 1728px artboard; scaled
             </p>
           ))}
         </div>
-        <p className="mt-2 pl-[20px] font-mono text-xs font-semibold uppercase tracking-[0.08em] text-brand-purple lg:hidden">
+        <p className="mt-2 max-w-[680px] pl-[20px] text-[15px] leading-[1.6] text-text-secondary lg:hidden">
           {PROBLEM_SHEET_CAPTION}
-        </p>
-        <p className="mt-4 max-w-[680px] pl-[20px] text-[15px] leading-[1.6] text-text-secondary lg:hidden">
-          {PROBLEM_SHEET_NOTE}
         </p>
         <p className="mt-6 text-[17px] lg:text-[20px] text-brand-purple">So what do these twenty-five actually give you?</p>
         <div className="mt-4 h-[30px] lg:h-10 w-px bg-border" aria-hidden="true" />


### PR DESCRIPTION
One concept, one PR: reconcile the live slide 01 copy to the approved deck, verbatim. Copy changes only — the fan geometry and the table structure are untouched.

## Audit (read-only, before editing)

Component: `src/components/landing/Landing.tsx` — consts at :164–229, section `aria-label="The problem"` at :978+.

| Element | Live text (pre-PR) | Target text | Verdict |
|---|---|---|---|
| Label | `01 / THE PROBLEM` (:979) | `01 / THE PROBLEM` | SAME |
| Headline | `Twenty-five tools.` + `<br />` + `None of them knows what the others did.` (:980–982) | `Twenty-five tools.` / `None of them knows what the others did.` | SAME |
| Sub | `Your business is one system. Your software isn&apos;t.` → renders straight apostrophe (:984) | `Your business is one system. Your software isn't.` | SAME |
| Six family names | `PROBLEM_SOURCES` (:164–171), CSS-uppercased → THE WORK · MONEY IN · MONEY OUT · WHAT YOU OWN · WHAT YOU OWE · THE PROOF | same six, converging to BY HAND | SAME |
| BY HAND | SVG text, desktop + mobile | `BY HAND` | SAME |
| Table headers | WORK \| IN \| OUT \| OWN \| OWE \| PROOF (:195–200) | same | SAME |
| 25 tools, grouping 3/4/6/5/3/4 | `PROBLEM_SHEET` (:194–201), all 25 names | same, character-for-character | SAME |
| **Caption** | Two lines: `A spreadsheet` (rendered `A SPREADSHEET`, mono caps kicker) + `As current as the last time you typed into it.` (:226–227) | **One line: `A spreadsheet — as current as the last time you typed into it.`** | **DIFF** |
| Closing question | `So what do these twenty-five actually give you?` (:1170) | same | SAME |

## Change (the one diff, only the one diff)

- The two consts collapse into one: `PROBLEM_SHEET_CAPTION = 'A spreadsheet — as current as the last time you typed into it.'` (em dash U+2014, byte-verified).
- Each breakpoint renders it exactly once — desktop as a child of the sheet column (keeps the table's left edge), mobile with the existing `pl-[20px]` grid alignment.
- Every class on the merged `<p>`s already exists in this component (`mt-5`, `mt-2`, `max-w-[680px]`, `pl-[20px]`, `text-[15px]`, `leading-[1.6]`, `text-text-secondary`, `lg:hidden`) — no new colors, sizes, or inline hex.
- Comments updated only where they described the retired two-line pair.
- Not touched: fan geometry consts, both SVGs' paths and coordinates, the `<table>` markup, slides 02/03/04.

## Verification

- `npx tsc --noEmit` — clean.
- `eslint src/components/landing/Landing.tsx` — 0 problems (identical before and after; the repo-wide `npm run lint` carries 654 pre-existing errors in unrelated root scripts, none in this file, none introduced).
- Two independent adversarial verifiers re-derived every rendered slide-01 string against the deck target (character-for-character, both breakpoints) and audited the diff for scope — both pass; zero dangling references to the deleted `PROBLEM_SHEET_NOTE`.

Branch note: work landed on the session-designated `claude/slide-01-deck-reco-ab1fvj` rather than the prompt's `claude/slide-01-deck-reconcile` — the harness pins one branch per session and forbids pushing elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc

---
_Generated by [Claude Code](https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc)_