### PR TITLE
fix: true-slots rule — liteapi in the flights slots; matcher claims propose-true; example declared

### DIFF
--- a/src/components/home/TravelShowcaseSections.tsx
+++ b/src/components/home/TravelShowcaseSections.tsx
@@ -120,7 +120,7 @@ function TravelHeroTerminal() {
         <ExampleTag text="Real vendors" />
       </div>
       <div className="mt-2 space-y-0.5 text-text-secondary">
-        <p><span className="text-text-faint">FLIGHTS</span> real offers <span className="float-right text-text-secondary">Duffel</span></p>
+        <p><span className="text-text-faint">FLIGHTS</span> real offers <span className="float-right text-text-secondary">LiteAPI</span></p>
         <p><span className="text-text-faint">HOTELS</span> search + guest booking <span className="float-right text-text-secondary">LiteAPI</span></p>
         <p><span className="text-text-faint">ACTIVITIES + TRANSFERS</span> real tours &amp; rides <span className="float-right text-text-secondary">Viator</span></p>
         <p><span className="text-text-faint">PLACES</span> premium local picks <span className="float-right text-text-secondary">Google</span></p>
@@ -199,7 +199,7 @@ function FlightCheckoutMirror() {
   return (
     <DarkSlide title="Flight checkout — real card element, test rails" tag="Mirror · labeled">
       <div className="space-y-1 text-text-secondary">
-        <p><span className="text-text-faint">search</span> <span className="float-right text-text-secondary">real Duffel offers, real prices</span></p>
+        <p><span className="text-text-faint">search</span> <span className="float-right text-text-secondary">real LiteAPI offers, real prices</span></p>
         <p><span className="text-text-faint">passenger</span> <span className="float-right text-text-secondary">name · DOB · passport (intl)</span></p>
         <p><span className="text-text-faint">payment intent</span> <span className="float-right text-text-secondary">→ client_token</span></p>
         <p><span className="text-text-faint">card element</span> <span className="float-right text-text-secondary">Duffel&rsquo;s own — PCI, never our server</span></p>

--- a/src/components/landing/Landing.tsx
+++ b/src/components/landing/Landing.tsx
@@ -289,7 +289,7 @@ const PROVIDER_MENU = [
   ['banks & accounts', 'plaid', 'teller'],
   ['card money', 'stripe', 'square'],
   ['trades & market data', 'tastytrade', 'schwab · ibkr · alpaca · tradier · snaptrade'],
-  ['flights', 'duffel', 'amadeus'],
+  ['flights', 'liteapi', 'amadeus'],
   ['hotels', 'liteapi', 'amadeus'],
   ['activities', 'viator', '—'],
   ['locations', 'google places', '—'],
@@ -367,7 +367,7 @@ const IMPORT_ARRIVALS = [
   ['plaid · boa', 'transaction', '09:14:09Z', 'DONE'],
   ['stripe', 'payout', '09:14:02Z', 'DONE'],
   ['tastytrade', 'quote', '10:31:00Z', 'DONE'],
-  ['duffel', 'booking', '10:33:27Z', 'DONE'],
+  ['liteapi', 'booking', '10:33:27Z', 'DONE'],
   ['liteapi', 'stay', '10:36:44Z', 'DONE'],
   ['viator', 'activity', '10:39:12Z', 'DONE'],
   ['google places', 'place', '10:42:58Z', 'DONE'],
@@ -379,7 +379,7 @@ const IMPORT_ARRIVALS = [
 
 // ROUTING-RULES (PR-DECK → PR-STEP-2 → PR-SIX): the whole routing decision,
 // for the 04 / THE ROUTING slide, as [provider, resource, kind, means].
-// FOURTEEN ROWS — eleven of the providers Step 02 names, five kinds,
+// FOURTEEN ROWS — ten of the providers Step 02 names, five kinds,
 // providers repeating because a feed sends more than one shape. The MEANS
 // column speaks only on a kind's FIRST appearance ('something that happened'
 // · 'one of your accounts' · 'how things stood at one moment' · 'a fact
@@ -404,7 +404,7 @@ const ROUTING_RULES = [
   ['tastytrade', 'fill', 'EVENT', ''],
   ['sec', 'filing', 'REFERENCE', ''],
   ['fred', 'series', 'REFERENCE', ''],
-  ['duffel', 'booking', 'EVENT', ''],
+  ['liteapi', 'booking', 'EVENT', ''],
   ['liteapi', 'stay', 'EVENT', ''],
   ['viator', 'activity', 'EVENT', ''],
   ['google places', 'place', 'REFERENCE', ''],
@@ -1077,7 +1077,7 @@ export default function Landing({ onRequireAuth, onRequireLogin, logoAvailabilit
               {/* HERO-REPO-1 (Alex's rationale): the hosted product leads —
                   "Create free account" is the promoted white CTA. The repo
                   joins as the bordered-ghost secondary: cloning requires
-                  provisioning every API (Duffel / LiteAPI / Plaid / Stripe /
+                  provisioning every API (LiteAPI / Plaid / Stripe /
                   Anthropic / …) — most won't, many can't, and Alex sells setup
                   for those who want it; open-sourcing extends the honesty
                   thesis to the code. "See how it works ↓" left the hero (the
@@ -1841,7 +1841,7 @@ export default function Landing({ onRequireAuth, onRequireLogin, logoAvailabilit
             ))}
           </table>
 
-          <p className="mt-10 lg:mt-[76px] font-mono text-[10px] lg:text-[11px] uppercase tracking-[0.20em] text-brand-amber">TWELVE ARRIVALS, ONE TABLE</p>
+          <p className="mt-10 lg:mt-[76px] font-mono text-[10px] lg:text-[11px] uppercase tracking-[0.20em] text-brand-amber">TWELVE ARRIVALS, ONE TABLE — AN EXAMPLE</p>
 
           {/* TABLE 2 — the twelve arrivals, four columns
               (provider·connection | resource | time | status), no thead (the
@@ -1854,7 +1854,7 @@ export default function Landing({ onRequireAuth, onRequireLogin, logoAvailabilit
           <table className="mt-[14px] lg:mt-[18px] w-full table-fixed border-separate border-spacing-0 border border-border">
             <tbody>
               {IMPORT_ARRIVALS.map((row, r) => (
-                <tr key={row[0]}>
+                <tr key={`${row[0]}-${row[1]}`}>
                   {row.map((cell, c) => (
                     <td
                       key={cell}
@@ -2331,7 +2331,7 @@ export default function Landing({ onRequireAuth, onRequireLogin, logoAvailabilit
               checks — the text below never restates them. */}
           <p className={`mt-[22px] lg:mt-8 ${DECK.statement}`}>Click; one match.</p>
           <p className={`mt-2 ${DECK.statement}`}>The deposit found its invoice. The fill found its order. The card charge found its booking. Nobody hunted through statements!</p>
-          <p className={`mt-2 ${DECK.statement}`}>(A piece of this is already alive today: card charges find their bookings on their own.)</p>
+          <p className={`mt-2 ${DECK.statement}`}>(A piece of this is already alive today: card charges find their bookings and propose the match — you approve it.)</p>
           <p className={`mt-2 ${DECK.statement}`}>Matched means real; the world just confirmed what you did.</p>
           <p className={DECK.q}>Matched and real. So who writes the debits and credits?</p>
         </div>
@@ -2679,7 +2679,7 @@ export default function Landing({ onRequireAuth, onRequireLogin, logoAvailabilit
             </p>
             <p className="mt-2 font-mono text-[11px] leading-[1.6] lg:text-[12px] text-text-secondary">{HOURS_TRUTH}</p>
           </div>
-          <p className={`mt-[14px] ${DECK.statement}`}>The travel match is already alive today: card charges find their bookings on their own.</p>
+          <p className={`mt-[14px] ${DECK.statement}`}>The travel match is already alive today: card charges find their bookings and propose the match — you approve it.</p>
 
           <div className={DECK.hairline} aria-hidden="true" />
           <p className={DECK.q}>Beautiful. But why should you believe any of it?</p>

--- a/src/components/sections/ModulesSection.tsx
+++ b/src/components/sections/ModulesSection.tsx
@@ -241,13 +241,13 @@ export default function ModulesSection() {
                 Plan trips. Split costs. Skip the spreadsheet.
               </h3>
               <p className="text-terminal-lg text-text-muted mb-8 leading-relaxed">
-                Create a trip, invite people, build the itinerary together. Date finder shows when everyone's free. AI assistant pulls real vendor data from Google Places and flight quotes from Duffel — picks places to stay, eat, and do stuff based on your budget and preferences. Commit the costs, they flow into your budget and calendar.
+                Create a trip, invite people, build the itinerary together. Date finder shows when everyone's free. AI assistant pulls real vendor data from Google Places and flight quotes from LiteAPI — picks places to stay, eat, and do stuff based on your budget and preferences. Commit the costs, they flow into your budget and calendar.
               </p>
               <ul className="space-y-3">
                 {[
                   'Invite travelers, find dates that work',
                   'AI recommends lodging, food, activities',
-                  'Live flight quotes from Duffel',
+                  'Live flight quotes from LiteAPI',
                   'Split expenses — see who owes who',
                   'Commit costs → budget + calendar'
                 ].map((item, i) => (


### PR DESCRIPTION
## PR-TRUE-SLOTS

Precondition held: origin/main = `68a14189`, "posting took zero" present. Assumes the founder's confirmed production ruling `FLIGHTS_LANE=liteapi`. Three files, `13+/13−`.

### Ruled edits, delivered (fresh cites)

| # | Edit | Cite |
|---|---|---|
| 1 | Menu flights TODAY → `liteapi` | `Landing.tsx:292` |
| 2 | Arrivals row → `['liteapi', 'booking', '10:33:27Z', 'DONE']` | `:370` |
| 3 | Routing row → `['liteapi', 'booking', 'EVENT', '']` | `:407` |
| 4 | "Duffel / " removed from the provisioning list — **anchor note: `:1080` is the HERO-REPO-1 comment, not rendered DFY copy**; applied as ruled | `:1080` |
| 5 | The four ruled showcase claims → LiteAPI, wording otherwise untouched — **anchor note: `ModulesSection.tsx` lives at `src/components/sections/`, not `home/`** | `sections/ModulesSection.tsx:244,:250`; `home/TravelShowcaseSections.tsx:123,:202` |
| 6 | Caption → `TWELVE ARRIVALS, ONE TABLE — AN EXAMPLE` | `Landing.tsx:1844` |
| 7 | Both alive-today lines → "card charges find their bookings and propose the match — you approve it", chrome preserved | `:2334`, `:2682` |

**Two companion fixes required by the ruled edits, flagged:** the arrivals `<tr>` key went composite (`` key={`${row[0]}-${row[1]}`} ``, `:1857`) because edit 2 creates two rows with `row[0]==='liteapi'` — duplicate React keys otherwise; and the routing comment's "eleven of the providers" became "ten" (`:381`) — duffel's departure drops the table's provider count.

### Verification

- `tsc --noEmit` clean · `assert:showroom` passes · chain 14/14 closers verbatim
- Census line **unchanged and code-true**: "121 feeds from 20 providers — counted August 24, 2026"
- Line 1 (slide 09) byte-matches essay v10 Step 9. All ruled slots and the caption verified exact. Rendered duffel = 0 in `Landing.tsx` and `ModulesSection.tsx`

### Reported, not improvised — for the founder's ruling

1. **Verify-gate miss, declared:** "rendered duffel = 0" is NOT met for `TravelShowcaseSections.tsx` — it carries **five rendered Duffel strings the ruling did not enumerate**, all describing the Duffel checkout rail specifically: `:205` "Duffel's own — PCI, never our server", `:208` "Test mode — no real charge. Use a Duffel test card.", `:344` "Guests search real vendors — Duffel flights…", `:358` "The search is live Duffel inventory. The checkout is the real thing too — Duffel's own card element…" (plus comments `:31,:45,:62,:195`). Blind word-swaps would create falsehoods (LiteAPI's checkout is not "Duffel's own card element"), so these need ruled wording.
2. **Essay-internal discrepancy:** essay v10's Step 9 (`:219`) carries the new propose-true clause, but its Step 13 (`:319`) still says "on their own" — so slide 13's line now matches the ruled clause, not essay Step 13 byte-for-byte. One word in the essay doc closes it.
3. **Census wording drift:** essay v10 now says "We will show you a small **example**"; the deck's census line still says "small **sample**" — not in this PR's edit list ("NOTHING ELSE"), left untouched.
4. **Pre-existing eslint:** `ModulesSection.tsx` fails `react/no-unescaped-entities` ×4 (`:12,:244,:361`) — verified identical on origin/main before this diff; not introduced or fixed here.

Do not merge — Alex reviews.

---
_Generated by [Claude Code](https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc)_