### PR TITLE
feat(security): encrypt the two stored provider tokens at rest; no session body in logs (SEC-02)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,22 @@ PLAID_SECRET="your-secret"
 # Note: App forces production environment for real data
 
 # ═══════════════════════════════════════════════════════════════
+# PROVIDER TOKENS AT REST (SEC-02) — Required
+# ═══════════════════════════════════════════════════════════════
+# plaid_items.accessToken and tastytrade_connections.sessionToken are stored
+# AES-256-GCM encrypted (src/lib/secrets/tokenCipher.ts). Every read and write
+# of those columns goes through the cipher; readers accept ciphertext ONLY —
+# a plaintext row throws "token not encrypted", there is no dual-read path.
+# Missing or short key → TokenCipherKeyError on the first use (not at build).
+# Set BOTH in Vercel (production + preview) before merging SEC-02, then run
+# `npx tsx scripts/reencrypt-tokens.ts` once locally against production.
+# KEY: base64 of exactly 32 random bytes →  openssl rand -base64 32
+# KEY_ID: a short label embedded in every stored value (enc:v1:<KEY_ID>:…);
+# it must match at decrypt time. Rotation is NOT implemented in SEC-02.
+TOKEN_ENCRYPTION_KEY=""
+TOKEN_ENCRYPTION_KEY_ID="k1"
+
+# ═══════════════════════════════════════════════════════════════
 # ANTHROPIC (AI Market Brief + Strategy Analysis)
 # ═══════════════════════════════════════════════════════════════
 ANTHROPIC_API_KEY="sk-ant-..."

--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ These are the written laws in `CLAUDE.md`, stated as practice:
 - Audit log: a hash chain — each entry stores `prev_hash` and its own sha256 `content_hash` with a `sequence_number` (`prisma/schema.prisma:2441-2443`; written at `src/lib/audit/writeAuditLog.ts:99`); `src/lib/audit/verifyAuditChain.ts:47, 80` recomputes the chain.
 - Citations: `src/lib/citations/verifyCitation.ts:97` re-fetches the source and re-hashes it against `citations.retrieved_content_hash` (`prisma/schema.prisma:2287`); the column's only writer stores an empty string today (`src/lib/discovery/materializeProposal.ts:165`), so the check is structurally dead until the arrivals rebuild lands the real hash.
 - Corpus: the four ingest persisters hash content with sha256 on write — `src/lib/corpus/ingest/ecfr-persist.ts:28`, `uscode-persist.ts:32`, `fedreg-persist.ts:31`, `irb-persist.ts:32`.
+- Provider tokens at rest: AES-256-GCM with a key held in the deployment env (`src/lib/secrets/tokenCipher.ts`); readers accept ciphertext only.
 - Report a vulnerability to astuart@templestuart.com.
 
 ## Providers
@@ -229,6 +230,7 @@ You need Node (the code is typed against `@types/node ^20`), PostgreSQL, and a h
 | Core | `DATABASE_URL` (read by Prisma, `prisma/schema.prisma:7`), `JWT_SECRET`, `NEXTAUTH_SECRET`, `OWNER_EMAIL`, `NEXT_PUBLIC_OWNER_EMAIL`, `NEXT_PUBLIC_APP_URL`, `NEXT_PUBLIC_BASE_URL` | Required |
 | Set by the platform | `NODE_ENV`, `VERCEL`, `NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA` | Provided by Vercel / Node; nothing to set |
 | Plaid (bank sync) | `PLAID_CLIENT_ID`, `PLAID_SECRET` | Required unless Books sync is disabled |
+| Provider tokens at rest | `TOKEN_ENCRYPTION_KEY` (base64 of 32 bytes), `TOKEN_ENCRYPTION_KEY_ID` (`src/lib/secrets/tokenCipher.ts`) | Required — every Plaid and tastytrade token read or write fails loud without both |
 | Stripe (payments) | `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY`, `STRIPE_PRO_PRICE_ID`, `STRIPE_PRO_PLUS_PRICE_ID`; per entitlement `STRIPE_TAB_<KEY>_PRICE_ID`, `STRIPE_CAT_<KEY>_PRICE_ID`, `STRIPE_BUNDLE_ALL_PRICE_ID` (`src/lib/stripe.ts:49-55`) | Required to sell modules; skip to run everything unlocked |
 | Flights and stays (LiteAPI) | `LITEAPI_SANDBOX_KEY`, `LITEAPI_PRODUCTION_KEY`, `LITEAPI_MODE`, `FLIGHTS_LANE` (set to `liteapi`; `src/lib/flightsLane.ts:20`) | Required unless travel is disabled |
 | Tours (Viator) | `VIATOR_API_KEY` | Required unless activities are disabled |

--- a/scripts/reencrypt-tokens.ts
+++ b/scripts/reencrypt-tokens.ts
@@ -1,0 +1,115 @@
+/*
+ * ═══════════════════════════════════════════════════════════════════════
+ * Temple Stuart — SEC-02 one-time token re-encryption
+ *
+ * Encrypts every plaintext value of the two stored provider secrets:
+ *   plaid_items.accessToken
+ *   tastytrade_connections.sessionToken
+ * using src/lib/secrets/tokenCipher.ts (AES-256-GCM, key from env).
+ *
+ * Run ONCE by Alex, locally, against production, with the key set — AFTER the
+ * key is in Vercel and BEFORE the ciphertext-only readers deploy:
+ *
+ *   DATABASE_URL="postgresql://…" \
+ *   TOKEN_ENCRYPTION_KEY="<base64 32 bytes>" \
+ *   TOKEN_ENCRYPTION_KEY_ID="k1" \
+ *   npx tsx scripts/reencrypt-tokens.ts
+ *
+ * Rules:
+ *   - refuses to run if DATABASE_URL, TOKEN_ENCRYPTION_KEY, or
+ *     TOKEN_ENCRYPTION_KEY_ID is missing (no defaults, no placeholders);
+ *   - ONE transaction: every row of both columns, or none;
+ *   - a row is touched only if it is not already ciphertext, so a second run
+ *     updates zero rows (idempotent);
+ *   - an empty stored value makes encryptToken throw → the whole transaction
+ *     rolls back and the row is named, because an empty secret is not a secret.
+ * Prints counts before and after. Never prints a token, plaintext or cipher.
+ * ═══════════════════════════════════════════════════════════════════════
+ */
+
+import { PrismaClient } from '@prisma/client';
+import { encryptToken, isCiphertext } from '../src/lib/secrets/tokenCipher';
+
+const REQUIRED = ['DATABASE_URL', 'TOKEN_ENCRYPTION_KEY', 'TOKEN_ENCRYPTION_KEY_ID'] as const;
+for (const name of REQUIRED) {
+  if (!process.env[name]) {
+    console.error(`reencrypt-tokens: refusing to run — ${name} is not set`);
+    process.exit(2);
+  }
+}
+
+// Fail loud on key problems BEFORE opening a transaction.
+encryptToken('preflight');
+
+type Counts = { total: number; plaintext: number; ciphertext: number };
+function count(values: string[]): Counts {
+  const ciphertext = values.filter((v) => isCiphertext(v)).length;
+  return { total: values.length, ciphertext, plaintext: values.length - ciphertext };
+}
+
+const prisma = new PrismaClient();
+
+async function main() {
+  const result = await prisma.$transaction(
+    async (tx) => {
+      const items = await tx.plaid_items.findMany({ select: { id: true, accessToken: true } });
+      const conns = await tx.tastytrade_connections.findMany({ select: { id: true, sessionToken: true } });
+      const before = {
+        plaid_items: count(items.map((i) => i.accessToken)),
+        tastytrade_connections: count(conns.map((c) => c.sessionToken)),
+      };
+
+      let updatedItems = 0;
+      for (const item of items) {
+        if (isCiphertext(item.accessToken)) continue;
+        let stored: string;
+        try {
+          stored = encryptToken(item.accessToken);
+        } catch (err) {
+          throw new Error(`plaid_items.id=${item.id}: ${err instanceof Error ? err.message : String(err)}`);
+        }
+        await tx.plaid_items.update({ where: { id: item.id }, data: { accessToken: stored } });
+        updatedItems++;
+      }
+
+      let updatedConns = 0;
+      for (const conn of conns) {
+        if (isCiphertext(conn.sessionToken)) continue;
+        let stored: string;
+        try {
+          stored = encryptToken(conn.sessionToken);
+        } catch (err) {
+          throw new Error(`tastytrade_connections.id=${conn.id}: ${err instanceof Error ? err.message : String(err)}`);
+        }
+        await tx.tastytrade_connections.update({ where: { id: conn.id }, data: { sessionToken: stored } });
+        updatedConns++;
+      }
+
+      const itemsAfter = await tx.plaid_items.findMany({ select: { accessToken: true } });
+      const connsAfter = await tx.tastytrade_connections.findMany({ select: { sessionToken: true } });
+      const after = {
+        plaid_items: count(itemsAfter.map((i) => i.accessToken)),
+        tastytrade_connections: count(connsAfter.map((c) => c.sessionToken)),
+      };
+      if (after.plaid_items.plaintext !== 0 || after.tastytrade_connections.plaintext !== 0) {
+        throw new Error('post-condition failed: plaintext rows remain after re-encryption');
+      }
+      return { before, after, updated: { plaid_items: updatedItems, tastytrade_connections: updatedConns } };
+    },
+    { timeout: 120_000 },
+  );
+
+  console.log('reencrypt-tokens: committed');
+  console.log('  key id:', process.env.TOKEN_ENCRYPTION_KEY_ID);
+  console.log('  before:', JSON.stringify(result.before));
+  console.log('  updated:', JSON.stringify(result.updated));
+  console.log('  after: ', JSON.stringify(result.after));
+  console.log('  idempotent: a second run will update zero rows');
+}
+
+main()
+  .catch((err) => {
+    console.error('reencrypt-tokens: FAILED — transaction rolled back, nothing changed:', err instanceof Error ? err.message : String(err));
+    process.exitCode = 1;
+  })
+  .finally(() => prisma.$disconnect());

--- a/src/app/api/admin/backfill-transaction-fields/route.ts
+++ b/src/app/api/admin/backfill-transaction-fields/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { plaidClient } from '@/lib/plaid';
 import { requireAdmin } from '@/lib/require-admin';
+import { decryptToken } from '@/lib/secrets/tokenCipher';
 
 /**
  * POST /api/admin/backfill-transaction-fields
@@ -48,7 +49,7 @@ export async function POST() {
 
         while (hasMore) {
           const response = await plaidClient.transactionsGet({
-            access_token: item.accessToken,
+            access_token: decryptToken(item.accessToken),
             start_date: '2024-01-01',
             end_date: new Date().toISOString().split('T')[0],
             options: {

--- a/src/app/api/investments/analyze/route.ts
+++ b/src/app/api/investments/analyze/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { plaidClient } from '@/lib/plaid';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { decryptToken } from '@/lib/secrets/tokenCipher';
 
 export async function GET() {
   try {
@@ -26,7 +27,7 @@ export async function GET() {
       try {
         // Get investment holdings
         const holdingsResponse = await plaidClient.investmentsHoldingsGet({
-          access_token: item.accessToken
+          access_token: decryptToken(item.accessToken)
         });
         
         if (holdingsResponse.data.holdings) {
@@ -35,7 +36,7 @@ export async function GET() {
 
         // Get investment transactions
         const transactionsResponse = await plaidClient.investmentsTransactionsGet({
-          access_token: item.accessToken,
+          access_token: decryptToken(item.accessToken),
           start_date: '2020-01-01',
           end_date: new Date().toISOString().split('T')[0]
         });

--- a/src/app/api/investments/route.ts
+++ b/src/app/api/investments/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { plaidClient } from '@/lib/plaid';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { decryptToken } from '@/lib/secrets/tokenCipher';
 
 export async function GET() {
   try {
@@ -28,11 +29,11 @@ export async function GET() {
     for (const item of plaidItems) {
       try {
         const holdingsResponse = await plaidClient.investmentsHoldingsGet({
-          access_token: item.accessToken
+          access_token: decryptToken(item.accessToken)
         });
 
         const transactionsResponse = await plaidClient.investmentsTransactionsGet({
-          access_token: item.accessToken,
+          access_token: decryptToken(item.accessToken),
           start_date: '2020-01-01',
           end_date: new Date().toISOString().split('T')[0]
         });

--- a/src/app/api/plaid/exchange-token/route.ts
+++ b/src/app/api/plaid/exchange-token/route.ts
@@ -4,6 +4,7 @@ import { prisma } from '@/lib/prisma';
 import { plaidClient } from '@/lib/plaid';
 import { CountryCode } from 'plaid';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { encryptToken } from '@/lib/secrets/tokenCipher';
 
 export async function POST(request: Request) {
   try {
@@ -62,7 +63,8 @@ export async function POST(request: Request) {
       data: {
         id: plaidItemId,
         itemId,
-        accessToken,
+        // SEC-02: the Plaid access token lands encrypted; readers accept ciphertext only.
+        accessToken: encryptToken(accessToken),
         institutionId: institutionId || 'unknown',
         institutionName: institutionName,
         userId: user.id,

--- a/src/app/api/plaid/sync/route.ts
+++ b/src/app/api/plaid/sync/route.ts
@@ -7,6 +7,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { Configuration, PlaidApi, PlaidEnvironments } from 'plaid';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { decryptToken } from '@/lib/secrets/tokenCipher';
 
 const plaidConfig = new Configuration({
   basePath: PlaidEnvironments.production,
@@ -60,7 +61,7 @@ export async function POST(request: NextRequest) {
 
     // Sync transactions
     const transactionsResponse = await plaidClient.transactionsGet({
-      access_token: item.accessToken,
+      access_token: decryptToken(item.accessToken),
       start_date: thirtyDaysAgo.toISOString().split('T')[0],
       end_date: now.toISOString().split('T')[0],
     });

--- a/src/app/api/tastytrade/connect/route.ts
+++ b/src/app/api/tastytrade/connect/route.ts
@@ -3,6 +3,7 @@ import { prisma } from '@/lib/prisma';
 import { getTastytradeClient } from '@/lib/tastytrade';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { requireAdmin } from '@/lib/require-admin';
+import { encryptToken } from '@/lib/secrets/tokenCipher';
 
 export async function POST() {
   try {
@@ -55,7 +56,7 @@ export async function POST() {
       create: {
         userId: user.id,
         ttUsername: 'oauth',
-        sessionToken: 'oauth',
+        sessionToken: encryptToken('oauth'),
         accountNumbers,
         status: 'active',
         connectedAt: new Date(),
@@ -63,7 +64,7 @@ export async function POST() {
       },
       update: {
         ttUsername: 'oauth',
-        sessionToken: 'oauth',
+        sessionToken: encryptToken('oauth'),
         rememberToken: null,
         accountNumbers,
         status: 'active',

--- a/src/app/api/transactions/fix-categories/route.ts
+++ b/src/app/api/transactions/fix-categories/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { plaidClient } from '@/lib/plaid';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { decryptToken } from '@/lib/secrets/tokenCipher';
 
 export async function POST() {
   try {
@@ -28,7 +29,7 @@ export async function POST() {
     for (const item of plaidItems) {
       try {
         const response = await plaidClient.transactionsGet({
-          access_token: item.accessToken,
+          access_token: decryptToken(item.accessToken),
           start_date: '2024-01-01',
           end_date: new Date().toISOString().split('T')[0]
         });

--- a/src/app/api/transactions/resync-with-rich-data/route.ts
+++ b/src/app/api/transactions/resync-with-rich-data/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { plaidClient } from '@/lib/plaid';
 import { prisma } from '@/lib/prisma';
+import { decryptToken } from '@/lib/secrets/tokenCipher';
 
 export async function POST() {
   try {
@@ -35,7 +36,7 @@ export async function POST() {
 
     for (const item of plaidItems) {
       const response = await plaidClient.transactionsGet({
-        access_token: item.accessToken,
+        access_token: decryptToken(item.accessToken),
         start_date: startDate,
         end_date: endDate,
         options: {

--- a/src/app/api/transactions/sync-complete/route.ts
+++ b/src/app/api/transactions/sync-complete/route.ts
@@ -3,6 +3,7 @@ import { prisma } from '@/lib/prisma';
 import { plaidClient } from '@/lib/plaid';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { requireTabAccess } from '@/lib/auth-helpers';
+import { decryptToken } from '@/lib/secrets/tokenCipher';
 
 export const maxDuration = 300; // 5 minutes for Pro plan
 
@@ -62,7 +63,7 @@ export async function POST() {
 
         while (hasMore) {
           const response = await plaidClient.transactionsGet({
-            access_token: item.accessToken,
+            access_token: decryptToken(item.accessToken),
             start_date: '2024-01-01',
             end_date: new Date().toISOString().split('T')[0],
             options: {
@@ -182,7 +183,7 @@ export async function POST() {
 
         while (hasMore) {
           const investResponse = await plaidClient.investmentsTransactionsGet({
-            access_token: item.accessToken,
+            access_token: decryptToken(item.accessToken),
             start_date: '2024-01-01',
             end_date: new Date().toISOString().split('T')[0],
             options: {

--- a/src/app/api/transactions/sync-full/route.ts
+++ b/src/app/api/transactions/sync-full/route.ts
@@ -7,6 +7,7 @@ import { prisma } from '@/lib/prisma';
 import { plaidClient } from '@/lib/plaid';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { requireTabAccess } from '@/lib/auth-helpers';
+import { decryptToken } from '@/lib/secrets/tokenCipher';
 
 export async function POST() {
   console.warn('DEPRECATED: /api/transactions/sync-full called — use /api/transactions/sync-complete');
@@ -49,7 +50,7 @@ export async function POST() {
         const startDate = new Date(Date.now() - 730 * 24 * 60 * 60 * 1000).toISOString().split('T')[0]; // 2 years
         
         const response = await plaidClient.transactionsGet({
-          access_token: item.accessToken,
+          access_token: decryptToken(item.accessToken),
           start_date: startDate,
           end_date: endDate,
           options: {

--- a/src/app/api/transactions/sync/route.ts
+++ b/src/app/api/transactions/sync/route.ts
@@ -7,6 +7,7 @@ import { prisma } from '@/lib/prisma';
 import { plaidClient } from '@/lib/plaid';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { requireTabAccess } from '@/lib/auth-helpers';
+import { decryptToken } from '@/lib/secrets/tokenCipher';
 
 export async function POST() {
   console.warn('DEPRECATED: /api/transactions/sync called — use /api/transactions/sync-complete');
@@ -46,7 +47,7 @@ export async function POST() {
         
         while (hasMore) {
           const request: any = {
-            access_token: item.accessToken,
+            access_token: decryptToken(item.accessToken),
             count: 500
           };
           

--- a/src/lib/__tests__/tokenCipher.test.ts
+++ b/src/lib/__tests__/tokenCipher.test.ts
@@ -1,0 +1,134 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { randomBytes } from 'node:crypto';
+import {
+  decryptToken,
+  encryptToken,
+  isCiphertext,
+  TokenCipherError,
+  TokenCipherKeyError,
+  TokenNotEncryptedError,
+} from '../secrets/tokenCipher';
+
+// SEC-02 — provider tokens at rest. Hermetic: the key is generated in-process.
+// Proves the round trip, the stored form, that tamper and plaintext both throw
+// (no dual-read path), and that the key is required at first use.
+
+const KEY = randomBytes(32).toString('base64');
+const STORED_FORM = /^enc:v1:[A-Za-z0-9_-]+:[A-Za-z0-9+/=]+:[A-Za-z0-9+/=]+:[A-Za-z0-9+/=]+$/;
+
+function withKey(key: string | undefined, keyId: string | undefined, fn: () => void) {
+  const prev = { key: process.env.TOKEN_ENCRYPTION_KEY, id: process.env.TOKEN_ENCRYPTION_KEY_ID };
+  if (key === undefined) delete process.env.TOKEN_ENCRYPTION_KEY; else process.env.TOKEN_ENCRYPTION_KEY = key;
+  if (keyId === undefined) delete process.env.TOKEN_ENCRYPTION_KEY_ID; else process.env.TOKEN_ENCRYPTION_KEY_ID = keyId;
+  try {
+    fn();
+  } finally {
+    if (prev.key === undefined) delete process.env.TOKEN_ENCRYPTION_KEY; else process.env.TOKEN_ENCRYPTION_KEY = prev.key;
+    if (prev.id === undefined) delete process.env.TOKEN_ENCRYPTION_KEY_ID; else process.env.TOKEN_ENCRYPTION_KEY_ID = prev.id;
+  }
+}
+
+test('round trip: encrypt then decrypt returns the plaintext', () => {
+  withKey(KEY, 'k1', () => {
+    const plain = 'access-production-0f3c9a2e-1b4d-4c8e-9a7f-2d6e5b4c3a1f';
+    const stored = encryptToken(plain);
+    assert.match(stored, STORED_FORM);
+    assert.equal(isCiphertext(stored), true);
+    assert.equal(decryptToken(stored), plain);
+  });
+});
+
+test('stored form parts: 12-byte iv, 16-byte tag, key id embedded', () => {
+  withKey(KEY, 'k1', () => {
+    const [prefix, version, keyId, iv, tag] = encryptToken('t').split(':');
+    assert.equal(`${prefix}:${version}`, 'enc:v1');
+    assert.equal(keyId, 'k1');
+    assert.equal(Buffer.from(iv, 'base64').length, 12);
+    assert.equal(Buffer.from(tag, 'base64').length, 16);
+  });
+});
+
+test('fresh iv per call: the same plaintext never encrypts to the same ciphertext', () => {
+  withKey(KEY, 'k1', () => {
+    assert.notEqual(encryptToken('same'), encryptToken('same'));
+  });
+});
+
+test('tamper: a flipped ciphertext byte throws TokenCipherError', () => {
+  withKey(KEY, 'k1', () => {
+    const stored = encryptToken('a-real-token-value');
+    const parts = stored.split(':');
+    const ct = Buffer.from(parts[5], 'base64');
+    ct[0] ^= 0x01;
+    parts[5] = ct.toString('base64');
+    assert.throws(() => decryptToken(parts.join(':')), TokenCipherError);
+  });
+});
+
+test('tamper: a flipped auth-tag byte throws TokenCipherError', () => {
+  withKey(KEY, 'k1', () => {
+    const stored = encryptToken('a-real-token-value');
+    const parts = stored.split(':');
+    const tag = Buffer.from(parts[4], 'base64');
+    tag[3] ^= 0x80;
+    parts[4] = tag.toString('base64');
+    assert.throws(() => decryptToken(parts.join(':')), TokenCipherError);
+  });
+});
+
+test('tamper: a swapped key id throws TokenCipherError', () => {
+  withKey(KEY, 'k1', () => {
+    const stored = encryptToken('a-real-token-value').replace('enc:v1:k1:', 'enc:v1:k2:');
+    assert.throws(() => decryptToken(stored), TokenCipherError);
+  });
+});
+
+test('wrong key: ciphertext from another key fails authentication', () => {
+  let stored = '';
+  withKey(KEY, 'k1', () => { stored = encryptToken('a-real-token-value'); });
+  withKey(randomBytes(32).toString('base64'), 'k1', () => {
+    assert.throws(() => decryptToken(stored), TokenCipherError);
+  });
+});
+
+test('plaintext handed to a reader throws TokenNotEncryptedError — no dual-read path', () => {
+  withKey(KEY, 'k1', () => {
+    assert.equal(isCiphertext('access-production-plaintext'), false);
+    assert.throws(() => decryptToken('access-production-plaintext'), TokenNotEncryptedError);
+    assert.throws(() => decryptToken(''), TokenNotEncryptedError);
+  });
+});
+
+test('malformed ciphertext throws TokenCipherError', () => {
+  withKey(KEY, 'k1', () => {
+    assert.throws(() => decryptToken('enc:v1:k1:only-two-parts'), TokenCipherError);
+    assert.throws(() => decryptToken('enc:v1:k1:AAAA:BBBB:CCCC'), TokenCipherError);
+  });
+});
+
+test('empty plaintext and double encryption are refused', () => {
+  withKey(KEY, 'k1', () => {
+    assert.throws(() => encryptToken(''), TokenCipherError);
+    assert.throws(() => encryptToken(encryptToken('x')), TokenCipherError);
+  });
+});
+
+test('missing key throws TokenCipherKeyError at first use', () => {
+  withKey(undefined, 'k1', () => {
+    assert.throws(() => encryptToken('x'), TokenCipherKeyError);
+    assert.throws(() => decryptToken('enc:v1:k1:AAAAAAAAAAAAAAAA:AAAAAAAAAAAAAAAAAAAAAA==:AA=='), TokenCipherKeyError);
+  });
+});
+
+test('short key and missing or bad key id throw TokenCipherKeyError', () => {
+  withKey(randomBytes(16).toString('base64'), 'k1', () => {
+    assert.throws(() => encryptToken('x'), TokenCipherKeyError);
+  });
+  withKey(KEY, undefined, () => {
+    assert.throws(() => encryptToken('x'), TokenCipherKeyError);
+  });
+  withKey(KEY, 'has:colon', () => {
+    assert.throws(() => encryptToken('x'), TokenCipherKeyError);
+  });
+});

--- a/src/lib/plaid-sync-fix.ts
+++ b/src/lib/plaid-sync-fix.ts
@@ -1,5 +1,6 @@
 import { prisma } from './prisma';
 import { plaidClient } from './plaid';
+import { decryptToken } from './secrets/tokenCipher';
 
 export async function fixPlaidSync(userId: string) {
   try {
@@ -12,7 +13,7 @@ export async function fixPlaidSync(userId: string) {
     for (const item of plaidItems) {
       try {
         const response = await plaidClient.transactionsGet({
-          access_token: item.accessToken,
+          access_token: decryptToken(item.accessToken),
           start_date: '2024-01-01',
           end_date: new Date().toISOString().split('T')[0]
         });

--- a/src/lib/secrets/tokenCipher.ts
+++ b/src/lib/secrets/tokenCipher.ts
@@ -1,0 +1,119 @@
+/**
+ * SEC-02 — provider tokens at rest.
+ *
+ * The two stored provider secrets (plaid_items.accessToken and
+ * tastytrade_connections.sessionToken) are written ONLY through encryptToken()
+ * and read ONLY through decryptToken(). No other module touches the raw column
+ * value. Readers accept ciphertext only: a plaintext value throws — there is no
+ * dual-read path, by rule (a dual read is fallback logic).
+ *
+ * Stored form:  enc:v1:<keyId>:<iv>:<tag>:<ct>   (base64 parts; base64 never
+ * contains ':' so the split is unambiguous). AES-256-GCM, 12-byte random IV,
+ * 16-byte auth tag, the header `enc:v1:<keyId>` bound as AAD so a swapped key id
+ * fails authentication.
+ *
+ * Key: TOKEN_ENCRYPTION_KEY (base64 of exactly 32 bytes) and
+ * TOKEN_ENCRYPTION_KEY_ID (short id, [A-Za-z0-9_-]). Both are read at FIRST USE,
+ * not at import, so `next build` and any page-data collection that imports a
+ * route never needs the key; a missing or short key throws TokenCipherKeyError
+ * on the first encrypt/decrypt call.
+ */
+import { createCipheriv, createDecipheriv, randomBytes } from 'node:crypto';
+
+const PREFIX = 'enc:v1:';
+const ALGORITHM = 'aes-256-gcm';
+const KEY_BYTES = 32;
+const IV_BYTES = 12;
+const TAG_BYTES = 16;
+const KEY_ID_PATTERN = /^[A-Za-z0-9_-]+$/;
+
+/** The key material is missing, malformed, or the wrong length. */
+export class TokenCipherKeyError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'TokenCipherKeyError';
+  }
+}
+
+/** A reader was handed a value that is not in the stored ciphertext form. */
+export class TokenNotEncryptedError extends Error {
+  constructor(message = 'token not encrypted') {
+    super(message);
+    this.name = 'TokenNotEncryptedError';
+  }
+}
+
+/** Malformed ciphertext, key-id mismatch, or failed authentication (tamper / wrong key). */
+export class TokenCipherError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'TokenCipherError';
+  }
+}
+
+function loadKey(): { key: Buffer; keyId: string } {
+  const raw = process.env.TOKEN_ENCRYPTION_KEY;
+  const keyId = process.env.TOKEN_ENCRYPTION_KEY_ID;
+  if (!raw) throw new TokenCipherKeyError('TOKEN_ENCRYPTION_KEY is not set');
+  if (!keyId) throw new TokenCipherKeyError('TOKEN_ENCRYPTION_KEY_ID is not set');
+  if (!KEY_ID_PATTERN.test(keyId)) {
+    throw new TokenCipherKeyError('TOKEN_ENCRYPTION_KEY_ID must match [A-Za-z0-9_-]+ (it is embedded in the stored form)');
+  }
+  const key = Buffer.from(raw, 'base64');
+  if (key.length !== KEY_BYTES) {
+    throw new TokenCipherKeyError(`TOKEN_ENCRYPTION_KEY must be base64 of exactly ${KEY_BYTES} bytes (decoded ${key.length})`);
+  }
+  return { key, keyId };
+}
+
+/** True when the value is in the stored ciphertext form. Never throws. */
+export function isCiphertext(value: unknown): value is string {
+  return typeof value === 'string' && value.startsWith(PREFIX);
+}
+
+/** Encrypt a plaintext provider token for storage. Refuses empty input and double encryption. */
+export function encryptToken(plain: string): string {
+  if (typeof plain !== 'string' || plain.length === 0) {
+    throw new TokenCipherError('refusing to encrypt an empty token');
+  }
+  if (isCiphertext(plain)) {
+    throw new TokenCipherError('refusing to encrypt a value that is already ciphertext');
+  }
+  const { key, keyId } = loadKey();
+  const iv = randomBytes(IV_BYTES);
+  const cipher = createCipheriv(ALGORITHM, key, iv, { authTagLength: TAG_BYTES });
+  cipher.setAAD(Buffer.from(`${PREFIX}${keyId}`, 'utf8'));
+  const ciphertext = Buffer.concat([cipher.update(plain, 'utf8'), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return `${PREFIX}${keyId}:${iv.toString('base64')}:${tag.toString('base64')}:${ciphertext.toString('base64')}`;
+}
+
+/** Decrypt a stored provider token. Throws on plaintext, malformed input, key-id mismatch, or tamper. */
+export function decryptToken(stored: string): string {
+  if (!isCiphertext(stored)) {
+    throw new TokenNotEncryptedError();
+  }
+  const parts = stored.slice(PREFIX.length).split(':');
+  if (parts.length !== 4) {
+    throw new TokenCipherError('malformed ciphertext: expected enc:v1:<keyId>:<iv>:<tag>:<ct>');
+  }
+  const [keyId, ivB64, tagB64, ctB64] = parts;
+  const { key, keyId: activeKeyId } = loadKey();
+  if (keyId !== activeKeyId) {
+    throw new TokenCipherError(`ciphertext key id "${keyId}" does not match TOKEN_ENCRYPTION_KEY_ID "${activeKeyId}"`);
+  }
+  const iv = Buffer.from(ivB64, 'base64');
+  const tag = Buffer.from(tagB64, 'base64');
+  const ciphertext = Buffer.from(ctB64, 'base64');
+  if (iv.length !== IV_BYTES || tag.length !== TAG_BYTES) {
+    throw new TokenCipherError('malformed ciphertext: bad iv or tag length');
+  }
+  const decipher = createDecipheriv(ALGORITHM, key, iv, { authTagLength: TAG_BYTES });
+  decipher.setAAD(Buffer.from(`${PREFIX}${keyId}`, 'utf8'));
+  decipher.setAuthTag(tag);
+  try {
+    return Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString('utf8');
+  } catch {
+    throw new TokenCipherError('ciphertext authentication failed (tampered, or encrypted under a different key)');
+  }
+}

--- a/src/lib/tastytrade.ts
+++ b/src/lib/tastytrade.ts
@@ -163,7 +163,8 @@ export async function getTastytradeSessionToken(): Promise<string> {
       body: JSON.stringify({ login: username, password: password, 'remember-me': true }),
     });
     const text = await resp.text();
-    console.log('[TT Auth] Manual JWT+castle+creds:', resp.status, text.slice(0, 300));
+    // SEC-02: never log the /sessions body — it carries the session token on success.
+    console.log('[TT Auth] Manual JWT+castle+creds status:', resp.status);
 
     if (resp.ok) {
       const data = JSON.parse(text);


### PR DESCRIPTION
**Do not merge — Alex merges after Vercel Preview (SOC 2 gate).** This PR is **cutover-ordered**: read the merge procedure below before merging.

## Why

`plaid_items.accessToken` is stored plaintext (`src/app/api/plaid/exchange-token/route.ts:61-71`), `tastytrade_connections.sessionToken` exists to hold a real token (`prisma/schema.prisma:1688`), and `src/lib/tastytrade.ts:166` logged the first 300 chars of the `/sessions` response body, which carries the session token on success. Ruled: AES-256-GCM, key in env, ciphertext-only readers, no dual-read path, one re-encryption script Alex runs once. Branch from main `3e7abee9`.

## Audit (before writing)

**Every read and write of `plaid_items.accessToken` in `src/`** — the eleven `findMany`/`findFirst` sites the REBUILD-01 census counted, plus the writer:

| # | site (main) | kind | this PR |
|---|---|---|---|
| 1 | `admin/backfill-transaction-fields/route.ts:32` find, `:51` `access_token: item.accessToken` | read | `decryptToken` at `:52` |
| 2 | `transactions/sync-complete/route.ts:28` find, `:65` and `:185` | read ×2 | `:66`, `:186` |
| 3 | `transactions/fix-categories/route.ts:22` find, `:31` | read | `:32` |
| 4 | `transactions/sync/route.ts:31` find, `:49` | read | `:50` |
| 5 | `transactions/sync-full/route.ts:31` find, `:52` | read | `:53` |
| 6 | `transactions/resync-with-rich-data/route.ts:27` find, `:38` | read | `:39` |
| 7 | `plaid/sync/route.ts:47` findFirst, `:54` presence check, `:63` | read | `:64` (the `!item?.accessToken` presence check at `:55` is untouched: it uses no value) |
| 8 | `investments/route.ts:22` find, `:31`, `:35` | read ×2 | `:32`, `:36` |
| 9 | `investments/analyze/route.ts:21` find, `:29`, `:38` | read ×2 | `:30`, `:39` |
| 10 | `lib/plaid-sync-fix.ts:6` find, `:15` | read | `:16` |
| 11 | `accounts/route.ts:25` find | fetches the column, never uses it | unchanged |
| 12 | `plaid/items/route.ts:29` find | `select: { id }` since SEC-01 | unchanged |
| W | `plaid/exchange-token/route.ts:61-71` create, `:65` `accessToken,` | **write** | `encryptToken(accessToken)` at `:67`; the in-memory value is still used for `itemGet` `:42` and `accountsGet` `:77` before storage |

**Every read and write of `tastytrade_connections.sessionToken`**: writes at `tastytrade/connect/route.ts:58` (create) and `:66` (update), both the literal `'oauth'` — now `encryptToken('oauth')` at `:59`/`:67`. Reads of the value: **none** (`status/route.ts:38` selects other fields; `lib/tastytrade.ts:22/:43/:85` never touch it; the `sessionToken` locals at `lib/tastytrade.ts:134-178` are provider-response variables, not the column). `rememberToken: null` at `:68` clears the unused column and stays.

**Log lines that could carry a token or a provider session body:**

| site | what | this PR |
|---|---|---|
| `lib/tastytrade.ts:166` `console.log('[TT Auth] Manual JWT+castle+creds:', resp.status, text.slice(0, 300))` | the `/sessions` 200 body, which contains `data['session-token']` | **deleted; status-only log kept** |
| `lib/tastytrade.ts:147` | the `/sessions` **error** body (first 300 chars) — a failed login carries no token | reported, unchanged |
| `lib/tastytrade.ts:135, :172`; `backtest/run:33`, `simulate:32` | token **length** only | safe |
| `plaid/*`, `transactions/sync*`, `fix-categories:54`, `backfill:128`, `investments/*`, `plaid-sync-fix:31` — 20 `console.error('…', error)` sites that print a **whole Plaid SDK error** | **finding, not fixed here.** plaid 11.0.0 rides axios 0.21.4, whose enhanced errors carry `config.headers` (`PLAID-SECRET`) and `config.data` (the request body with `access_token`). Proved locally with `axios/lib/core/enhanceError`: `util.inspect(err)` prints both. Encrypting at rest does not stop this: the decrypted token is in the request that fails. | out of this PR's ruled scope; needs its own ruling (a Plaid-error summarizer that logs `response.data` only) |

**NextAuth `Account.access_token` / `refresh_token`** (`prisma/schema.prisma:998-1005`, `Account @@unique([provider, providerAccountId])`): `src/app/api/auth/[...nextauth]/route.ts:16-22` uses `PrismaAdapter` with Google and GitHub providers, so the adapter populates those columns on every OAuth sign-in by construction. Row counts are not verifiable from here (no Azure access). Out of scope, report only.

**Where the key would be missing** (the fail-loud is placed at first use, inside `loadKey()`, never at import):

| context | needs the key? | behaviour |
|---|---|---|
| `next build` / page-data collection | no — the helper reads env only inside `encryptToken`/`decryptToken` | build passes without the vars (verified) |
| Vercel production and preview | yes — every Plaid and tastytrade token read or write | `TokenCipherKeyError` on the first call; set both vars in both environments (cutover step 1) |
| `vercel.json` cron `/api/cron/auto-categorize` | no — touches neither column | n/a |
| Inngest functions (`src/inngest/**`) | no — none imports `plaid_items`, `tastytrade_connections`, `plaidClient`, or the tastytrade client (grep) | n/a |
| `scripts/reencrypt-tokens.ts` | yes | refuses to start without `DATABASE_URL`, `TOKEN_ENCRYPTION_KEY`, `TOKEN_ENCRYPTION_KEY_ID`; runs `encryptToken('preflight')` before opening the transaction |
| `npm test` | generated in-process | hermetic |

STOP RULE: every reader is a TypeScript call site on `item.accessToken`; all were routable through the helper. No raw SQL touches either column (grep).

## Build

- `src/lib/secrets/tokenCipher.ts` — `encryptToken(plain)`, `decryptToken(stored)`, `isCiphertext(value)`. AES-256-GCM, 12-byte random IV, 16-byte tag, the header `enc:v1:<keyId>` bound as AAD. Key `TOKEN_ENCRYPTION_KEY` (base64 of exactly 32 bytes), id `TOKEN_ENCRYPTION_KEY_ID` (`[A-Za-z0-9_-]+`). Stored form `enc:v1:<keyId>:<iv>:<tag>:<ct>`. Errors: `TokenCipherKeyError` (missing / short / bad id), `TokenNotEncryptedError` (`"token not encrypted"` — a plaintext value handed to a reader), `TokenCipherError` (malformed, key-id mismatch, tamper, wrong key). `encryptToken` refuses empty input and double encryption.
- 13 call sites in 10 files read through `decryptToken`; the Plaid writer and both tastytrade writes go through `encryptToken`. **Grep proof** over every `accessToken` / `sessionToken` / `rememberToken` occurrence in `src/` (excluding the deck, the helper, its test): 38 lines, every one a cipher call or a listed non-value use (presence check, in-memory Plaid response before storage, the SDK's own `client.accessToken` JWT property, provider-response locals). **Raw column accesses outside the helper: 0.**
- `lib/tastytrade.ts:166` body log deleted; `console.log('[TT Auth] Manual JWT+castle+creds status:', resp.status)` kept.
- `scripts/reencrypt-tokens.ts` — one transaction over both columns; a row is touched only if `!isCiphertext`; counts printed before and after; a second run updates zero rows; an empty stored value makes `encryptToken` throw, the transaction rolls back and the row id is named. Tracked with a deliberate `git add -f` per `.gitignore:82-87` (PR-SCRIPTS-GITIGNORE: "adding a NEW repo script deliberately requires git add -f") — second commit `ac1898bd`.
- `.env.example` — the two vars with generation (`openssl rand -base64 32`), placement, and the note that rotation is not implemented in this PR.
- `README.md` — security bullet "Provider tokens at rest: AES-256-GCM with a key held in the deployment env (`src/lib/secrets/tokenCipher.ts`); readers accept ciphertext only." and an env-table row; regenerated by the README generator, whose env assert (table == `process.env` grep) passed. The census date is pinned so only those two lines changed.
- `src/lib/__tests__/tokenCipher.test.ts` — 12 tests, picked up by `npm test`.

## CUTOVER — merge procedure, in this order

1. **Alex sets `TOKEN_ENCRYPTION_KEY` and `TOKEN_ENCRYPTION_KEY_ID` in Vercel, production AND preview.** Key: `openssl rand -base64 32`. Id: a short label, e.g. `k1`.
2. **Alex runs the script locally against production with the same values:**
   ```
   DATABASE_URL="postgresql://…" TOKEN_ENCRYPTION_KEY="…" TOKEN_ENCRYPTION_KEY_ID="k1" npx tsx scripts/reencrypt-tokens.ts
   ```
   Paste the printed `before` / `updated` / `after` counts into this PR. Expected: `after.plaintext = 0` for both tables. A second run must print `updated: {"plaid_items":0,"tastytrade_connections":0}`.
3. **Alex merges.** Production deploys ciphertext-only readers within minutes.

**Between steps 2 and 3 the old code hands ciphertext to Plaid and fails loud** (every Plaid sync route, investments, fix-categories, backfill). That window is acceptable and expected: nothing is written wrongly, the calls just fail until the new readers deploy. Doing step 2 before step 1 would leave production without a key when it deploys; doing 3 before 2 would make every reader throw `TokenNotEncryptedError` on the plaintext rows. Neither path corrupts data.

## Verify

| Check | Result |
|---|---|
| `npm test` | 37/37 pass (12 tokenCipher + 25 url-guard) |
| `npx tsc --noEmit` | exit 0; the script (excluded from `tsconfig.json` by `"exclude": ["scripts"]`) type-checked separately with a scratch config extending it: exit 0 |
| eslint | **0 on the three new files** and **0 findings introduced**: per-file problem counts on main vs branch are identical for all 13 touched files (33 pre-existing `no-explicit-any` errors and 3 warnings on main, same counts on the branch). `eslint 0` across the touched routes is not reachable without a lint PR; not widened here |
| `next build` | compiled, types valid; page-data collection dies at the pre-existing `/api/admin/backfill-transaction-fields` `PLAID_CLIENT_ID` assert (Vercel-only secrets), as on every prior PR. **The build never needed the cipher key** |
| Grep proof | 38 occurrences classified, 0 raw column accesses outside the helper |
| Diff scope | the 10 reader files, the 2 writer files, `lib/tastytrade.ts`, the helper, its test, the script, `.env.example`, `README.md` (2 lines) |

### Test output
```
# tests 37
# pass 37
# fail 0
```
tokenCipher cases: round trip · stored-form parts (12-byte iv, 16-byte tag, key id) · fresh iv per call · tamper: ciphertext byte · tamper: auth-tag byte · tamper: swapped key id · wrong key · plaintext to a reader throws TokenNotEncryptedError · malformed throws TokenCipherError · empty and double encryption refused · missing key throws TokenCipherKeyError at first use · short key / missing or bad key id throw TokenCipherKeyError.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc

---
_Generated by [Claude Code](https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc)_