### PR TITLE
feat(landing): slide 07 — the honest current-state line under the loop

### DIFF
--- a/src/components/landing/Landing.tsx
+++ b/src/components/landing/Landing.tsx
@@ -2882,6 +2882,7 @@ export default function Landing({ onRequireAuth, onRequireLogin, logoAvailabilit
 
           <div className={DECK.hairline} aria-hidden="true" />
           <p className={`mt-[22px] lg:mt-8 ${DECK.statement}`}>Twenty-five tools. Twenty-five loops. One shape!</p>
+          <p className={`mt-2 ${DECK.statement}`}>This loop is the blueprint — the shape we&apos;re building every tool toward. Today, hotel bookings commit for real; flights, trades, and invoices run discover → decide → draft, and commit is the beat we&apos;re wiring to the same loop next.</p>
           <p className={DECK.q}>Twenty-five loops. Where do all the commits land?</p>
         </div>
       </section>


### PR DESCRIPTION
**Do not merge — Alex merges after Vercel Preview (SOC 2 gate).**

**The diff is exactly one added line, zero removed** — proved with `git diff -U0` — in `src/components/landing/Landing.tsx`, inside the deck-07 section only.

The line sits after "Twenty-five tools. Twenty-five loops. One shape!" and before the transition question, in the deck-09 hedge idiom (`mt-2 ${DECK.statement}` — the same tier as "(A piece of this is already alive today: …)"), so it reads as an honest note, not a headline:

> This loop is the blueprint — the shape we're building every tool toward. Today, hotel bookings commit for real; flights, trades, and invoices run discover → decide → draft, and commit is the beat we're wiring to the same loop next.

Everything else stays whole: eyebrow, headline, sub, the LOOP_BEATS band and its arrows, every LOOP_ROWS table cell, the "One shape!" statement, and the transition Q.

## Verify
- `npx tsc --noEmit` clean · eslint 0 · `assert:showroom` ✔ · chain 14/14 closers verbatim forward order.
- `git diff origin/main`: only Landing.tsx; 1 insertion, 0 deletions. Slides 01–06 and 08–14 untouched by construction (a pure single-line insertion). "07 /" appears at the same three pre-existing sites as origin/main (acts ledger, section comment, one rendered eyebrow) — still a single rendered "07".

---
_Generated by [Claude Code](https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc)_