### PR TITLE
fix(security): no provider secret in a log line — Plaid and tastytrade error summarizers (SEC-02b)

### DIFF
--- a/src/app/api/admin/backfill-transaction-fields/route.ts
+++ b/src/app/api/admin/backfill-transaction-fields/route.ts
@@ -3,6 +3,7 @@ import { prisma } from '@/lib/prisma';
 import { plaidClient } from '@/lib/plaid';
 import { requireAdmin } from '@/lib/require-admin';
 import { decryptToken } from '@/lib/secrets/tokenCipher';
+import { summarizePlaidError } from '@/lib/plaid/summarizeError';
 
 /**
  * POST /api/admin/backfill-transaction-fields
@@ -126,7 +127,7 @@ export async function POST() {
           hasMore = response.data.total_transactions > offset;
         }
       } catch (error) {
-        console.error(`Error backfilling item ${item.id}:`, error);
+        console.error(`Error backfilling item ${item.id}:`, summarizePlaidError(error));
       }
     }
 
@@ -136,7 +137,7 @@ export async function POST() {
       fieldsBackfilled: totalFieldsBackfilled
     });
   } catch (error) {
-    console.error('Backfill error:', error);
+    console.error('Backfill error:', summarizePlaidError(error));
     return NextResponse.json({ error: 'Failed to backfill' }, { status: 500 });
   }
 }

--- a/src/app/api/investments/analyze/route.ts
+++ b/src/app/api/investments/analyze/route.ts
@@ -3,6 +3,7 @@ import { prisma } from '@/lib/prisma';
 import { plaidClient } from '@/lib/plaid';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { decryptToken } from '@/lib/secrets/tokenCipher';
+import { summarizePlaidError } from '@/lib/plaid/summarizeError';
 
 export async function GET() {
   try {
@@ -45,7 +46,7 @@ export async function GET() {
           allTransactions = allTransactions.concat(transactionsResponse.data.investment_transactions);
         }
       } catch (error) {
-        console.error('Error fetching investment data:', error);
+        console.error('Error fetching investment data:', summarizePlaidError(error));
       }
     }
 
@@ -58,7 +59,7 @@ export async function GET() {
       }
     });
   } catch (error) {
-    console.error('Investment analysis error:', error);
+    console.error('Investment analysis error:', summarizePlaidError(error));
     return NextResponse.json({ error: 'Failed to analyze investments' }, { status: 500 });
   }
 }

--- a/src/app/api/investments/route.ts
+++ b/src/app/api/investments/route.ts
@@ -3,6 +3,7 @@ import { prisma } from '@/lib/prisma';
 import { plaidClient } from '@/lib/plaid';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { decryptToken } from '@/lib/secrets/tokenCipher';
+import { summarizePlaidError } from '@/lib/plaid/summarizeError';
 
 export async function GET() {
   try {
@@ -45,13 +46,13 @@ export async function GET() {
           transactions: transactionsResponse.data.investment_transactions,
         });
       } catch (error) {
-        console.error('Error fetching investment data:', error);
+        console.error('Error fetching investment data:', summarizePlaidError(error));
       }
     }
 
     return NextResponse.json(investmentData);
   } catch (error) {
-    console.error('Error in investments route:', error);
+    console.error('Error in investments route:', summarizePlaidError(error));
     return NextResponse.json({ error: 'Failed to fetch investments' }, { status: 500 });
   }
 }

--- a/src/app/api/plaid/exchange-token/route.ts
+++ b/src/app/api/plaid/exchange-token/route.ts
@@ -5,6 +5,7 @@ import { plaidClient } from '@/lib/plaid';
 import { CountryCode } from 'plaid';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { encryptToken } from '@/lib/secrets/tokenCipher';
+import { summarizePlaidError } from '@/lib/plaid/summarizeError';
 
 export async function POST(request: Request) {
   try {
@@ -135,7 +136,7 @@ export async function POST(request: Request) {
 
     return NextResponse.json({ success: true });
   } catch (error) {
-    console.error('Token exchange error:', error);
+    console.error('Token exchange error:', summarizePlaidError(error));
     return NextResponse.json({ error: 'Failed to exchange token' }, { status: 500 });
   }
 }

--- a/src/app/api/plaid/link-token/route.ts
+++ b/src/app/api/plaid/link-token/route.ts
@@ -4,6 +4,7 @@ import { prisma } from '@/lib/prisma';
 import { plaidClient } from '@/lib/plaid';
 import { Products, CountryCode } from 'plaid';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { summarizePlaidError } from '@/lib/plaid/summarizeError';
 
 export async function POST() {
   try {
@@ -45,7 +46,7 @@ export async function POST() {
       expiration: createTokenResponse.data.expiration 
     });
   } catch (error: any) {
-    console.error('Error creating link token:', error);
+    console.error('Error creating link token:', summarizePlaidError(error));
     return NextResponse.json(
       { error: 'Failed to create link token', details: error.message },
       { status: 500 }

--- a/src/app/api/plaid/sync/route.ts
+++ b/src/app/api/plaid/sync/route.ts
@@ -8,6 +8,7 @@ import { prisma } from '@/lib/prisma';
 import { Configuration, PlaidApi, PlaidEnvironments } from 'plaid';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { decryptToken } from '@/lib/secrets/tokenCipher';
+import { summarizePlaidError } from '@/lib/plaid/summarizeError';
 
 const plaidConfig = new Configuration({
   basePath: PlaidEnvironments.production,
@@ -132,7 +133,7 @@ export async function POST(request: NextRequest) {
       synced: transactions.length 
     });
   } catch (error: any) {
-    console.error('Sync error:', error);
+    console.error('Sync error:', summarizePlaidError(error));
     return NextResponse.json({ error: error.message }, { status: 500 });
   }
 }

--- a/src/app/api/tastytrade/balances/route.ts
+++ b/src/app/api/tastytrade/balances/route.ts
@@ -3,6 +3,7 @@ import { prisma } from '@/lib/prisma';
 import { getAuthenticatedClient, getTastytradeConnection } from '@/lib/tastytrade';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { requireAdmin } from '@/lib/require-admin';
+import { summarizeTastytradeError } from '@/lib/tastytrade/summarizeError';
 
 export async function GET() {
   try {
@@ -59,7 +60,7 @@ export async function GET() {
 
     return NextResponse.json({ balances, failed_accounts: failedAccounts });
   } catch (error: any) {
-    console.error('[Tastytrade] Balances error:', error);
+    console.error('[Tastytrade] Balances error:', summarizeTastytradeError(error));
     return NextResponse.json({ error: 'Failed to fetch balances' }, { status: 500 });
   }
 }

--- a/src/app/api/tastytrade/callback/route.ts
+++ b/src/app/api/tastytrade/callback/route.ts
@@ -3,6 +3,7 @@ import { prisma } from '@/lib/prisma';
 import { getTastytradeClient } from '@/lib/tastytrade';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { requireAdmin } from '@/lib/require-admin';
+import { summarizeTastytradeError } from '@/lib/tastytrade/summarizeError';
 
 // With OAuth, the SDK auto-refreshes access tokens.
 // This endpoint validates the OAuth client still works and updates lastUsedAt.
@@ -61,7 +62,7 @@ export async function POST() {
       message: 'Session refreshed successfully',
     });
   } catch (error: any) {
-    console.error('[Tastytrade] Callback error:', error);
+    console.error('[Tastytrade] Callback error:', summarizeTastytradeError(error));
     return NextResponse.json({ error: 'Failed to refresh session' }, { status: 500 });
   }
 }

--- a/src/app/api/tastytrade/chains/route.ts
+++ b/src/app/api/tastytrade/chains/route.ts
@@ -3,6 +3,7 @@ import { prisma } from '@/lib/prisma';
 import { getAuthenticatedClient } from '@/lib/tastytrade';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { requireTabAccess } from '@/lib/auth-helpers';
+import { summarizeTastytradeError } from '@/lib/tastytrade/summarizeError';
 
 // Convert OCC symbol (e.g. "SPY   260221P00690000") to DXFeed format (".SPY260221P690")
 function occToDxFeed(occ: string): string | null {
@@ -117,7 +118,7 @@ export async function POST(request: Request) {
 
     return NextResponse.json({ chain: { symbol, expirations }, strikes_skipped_no_price: strikesSkippedNoPrice });
   } catch (error: any) {
-    console.error('[Tastytrade] Chains error:', error);
+    console.error('[Tastytrade] Chains error:', summarizeTastytradeError(error));
     return NextResponse.json({ error: 'Failed to fetch option chain' }, { status: 500 });
   }
 }

--- a/src/app/api/tastytrade/connect/route.ts
+++ b/src/app/api/tastytrade/connect/route.ts
@@ -4,6 +4,7 @@ import { getTastytradeClient } from '@/lib/tastytrade';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { requireAdmin } from '@/lib/require-admin';
 import { encryptToken } from '@/lib/secrets/tokenCipher';
+import { summarizeTastytradeError } from '@/lib/tastytrade/summarizeError';
 
 export async function POST() {
   try {
@@ -79,7 +80,7 @@ export async function POST() {
       message: 'Tastytrade account connected successfully',
     });
   } catch (error: any) {
-    console.error('[Tastytrade] Connect error:', error);
+    console.error('[Tastytrade] Connect error:', summarizeTastytradeError(error));
     return NextResponse.json({ error: 'Failed to connect Tastytrade account' }, { status: 500 });
   }
 }

--- a/src/app/api/tastytrade/greeks/route.ts
+++ b/src/app/api/tastytrade/greeks/route.ts
@@ -5,6 +5,7 @@ import { MarketDataSubscriptionType } from '@tastytrade/api';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { requireTabAccess } from '@/lib/auth-helpers';
 import { numOrNull, firstNumOrNull } from '@/lib/parse-num';
+import { summarizeTastytradeError } from '@/lib/tastytrade/summarizeError';
 
 export async function POST(request: Request) {
   try {
@@ -113,7 +114,7 @@ export async function POST(request: Request) {
 
     return NextResponse.json({ greeks: data });
   } catch (error: any) {
-    console.error('[Tastytrade] Greeks error:', error);
+    console.error('[Tastytrade] Greeks error:', summarizeTastytradeError(error));
     return NextResponse.json({ error: 'Failed to fetch greeks' }, { status: 500 });
   }
 }

--- a/src/app/api/tastytrade/positions/route.ts
+++ b/src/app/api/tastytrade/positions/route.ts
@@ -3,6 +3,7 @@ import { prisma } from '@/lib/prisma';
 import { getAuthenticatedClient, getTastytradeConnection } from '@/lib/tastytrade';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { requireAdmin } from '@/lib/require-admin';
+import { summarizeTastytradeError } from '@/lib/tastytrade/summarizeError';
 
 export async function GET() {
   try {
@@ -63,7 +64,7 @@ export async function GET() {
 
     return NextResponse.json({ positions: allPositions, accounts: accountNumbers, failed_accounts: failedAccounts });
   } catch (error: any) {
-    console.error('[Tastytrade] Positions error:', error);
+    console.error('[Tastytrade] Positions error:', summarizeTastytradeError(error));
     return NextResponse.json({ error: 'Failed to fetch positions' }, { status: 500 });
   }
 }

--- a/src/app/api/tastytrade/quotes/route.ts
+++ b/src/app/api/tastytrade/quotes/route.ts
@@ -5,6 +5,7 @@ import { MarketDataSubscriptionType } from '@tastytrade/api';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { requireTabAccess } from '@/lib/auth-helpers';
 import { numOrNull, firstNumOrNull } from '@/lib/parse-num';
+import { summarizeTastytradeError } from '@/lib/tastytrade/summarizeError';
 
 export async function POST(request: Request) {
   try {
@@ -95,7 +96,7 @@ export async function POST(request: Request) {
 
     return NextResponse.json({ quotes });
   } catch (error: any) {
-    console.error('[Tastytrade] Quotes error:', error);
+    console.error('[Tastytrade] Quotes error:', summarizeTastytradeError(error));
     return NextResponse.json({ error: 'Failed to fetch quotes' }, { status: 500 });
   }
 }

--- a/src/app/api/tastytrade/scanner/route.ts
+++ b/src/app/api/tastytrade/scanner/route.ts
@@ -4,6 +4,7 @@ import { getAuthenticatedClient } from '@/lib/tastytrade';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { requireTabAccess } from '@/lib/auth-helpers';
 import { numOrNull, firstNumOrNull } from '@/lib/parse-num';
+import { summarizeTastytradeError } from '@/lib/tastytrade/summarizeError';
 
 export const maxDuration = 300;
 
@@ -207,7 +208,7 @@ export async function GET(request: Request) {
           });
           return Array.isArray(raw) ? raw : [];
         } catch (err) {
-          console.error('[Scanner] Batch error:', err);
+          console.error('[Scanner] Batch error:', summarizeTastytradeError(err));
           batchErrors.push(`batch of ${batch.length} symbols FAILED: ${err instanceof Error ? err.message : String(err)}`);
           symbolsFailedCount += batch.length;
           return [];
@@ -296,7 +297,7 @@ export async function GET(request: Request) {
       fetchedAt: new Date().toISOString(),
     });
   } catch (error: any) {
-    console.error('[Tastytrade] Scanner error:', error);
+    console.error('[Tastytrade] Scanner error:', summarizeTastytradeError(error));
     return NextResponse.json({ error: 'Failed to fetch scanner data' }, { status: 500 });
   }
 }

--- a/src/app/api/transactions/fix-categories/route.ts
+++ b/src/app/api/transactions/fix-categories/route.ts
@@ -3,6 +3,7 @@ import { prisma } from '@/lib/prisma';
 import { plaidClient } from '@/lib/plaid';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { decryptToken } from '@/lib/secrets/tokenCipher';
+import { summarizePlaidError } from '@/lib/plaid/summarizeError';
 
 export async function POST() {
   try {
@@ -52,7 +53,7 @@ export async function POST() {
           updatedCount += result.count;
         }
       } catch (error) {
-        console.error('Error fixing categories for item:', item.id, error);
+        console.error('Error fixing categories for item:', item.id, summarizePlaidError(error));
       }
     }
 
@@ -61,7 +62,7 @@ export async function POST() {
       updatedCount 
     });
   } catch (error) {
-    console.error('Fix categories error:', error);
+    console.error('Fix categories error:', summarizePlaidError(error));
     return NextResponse.json({ error: 'Failed to fix categories' }, { status: 500 });
   }
 }

--- a/src/app/api/transactions/sync-complete/route.ts
+++ b/src/app/api/transactions/sync-complete/route.ts
@@ -4,6 +4,7 @@ import { plaidClient } from '@/lib/plaid';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { requireTabAccess } from '@/lib/auth-helpers';
 import { decryptToken } from '@/lib/secrets/tokenCipher';
+import { summarizePlaidError } from '@/lib/plaid/summarizeError';
 
 export const maxDuration = 300; // 5 minutes for Pro plan
 
@@ -163,7 +164,7 @@ export async function POST() {
           }
         }
       } catch (error) {
-        console.error('Error syncing transactions:', error);
+        console.error('Error syncing transactions:', summarizePlaidError(error));
       }
 
       // Sync investment transactions + securities
@@ -266,7 +267,7 @@ export async function POST() {
           hasMore = investResponse.data.total_investment_transactions > offset;
         }
       } catch (error) {
-        console.error('Error syncing investment transactions:', error);
+        console.error('Error syncing investment transactions:', summarizePlaidError(error));
       }
     }
 
@@ -283,7 +284,7 @@ export async function POST() {
       }
     });
   } catch (error) {
-    console.error('Complete sync error:', error);
+    console.error('Complete sync error:', summarizePlaidError(error));
     return NextResponse.json({ error: 'Failed to sync' }, { status: 500 });
   }
 }

--- a/src/app/api/transactions/sync-full/route.ts
+++ b/src/app/api/transactions/sync-full/route.ts
@@ -8,6 +8,7 @@ import { plaidClient } from '@/lib/plaid';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { requireTabAccess } from '@/lib/auth-helpers';
 import { decryptToken } from '@/lib/secrets/tokenCipher';
+import { summarizePlaidError } from '@/lib/plaid/summarizeError';
 
 export async function POST() {
   console.warn('DEPRECATED: /api/transactions/sync-full called — use /api/transactions/sync-complete');
@@ -93,7 +94,7 @@ export async function POST() {
           totalAdded++;
         }
       } catch (error) {
-        console.error('Error syncing item:', item.id, error);
+        console.error('Error syncing item:', item.id, summarizePlaidError(error));
       }
     }
 
@@ -106,7 +107,7 @@ export async function POST() {
       }
     });
   } catch (error) {
-    console.error('Full sync error:', error);
+    console.error('Full sync error:', summarizePlaidError(error));
     return NextResponse.json({ error: 'Failed to sync' }, { status: 500 });
   }
 }

--- a/src/app/api/transactions/sync/route.ts
+++ b/src/app/api/transactions/sync/route.ts
@@ -8,6 +8,7 @@ import { plaidClient } from '@/lib/plaid';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { requireTabAccess } from '@/lib/auth-helpers';
 import { decryptToken } from '@/lib/secrets/tokenCipher';
+import { summarizePlaidError } from '@/lib/plaid/summarizeError';
 
 export async function POST() {
   console.warn('DEPRECATED: /api/transactions/sync called — use /api/transactions/sync-complete');
@@ -122,7 +123,7 @@ export async function POST() {
           cursor = next_cursor;
         }
       } catch (error) {
-        console.error('Error syncing transactions for item:', item.id, error);
+        console.error('Error syncing transactions for item:', item.id, summarizePlaidError(error));
       }
     }
 
@@ -135,7 +136,7 @@ export async function POST() {
       }
     });
   } catch (error) {
-    console.error('Transaction sync error:', error);
+    console.error('Transaction sync error:', summarizePlaidError(error));
     return NextResponse.json({ error: 'Failed to sync transactions' }, { status: 500 });
   }
 }

--- a/src/lib/__tests__/summarizeError.test.ts
+++ b/src/lib/__tests__/summarizeError.test.ts
@@ -1,0 +1,111 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { inspect } from 'node:util';
+import { summarizePlaidError } from '../plaid/summarizeError';
+import { summarizeTastytradeError } from '../tastytrade/summarizeError';
+
+// SEC-02b — the summarizers must never surface the request side of an axios
+// error. The fabricated errors below mirror axios 0.21's enhanced Error shape
+// (plaid 11 and @tastytrade/api both resolve to the root axios 0.21.4): the
+// request headers and body ride on `config`, and `response.config` repeats them.
+
+const PLAID_SECRET = 'PLAID-SECRET-VALUE-9f3c1e';
+const ACCESS_TOKEN = 'access-production-6b2d7a4e-token';
+const JWT = 'eyJhbGciOi.tastytrade-jwt.sig';
+
+function fabricatePlaidError() {
+  const config = {
+    url: 'https://production.plaid.com/transactions/get',
+    method: 'post',
+    headers: { 'PLAID-CLIENT-ID': 'client-id', 'PLAID-SECRET': PLAID_SECRET },
+    data: JSON.stringify({ access_token: ACCESS_TOKEN, start_date: '2024-01-01' }),
+  };
+  return Object.assign(new Error('Request failed with status code 429'), {
+    isAxiosError: true,
+    config,
+    request: { _header: `PLAID-SECRET: ${PLAID_SECRET}` },
+    response: {
+      status: 429,
+      statusText: 'Too Many Requests',
+      headers: { 'content-type': 'application/json' },
+      config,
+      data: {
+        error_type: 'RATE_LIMIT_EXCEEDED',
+        error_code: 'TRANSACTIONS_LIMIT',
+        error_message: 'rate limit exceeded for this item',
+        display_message: null,
+        request_id: 'req_7Hq2',
+      },
+    },
+  });
+}
+
+function fabricateTastytradeError() {
+  const config = {
+    url: 'https://api.tastyworks.com/sessions',
+    headers: { Authorization: `Bearer ${JWT}` },
+    data: JSON.stringify({ login: 'user@example.com', password: 'hunter2-password', 'remember-me': true }),
+  };
+  return Object.assign(new Error('Request failed with status code 401'), {
+    isAxiosError: true,
+    config,
+    response: {
+      status: 401,
+      headers: {},
+      config,
+      data: { error: { code: 'invalid_credentials', message: 'Invalid login' } },
+    },
+  });
+}
+
+test('the raw axios error really does leak the secrets when inspected (the bug)', () => {
+  const raw = inspect(fabricatePlaidError());
+  assert.ok(raw.includes(PLAID_SECRET));
+  assert.ok(raw.includes(ACCESS_TOKEN));
+});
+
+test('summarizePlaidError keeps status and the five Plaid fields', () => {
+  const s = summarizePlaidError(fabricatePlaidError());
+  assert.equal(s.status, 429);
+  assert.equal(s.error_type, 'RATE_LIMIT_EXCEEDED');
+  assert.equal(s.error_code, 'TRANSACTIONS_LIMIT');
+  assert.equal(s.error_message, 'rate limit exceeded for this item');
+  assert.equal(s.request_id, 'req_7Hq2');
+  assert.equal(s.name, 'Error');
+  assert.equal(s.message, 'Request failed with status code 429');
+});
+
+test('summarizePlaidError output carries neither PLAID-SECRET nor access_token, in JSON or inspect', () => {
+  const s = summarizePlaidError(fabricatePlaidError());
+  for (const rendered of [JSON.stringify(s), inspect(s, { depth: null })]) {
+    assert.ok(!rendered.includes('PLAID-SECRET'));
+    assert.ok(!rendered.includes(PLAID_SECRET));
+    assert.ok(!rendered.includes('access_token'));
+    assert.ok(!rendered.includes(ACCESS_TOKEN));
+    assert.ok(!rendered.includes('config'));
+    assert.ok(!rendered.includes('headers'));
+  }
+  assert.deepEqual(Object.keys(s).sort(), ['error_code', 'error_message', 'error_type', 'message', 'name', 'request_id', 'status']);
+});
+
+test('summarizePlaidError on a non-Plaid error keeps name and message only', () => {
+  const s = summarizePlaidError(new TypeError('Cannot read properties of undefined'));
+  assert.deepEqual(s, { name: 'TypeError', message: 'Cannot read properties of undefined' });
+  assert.deepEqual(summarizePlaidError('plain string'), { message: 'plain string' });
+  assert.deepEqual(summarizePlaidError(null), {});
+  assert.deepEqual(summarizePlaidError({ response: { status: 'x', data: 'not-an-object' } }), {});
+});
+
+test('summarizeTastytradeError keeps status and the error code, never the Authorization header or login body', () => {
+  const s = summarizeTastytradeError(fabricateTastytradeError());
+  assert.equal(s.status, 401);
+  assert.equal(s.code, 'invalid_credentials');
+  assert.equal(s.error_message, 'Invalid login');
+  for (const rendered of [JSON.stringify(s), inspect(s, { depth: null })]) {
+    assert.ok(!rendered.includes('Bearer'));
+    assert.ok(!rendered.includes(JWT));
+    assert.ok(!rendered.includes('password'));
+    assert.ok(!rendered.includes('hunter2'));
+    assert.ok(!rendered.includes('Authorization'));
+  }
+});

--- a/src/lib/plaid-sync-fix.ts
+++ b/src/lib/plaid-sync-fix.ts
@@ -1,6 +1,7 @@
 import { prisma } from './prisma';
 import { plaidClient } from './plaid';
 import { decryptToken } from './secrets/tokenCipher';
+import { summarizePlaidError } from './plaid/summarizeError';
 
 export async function fixPlaidSync(userId: string) {
   try {
@@ -29,13 +30,13 @@ export async function fixPlaidSync(userId: string) {
           updatedCount++;
         }
       } catch (error) {
-        console.error('Error fixing sync for item:', item.id, error);
+        console.error('Error fixing sync for item:', item.id, summarizePlaidError(error));
       }
     }
 
     return { success: true, updatedCount };
   } catch (error) {
-    console.error('Fix plaid sync error:', error);
+    console.error('Fix plaid sync error:', summarizePlaidError(error));
     return { success: false, error };
   }
 }

--- a/src/lib/plaid/summarizeError.ts
+++ b/src/lib/plaid/summarizeError.ts
@@ -1,0 +1,52 @@
+/**
+ * SEC-02b — no provider secret in a log line.
+ *
+ * plaid 11 rides axios 0.21, whose errors carry the whole request on
+ * `err.config`: `config.headers` holds PLAID-CLIENT-ID and PLAID-SECRET,
+ * `config.data` holds the JSON body with the item's access_token. Passing the
+ * raw error to console.error prints both (util.inspect walks two levels).
+ *
+ * This summarizer reads ONLY `err.response?.status` and the fields of Plaid's
+ * documented error body on `err.response?.data` — error_type, error_code,
+ * error_message, request_id — plus the Error's own `name` and `message` so a
+ * non-Plaid error caught in the same block (Prisma, auth) still leaves a
+ * trace. It never touches `config`, `request`, `headers`, or the request body.
+ */
+
+export interface PlaidErrorSummary {
+  status?: number;
+  error_type?: string;
+  error_code?: string;
+  error_message?: string;
+  request_id?: string;
+  name?: string;
+  message?: string;
+}
+
+function str(v: unknown): string | undefined {
+  return typeof v === 'string' ? v : undefined;
+}
+
+export function summarizePlaidError(err: unknown): PlaidErrorSummary {
+  const summary: PlaidErrorSummary = {};
+  if (err instanceof Error) {
+    summary.name = err.name;
+    summary.message = err.message;
+  } else if (typeof err === 'string') {
+    summary.message = err;
+  }
+  const response = (err as { response?: unknown } | null)?.response;
+  if (response && typeof response === 'object') {
+    const status = (response as { status?: unknown }).status;
+    if (typeof status === 'number') summary.status = status;
+    const data = (response as { data?: unknown }).data;
+    if (data && typeof data === 'object') {
+      const d = data as Record<string, unknown>;
+      summary.error_type = str(d.error_type);
+      summary.error_code = str(d.error_code);
+      summary.error_message = str(d.error_message);
+      summary.request_id = str(d.request_id);
+    }
+  }
+  return summary;
+}

--- a/src/lib/tastytrade.ts
+++ b/src/lib/tastytrade.ts
@@ -144,7 +144,8 @@ export async function getTastytradeSessionToken(): Promise<string> {
   } catch (e: any) {
     const status = e?.response?.status;
     const data = e?.response?.data;
-    console.log('[TT Auth] SDK login failed:', status, JSON.stringify(data)?.slice(0, 300));
+    // SEC-02b: status and tastytrade's error code only — never a slice of the body.
+    console.log('[TT Auth] SDK login failed:', status, data?.error?.code);
   }
 
   // Approach 2: Manual POST with x-castle-request-token + JWT auth

--- a/src/lib/tastytrade/summarizeError.ts
+++ b/src/lib/tastytrade/summarizeError.ts
@@ -1,0 +1,44 @@
+/**
+ * SEC-02b — no provider secret in a log line.
+ *
+ * @tastytrade/api rides axios too; its errors carry `config.headers`
+ * (Authorization: Bearer <OAuth JWT or session token>) and, for
+ * sessionService.login, `config.data` with the login and password. This
+ * summarizer reads ONLY `err.response?.status` and tastytrade's error body
+ * `err.response?.data.error` — `code` and `message` — plus the Error's own
+ * `name` and `message`. Never `config`, `request`, `headers`, or the body.
+ */
+
+export interface TastytradeErrorSummary {
+  status?: number;
+  code?: string;
+  error_message?: string;
+  name?: string;
+  message?: string;
+}
+
+function str(v: unknown): string | undefined {
+  return typeof v === 'string' ? v : undefined;
+}
+
+export function summarizeTastytradeError(err: unknown): TastytradeErrorSummary {
+  const summary: TastytradeErrorSummary = {};
+  if (err instanceof Error) {
+    summary.name = err.name;
+    summary.message = err.message;
+  } else if (typeof err === 'string') {
+    summary.message = err;
+  }
+  const response = (err as { response?: unknown } | null)?.response;
+  if (response && typeof response === 'object') {
+    const status = (response as { status?: unknown }).status;
+    if (typeof status === 'number') summary.status = status;
+    const data = (response as { data?: unknown }).data;
+    const error = data && typeof data === 'object' ? (data as { error?: unknown }).error : undefined;
+    if (error && typeof error === 'object') {
+      summary.code = str((error as Record<string, unknown>).code);
+      summary.error_message = str((error as Record<string, unknown>).message);
+    }
+  }
+  return summary;
+}


### PR DESCRIPTION
**Do not merge — Alex merges after Vercel Preview (SOC 2 gate).**

## Why

Twenty catch sites in the Plaid routes and nine in the tastytrade routes logged the raw SDK error object. `plaid@11.0.0` and `@tastytrade/api@6.0.1` both resolve to the root `axios@0.21.4` (no nested axios), whose enhanced errors carry the whole request on `err.config`: `config.headers` holds `PLAID-SECRET` (or `Authorization: Bearer <JWT>`), `config.data` holds the request body with `access_token` (or the login password). `util.inspect` walks two levels, so `console.error('…', error)` prints both. Tonight's production log printed a whole Plaid 429 from `transactions/sync-complete`. Branch from main `cec371d6`.

## Audit — every catch in `src/` that logs an SDK error object whole

541 whole-object `console.*(…, error|err|e)` sites exist in `src/`; the ones inside a file that calls a provider SDK are classified below by the SDK's error shape.

**Error shapes (from `node_modules`):**

| SDK | transport | what the error object carries | verdict |
|---|---|---|---|
| plaid 11.0.0 | axios 0.21.4 | `config.headers` (PLAID-CLIENT-ID, PLAID-SECRET), `config.data` (body with access_token), `request`, `response.config` again | **FIX** |
| @tastytrade/api 6.0.1 | axios 0.21.4 | `config.headers.Authorization` (JWT / session token), `config.data` (login + password on `sessionService.login`) | **FIX** |
| stripe 20.3.0 | own http | `raw` (Stripe's error body), `headers` (response headers), `requestId`, `statusCode` — `stripe/cjs/Error.js:53-61`; no request, no key | fine |
| @anthropic-ai/sdk 0.96.0, openai 6.7.0 | own fetch | `status`, response `headers`, `error` body — `sdk/core/error.js:12-15`; no request, no key | fine |
| LiteAPI, Viator, Travel Buddy, Google Places, Duffel, xAI, Voyage, Resend | fetch | our own error classes built from an endpoint literal, the status, and the response text (`liteapiClient.ts:253-980`, `viatorClient.ts:91-349`, `travelBuddyClient.ts:126`, `placesSearch.ts:93-207`); no URL, no key, no request body | fine |

**FIX sites — Plaid (the twenty)**

| # | site on main | context | now |
|---|---|---|---|
| 1-2 | `admin/backfill-transaction-fields/route.ts:129`, `:139` | `transactionsGet :51` | `summarizePlaidError` |
| 3-4 | `investments/analyze/route.ts:48`, `:61` | holdings/investments gets `:29`, `:38` | ✓ |
| 5-6 | `investments/route.ts:48`, `:54` | `:31`, `:35` | ✓ |
| 7 | `plaid/exchange-token/route.ts:138` | exchange, itemGet, institutions, accountsGet `:31-76` | ✓ |
| 8 | `plaid/link-token/route.ts:48` | `linkTokenCreate :41` | ✓ |
| 9 | `plaid/sync/route.ts:135` | `transactionsGet :63` | ✓ |
| 10-11 | `transactions/fix-categories/route.ts:55`, `:64` | `:31` | ✓ |
| 12-14 | `transactions/sync-complete/route.ts:166`, `:269`, `:286` | `:65`, `:185` — the site that printed tonight's 429 | ✓ |
| 15-16 | `transactions/sync-full/route.ts:96`, `:109` | `:52` | ✓ |
| 17-18 | `transactions/sync/route.ts:125`, `:138` | `transactionsSync :58` | ✓ |
| 19-20 | `lib/plaid-sync-fix.ts:32`, `:38` | `:15` | ✓ |

**FIX sites — tastytrade SDK (nine) plus one trim**

| # | site on main | context | now |
|---|---|---|---|
| 1 | `tastytrade/balances/route.ts:62` | `getAccountBalanceValues :43` | `summarizeTastytradeError` |
| 2 | `tastytrade/callback/route.ts:64` | `getCustomerResource :41` | ✓ |
| 3 | `tastytrade/chains/route.ts:120` | `getNestedOptionChain :58` | ✓ |
| 4 | `tastytrade/connect/route.ts:82` | `getCustomerAccounts :41` | ✓ |
| 5 | `tastytrade/greeks/route.ts:116` | `quoteStreamer.connect :89` (fetches a streamer token over axios) | ✓ |
| 6 | `tastytrade/positions/route.ts:66` | `getPositionsList :43` | ✓ |
| 7 | `tastytrade/quotes/route.ts:98` | `quoteStreamer.connect :78` | ✓ |
| 8-9 | `tastytrade/scanner/route.ts:210`, `:299` | `getMarketMetrics :205` | ✓ |
| trim | `lib/tastytrade.ts:147` `JSON.stringify(data)?.slice(0, 300)` | failed-login body | `status, data?.error?.code` only |

**Fine sites (unchanged), by shape**

| group | sites |
|---|---|
| tastytrade files with no axios call in the try | `tastytrade/status/route.ts:55`, `disconnect/route.ts:44` (Prisma only); `backtest/run/route.ts:129`, `simulate/route.ts:131` (fetch; `getTastytradeSessionToken` catches its own SDK errors at `tastytrade.ts:145-149`, `:181` and rethrows a plain Error) |
| Stripe | `stripe/checkout-entitlement/route.ts:75`, `checkout/route.ts:59`, `portal/route.ts:29`, `webhook/route.ts:361` |
| Anthropic / OpenAI | `ai/market-brief:207`, `strategy-analysis:145`, `cart-plan:226`, `meal-plan:416`, `meal-planner:129`, `spending-insights:67`, `operations/ai/optimize-north-star-section:328`, `operations/content/generate-script:195`, `operations/projects/[id]/research:118`, `tasks/bulk-create:249`, `ops/ai-plan:153`, `ops/brain-dump:95` |
| LiteAPI routes | `travel/hotels/{content:59, reviews:63, search:120}`, `travel/liteapi/{book:148,:291; flights/book:96,:245; flights/prebook:193; flights/search:147; flights/verify:92; prebook:73}`, `travel/locations/{cities:48, countries:41}`, `reservations/[id]/cancel:227,:274` |
| Viator, Places, Travel Buddy, Duffel, xAI, Voyage | `viatorClient.ts:455-570`, `travel/activities/search:115`, `transfers/search:117`, `places/category-search:175`, `places/photo:66`, `placesCache.ts:59,:133`, `verification.ts:42-119` (dead), `travel/visa/check:109`, `flights/search:112`, `duffel.ts:108`, `grok.ts:56,:212`, `grokAgent.ts:325`, `workbench/recent-chunks:101`, `trips/[id]/ai-assistant:547` |

Not in scope and unchanged: the remaining ~450 whole-object logs sit in Prisma-only routes and client components (fetch to our own API); they carry no provider secret.

## Build

- `src/lib/plaid/summarizeError.ts` — `summarizePlaidError(err)` → `{ status, error_type, error_code, error_message, request_id, name, message }`. Reads only `err.response?.status` and the four Plaid fields on `err.response?.data`; `name` and `message` come from the Error itself (never the body) so a Prisma or auth error caught in the same block still leaves a trace. Never `config`, `request`, `headers`, or the request body. `src/lib/plaid.ts` keeps resolving `@/lib/plaid` (file beats directory).
- `src/lib/tastytrade/summarizeError.ts` — `summarizeTastytradeError(err)` → `{ status, code, error_message, name, message }` from `response.status` and `response.data.error`.
- 29 sites rewritten to `console.error('<context>', summarize…(err))`; one import per file.
- `src/lib/__tests__/summarizeError.test.ts` — fabricates an axios 0.21-shaped error carrying `PLAID-SECRET` and `access_token` in `config.headers` / `config.data` / `request` / `response.config`; proves the raw error leaks both under `inspect` (the bug), and that neither string, nor `config`, nor `headers`, appears in the summarizer output as `JSON.stringify` or `inspect(depth: null)`. Tastytrade twin for `Authorization`, the JWT, `password`. Non-Plaid inputs (TypeError, string, null, malformed response) covered.

## Verify

| Check | Result |
|---|---|
| `npx tsc --noEmit` | exit 0 |
| `npm test` | 42/42 (5 new summarizer tests, 12 tokenCipher, 25 url-guard) |
| eslint | **0 on the three new files** (`--max-warnings 0`); per-file counts on the 20 touched files are identical on main and on this branch (all pre-existing `no-explicit-any`), so **0 findings introduced** |
| `next build` | compiled, types valid; page-data collection dies at the pre-existing `/api/admin/backfill-transaction-fields` `PLAID_CLIENT_ID` assert, as on every prior PR |
| grep proof | `console.(error|warn|log)(…, error|err|e)` over the 20 FIX files: **0 remaining**; `slice(0, 300)` in `lib/tastytrade.ts`: 0; summarizer calls: 29 |
| diff scope | the 20 cited files + 2 summarizers + 1 test; 23 files, +257/−30 |

### Test output
```
ok 1 - the raw axios error really does leak the secrets when inspected (the bug)
ok 2 - summarizePlaidError keeps status and the five Plaid fields
ok 3 - summarizePlaidError output carries neither PLAID-SECRET nor access_token, in JSON or inspect
ok 4 - summarizePlaidError on a non-Plaid error keeps name and message only
ok 5 - summarizeTastytradeError keeps status and the error code, never the Authorization header or login body
# tests 42
# pass 42
# fail 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc

---
_Generated by [Claude Code](https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc)_