### PR TITLE
style(landing): slides 01–03 — tighter rhythm, the drawing enters the first screen

### DIFF
--- a/src/components/landing/Landing.tsx
+++ b/src/components/landing/Landing.tsx
@@ -1579,11 +1579,11 @@ export default function Landing({ onRequireAuth, onRequireLogin, logoAvailabilit
             Your life is one system. Your software isn&apos;t.
           </p>
           {/* PR-MOVES → PR-MOVES-2: the essay's four-moves block, verbatim. */}
-          <p className={`mt-6 ${DECK.statement}`}>This step is four moves:</p>
-          <p className={`mt-2 ${DECK.statement}`}><span className="font-mono text-brand-gold">(a)</span> The problem gets named.</p>
-          <p className={`mt-2 ${DECK.statement}`}><span className="font-mono text-brand-gold">(b)</span> The tools to solve it get listed.</p>
-          <p className={`mt-2 ${DECK.statement}`}><span className="font-mono text-brand-gold">(c)</span> The families to sort the tools into get created.</p>
-          <p className={`mt-2 ${DECK.statement}`}><span className="font-mono text-brand-gold">(d)</span> Each tool gets moved from the list into the table, under its family.</p>
+          <p className={`mt-6 lg:mt-5 ${DECK.statement}`}>This step is four moves:</p>
+          <p className={`mt-2 lg:mt-0 lg:leading-[2] ${DECK.statement}`}><span className="font-mono text-brand-gold">(a)</span> The problem gets named.</p>
+          <p className={`mt-2 lg:mt-0 lg:leading-[2] ${DECK.statement}`}><span className="font-mono text-brand-gold">(b)</span> The tools to solve it get listed.</p>
+          <p className={`mt-2 lg:mt-0 lg:leading-[2] ${DECK.statement}`}><span className="font-mono text-brand-gold">(c)</span> The families to sort the tools into get created.</p>
+          <p className={`mt-2 lg:mt-0 lg:leading-[2] ${DECK.statement}`}><span className="font-mono text-brand-gold">(d)</span> Each tool gets moved from the list into the table, under its family.</p>
 
           {/* ── S1-VIZ (PR-S1-VIZ, per the approved CD-S1 mockup 1a): the four
               moves DRAWN. The fan is retired — the visual is move (b) as a
@@ -1792,11 +1792,11 @@ export default function Landing({ onRequireAuth, onRequireLogin, logoAvailabilit
           {/* PR-S2: the essay's Step 2 moves block, verbatim — slide-01
               grammar, letters in the gold mono tier (the moves block is
               the only home for letters; no letters enter the drawing). */}
-          <p className={`mt-6 ${DECK.statement}`}>This step is four moves:</p>
-          <p className={`mt-2 ${DECK.statement}`}><span className="font-mono text-brand-gold">(a)</span> Start from the table Step 1 built.</p>
-          <p className={`mt-2 ${DECK.statement}`}><span className="font-mono text-brand-gold">(b)</span> Go tool by tool and ask one question: does this tool&apos;s data arrive from outside — someone else telling you what happened?</p>
-          <p className={`mt-2 ${DECK.statement}`}><span className="font-mono text-brand-gold">(c)</span> If yes, pick the company that sends it. That company is a provider.</p>
-          <p className={`mt-2 ${DECK.statement}`}><span className="font-mono text-brand-gold">(d)</span> If no, the tool stays home: the system will be that tool, and its data gets born here.</p>
+          <p className={`mt-6 lg:mt-5 ${DECK.statement}`}>This step is four moves:</p>
+          <p className={`mt-2 lg:mt-0 lg:leading-[2] ${DECK.statement}`}><span className="font-mono text-brand-gold">(a)</span> Start from the table Step 1 built.</p>
+          <p className={`mt-2 lg:mt-0 lg:leading-[2] ${DECK.statement}`}><span className="font-mono text-brand-gold">(b)</span> Go tool by tool and ask one question: does this tool&apos;s data arrive from outside — someone else telling you what happened?</p>
+          <p className={`mt-2 lg:mt-0 lg:leading-[2] ${DECK.statement}`}><span className="font-mono text-brand-gold">(c)</span> If yes, pick the company that sends it. That company is a provider.</p>
+          <p className={`mt-2 lg:mt-0 lg:leading-[2] ${DECK.statement}`}><span className="font-mono text-brand-gold">(d)</span> If no, the tool stays home: the system will be that tool, and its data gets born here.</p>
 
           {/* THE WALK, desktop (PR-S2-LINES) — four absolute layers in one
               relative row of height S2_GEOM.H: Step 1's sheet condensed
@@ -1806,7 +1806,7 @@ export default function Landing({ onRequireAuth, onRequireLogin, logoAvailabilit
               provider menu reordered to land the walk (right), and the
               overlay: sixteen short arcs pull-out → menu, ZERO crossings;
               'our AI' takes NO arrow. */}
-          <div className="relative mt-10 hidden lg:mt-[76px] lg:block" style={{ height: S2_GEOM.H, maxWidth: S2_GEOM.W }}>
+          <div className="relative mt-10 hidden lg:mt-8 lg:block" style={{ height: S2_GEOM.H, maxWidth: S2_GEOM.W }}>
             <div className="absolute left-0 top-0" style={{ width: `${(S2_GEOM.TABLE_W / S2_GEOM.W) * 100}%` }}>
               <table className="w-full table-fixed border-separate border-spacing-0 border border-border bg-white">
                 <thead>
@@ -2019,23 +2019,23 @@ export default function Landing({ onRequireAuth, onRequireLogin, logoAvailabilit
           {/* PR-S3: the essay's Step 3 moves block, verbatim — slide-01
               grammar, letters in the gold mono tier. The two old arrival
               intro lines died into moves (c)/(d) — zero renders. */}
-          <p className={`mt-6 ${DECK.statement}`}>This step is four moves:</p>
-          <p className={`mt-2 ${DECK.statement}`}><span className="font-mono text-brand-gold">(a)</span> Start from the menu Step 2 built — the providers in the TODAY column.</p>
-          <p className={`mt-2 ${DECK.statement}`}><span className="font-mono text-brand-gold">(b)</span> Ask each provider for its data.</p>
-          <p className={`mt-2 ${DECK.statement}`}><span className="font-mono text-brand-gold">(c)</span> The answer comes back, and it gets stored as one row, word for word, before anyone decides what it means. That row is an arrival.</p>
-          <p className={`mt-2 ${DECK.statement}`}><span className="font-mono text-brand-gold">(d)</span> Each row gets stamped: who sent it, what it is, its fingerprint, when we asked, when it arrived, when we read it, and how far it got.</p>
+          <p className={`mt-6 lg:mt-5 ${DECK.statement}`}>This step is four moves:</p>
+          <p className={`mt-2 lg:mt-0 lg:leading-[2] ${DECK.statement}`}><span className="font-mono text-brand-gold">(a)</span> Start from the menu Step 2 built — the providers in the TODAY column.</p>
+          <p className={`mt-2 lg:mt-0 lg:leading-[2] ${DECK.statement}`}><span className="font-mono text-brand-gold">(b)</span> Ask each provider for its data.</p>
+          <p className={`mt-2 lg:mt-0 lg:leading-[2] ${DECK.statement}`}><span className="font-mono text-brand-gold">(c)</span> The answer comes back, and it gets stored as one row, word for word, before anyone decides what it means. That row is an arrival.</p>
+          <p className={`mt-2 lg:mt-0 lg:leading-[2] ${DECK.statement}`}><span className="font-mono text-brand-gold">(d)</span> Each row gets stamped: who sent it, what it is, its fingerprint, when we asked, when it arrived, when we read it, and how far it got.</p>
 
           {/* PR-S3-ONE-TABLE: the bridge — the essay's read-across line,
               verbatim, statement tier, above the table. Desktop-only:
               the phone cannot name every part at the top, so its
               counterpart is the declared line in the mobile stack. */}
-          <p className={`mt-10 hidden lg:mt-[76px] lg:block ${DECK.statement}`}>Every part of a row is named at the top of the table, and nineteen rows are shown. Read across plaid&apos;s row — from your Chase connection — and you have read one whole arrival.</p>
+          <p className={`mt-10 hidden lg:mt-8 lg:block ${DECK.statement}`}>Every part of a row is named at the top of the table, and nineteen rows are shown. Read across plaid&apos;s row — from your Chase connection — and you have read one whole arrival.</p>
 
           {/* THE ASK, desktop caption — the arrivals caption in the act's
               rust chrome, aligned over the table panel (marginLeft from
               S3_GEOM — exact at full width, drifting only where the row
               shrinks below S3_GEOM.W). */}
-          <p className="mt-6 hidden font-mono text-[11px] uppercase tracking-[0.20em] text-brand-amber lg:block" style={{ marginLeft: S3_GEOM.TABLE_X }}>ONE ARRIVAL PER PROVIDER — AN EXAMPLE</p>
+          <p className="mt-5 hidden font-mono text-[11px] uppercase tracking-[0.20em] text-brand-amber lg:block" style={{ marginLeft: S3_GEOM.TABLE_X }}>ONE ARRIVAL PER PROVIDER — AN EXAMPLE</p>
 
           {/* THE ONE TABLE, desktop (PR-S3-ONE-TABLE) — the two tables
               became one: the providers list (top offset S3_LIST_TOP —
@@ -2049,7 +2049,7 @@ export default function Landing({ onRequireAuth, onRequireLogin, logoAvailabilit
               ringed (the essay's read-across row); PENDING and FAILED
               ink rust. 18 of 19 arrows run dead level; plaid→chase
               rises one pitch; zero crossings. */}
-          <div className="relative mt-[14px] hidden lg:mt-[18px] lg:block" style={{ height: S3_H, maxWidth: S3_GEOM.W }}>
+          <div className="relative mt-[14px] hidden lg:mt-3 lg:block" style={{ height: S3_H, maxWidth: S3_GEOM.W }}>
             <div className="absolute left-0 border border-border bg-white" style={{ top: S3_LIST_TOP, width: `${(S3_GEOM.LIST_W / S3_GEOM.W) * 100}%` }}>
               <p className="flex h-[26px] items-center overflow-hidden whitespace-nowrap bg-bg-row px-[6px] font-mono text-[7px] font-normal uppercase tracking-[0.14em] text-text-faint border-b border-b-border">THE PROVIDERS WE PICKED</p>
               {S3_PROVIDERS.map((p, i) => (


### PR DESCRIPTION
PR-RHYTHM. Spacing tokens only on the three walked slides, desktop breakpoint; mobile stacks untouched. One file: `src/components/landing/Landing.tsx` (+19/−19). Precondition held: origin/main is the #1599 merge and renders "PLAID · CHASE'S ROW".

## The six class edits (file:line)
| # | What | Change | Where |
|---|---|---|---|
| 1 | Moves lead — sub → moves 20px | `mt-6` → `mt-6 lg:mt-5` | `:1582` · `:1795` · `:2022` (×3) |
| 2 | Lettered lines — one block, 28px pitch | `mt-2` → `mt-2 lg:mt-0 lg:leading-[2]` | `:1583-1586` · `:1796-1799` · `:2023-2026` (×12) |
| 3 | S2 moves → drawing 32px | `lg:mt-[76px]` → `lg:mt-8` | `:1809` |
| 4 | S3 moves → bridge 32px | `lg:mt-[76px]` → `lg:mt-8` | `:2032` |
| 5 | S3 bridge → caption 20px | `mt-6` → `mt-5` (lg-only element) | `:2038` |
| 6 | S3 caption → drawing 12px | `lg:mt-[18px]` → `lg:mt-3` | `:2052` |

S1's moves→drawing gap was already `lg:mt-8` (32px, `:1627`) and all three drawing→paragraph gaps already `mt-8` — untouched. Every touched class keeps its mobile base token, so phones render byte-for-byte the same rhythm as before.

## Proven, not promised
- **The diff is className-only**: the script strips every `className` attribute from both files and the result is **byte-identical to origin/main**.
- Slides 01–03 rendered text: all 54 extracted text runs match origin/main exactly. Slides 04–14: byte-identical from `#deck-04` onward. Ten geometry/data consts compared byte-identical.
- `tsc --noEmit` clean · eslint 0 errors on the file · `assert:showroom` green · chain 14/14 verbatim.

## Measured heights (class math at lg — computed from the tokens with preflight line-height 1.5 where no leading is set; not a browser measurement)
Sub-bottom → drawing-top:
| Slide | Before | After | Saved |
|---|---|---|---|
| 01 | ~193px | ~185px | 8px |
| 02 | ~237px | ~185px | 52px |
| 03 | ~313px | ~251px | 62px |

Moves block itself: 161px → 153px (lead 21px line + four 28px-pitch lines).

## The item-3 report — slide 03 at 1440×900
From the slide's top edge (section `pt-[60px]` + bar ~41 + h2 26+91 + sub 22+24 ≈ 264px of head), the drawing's top now sits at ≈ **515px** — the table **enters the first screen with ≈385px visible** (the three header tiers plus roughly the first eleven rows). The full table (S3_H = 542px) bottoms out at ≈ **1057px**, so the **complete** table still overflows a 900px viewport by ≈ **157px**. Per the ruling, row pitch was not touched — closing that gap is a geometry ruling for the founder (each ROW_H point below 24 buys ~19px; or the head above the drawing carries the remainder).

Do not merge — for review.

---
_Generated by [Claude Code](https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc)_