### PR TITLE
feat(landing): the two mechanical truths — who decides a kind, and the two doors

### DIFF
--- a/src/components/landing/Landing.tsx
+++ b/src/components/landing/Landing.tsx
@@ -1995,9 +1995,10 @@ export default function Landing({ onRequireAuth, onRequireLogin, logoAvailabilit
             </tbody>
           </table>
 
-          {/* PR-VOICE: the essay's fifth-kind tease and the rule block, after
-              the routing table. */}
-          <p className={`mt-[22px] lg:mt-8 ${DECK.statement}`}>And there is a fifth kind; but no feed ever earns it. We will meet it soon.</p>
+          {/* PR-MECHANICS: the essay's who-decides passage, verbatim, then
+              (PR-VOICE) the fifth-kind tease and the rule block. */}
+          <p className={`mt-[22px] lg:mt-8 ${DECK.statement}`}>And who decides the kind? We do — once per feed. We ask one question: what IS this thing, really? The answer becomes the rule&apos;s row, and the system applies it forever after.</p>
+          <p className={`mt-2 ${DECK.statement}`}>And there is a fifth kind; but no feed ever earns it. We will meet it soon.</p>
           <p className={`mt-2 ${DECK.statement}`}>Here is what makes this step different from every software you have ever met: each kind is given by a rule, and a rule is one written row in a table. Anyone can read it. Anyone can argue with it. It is not a guess buried in code.</p>
           <div className="mt-8 lg:mt-12 h-px w-full bg-border" aria-hidden="true" />
           <p className="mt-[22px] lg:mt-8 text-[12px] lg:text-[14px] text-text-faint">
@@ -2127,6 +2128,8 @@ export default function Landing({ onRequireAuth, onRequireLogin, logoAvailabilit
               </div>
             ))}
           </div>
+          {/* PR-MECHANICS: the essay's two-doors mechanical truth, verbatim. */}
+          <p className={`mt-[22px] lg:mt-8 ${DECK.statement}`}>And here is the mechanical truth: this step adds nothing to the tables. Observed things already live in the tables from Step 5; that is the world&apos;s door. Authored things will get their own home in Step 8; that is your door. Two doors into one system — and how the two connect comes soon.</p>
 
           <div className={DECK.hairline} aria-hidden="true" />
           <p className={DECK.q}>So how exactly do you make something happen?</p>


### PR DESCRIPTION
## PR-MECHANICS — copy only, two insertions

Precondition held: main contains `LABEL EVERY FEED BY ITS KIND` (#1582 merged at `1983eed4`). One file, `6+/3−`.

### Edit 1 — who decides the kind (slide 04, `Landing.tsx:2001`)

Essay-verbatim, statement tier, seated between the routing table and the fifth-kind tease:

> And who decides the kind? We do — once per feed. We ask one question: what IS this thing, really? The answer becomes the rule's row, and the system applies it forever after.

One spacing note, flagged: the fifth-kind tease keeps its text byte-identical but drops from the lead-statement margin (`mt-[22px] lg:mt-8`) to the follower margin (`mt-2`) — the statement-stack idiom's rule that the first statement after a block carries the big margin, which the new passage now is.

### Edit 2 — the two doors (slide 06, `Landing.tsx:2126`)

Essay-verbatim, statement tier, seated between the observed/authored columns (whose AUTHORED column ends on the (1)(2) draft/commit lines) and the closer:

> And here is the mechanical truth: this step adds nothing to the tables. Observed things already live in the tables from Step 5; that is the world's door. Authored things will get their own home in Step 8; that is your door. Two doors into one system — and how the two connect comes soon.

Its "Step 5" / "Step 8" references match the deck's current numbering.

### Edit 3 — nothing else

### Verification (all pass)

- `tsc --noEmit` clean · `eslint` 0 problems · `assert:showroom` passes
- Chain check: 14/14 closers verbatim, forward order
- Both passages byte-identical to the essay (apostrophes render as `&apos;` per house JSX idiom; verified after entity-decode) and position-proven: routing-table → who-decides → fifth-kind tease, and grid → two-doors → hairline → closer

Do not merge — Alex reviews.

---
_Generated by [Claude Code](https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc)_