### PR TITLE
feat(landing): step 1 declares its three moves — a, b, c

### DIFF
--- a/src/components/landing/Landing.tsx
+++ b/src/components/landing/Landing.tsx
@@ -15,7 +15,7 @@
  *   [PR-MODULES placeholder — "the what", content TBD]
  *   DONE-FOR-YOU        — the professional-services panel
  *   THE PIPELINE header — names the 14-step run (essay front matter, PR-CHROME)
- *   01 / IDENTIFY THE PROBLEM, THE TOOLS YOU NEED, AND THEIR FAMILIES — the six-source fan + the twenty-five-tool sheet
+ *   01 / IDENTIFY THE PROBLEM — three moves, the six-source fan + the twenty-five-tool sheet
  *   02 / LOOK AT THE TOOLS AND PICK THE PROVIDERS BEHIND THEM — the provider menu + the open doors
  *   03 / IMPORT THE DATA AND SEE HOW IT ARRIVES — the raw import table, twelve arrivals, the promises
  *   04 / LABEL EVERY FEED BY ITS KIND — one rule per feed, thirteen rows, four kinds
@@ -1486,7 +1486,7 @@ export default function Landing({ onRequireAuth, onRequireLogin, logoAvailabilit
           onClick={() => toggleStep(0)}
           className={DECK.stepButton}
         >
-          <span className="font-mono text-xs lg:text-[10px] font-semibold uppercase tracking-[0.12em] text-text-faint">01 / IDENTIFY THE PROBLEM, THE TOOLS YOU NEED, AND THEIR FAMILIES</span>
+          <span className="font-mono text-xs lg:text-[10px] font-semibold uppercase tracking-[0.12em] text-text-faint">01 / IDENTIFY THE PROBLEM</span>
           <span aria-hidden="true" className="font-mono text-xs lg:text-[10px] font-semibold uppercase tracking-[0.12em] text-text-faint">{openSteps[0] ? '−' : '+'}</span>
         </button>
         <div id="deck-01-body" className={openSteps[0] ? undefined : 'hidden'}>
@@ -1496,6 +1496,11 @@ export default function Landing({ onRequireAuth, onRequireLogin, logoAvailabilit
           <p className="mt-4 max-w-[680px] text-[15px] leading-[1.6] text-text-secondary">
             Your business is one system. Your software isn&apos;t.
           </p>
+          {/* PR-MOVES: the essay's three-moves block, verbatim. */}
+          <p className={`mt-6 ${DECK.statement}`}>This step is three moves:</p>
+          <p className={`mt-2 ${DECK.statement}`}>(a) Name the problem.</p>
+          <p className={`mt-2 ${DECK.statement}`}>(b) List the tools it takes to solve it.</p>
+          <p className={`mt-2 ${DECK.statement}`}>(c) Sort the tools into families.</p>
 
           {/* DESKTOP FAN — viewBox 900×224, rendered 1:1. Origins sit at x=168,
               clear of the label column; each line runs right to x=336 then


### PR DESCRIPTION
## PR-MOVES — copy only

Precondition held: main contains `small example` (#1586 merged at `09d42b2e`). One file, `7+/2−`.

### Edits (file:line)

| # | Edit | Cite |
|---|---|---|
| 1 | Bar label → `01 / IDENTIFY THE PROBLEM` — exact uppercase of essay v12's reverted Step 1 title. ACTS map truth-updated (`:18` — now "three moves, the six-source fan + the twenty-five-tool sheet"); sweep confirms zero stale quotes of the long label remain | `Landing.tsx:1489` |
| 2 | The essay's moves block, byte-verbatim, statement tier — lead line + (a)/(b)/(c) — seated between the slide's sub and the fan (position-proven sub → block → fan) | `:1497–1500` |
| 3 | Nothing else — headline, fan, sheet, closer untouched | — |

### Verification (all pass)

- `tsc --noEmit` clean · `eslint` 0 problems · `assert:showroom` passes
- Chain 14/14 closers verbatim, forward order
- Label = exact uppercase of the essay title; all four block lines byte-identical in essay v12; placement position-checked

Do not merge — Alex reviews.

---
_Generated by [Claude Code](https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc)_