### PR TITLE
PR-PIPE-TITLE: pipeline header states the data-pipe-and-foundation claim

### DIFF
--- a/src/components/landing/Landing.tsx
+++ b/src/components/landing/Landing.tsx
@@ -1235,12 +1235,14 @@ export default function Landing({ onRequireAuth, onRequireLogin, logoAvailabilit
         </div>
 
 
-      {/* ── THE PIPELINE HEADER (PR-CHROME). Names the 13-step run so the
-            collapsed bars below read as one unit. The headline and sub are
-            the essay's front matter, VERBATIM — no invented sentences; the
-            two mono lines are the run's name and the essay's Date · Time ·
-            Money subtitle in the label tier. Act grammar, existing classes
-            only.
+      {/* ── THE PIPELINE HEADER (PR-CHROME → PR-PIPE-TITLE). Names the
+            13-step run so the collapsed bars below read as one unit, and
+            says what the pipeline IS — the data pipe the whole system runs
+            on. The headline and sub are the essay's front matter, VERBATIM
+            (the essay updated to the data-pipe-and-foundation claim in the
+            same breath as this PR); the two mono lines are the run's name
+            and the essay's Date · Time · Money subtitle in the label tier.
+            Act grammar, existing classes only.
             SEAM: this act takes border-b — done-for-you's border-b closes
             done-for-you|header from above, and this act's border-b closes
             header|01, which preserves 01's own no-border exception exactly
@@ -1250,10 +1252,10 @@ export default function Landing({ onRequireAuth, onRequireLogin, logoAvailabilit
         <p className={DECK.eyebrow}>THE PIPELINE — 13 STEPS</p>
         <p className={`mt-2 ${DECK.eyebrow}`}>DATE · TIME · MONEY</p>
         <h2 className={DECK.h2}>
-          One Ledger. One Calendar.
+          One data pipe runs the whole system.
         </h2>
         <p className={DECK.sub}>
-          The full system, start to end. Written so anyone can understand it — and build it.
+          Thirteen steps turn raw data into one Ledger and one Calendar — the foundation everything else is built on. Written so anyone can understand it — and build it.
         </p>
       </section>
 


### PR DESCRIPTION
Two rendered strings change; nothing else (10+/8−, one file — the extra lines are the act comment's provenance note). Precondition verified: `origin/main` (`605ab3f2`, the #1572 merge) contains "Who is this for?".

## Audit cites (pre-edit)

Header act: comment :1238–1248 (provenance: "the essay's front matter, VERBATIM"), eyebrows :1250–1251, h2 text :1253 ("One Ledger. One Calendar.", single line), sub :1256. Slide 11's own h2 at :2326 (`One Ledger. One Calendar.<br />All twenty-five.`) — the near-twin that must not move.

## Edits

1. **h2** (:1255) → `One data pipe runs the whole system.` — same element, same `DECK.h2` classes, still one line, no `<br />`.
2. **Sub** (:1258) → `Thirteen steps turn raw data into one Ledger and one Calendar — the foundation everything else is built on. Written so anyone can understand it — and build it.` — same element, same `DECK.sub` classes; both em dashes are U+2014.
3. **Act comment** (:1238–1245) → records that the essay's front matter updated to the data-pipe-and-foundation claim in the same breath, so "essay front matter, verbatim" stays a true statement.
4. Nothing else: eyebrow lines ("THE PIPELINE — 13 STEPS", "DATE · TIME · MONEY"), bars, steps, and the personas act are frozen (context-only in the diff).

## Verification (scripted)

- Both new strings render exactly; both old strings absent from the file.
- **Slide 11 confirmed untouched**: `One Ledger. One Calendar.<br />All twenty-five.` still present — the absence check for the old header h2 was scoped to its single-line no-br form so the slide-11 twin couldn't mask a miss.
- Chain check 13/13 closers verbatim, in order.
- `npx tsc --noEmit` clean · `eslint` on the file 0 problems · `assert:showroom` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc

---
_Generated by [Claude Code](https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc)_