### PR TITLE
fix(landing): 7's honest line — the second real commit named

### DIFF
--- a/src/components/landing/Landing.tsx
+++ b/src/components/landing/Landing.tsx
@@ -3594,7 +3594,7 @@ export default function Landing({ onRequireAuth, onRequireLogin, logoAvailabilit
 
           <div className={DECK.hairline} aria-hidden="true" />
           <p className={`mt-[22px] lg:mt-8 ${DECK.statement}`}>Twenty-five tools. Twenty-five loops. One shape!</p>
-          <p className={`mt-2 ${DECK.statement}`}>This loop is the blueprint — the shape we&apos;re building every tool toward. Today, hotel bookings commit for real; the rest run discover → decide → draft, and commit is the beat we&apos;re wiring to the same loop, tool by tool.</p>
+          <p className={`mt-2 ${DECK.statement}`}>This loop is the blueprint — the shape we&apos;re building every tool toward. Today, hotel bookings commit for real and an accepted task fires its build; the rest run discover → decide → draft, and commit is the beat we&apos;re wiring to the same loop, tool by tool.</p>
           <p className={DECK.q}>Twenty-five loops. Where do all the commits land?</p>
         </div>
       </section>


### PR DESCRIPTION
**Do not merge — Alex merges after Vercel Preview (SOC 2 gate).**

One substring replaced inside slide 7's honest-state paragraph (`Landing.tsx:3597`), count-1 asserted against the file's own bytes. EXEC-2 (fa105a4e) made a second commit real — accepting a task fires `fireExecutionRoutine` (`src/app/api/operations/projects/[id]/tasks/[taskId]/route.ts:395-405`) — which slide 13's honest line and the README's Projects row already state; slide 7 was the stale slot.

## Before (verbatim)

> This loop is the blueprint — the shape we&apos;re building every tool toward. Today, hotel bookings commit for real; the rest run discover → decide → draft, and commit is the beat we&apos;re wiring to the same loop, tool by tool.

## After (verbatim)

> This loop is the blueprint — the shape we&apos;re building every tool toward. Today, hotel bookings commit for real and an accepted task fires its build; the rest run discover → decide → draft, and commit is the beat we&apos;re wiring to the same loop, tool by tool.

## Scope + verification

- `git diff origin/main`: `Landing.tsx` only, 1 line (−1/+1); S5–S14 laws byte-identical; chain 14/14 forward order
- `npx tsc --noEmit` clean; `npx eslint` 0 problems; `npm run assert:showroom` passed
- `next build`: ✓ Compiled successfully, types valid; page-data collection dies at the pre-existing PLAID env wall (Vercel-only secrets — same as every deck PR, unrelated)

**Follow-on:** the README's gap-ledger row 07 (PR #1623, now merged) derives from this line; its generator already switches to "commit is real for two tools (hotel bookings, accepted tasks); the other twenty-three stop at draft." once this merges — one regenerate + PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc

---
_Generated by [Claude Code](https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc)_