### PR TITLE
fix(security): no Plaid access token to the browser; user-scope the fix-categories write (SEC-01)

### DIFF
--- a/src/app/api/plaid/items/route.ts
+++ b/src/app/api/plaid/items/route.ts
@@ -1,9 +1,9 @@
 import { requireTabAccess } from '@/lib/auth-helpers';
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 
-export async function GET(request: NextRequest) {
+export async function GET() {
   try {
     const userEmail = await getVerifiedEmail();
     
@@ -23,13 +23,20 @@ export async function GET(request: NextRequest) {
     const tierGate = await requireTabAccess(user.id, 'tab:books');
     if (tierGate) return tierGate;
 
+    // SEC-01: the only consumer (src/components/dashboard/ImportDataSection.tsx:63-69)
+    // reads `item.id` and nothing else. Select exactly that — the row's accessToken
+    // is a Plaid secret and must never reach the browser.
     const items = await prisma.plaid_items.findMany({
-      where: { userId: user.id }
+      where: { userId: user.id },
+      select: { id: true },
     });
-    
-    return NextResponse.json(items);
-  } catch (error: any) {
+
+    // Compile-time proof that no token field is in the response type: a select
+    // that re-adds accessToken fails `satisfies` (string is not assignable to never).
+    return NextResponse.json(items satisfies ReadonlyArray<{ id: string; accessToken?: never }>);
+  } catch (error: unknown) {
     console.error('Error fetching items:', error);
-    return NextResponse.json({ error: error.message }, { status: 500 });
+    const message = error instanceof Error ? error.message : String(error);
+    return NextResponse.json({ error: message }, { status: 500 });
   }
 }

--- a/src/app/api/transactions/fix-categories/route.ts
+++ b/src/app/api/transactions/fix-categories/route.ts
@@ -34,14 +34,21 @@ export async function POST() {
         });
 
         for (const plaidTxn of response.data.transactions) {
-          await prisma.transactions.updateMany({
-            where: { transactionId: plaidTxn.transaction_id },
+          // SEC-01: transactions carry no userId (prisma/schema.prisma:414-450). The
+          // real ownership path is transactions.accountId → accounts.plaidItemId →
+          // plaid_items.userId. The write is scoped to THIS item under THIS user;
+          // a transactionId held by another user matches zero rows. No fallback.
+          const result = await prisma.transactions.updateMany({
+            where: {
+              transactionId: plaidTxn.transaction_id,
+              accounts: { plaid_items: { id: item.id, userId: user.id } },
+            },
             data: { 
               category: plaidTxn.category ? plaidTxn.category.join(', ') : null,
               merchantName: plaidTxn.merchant_name
             }
           });
-          updatedCount++;
+          updatedCount += result.count;
         }
       } catch (error) {
         console.error('Error fixing categories for item:', item.id, error);


### PR DESCRIPTION
**Do not merge — Alex merges after Vercel Preview (SOC 2 gate).**

## Why

Two Security-first breaks (no secrets to the client; every write user-scoped), one concept.

| | Route | Break | On main |
|---|---|---|---|
| A | `src/app/api/plaid/items/route.ts` | `findMany` with no `select` returned whole `plaid_items` rows — `accessToken` included — to the browser | `:26-30` (the task cited `:7-11`; the find is at `:26-28`, the return at `:30`) |
| B | `src/app/api/transactions/fix-categories/route.ts` | `updateMany where { transactionId }` alone, unscoped to the authed user | `:37-38` |

## Audit (read before writing)

**Consumers of `/api/plaid/items`** — exactly one in the repo: `src/components/dashboard/ImportDataSection.tsx:63-69`, which reads `item.id` and nothing else (it posts `{ itemId: item.id }` to `/api/plaid/sync`).

**Routes returning `plaid_items` / `tastytrade_connections` rows without a `select`** — census of every `findMany/findFirst/findUnique`:

| Site | select? | Reaches the client? |
|---|---|---|
| `plaid/items/route.ts:26` | no | **YES — whole rows incl. `accessToken`** → FIX A |
| `accounts/route.ts:25` | no (`include: accounts`) | no — projected at `:32-44` (id, institutionName, accounts[...]) |
| `transactions/sync-complete/route.ts:28`, `sync/route.ts:31`, `sync-full/route.ts:31`, `resync-with-rich-data/route.ts:27`, `admin/backfill-transaction-fields/route.ts:32`, `investments/route.ts:22`, `investments/analyze/route.ts:21`, `transactions/fix-categories/route.ts:22`, `plaid/sync/route.ts:47`, `lib/plaid-sync-fix.ts:6` | no | no — `accessToken` used server-side for Plaid calls; responses are counts / Plaid data |
| `transactions/review-queue/route.ts:30-36` (`accounts: { include: { plaid_items: true } }`) | no | no — mapping at `:43-54` projects only `institutionName`. **Over-fetch of the token from the DB, not an exfil**; left as is (out of concept) |
| `transactions/route.ts:44`, `bank-reconciliations/route.ts:41` | `select: { institutionName }` | safe |
| `owner/accounts/route.ts:33` | `_count` | count only |
| `tastytrade/status/route.ts:38` | yes (`accountNumbers,status,connectedAt,lastUsedAt`) | safe |
| `tastytrade/disconnect/route.ts:26`, `callback/route.ts:30`, `lib/tastytrade.ts:85` | no | no — existence / status checks; responses carry messages only |
| `lib/tastytrade.ts:43` `getTastytradeConnection` → `balances/route.ts:35`, `positions/route.ts:35` | no | no — only `accountNumbers` read; responses carry balances / positions |

No second token-returning route exists, so this PR touches only the two cited routes.

**Ownership path in the schema** — `transactions` (`prisma/schema.prisma:414-450`) has **no `userId`**. `transactions.accountId` → `accounts` (`:31-60`: `plaidItemId String?` `:33`, `userId String?` `:45`) → `plaid_items.userId String` (`:311`). The real path is the account/item join.

## FIX A — items route

Before (`:26-30` on main):
```ts
const items = await prisma.plaid_items.findMany({ where: { userId: user.id } });
return NextResponse.json(items);
```
After (`:29-36`):
```ts
const items = await prisma.plaid_items.findMany({ where: { userId: user.id }, select: { id: true } });
return NextResponse.json(items satisfies ReadonlyArray<{ id: string; accessToken?: never }>);
```
Response shape unchanged: a JSON array of item objects; each object now carries exactly the field the consumer reads. The `satisfies` clause is the compile-time proof that no token field is in the response type.

Also in this file: the two pre-existing lint findings (`request` unused at `:6`, `catch (error: any)` at `:31`) are cleared so the route lints at 0 — `GET()` drops the unused param, the catch narrows `unknown` to a message.

## FIX B — fix-categories

Before (`:37-38` on main):
```ts
await prisma.transactions.updateMany({ where: { transactionId: plaidTxn.transaction_id }, data: {...} });
updatedCount++;
```
After (`:41-51`):
```ts
const result = await prisma.transactions.updateMany({
  where: {
    transactionId: plaidTxn.transaction_id,
    accounts: { plaid_items: { id: item.id, userId: user.id } },
  },
  data: {...}
});
updatedCount += result.count;
```
The write is scoped to the item under iteration **and** the authed user via the schema's real join. A `transactionId` held by another user matches zero rows. No fallback branch exists. `updatedCount` now reports rows actually updated instead of every Plaid transaction seen.

## Verify

| Check | Result |
|---|---|
| `npx tsc --noEmit` | exit 0 |
| `npx eslint` on both routes, `--max-warnings 0` | exit 0 (main's version of the items route: 1 error + 1 warning, both pre-existing) |
| `next build` | compiled, types valid; page-data collection dies at the pre-existing `/api/admin/backfill-transaction-fields` `PLAID_CLIENT_ID and PLAID_SECRET must be set` module assert (Vercel-only secrets) — same as every prior PR |
| Response type contains no token field | negative proof: a scratch file re-adding `accessToken: true` to the select fails `TS1360 … Type 'string' is not assignable to type 'undefined'` on the `satisfies` line; the shipped select passes |
| Diff scope | `git diff origin/main --stat`: exactly the two cited routes, +24/−10 |

## Observations not acted on (out of concept)
- `fix-categories` makes a paid `transactionsGet` call with no `requireTabAccess` gate (the items route has one at `:23`).
- `fix-categories:53-55` swallows per-item errors with `console.error` and continues.
- `review-queue/route.ts:33` still fetches `accessToken` from the DB via `plaid_items: true` even though it never leaves the server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc

---
_Generated by [Claude Code](https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc)_