### PR TITLE
fix(landing): literal titles — the lane metaphor dies

### DIFF
--- a/src/components/landing/Landing.tsx
+++ b/src/components/landing/Landing.tsx
@@ -20,10 +20,10 @@
  *   03 / IMPORT THE DATA      — the raw import table, twelve arrivals, the promises
  *   04 / LABEL THE DATA       — one rule per feed, thirteen rows, four kinds
  *   05 / MAP THE DATA TO ITS TABLE — five tables; the kind is the address
- *   06 / SPLIT THE DATA INTO TWO LANES — observed vs authored
+ *   06 / SEPARATE WHAT HAPPENED TO YOU FROM WHAT YOU DID — observed vs authored
  *   07 / RUN THE LOOP         — discover → decide → commit → record
  *   08 / STORE EVERYTHING YOU DO IN ONE MASTER TABLE
- *   09 / MATCH THE TWO LANES  — the deposit meets the invoice
+ *   09 / MATCH WHAT HAPPENED TO WHAT YOU DID — the deposit meets the invoice
  *   10 / LET THE RULES WRITE THE LINES
  *   11 / TURN THE LINES INTO ANSWERS
  *   12 / OPEN THE TWO WINDOWS — the Ledger and the Calendar
@@ -458,8 +458,11 @@ const IMPORT_TRIO = [
 // punctuation-derived.
 // ─────────────────────────────────────────────────────────────────────────
 
-// DECK-05 (PR-VOICE): the two lanes, each a rust header over the essay's own
-// sentences — one <p> per line, in the lane's prose tier. AUTHORED's last
+// DECK-06 (PR-VOICE → PR-LANES): the observed and authored columns, each a
+// rust header over the essay's own sentences — one <p> per line, in the
+// column's prose tier. (The const keeps its historical LANE_COLUMNS name —
+// the lane metaphor died as rendered copy in PR-LANES; the identifier is
+// code, not copy.) AUTHORED's last
 // three lines are the essay's framing + (1)(2) draft/commit enumeration; the
 // '(N) ' prefixes are content, not styling.
 const LANE_COLUMNS = [
@@ -2081,11 +2084,11 @@ export default function Landing({ onRequireAuth, onRequireLogin, logoAvailabilit
         </div>
       </section>
 
-      {/* ── DECK-06 / THE TWO LANES. First of the PR-DECK back nine. From
+      {/* ── DECK-06 / OBSERVED VS AUTHORED. First of the PR-DECK back nine. From
             here down, the act grammar rides the module-scope DECK const so
             nine acts cannot drift from 01–04 or from each other. Bare
             two-column prose — the deck gives 05 no table. border-t closes
-            handoff|lanes per the seam ledger. */}
+            handoff|06 per the seam ledger. */}
       <section id="deck-06" aria-label="The two lanes" className={openSteps[5] ? DECK.section : DECK.sectionBar}>
         <button
           type="button"
@@ -2094,7 +2097,7 @@ export default function Landing({ onRequireAuth, onRequireLogin, logoAvailabilit
           onClick={() => toggleStep(5)}
           className={DECK.stepButton}
         >
-          <span className={DECK.eyebrow}>06 / SPLIT THE DATA INTO TWO LANES</span>
+          <span className={DECK.eyebrow}>06 / SEPARATE WHAT HAPPENED TO YOU FROM WHAT YOU DID</span>
           <span aria-hidden="true" className={DECK.eyebrow}>{openSteps[5] ? '−' : '+'}</span>
         </button>
         <div id="deck-06-body" className={openSteps[5] ? undefined : 'hidden'}>
@@ -2259,7 +2262,7 @@ export default function Landing({ onRequireAuth, onRequireLogin, logoAvailabilit
           onClick={() => toggleStep(8)}
           className={DECK.stepButton}
         >
-          <span className={DECK.eyebrow}>09 / MATCH THE TWO LANES</span>
+          <span className={DECK.eyebrow}>09 / MATCH WHAT HAPPENED TO WHAT YOU DID</span>
           <span aria-hidden="true" className={DECK.eyebrow}>{openSteps[8] ? '−' : '+'}</span>
         </button>
         <div id="deck-09-body" className={openSteps[8] ? undefined : 'hidden'}>
@@ -2267,7 +2270,7 @@ export default function Landing({ onRequireAuth, onRequireLogin, logoAvailabilit
             The deposit meets the invoice.<br />The fill meets the order.
           </h2>
           <p className={DECK.sub}>
-            Now the two lanes meet.
+            Now observed meets authored.
           </p>
 
           <div className="mt-10 lg:mt-[76px] grid gap-6 lg:grid-cols-[1fr_260px_1fr] lg:gap-0">


### PR DESCRIPTION
## PR-LANES — three rendered strings, nothing else

Precondition held: main contains `THE JOB` (#1578 merged at `5cbc751e`). One file, `12+/9−`.

### The three edits

| # | Was | Now | Where |
|---|---|---|---|
| 1 | `06 / SPLIT THE DATA INTO TWO LANES` | `06 / SEPARATE WHAT HAPPENED TO YOU FROM WHAT YOU DID` | bar label `Landing.tsx:2100` (+ ACTS map `:23`) |
| 2 | `09 / MATCH THE TWO LANES` | `09 / MATCH WHAT HAPPENED TO WHAT YOU DID` | bar label `:2265` (+ ACTS map `:26`) |
| 3 | "Now the two lanes meet." | "Now observed meets authored." | slide-09 opener `:2273` |

All three match the attached essay's Step 6/Step 9 titles and Step 9 opener verbatim.

### The sweep (`grep -i lane`) — full disposition

| Hit | Disposition |
|---|---|
| `aria-label="The two lanes"` on the deck-06 section (`:2092`) | **Reported, not changed** — user-facing to assistive tech but not one of the three ruled strings. Yours to rule; a follow-up one-liner if you want it to say e.g. "Observed vs authored" |
| `LANE_COLUMNS` const name + `lane` map variable (`:468`, `:2112–2115`) | Code identifiers, never rendered — kept, declared in the comment |
| Comments (`:461–464` const provenance, `:2087` act comment, `:2091` seam note, ACTS map lines) | Truth-updated |

### Also observed, not touched (out of mandate)

Five const-provenance comments carry stale pre-renumber anchors from PR-STEP-2: `DECK-06 (PR-VOICE)` on LOOP_BEATS `:484` (act is 07 now), `DECK-07` on the master-table const `:502` (→08), `DECK-09` on the sale `:530` (→10), `DECK-12` on the truths `:625` (→13), `DECK-13` on the reverse walk `:646` (→14). None mention lanes; a one-pass comment sweep can fix them if you want it.

### Verification (all pass)

- `tsc --noEmit` clean · `eslint` 0 problems · `assert:showroom` passes
- Chain check: 14/14 closers verbatim, forward order (closers untouched)
- `grep -i lane`: **zero rendered text hits** — the survivors are the reported aria-label, code identifiers, and truth-updated comments

Do not merge — Alex reviews.

---
_Generated by [Claude Code](https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc)_