### PR TITLE
PR-PERSONAS-CHROME: personas act adopts the standard act grammar

### DIFF
--- a/src/components/landing/Landing.tsx
+++ b/src/components/landing/Landing.tsx
@@ -1187,17 +1187,24 @@ export default function Landing({ onRequireAuth, onRequireLogin, logoAvailabilit
         </div>
       </section>
 
-        {/* ACT 2 — PERSONAS-3 (value cases): hook question + one outcome
+        {/* ACT 2 — PERSONAS (value cases): hook question + one outcome
             sentence per row; module-name fragments wear the mono purple
             idiom mid-sentence. Rows: border-light rules (§0's inner
             hairline — the exact #EBE4F7 token). The '·' in the act label
-            wears gold — the Act 1 label's own separator idiom. */}
+            wears gold. PERSONAS-CHROME: the act adopts the standard act
+            grammar — DONE-FOR-YOU's eyebrow/h2/py-10 classes verbatim,
+            left-aligned, rows full container width; the sentence tier is
+            slide 09's body tier. Row texts and the label are FROZEN; the
+            outer div's border-b (the personas|header rule) is untouched. */}
         <div className="w-full border-b border-border">
-          <div className="max-w-7xl mx-auto px-4 lg:px-8 pt-10 lg:pt-[60px] pb-12 lg:pb-[68px]">
-            <p className="text-center font-mono text-xs lg:text-[10px] font-semibold tracking-[0.16em] text-text-muted">
+          <div className="max-w-7xl mx-auto px-4 lg:px-8 py-10">
+            <p className="font-mono text-xs lg:text-[10px] font-semibold uppercase tracking-wider text-text-faint">
               ONE SYSTEM <span className="text-brand-gold">·</span> SIX LIVES
             </p>
-            <div className="mx-auto mt-5 max-w-[880px]">
+            <h2 className="mt-3 text-2xl sm:text-3xl font-medium tracking-tight text-brand-purple">
+              Who is this for?
+            </h2>
+            <div className="mt-5">
               {PERSONAS.map((row, index) => {
                 const open = openPersona === index;
                 return (
@@ -1211,7 +1218,7 @@ export default function Landing({ onRequireAuth, onRequireLogin, logoAvailabilit
                       <span className="font-mono text-xs font-semibold tracking-wider text-text-muted">{row.label}</span>
                       <span aria-hidden="true" className="font-mono text-[14px] text-text-faint lg:hidden">{open ? '−' : '+'}</span>
                     </button>
-                    <p className={`${open ? 'block' : 'hidden'} lg:block mt-1 text-[14.5px] text-text-primary lg:mt-0`}>
+                    <p className={`${open ? 'block' : 'hidden'} lg:block mt-1 text-[13px] leading-[1.5] lg:text-[15px] lg:leading-[1.6] text-text-secondary lg:mt-0`}>
                       {row.segments.map((seg, i) =>
                         seg.mono ? (
                           <span key={i} className="font-mono text-[12.5px] font-semibold text-brand-purple">{seg.text}</span>


### PR DESCRIPTION
Structure/classes only, 13+/6−, one file. Precondition verified: `origin/main` (`3a4e6288`, the #1571 merge) contains "ONE SYSTEM". The six row texts and the label are frozen and script-proven identical; the only new rendered string is the headline "Who is this for?".

## Audited class strings (transplant sources)

- **DONE-FOR-YOU** (pre-edit :1133–1156): section `w-full border-b border-border bg-bg-terminal`; container `max-w-7xl mx-auto px-4 lg:px-8 py-10`; eyebrow `font-mono text-xs lg:text-[10px] font-semibold uppercase tracking-wider text-text-faint`; h2 `mt-3 text-2xl sm:text-3xl font-medium tracking-tight text-brand-purple`.
- **Slide 09 body tier** (:2185): `text-[13px] leading-[1.5] lg:text-[15px] lg:leading-[1.6] text-text-secondary`.
- **Personas pre-edit** (:1195–1214): outer `w-full border-b border-border`; inner `…pt-10 lg:pt-[60px] pb-12 lg:pb-[68px]`; centered label (`text-center … tracking-[0.16em] text-text-muted`); `mx-auto mt-5 max-w-[880px]` row wrapper; sentence `text-[14.5px] text-text-primary`.

## Changes

- Container: inner div takes DONE-FOR-YOU's `py-10`; the outer div (and its border-b, the personas|header rule) is untouched — **no boundary moved, seam ledger stands as written**.
- Eyebrow: `ONE SYSTEM · SIX LIVES` left-aligned in DONE-FOR-YOU's eyebrow classes verbatim; the `·` keeps its gold span; centered idiom dropped.
- Headline: new h2 in DONE-FOR-YOU's h2 classes verbatim — "Who is this for?" (:1205).
- Rows: wrapper is now `mt-5` (full container width, left-aligned); the 220px/1fr row grid, border-light rules, and the 5010ca1f accordion wiring (button, aria-expanded, `−`/`+`, hidden body, one-open, FOUNDER default) unchanged.
- Row sentences adopt the slide-09 body tier verbatim, replacing `text-[14.5px] text-text-primary`; the hidden/block toggle and mono-purple fragment spans untouched.
- The ACT 2 comment records the chrome change.

## Freeze evidence (scripted)

- 6/6 row concatenations + labels **byte-identical to origin/main** (both consts parsed and compared programmatically).
- String-multiset diff: removals are the three superseded class strings only; additions are the four transplanted class strings — and the single rendered addition **"Who is this for?"** (multi-line JSX text, verified by direct grep at :1205).
- Chain check 13/13 closers verbatim in order; pipeline header intact.

## Gates

`npx tsc --noEmit` clean · `eslint` on the file 0 problems · `assert:showroom` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc

---
_Generated by [Claude Code](https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc)_