### PR TITLE
fix: showcase speaks the LiteAPI rail; census says example; slide 13 essay-synced

### DIFF
--- a/src/components/home/TravelShowcaseSections.tsx
+++ b/src/components/home/TravelShowcaseSections.tsx
@@ -59,7 +59,7 @@
  * ── VERBATIM STRINGS CARRIED ─────────────────────────────────────────────────
  *   "Flight search is temporarily paused. Please try again later."
  *                                          flights/search/route.ts:90
- *   "Test mode — no real charge. Use a Duffel test card."
+ *   "Test mode — no real charge. Use a Stripe test card."
  *                                          FlightCheckoutPanel.tsx:206
  *   "Test mode — use card 4242 4242 4242 4242, any future date, any CVV. No
  *    real charge."                         CheckoutPanel.tsx:269-270
@@ -202,10 +202,10 @@ function FlightCheckoutMirror() {
         <p><span className="text-text-faint">search</span> <span className="float-right text-text-secondary">real LiteAPI offers, real prices</span></p>
         <p><span className="text-text-faint">passenger</span> <span className="float-right text-text-secondary">name · DOB · passport (intl)</span></p>
         <p><span className="text-text-faint">payment intent</span> <span className="float-right text-text-secondary">→ client_token</span></p>
-        <p><span className="text-text-faint">card element</span> <span className="float-right text-text-secondary">Duffel&rsquo;s own — PCI, never our server</span></p>
+        <p><span className="text-text-faint">card element</span> <span className="float-right text-text-secondary">Nuitée&rsquo;s Stripe — PCI, never our server</span></p>
         <p><span className="text-text-faint">order</span> <span className="float-right text-text-secondary">server verifies intent, then books</span></p>
         <p className="mt-1 rounded border border-brand-amber/40 bg-brand-amber/10 px-2 py-1 text-[10px] text-brand-amber">
-          Test mode — no real charge. Use a Duffel test card.
+          Test mode — no real charge. Use a Stripe test card.
         </p>
         <p className="text-[10px] italic text-text-faint">
           Honest stops: live charging is double-flag-blocked, and orders don&rsquo;t persist to your
@@ -341,7 +341,7 @@ export default function TravelShowcase({ onRequireAuth }: Props) {
         {
           title: 'Real searches, free by design.',
           copy:
-            'Guests search real vendors — Duffel flights, LiteAPI hotels, Viator tours and rides, visa rules — with no account. It stays free because it has to: our vendor agreements require it, and the caps keep it safe. When a limit is hit, the page says "temporarily paused" instead of showing you something fake.',
+            'Guests search real vendors — LiteAPI flights and hotels, Viator tours and rides, visa rules — with no account. It stays free because it has to: our vendor agreements require it, and the caps keep it safe. When a limit is hit, the page says "temporarily paused" instead of showing you something fake.',
           panel: <GuardsPanel />,
           panelSide: 'left',
         },
@@ -355,7 +355,7 @@ export default function TravelShowcase({ onRequireAuth }: Props) {
         {
           title: 'Flights: real prices, real card element — honest about the rest.',
           copy:
-            'The search is live Duffel inventory. The checkout is the real thing too — Duffel’s own card element, payment verified server-side before any order. And the page tells you the truth: test mode, no real charge, and orders don’t persist to an account yet. No pretending.',
+            'The search is live LiteAPI inventory. The checkout is the real thing too — a Stripe card element on Nuitée’s own account, payment verified server-side before any order. And the page tells you the truth: test mode, no real charge, and orders don’t persist to an account yet. No pretending.',
           panel: <FlightCheckoutMirror />,
           panelSide: 'left',
         },

--- a/src/components/landing/Landing.tsx
+++ b/src/components/landing/Landing.tsx
@@ -351,7 +351,7 @@ const IMPORT_COLUMNS: ReadonlyArray<{ band: string; rows: ReadonlyArray<readonly
 
 // IMPORT-ARRIVALS (PR-STEP-2): twelve rows that landed, ONE PER SPEAKING
 // PROVIDER, as [provider·connection, resource, received, status] — the
-// SMALL SAMPLE the census line under the strip promises (PR-REALITY): twelve
+// SMALL EXAMPLE the census line under the strip promises (PR-REALITY): twelve
 // arrivals drawn from Step 02's menu, in the menu's row order. Plaid rows
 // TWICE with two different connections (chase / boa) because that is the
 // deck's own teaching — 'because you might have two or more banks' — and
@@ -1869,8 +1869,8 @@ export default function Landing({ onRequireAuth, onRequireLogin, logoAvailabilit
           </table>
           {/* PR-REALITY: the essay's census line, verbatim — the count is the
               2026-08-24 FEED-INVENTORY audit's number, and the strip above is
-              the small sample this line promises. */}
-          <p className={`mt-[14px] ${DECK.statement}`}>And here is the real size of it: today that is 121 feeds from 20 providers — counted August 24, 2026. We will show you a small sample, so the idea stays small enough to hold.</p>
+              the small example this line promises. */}
+          <p className={`mt-[14px] ${DECK.statement}`}>And here is the real size of it: today that is 121 feeds from 20 providers — counted August 24, 2026. We will show you a small example, so the idea stays small enough to hold.</p>
           {/* PR-SIX: the essay's handshake honesty line, verbatim. */}
           <p className={`mt-2 ${DECK.statement}`}>One more honest line: a few things we fetch are not data at all — handshakes, like the token that opens a bank connection. Handshakes are not data; they are how we knock on the door. They never enter the tables.</p>
 


### PR DESCRIPTION
## PR-SLOTS-2 — the last true-slots leftovers

Precondition held: main contains `TWELVE ARRIVALS, ONE TABLE — AN EXAMPLE` (#1585 merged at `6f4fd163`). Two files, `8+/8−`.

### Edits, delivered (file:line)

| # | Edit | Cite |
|---|---|---|
| 1 | Card-element cell → `Nuitée&amp;rsquo;s Stripe — PCI, never our server` (the file's `&amp;rsquo;` idiom preserved — a raw apostrophe would trip `react/no-unescaped-entities`) | `TravelShowcaseSections.tsx:205` |
| 2 | Test banner → "Test mode — no real charge. Use a **Stripe** test card." (+ the comment at `:62` quoting that string, lockstep) | `:208` |
| 3 | Vendors sentence → "…real vendors — LiteAPI flights and hotels, Viator tours and rides, visa rules…" — surrounding chrome untouched | `:344` |
| 4 | Checkout sentence → "The search is live LiteAPI inventory. The checkout is the real thing too — a Stripe card element on Nuitée's own account, payment verified server-side before any order." — trailing sentences untouched, typographic-apostrophe idiom preserved. **No fifth rendered Duffel string exists** — the remaining hits (`:31`, `:45`, `:195`) are code-path comments describing the mirrored checkout mechanics, not rendered copy | `:358` |
| 5 | Census line → "small **example**", essay v11 verbatim; numbers untouched (121/20, August 24, 2026). Two provenance comments quoting "sample" updated in lockstep (`:1872`, `:354`) | `Landing.tsx:1873` |
| 6 | Slide-13 line **confirmed byte-identical** to essay v11 Step 13 — the essay's own update closed the #1585-reported discrepancy; no edit needed | `:2682` |

### Verification (all pass)

- `tsc --noEmit` clean · `eslint` **0 problems on both touched files** (ModulesSection untouched — its 4 known pre-existing failures unchanged) · `assert:showroom` passes
- Chain 14/14 closers verbatim, forward order
- **Rendered duffel = 0 in TravelShowcaseSections.tsx** — the #1585 verify gate now closes
- Census line renders exactly and is byte-identical in essay v11; slide-13 line byte-identical in essay v11

Do not merge — Alex reviews.

---
_Generated by [Claude Code](https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc)_