### PR TITLE
fix(landing): 14's honest line — two overstatements trued

### DIFF
--- a/src/components/landing/Landing.tsx
+++ b/src/components/landing/Landing.tsx
@@ -4487,7 +4487,7 @@ export default function Landing({ onRequireAuth, onRequireLogin, logoAvailabilit
             ))}
           </div>
           <p className={`mt-[22px] lg:mt-8 ${DECK.statement}`}>That is why you can believe the screen: every number walks back to its source — the exact words a provider sent, or the document you committed — and the rule that wrote the line.</p>
-          <p className={`mt-2 ${DECK.statement}`}>Alive today: the fingerprint, on the rules and the books — every regulation pull is hashed the moment it lands, citation checks re-fetch the source and re-hash it, and the audit log hash-chains every write. Today the money feeds land already parsed — no stored word-for-word payload, no fingerprint yet; the arrivals table that saves the provider&apos;s exact words and fingerprints them on arrival is the shape we&apos;re building.</p>
+          <p className={`mt-2 ${DECK.statement}`}>Alive today: the fingerprint, on the rules and the audit log — every regulation pull is hashed the moment it lands, citation checks re-fetch the source and re-hash it, and the audit log hash-chains every entry it records. Today the money feeds land already parsed — no stored word-for-word payload, no fingerprint yet; the arrivals table that saves the provider&apos;s exact words and fingerprints them on arrival is the shape we&apos;re building.</p>
           <p className="mt-[22px] lg:mt-9 text-[17px] lg:text-[24px] text-brand-purple">Twenty-five tools. And now every one knows what the others did.</p>
         </div>
       </section>


### PR DESCRIPTION
**Do not merge — Alex merges after Vercel Preview (SOC 2 gate).**

Two substrings replaced inside deck-14's Alive-today paragraph (`Landing.tsx:4490`), per the deeper census: the audit chain is real (`prisma/schema.prisma:2437` — prev_hash, content_hash, sequence_number; `src/lib/audit/writeAuditLog.ts:99`) but is fed by explicit call sites only — the money and bookkeeping writers (`plaid/sync`, `transactions/sync*`, `transactions/manual`) call it zero times, and `journal_entries` carries no hash. So: not "the books", and "every entry it records", not "every write".

## Before (verbatim)

> Alive today: the fingerprint, on the rules and the books — every regulation pull is hashed the moment it lands, citation checks re-fetch the source and re-hash it, and the audit log hash-chains every write. Today the money feeds land already parsed — no stored word-for-word payload, no fingerprint yet; the arrivals table that saves the provider&apos;s exact words and fingerprints them on arrival is the shape we&apos;re building.

## After (verbatim)

> Alive today: the fingerprint, on the rules and the audit log — every regulation pull is hashed the moment it lands, citation checks re-fetch the source and re-hash it, and the audit log hash-chains every entry it records. Today the money feeds land already parsed — no stored word-for-word payload, no fingerprint yet; the arrivals table that saves the provider&apos;s exact words and fingerprints them on arrival is the shape we&apos;re building.

## Scope + verification

- `git diff origin/main`: `Landing.tsx` only, 1 line (−1/+1) — that paragraph, nothing else; S14_LAYOUT byte-identical; chain 14/14 forward order
- `npx tsc --noEmit` clean; `npx eslint` 0 problems; `npm run assert:showroom` passed
- `next build`: ✓ Compiled successfully, types valid; page-data collection dies at the pre-existing PLAID env wall (Vercel-only secrets — same as every deck PR, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc

---
_Generated by [Claude Code](https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc)_