### PR TITLE
PR-ALL-CLOSED: all steps collapsed by default; one-line pipeline headline

### DIFF
--- a/src/components/landing/Landing.tsx
+++ b/src/components/landing/Landing.tsx
@@ -35,7 +35,7 @@
  * piece — never render the same content as both drawing and text.
  * PR-COLLAPSE: each step is a disclosure —
  * header button (label + '+'/'−' glyph, the retired personas accordion's
- * shape, 5010ca1f) over a hidden-class body; step 1 open by default, a
+ * shape, 5010ca1f) over a hidden-class body; all 13 collapsed by default, a
  * #deck-NN hash opens its step on load. RUST NOTE: the deck's "rust" group-label
  * colour has no token in this palette; brand-amber (#d97706) is the mapping,
  * chosen over inventing a hex. If Design lands a true rust token, swap
@@ -885,10 +885,11 @@ export default function Landing({ onRequireAuth, onRequireLogin, logoAvailabilit
   const [showDemo, setShowDemo] = useState(false);
 
   // PR-COLLAPSE: one open flag per deck step, independent toggles (any
-  // number can be open). Step 1 ships expanded, 2–13 collapsed. Show/hide is
+  // number can be open). ALL 13 ship collapsed — the URL-hash effect below
+  // is the only thing that opens a step automatically. Show/hide is
   // instant — the body div takes the `hidden` class, no animation, and the
   // copy stays in the DOM (the personas-accordion arrangement, 5010ca1f).
-  const [openSteps, setOpenSteps] = useState<boolean[]>(() => DECK_STEP_IDS.map((_, i) => i === 0));
+  const [openSteps, setOpenSteps] = useState<boolean[]>(() => DECK_STEP_IDS.map(() => false));
   // A URL hash naming a step's section id expands that step after mount.
   // The hash never reaches the server, so this cannot be an SSR branch —
   // first paint is always the deterministic default above.
@@ -1135,7 +1136,7 @@ export default function Landing({ onRequireAuth, onRequireLogin, logoAvailabilit
         <p className={DECK.eyebrow}>THE PIPELINE — 13 STEPS</p>
         <p className={`mt-2 ${DECK.eyebrow}`}>DATE · TIME · MONEY</p>
         <h2 className={DECK.h2}>
-          One Ledger.<br />One Calendar.
+          One Ledger. One Calendar.
         </h2>
         <p className={DECK.sub}>
           The full system, start to end. Written so anyone can understand it — and build it.


### PR DESCRIPTION
Two chrome edits, nothing else. Base: `origin/main` at `30e70ae2` (#1568 merged — "THE PIPELINE — 13 STEPS" present), so this is a fresh branch per the spec.

## The diff (5+/4−, one file)

1. **All 13 steps collapsed on load** — `openSteps` initializes `DECK_STEP_IDS.map(() => false)` (Landing.tsx:892); the adjacent comment and the file-header PR-COLLAPSE note now state the new rule: all closed on load, the URL-hash effect is the only thing that opens a step automatically.
2. **One-line pipeline headline** — the header h2 drops its `<br />`: `One Ledger. One Calendar.` (Landing.tsx:1139). No class changes, no other characters; slide 11's own "One Ledger. One Calendar. / All twenty-five." headline keeps its break.

## Verification

- `npx tsc --noEmit` clean · `eslint` on the file 0 problems · `assert:showroom` passes.
- 13 collapsed bars at mount: the initializer is all-false and all 13 section classNames carry the `… : DECK.sectionBar` ternary (count verified = 13).
- `#deck-NN` hash expansion intact: the mount effect is untouched (`indexOf(window.location.hash.slice(1))` → sets that step true).
- The pipeline h2 contains no `<br />` and reads exactly "One Ledger. One Calendar." (script-verified, including that slide 11's headline is untouched).
- Hash effect, toggles, bar treatment, and all step copy unchanged — the whole diff is the two functional lines plus the two comment truthfulness fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc

---
_Generated by [Claude Code](https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc)_