### PR TITLE
fix(landing): your life is one system

### DIFF
--- a/src/components/landing/Landing.tsx
+++ b/src/components/landing/Landing.tsx
@@ -1439,7 +1439,7 @@ export default function Landing({ onRequireAuth, onRequireLogin, logoAvailabilit
             Twenty-five tools.<br />None of them knows what the others did.
           </h2>
           <p className="mt-4 max-w-[680px] text-[15px] leading-[1.6] text-text-secondary">
-            Your business is one system. Your software isn&apos;t.
+            Your life is one system. Your software isn&apos;t.
           </p>
           {/* PR-MOVES → PR-MOVES-2: the essay's four-moves block, verbatim. */}
           <p className={`mt-6 ${DECK.statement}`}>This step is four moves:</p>


### PR DESCRIPTION
## PR-S1-LIFE — one word

Precondition held: origin/main is `3a49f5ba`, the #1591 merge. One file, `1+/1−`.

### Edit

Slide 01 sub (`Landing.tsx:1442`): "Your **business** is one system. Your software isn't." → "Your **life** is one system. Your software isn't."

### The sweep

`grep "business is one system"` across the file returned exactly one hit — the render itself. No comment quotes the line, no other render exists; nothing to truth-update, nothing to report.

### Noted for the record

The attached essay (v14) has no counterpart sentence for this sub — it's a deck headline-slot line, not essay copy (headlines/subs have been verbatim-exempt since PR-VOICE), so no essay drift is created.

### Verification (all pass)

`tsc --noEmit` clean · `eslint` 0 problems · `assert:showroom` passes · chain 14/14 closers verbatim · old line zero hits · new line renders exactly once.

Do not merge — Alex reviews.

---
_Generated by [Claude Code](https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc)_