### PR TITLE
feat(landing): slide 07 loop to five tools + the stranded four-doors fix

### DIFF
--- a/src/components/landing/Landing.tsx
+++ b/src/components/landing/Landing.tsx
@@ -814,12 +814,17 @@ const LOOP_BEATS = [
   ['RECORD', 'it is written down forever.'],
 ] as const;
 
-// DECK-07: the three-tool loop table, [beat, travel, trading, invoicing].
+// DECK-07 (PR-FIVE): the five-tool loop table — five families of the
+// twenty-five, [beat, travel, trading, invoicing, bookkeeping, filings].
+// LOOP_TOOLS drives the desktop header AND the mobile stack — one order.
+// Bookkeeping's commit is honestly an internal post to the ledger; it
+// does not move the outside world the way book/trade/invoice/file do.
+const LOOP_TOOLS = ['TRAVEL', 'TRADING', 'INVOICING', 'BOOKKEEPING', 'ENT FILINGS'] as const;
 const LOOP_ROWS = [
-  ['DISCOVER', 'live flight prices', 'option chains', 'invoices coming due'],
-  ['DECIDE', 'a cart', 'a trade card', 'a draft invoice'],
-  ['COMMIT', 'the flight books, a confirmation code comes back', 'the order goes to the broker', 'invoice #14 goes out the door'],
-  ['RECORD', 'booking recorded', 'order recorded', 'invoice recorded'],
+  ['DISCOVER', 'live flight prices', 'option chains', 'invoices coming due', 'transactions waiting to be booked', 'filings coming due'],
+  ['DECIDE', 'a cart', 'a trade card', 'a draft invoice', 'a draft entry, an account picked', 'a draft filing'],
+  ['COMMIT', 'the flight books, a confirmation code comes back', 'the order goes to the broker', 'invoice #14 goes out the door', 'the entry posts to the ledger', 'it files with the state, a confirmation comes back'],
+  ['RECORD', 'booking recorded', 'order recorded', 'invoice recorded', 'entry recorded', 'filing recorded'],
 ] as const;
 
 // DECK-08 (PR-VOICE): the four things every document carries, [name, desc] —
@@ -2838,7 +2843,7 @@ export default function Landing({ onRequireAuth, onRequireLogin, logoAvailabilit
             Every tool runs the same four beats.<br />Discover. Decide. Commit. Record.
           </h2>
           <p className={DECK.sub}>
-            Book a flight, place a trade, send an invoice; same loop, different nouns.
+            Book a flight, place a trade, send an invoice, post an entry, file with the state; same loop, different nouns.
           </p>
 
           <div className="mt-10 lg:mt-[76px] flex flex-col gap-6 lg:flex-row lg:gap-0">
@@ -2858,22 +2863,25 @@ export default function Landing({ onRequireAuth, onRequireLogin, logoAvailabilit
             ))}
           </div>
 
-          <table className={`mt-10 lg:mt-[76px] ${DECK.table}`}>
+          {/* PR-FIVE: the faint caption, then the six-column table on
+              desktop; mobile stacks one block per tool below. */}
+          <p className="mt-10 lg:mt-[76px] text-[12px] lg:text-[14px] text-text-faint">five of twenty-five — every tool runs these same four beats.</p>
+          <table className={`mt-4 hidden lg:table ${DECK.table}`}>
             <thead>
               <tr>
-                <th scope="col" className={`w-[22%] lg:w-[16%] ${DECK.th}`} />
-                {(['TRAVEL', 'TRADING', 'INVOICING'] as const).map((head) => (
+                <th scope="col" className={`w-[16%] ${DECK.th}`} />
+                {LOOP_TOOLS.map((head) => (
                   <th key={head} scope="col" className={DECK.th}>{head}</th>
                 ))}
               </tr>
             </thead>
             <tbody>
-              {LOOP_ROWS.map(([beat, travel, trading, invoicing], r) => {
+              {LOOP_ROWS.map(([beat, ...cells], r) => {
                 const rule = r === LOOP_ROWS.length - 1 ? '' : DECK.rule;
                 return (
                   <tr key={beat}>
                     <th scope="row" className={`${DECK.pad} ${rule} text-left align-top font-mono text-[10px] lg:text-[11px] font-normal uppercase tracking-[0.18em] text-text-faint`}>{beat}</th>
-                    {[travel, trading, invoicing].map((cell, c) => (
+                    {cells.map((cell, c) => (
                       <td key={c} className={`${DECK.pad} ${rule} align-top text-[11px] leading-[1.4] lg:text-[13px] lg:leading-normal text-brand-purple`}>{cell}</td>
                     ))}
                   </tr>
@@ -2882,9 +2890,26 @@ export default function Landing({ onRequireAuth, onRequireLogin, logoAvailabilit
             </tbody>
           </table>
 
+          {/* PR-FIVE, mobile — six columns cannot fit at 375: one white
+              card per tool, its four beats as label → value lines, the
+              Pass-A tiers (faint labels, purple values). */}
+          <div className="mt-4 lg:hidden">
+            {LOOP_TOOLS.map((tool, i) => (
+              <div key={tool} className="mt-3 border border-border bg-white px-3 py-[10px] first:mt-0">
+                <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-text-faint">{tool}</p>
+                {LOOP_ROWS.map(([beat, ...cells]) => (
+                  <div key={beat} className="mt-[6px] grid grid-cols-[74px_1fr] gap-2">
+                    <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-text-faint">{beat}</span>
+                    <span className="text-[11px] leading-[1.4] text-brand-purple">{cells[i]}</span>
+                  </div>
+                ))}
+              </div>
+            ))}
+          </div>
+
           <div className={DECK.hairline} aria-hidden="true" />
           <p className={`mt-[22px] lg:mt-8 ${DECK.statement}`}>Twenty-five tools. Twenty-five loops. One shape!</p>
-          <p className={`mt-2 ${DECK.statement}`}>This loop is the blueprint — the shape we&apos;re building every tool toward. Today, hotel bookings commit for real; flights, trades, and invoices run discover → decide → draft, and commit is the beat we&apos;re wiring to the same loop next.</p>
+          <p className={`mt-2 ${DECK.statement}`}>This loop is the blueprint — the shape we&apos;re building every tool toward. Today, hotel bookings commit for real; flights, trades, invoices, ledger entries, and filings run discover → decide → draft, and commit is the beat we&apos;re wiring to the same loop next.</p>
           <p className={DECK.q}>Twenty-five loops. Where do all the commits land?</p>
         </div>
       </section>

--- a/src/components/landing/Landing.tsx
+++ b/src/components/landing/Landing.tsx
@@ -1955,7 +1955,7 @@ export default function Landing({ onRequireAuth, onRequireLogin, logoAvailabilit
             A tool is a job. A provider is a company you hire to feed that job.
           </p>
           {/* PR-S2: the essay's Step 2 moves block, verbatim — slide-01
-              grammar, letters in the gold mono tier (the moves block is
+              grammar, letters in the faint mono tier (the moves block is
               the only home for letters; no letters enter the drawing). */}
           <p className={`mt-6 lg:mt-5 ${DECK.statement}`}>This step is four moves:</p>
           <p className={`mt-2 lg:mt-0 lg:leading-[2] ${DECK.statement}`}><span className="font-mono text-text-faint">(a)</span> Start from the table Step 1 built.</p>
@@ -2182,7 +2182,7 @@ export default function Landing({ onRequireAuth, onRequireLogin, logoAvailabilit
             Now we ask the providers we picked for their data.
           </p>
           {/* PR-S3: the essay's Step 3 moves block, verbatim — slide-01
-              grammar, letters in the gold mono tier. The two old arrival
+              grammar, letters in the faint mono tier. The two old arrival
               intro lines died into moves (c)/(d) — zero renders. */}
           <p className={`mt-6 lg:mt-5 ${DECK.statement}`}>This step is four moves:</p>
           <p className={`mt-2 lg:mt-0 lg:leading-[2] ${DECK.statement}`}><span className="font-mono text-text-faint">(a)</span> Start from the menu Step 2 built — the providers in the TODAY column.</p>
@@ -2391,7 +2391,7 @@ export default function Landing({ onRequireAuth, onRequireLogin, logoAvailabilit
             Now we examine the data that we just imported in Step 3, and we give every feed a label.
           </p>
           {/* PR-S4: the essay's Step 4 moves block, verbatim — slide-01
-              grammar, gold letter tier, the #1600 rhythm. Who decides the
+              grammar, faint letter tier, the #1600 rhythm. Who decides the
               kind lives in moves (c)/(d) now. */}
           <p className={`mt-6 lg:mt-5 ${DECK.statement}`}>This step is four moves:</p>
           <p className={`mt-2 lg:mt-0 lg:leading-[2] ${DECK.statement}`}><span className="font-mono text-text-faint">(a)</span> Start from the arrivals table Step 3 built.</p>
@@ -2565,7 +2565,7 @@ export default function Landing({ onRequireAuth, onRequireLogin, logoAvailabilit
           </p>
 
           {/* PR-S5: the essay's Step 5 moves block, verbatim — slide-01
-              grammar, gold letter tier, the #1600 rhythm. */}
+              grammar, faint letter tier, the #1600 rhythm. */}
           <p className={`mt-6 lg:mt-5 ${DECK.statement}`}>This step is four moves:</p>
           <p className={`mt-2 lg:mt-0 lg:leading-[2] ${DECK.statement}`}><span className="font-mono text-text-faint">(a)</span> Start from the rule book Step 4 built.</p>
           <p className={`mt-2 lg:mt-0 lg:leading-[2] ${DECK.statement}`}><span className="font-mono text-text-faint">(b)</span> Create one table per kind: six tables, six names.</p>
@@ -3326,7 +3326,7 @@ export default function Landing({ onRequireAuth, onRequireLogin, logoAvailabilit
                     <tr key={beat}>
                       <th scope="row" className={`${DECK.pad} ${rule} text-left align-top font-mono text-[10px] lg:text-[11px] font-normal uppercase tracking-[0.18em] text-text-faint`}>{beat}</th>
                       {cells.map((cell, c) => (
-                        <td key={c} className={`${DECK.pad} ${rule} align-top text-[11px] leading-[1.4] lg:text-[13px] lg:leading-normal ${typeof cell === 'string' ? 'text-brand-purple' : 'font-mono text-text-faint'}`}>
+                        <td key={c} className={`${DECK.pad} ${rule} align-top text-[11px] leading-[1.4] lg:text-[13px] lg:leading-normal ${typeof cell === 'string' ? (cell === 'none — no money moved' ? 'text-text-faint' : 'text-brand-purple') : 'font-mono text-brand-purple'}`}>
                           {typeof cell === 'string' ? cell : <GoldSegments segments={cell} />}
                         </td>
                       ))}


### PR DESCRIPTION
**Do not merge — Alex merges after Vercel Preview (SOC 2 gate).**

Two parts, **two separate commits**, proved to audit independently: `git diff origin/main` decomposes into exactly the 10 cherry-picked lines and the 49 loop-expansion lines — nothing else. Only `Landing.tsx`; `S5_LAYOUT`/`S6_LAYOUT` byte-identical; chain 14/14; single rendered "07".

## Part 1 — the stranded four-doors fix (commit `981cc252`, cherry-pick of `2f8690b1`)
#1609 merged before its verify-fleet fix landed, stranding it. Cherry-picked clean (+5/−5) and verified in place: the four-door table's cell ternary now reads **exception → `text-text-faint`** (the documented "none — no money moved" gray) and **all other data cells → `text-brand-purple`** (segment cells included, matching THE MATH's purple base under gold values), plus the four stale "gold letter tier" comment truth-updates.

## Part 2 — the loop table to five tools (commit `dbcf6715`)
- **Sub**: "Book a flight, place a trade, send an invoice, post an entry, file with the state; same loop, different nouns."
- **`LOOP_ROWS`** gains BOOKKEEPING and ENT FILINGS columns with the ruled cells verbatim — bookkeeping's commit framed honestly as an internal post to the ledger (the const comment carries the note). `LOOP_TOOLS` extracted once and drives both the desktop header and the mobile stack — one order, no drift.
- **Caption** (faint tier, directly above the table): "five of twenty-five — every tool runs these same four beats."
- **Honest-state line** updated to name all five: "…flights, trades, invoices, ledger entries, and filings run discover → decide → draft…"
- **Mobile ≤375**: the six-column table goes `hidden lg:table`; mobile stacks one white card per tool — tool name as a faint header, four beats as label → value lines (faint mono labels, purple values, ≥10px), no horizontal scroll.
- Styling inherits Pass A throughout: white rows, tinted header band, purple data cells, faint headers. `LOOP_BEATS` band, headline, eyebrow, "One shape!", and the transition Q untouched.

## Verify
`npx tsc --noEmit` clean · eslint 0 · `assert:showroom` ✔ · `next build` compiled successfully (page-data collection stops at the pre-existing `/api/admin/backfill-transaction-fields` PLAID-secrets assert only Vercel can satisfy — unrelated; Vercel Preview is the full-build proof). Slides 01–06, 08–12, 14 carry no changes beyond Part 1's four one-line comment truth-updates (in slides 02–05's moves comments), which are part of the cherry-picked fix by construction.

---
_Generated by [Claude Code](https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc)_