### PR TITLE
fix(books): fail loud on the money paths — no silent 200, no blank page, no lying badge (HYG-01)

### DIFF
--- a/src/app/api/admin/backfill-transaction-fields/route.ts
+++ b/src/app/api/admin/backfill-transaction-fields/route.ts
@@ -3,7 +3,7 @@ import { prisma } from '@/lib/prisma';
 import { plaidClient } from '@/lib/plaid';
 import { requireAdmin } from '@/lib/require-admin';
 import { decryptToken } from '@/lib/secrets/tokenCipher';
-import { summarizePlaidError } from '@/lib/plaid/summarizeError';
+import { failureEnvelope } from '@/lib/plaid/failLoud';
 
 /**
  * POST /api/admin/backfill-transaction-fields
@@ -127,17 +127,24 @@ export async function POST() {
           hasMore = response.data.total_transactions > offset;
         }
       } catch (error) {
-        console.error(`Error backfilling item ${item.id}:`, summarizePlaidError(error));
+        // HYG-01: STOP AND DECLARE — no further items, the failure is the response.
+        const { status, body } = failureEnvelope('backfill', error, {
+          updated: totalUpdated, fieldsBackfilled: totalFieldsBackfilled,
+        });
+        console.error(`Error backfilling item ${item.id}:`, body.error);
+        return NextResponse.json(body, { status });
       }
     }
 
     return NextResponse.json({
+      ok: true,
       success: true,
       updated: totalUpdated,
       fieldsBackfilled: totalFieldsBackfilled
     });
   } catch (error) {
-    console.error('Backfill error:', summarizePlaidError(error));
-    return NextResponse.json({ error: 'Failed to backfill' }, { status: 500 });
+    const { status, body } = failureEnvelope('backfill', error);
+    console.error('Backfill error:', body.error);
+    return NextResponse.json(body, { status });
   }
 }

--- a/src/app/api/investment-transactions/route.ts
+++ b/src/app/api/investment-transactions/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { failureEnvelope } from '@/lib/plaid/failLoud';
 
 export async function GET() {
   try {
@@ -85,7 +86,9 @@ export async function GET() {
 
     return NextResponse.json(enrichedTxns);
   } catch (error) {
-    console.error('Error:', error);
-    return NextResponse.json([]);
+    // HYG-01: a failed read is declared, never an empty 200 that renders as "no rows".
+    const { status, body } = failureEnvelope('investment-transactions', error);
+    console.error('investment-transactions error:', body.error);
+    return NextResponse.json(body, { status });
   }
 }

--- a/src/app/api/investments/analyze/route.ts
+++ b/src/app/api/investments/analyze/route.ts
@@ -3,7 +3,7 @@ import { prisma } from '@/lib/prisma';
 import { plaidClient } from '@/lib/plaid';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { decryptToken } from '@/lib/secrets/tokenCipher';
-import { summarizePlaidError } from '@/lib/plaid/summarizeError';
+import { failureEnvelope } from '@/lib/plaid/failLoud';
 
 export async function GET() {
   try {
@@ -25,6 +25,9 @@ export async function GET() {
     });
 
     for (const item of plaidItems) {
+      // HYG-01: STOP AND DECLARE — a failed provider call is the response, never an
+      // empty page. `stage` names the call in flight.
+      let stage: 'holdings' | 'investments' = 'holdings';
       try {
         // Get investment holdings
         const holdingsResponse = await plaidClient.investmentsHoldingsGet({
@@ -36,6 +39,7 @@ export async function GET() {
         }
 
         // Get investment transactions
+        stage = 'investments';
         const transactionsResponse = await plaidClient.investmentsTransactionsGet({
           access_token: decryptToken(item.accessToken),
           start_date: '2020-01-01',
@@ -46,11 +50,14 @@ export async function GET() {
           allTransactions = allTransactions.concat(transactionsResponse.data.investment_transactions);
         }
       } catch (error) {
-        console.error('Error fetching investment data:', summarizePlaidError(error));
+        const { status, body } = failureEnvelope(stage, error);
+        console.error('Error fetching investment data:', body.error);
+        return NextResponse.json(body, { status });
       }
     }
 
     return NextResponse.json({
+      ok: true,
       holdings,
       transactions: allTransactions,
       summary: {
@@ -59,7 +66,8 @@ export async function GET() {
       }
     });
   } catch (error) {
-    console.error('Investment analysis error:', summarizePlaidError(error));
-    return NextResponse.json({ error: 'Failed to analyze investments' }, { status: 500 });
+    const { status, body } = failureEnvelope('investments', error);
+    console.error('Investment analysis error:', body.error);
+    return NextResponse.json(body, { status });
   }
 }

--- a/src/app/api/investments/route.ts
+++ b/src/app/api/investments/route.ts
@@ -3,7 +3,7 @@ import { prisma } from '@/lib/prisma';
 import { plaidClient } from '@/lib/plaid';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { decryptToken } from '@/lib/secrets/tokenCipher';
-import { summarizePlaidError } from '@/lib/plaid/summarizeError';
+import { failureEnvelope } from '@/lib/plaid/failLoud';
 
 export async function GET() {
   try {
@@ -28,11 +28,15 @@ export async function GET() {
     const investmentData = [];
     
     for (const item of plaidItems) {
+      // HYG-01: STOP AND DECLARE — a failed provider call is the response, never an
+      // empty list. `stage` names the call in flight.
+      let stage: 'holdings' | 'investments' = 'holdings';
       try {
         const holdingsResponse = await plaidClient.investmentsHoldingsGet({
           access_token: decryptToken(item.accessToken)
         });
 
+        stage = 'investments';
         const transactionsResponse = await plaidClient.investmentsTransactionsGet({
           access_token: decryptToken(item.accessToken),
           start_date: '2020-01-01',
@@ -46,13 +50,16 @@ export async function GET() {
           transactions: transactionsResponse.data.investment_transactions,
         });
       } catch (error) {
-        console.error('Error fetching investment data:', summarizePlaidError(error));
+        const { status, body } = failureEnvelope(stage, error);
+        console.error('Error fetching investment data:', body.error);
+        return NextResponse.json(body, { status });
       }
     }
 
     return NextResponse.json(investmentData);
   } catch (error) {
-    console.error('Error in investments route:', summarizePlaidError(error));
-    return NextResponse.json({ error: 'Failed to fetch investments' }, { status: 500 });
+    const { status, body } = failureEnvelope('investments', error);
+    console.error('Error in investments route:', body.error);
+    return NextResponse.json(body, { status });
   }
 }

--- a/src/app/api/plaid/sync/route.ts
+++ b/src/app/api/plaid/sync/route.ts
@@ -8,7 +8,7 @@ import { prisma } from '@/lib/prisma';
 import { Configuration, PlaidApi, PlaidEnvironments } from 'plaid';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { decryptToken } from '@/lib/secrets/tokenCipher';
-import { summarizePlaidError } from '@/lib/plaid/summarizeError';
+import { failureEnvelope } from '@/lib/plaid/failLoud';
 
 const plaidConfig = new Configuration({
   basePath: PlaidEnvironments.production,
@@ -129,11 +129,14 @@ export async function POST(request: NextRequest) {
     }
 
     return NextResponse.json({ 
+      ok: true,
       success: true, 
       synced: transactions.length 
     });
-  } catch (error: any) {
-    console.error('Sync error:', summarizePlaidError(error));
-    return NextResponse.json({ error: error.message }, { status: 500 });
+  } catch (error) {
+    // HYG-01: the failure is declared with a summarized body, never a bare message.
+    const { status, body } = failureEnvelope('transactions', error);
+    console.error('Sync error:', body.error);
+    return NextResponse.json(body, { status });
   }
 }

--- a/src/app/api/transactions/fix-categories/route.ts
+++ b/src/app/api/transactions/fix-categories/route.ts
@@ -3,7 +3,7 @@ import { prisma } from '@/lib/prisma';
 import { plaidClient } from '@/lib/plaid';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { decryptToken } from '@/lib/secrets/tokenCipher';
-import { summarizePlaidError } from '@/lib/plaid/summarizeError';
+import { failureEnvelope } from '@/lib/plaid/failLoud';
 
 export async function POST() {
   try {
@@ -53,16 +53,21 @@ export async function POST() {
           updatedCount += result.count;
         }
       } catch (error) {
-        console.error('Error fixing categories for item:', item.id, summarizePlaidError(error));
+        // HYG-01: STOP AND DECLARE — no further items, the failure is the response.
+        const { status, body } = failureEnvelope('categories', error, { updatedCount });
+        console.error('Error fixing categories for item:', item.id, body.error);
+        return NextResponse.json(body, { status });
       }
     }
 
     return NextResponse.json({ 
+      ok: true,
       success: true, 
       updatedCount 
     });
   } catch (error) {
-    console.error('Fix categories error:', summarizePlaidError(error));
-    return NextResponse.json({ error: 'Failed to fix categories' }, { status: 500 });
+    const { status, body } = failureEnvelope('categories', error);
+    console.error('Fix categories error:', body.error);
+    return NextResponse.json(body, { status });
   }
 }

--- a/src/app/api/transactions/resync-with-rich-data/route.ts
+++ b/src/app/api/transactions/resync-with-rich-data/route.ts
@@ -3,6 +3,7 @@ import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { plaidClient } from '@/lib/plaid';
 import { prisma } from '@/lib/prisma';
 import { decryptToken } from '@/lib/secrets/tokenCipher';
+import { failureEnvelope } from '@/lib/plaid/failLoud';
 
 export async function POST() {
   try {
@@ -65,11 +66,15 @@ export async function POST() {
     }
 
     return NextResponse.json({
+      ok: true,
       success: true,
       updated,
       message: `Updated ${updated} transactions with rich data!`
     });
-  } catch (error: any) {
-    return NextResponse.json({ error: error.message }, { status: 500 });
+  } catch (error) {
+    // HYG-01: summarized, user-safe failure body (was a bare error.message).
+    const { status, body } = failureEnvelope('transactions', error);
+    console.error('Resync error:', body.error);
+    return NextResponse.json(body, { status });
   }
 }

--- a/src/app/api/transactions/sync-complete/route.ts
+++ b/src/app/api/transactions/sync-complete/route.ts
@@ -4,7 +4,7 @@ import { plaidClient } from '@/lib/plaid';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { requireTabAccess } from '@/lib/auth-helpers';
 import { decryptToken } from '@/lib/secrets/tokenCipher';
-import { summarizePlaidError } from '@/lib/plaid/summarizeError';
+import { failureEnvelope, stageFailed, stageOk, syncEnvelope, type StageFailed } from '@/lib/plaid/failLoud';
 
 export const maxDuration = 300; // 5 minutes for Pro plan
 
@@ -37,242 +37,256 @@ export async function POST() {
     let totalSecurities = 0;
     let skippedTransactions = 0;
     let skippedInvestmentTransactions = 0;
+    // HYG-01: STOP AND DECLARE. The first failure ends its stage for the whole run;
+    // the outcome is declared in the response (200 / 207 / non-2xx), never hidden.
+    let transactionsFailure: StageFailed | null = null;
+    let investmentsFailure: StageFailed | null = null;
 
     for (const item of plaidItems) {
       console.log(`Syncing ${item.institutionName || 'Bank'}...`);
 
-      // Sync regular transactions
-      try {
-        // Batch lookup: fetch all existing transactions for this item's accounts
-        const accountIds = item.accounts.map(acc => acc.id);
-        const existingTxns = await prisma.transactions.findMany({
-          where: { accountId: { in: accountIds } },
-          select: {
-            transactionId: true,
-            personal_finance_category: true,
-            amount: true,
-            name: true,
-            date: true
-          }
-        });
-        const existingMap = new Map(
-          existingTxns.map(t => [t.transactionId, t])
-        );
-
-        let hasMore = true;
-        let offset = 0;
-
-        while (hasMore) {
-          const response = await plaidClient.transactionsGet({
-            access_token: decryptToken(item.accessToken),
-            start_date: '2024-01-01',
-            end_date: new Date().toISOString().split('T')[0],
-            options: {
-              offset: offset,
-              count: 100,
-              include_personal_finance_category: true
+      // Sync regular transactions — skipped once this stage has declared a failure.
+      if (!transactionsFailure) {
+        try {
+          // Batch lookup: fetch all existing transactions for this item's accounts
+          const accountIds = item.accounts.map(acc => acc.id);
+          const existingTxns = await prisma.transactions.findMany({
+            where: { accountId: { in: accountIds } },
+            select: {
+              transactionId: true,
+              personal_finance_category: true,
+              amount: true,
+              name: true,
+              date: true
             }
           });
+          const existingMap = new Map(
+            existingTxns.map(t => [t.transactionId, t])
+          );
 
-          // Update balances (first iteration only)
-          if (offset === 0 && response.data.accounts) {
-            for (const plaidAccount of response.data.accounts) {
-              const dbAccount = item.accounts.find(acc => acc.accountId === plaidAccount.account_id);
-              if (dbAccount) {
-                await prisma.accounts.update({
-                  where: { id: dbAccount.id },
-                  data: {
-                    currentBalance: plaidAccount.balances.current || 0,
-                    availableBalance: plaidAccount.balances.available || 0
+          let hasMore = true;
+          let offset = 0;
+
+          while (hasMore) {
+            const response = await plaidClient.transactionsGet({
+              access_token: decryptToken(item.accessToken),
+              start_date: '2024-01-01',
+              end_date: new Date().toISOString().split('T')[0],
+              options: {
+                offset: offset,
+                count: 100,
+                include_personal_finance_category: true
+              }
+            });
+
+            // Update balances (first iteration only)
+            if (offset === 0 && response.data.accounts) {
+              for (const plaidAccount of response.data.accounts) {
+                const dbAccount = item.accounts.find(acc => acc.accountId === plaidAccount.account_id);
+                if (dbAccount) {
+                  await prisma.accounts.update({
+                    where: { id: dbAccount.id },
+                    data: {
+                      currentBalance: plaidAccount.balances.current || 0,
+                      availableBalance: plaidAccount.balances.available || 0
+                    }
+                  });
+                }
+              }
+            }
+
+            for (const txn of response.data.transactions) {
+              const account = item.accounts.find(acc => acc.accountId === txn.account_id);
+              if (!account) continue;
+
+              const existing = existingMap.get(txn.transaction_id);
+
+              if (existing && existing.personal_finance_category !== null) {
+                // Already has complete data — skip expensive update
+                skippedTransactions++;
+                totalTransactions++;
+                continue;
+              }
+
+              const txnData = {
+                amount: txn.amount,
+                date: new Date(txn.date),
+                name: txn.name,
+                merchantName: txn.merchant_name,
+                category: txn.category?.join(', ') || null,
+                pending: txn.pending || false,
+                authorized_date: txn.authorized_date ? new Date(txn.authorized_date) : null,
+                authorized_datetime: txn.authorized_datetime ? new Date(txn.authorized_datetime) : null,
+                counterparties: (txn as any).counterparties || null,
+                location: (txn as any).location || null,
+                payment_channel: txn.payment_channel,
+                payment_meta: (txn as any).payment_meta || null,
+                personal_finance_category: (txn as any).personal_finance_category || null,
+                personal_finance_category_icon_url: (txn as any).personal_finance_category_icon_url,
+                transaction_code: txn.transaction_code,
+                transaction_type: (txn as any).transaction_type,
+                logo_url: (txn as any).logo_url,
+                website: (txn as any).website,
+                updatedAt: new Date()
+              };
+
+              await prisma.transactions.upsert({
+                where: { transactionId: txn.transaction_id },
+                create: {
+                  id: `txn_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`,
+                  transactionId: txn.transaction_id,
+                  accountId: account.id,
+                  ...txnData
+                },
+                update: txnData
+              });
+              totalTransactions++;
+
+              // If this is a posted transaction, delete any matching pending duplicates
+              if (!txn.pending) {
+                const twoDaysAgo = new Date(txn.date);
+                twoDaysAgo.setDate(twoDaysAgo.getDate() - 2);
+                const twoDaysAfter = new Date(txn.date);
+                twoDaysAfter.setDate(twoDaysAfter.getDate() + 2);
+
+                await prisma.transactions.deleteMany({
+                  where: {
+                    accountId: account.id,
+                    amount: txn.amount,
+                    pending: true,
+                    date: { gte: twoDaysAgo, lte: twoDaysAfter },
+                    transactionId: { not: txn.transaction_id }
                   }
                 });
               }
             }
-          }
 
-          for (const txn of response.data.transactions) {
-            const account = item.accounts.find(acc => acc.accountId === txn.account_id);
-            if (!account) continue;
+            offset += response.data.transactions.length;
+            hasMore = response.data.total_transactions > offset;
 
-            const existing = existingMap.get(txn.transaction_id);
-
-            if (existing && existing.personal_finance_category !== null) {
-              // Already has complete data — skip expensive update
-              skippedTransactions++;
-              totalTransactions++;
-              continue;
-            }
-
-            const txnData = {
-              amount: txn.amount,
-              date: new Date(txn.date),
-              name: txn.name,
-              merchantName: txn.merchant_name,
-              category: txn.category?.join(', ') || null,
-              pending: txn.pending || false,
-              authorized_date: txn.authorized_date ? new Date(txn.authorized_date) : null,
-              authorized_datetime: txn.authorized_datetime ? new Date(txn.authorized_datetime) : null,
-              counterparties: (txn as any).counterparties || null,
-              location: (txn as any).location || null,
-              payment_channel: txn.payment_channel,
-              payment_meta: (txn as any).payment_meta || null,
-              personal_finance_category: (txn as any).personal_finance_category || null,
-              personal_finance_category_icon_url: (txn as any).personal_finance_category_icon_url,
-              transaction_code: txn.transaction_code,
-              transaction_type: (txn as any).transaction_type,
-              logo_url: (txn as any).logo_url,
-              website: (txn as any).website,
-              updatedAt: new Date()
-            };
-
-            await prisma.transactions.upsert({
-              where: { transactionId: txn.transaction_id },
-              create: {
-                id: `txn_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`,
-                transactionId: txn.transaction_id,
-                accountId: account.id,
-                ...txnData
-              },
-              update: txnData
-            });
-            totalTransactions++;
-
-            // If this is a posted transaction, delete any matching pending duplicates
-            if (!txn.pending) {
-              const twoDaysAgo = new Date(txn.date);
-              twoDaysAgo.setDate(twoDaysAgo.getDate() - 2);
-              const twoDaysAfter = new Date(txn.date);
-              twoDaysAfter.setDate(twoDaysAfter.getDate() + 2);
-
-              await prisma.transactions.deleteMany({
-                where: {
-                  accountId: account.id,
-                  amount: txn.amount,
-                  pending: true,
-                  date: { gte: twoDaysAgo, lte: twoDaysAfter },
-                  transactionId: { not: txn.transaction_id }
-                }
-              });
+            if (!hasMore) {
+              console.log(`Synced ${response.data.total_transactions} transactions for ${item.institutionName} (${skippedTransactions} skipped — already complete)`);
             }
           }
-
-          offset += response.data.transactions.length;
-          hasMore = response.data.total_transactions > offset;
-
-          if (!hasMore) {
-            console.log(`Synced ${response.data.total_transactions} transactions for ${item.institutionName} (${skippedTransactions} skipped — already complete)`);
-          }
+        } catch (error) {
+          transactionsFailure = stageFailed('transactions', error);
+          console.error('Transactions stage failed:', transactionsFailure.error);
         }
-      } catch (error) {
-        console.error('Error syncing transactions:', summarizePlaidError(error));
       }
 
-      // Sync investment transactions + securities
-      try {
-        // Batch lookup: fetch all existing investment transaction IDs for this item's accounts
-        const accountIds = item.accounts.map(acc => acc.id);
-        const existingInvTxns = await prisma.investment_transactions.findMany({
-          where: { accountId: { in: accountIds } },
-          select: { investment_transaction_id: true }
-        });
-        const existingInvSet = new Set(
-          existingInvTxns.map(t => t.investment_transaction_id)
-        );
-
-        let offset = 0;
-        let hasMore = true;
-
-        while (hasMore) {
-          const investResponse = await plaidClient.investmentsTransactionsGet({
-            access_token: decryptToken(item.accessToken),
-            start_date: '2024-01-01',
-            end_date: new Date().toISOString().split('T')[0],
-            options: {
-              offset: offset,
-              count: 100
-            }
+      // Sync investment transactions + securities — same rule.
+      if (!investmentsFailure) {
+        try {
+          // Batch lookup: fetch all existing investment transaction IDs for this item's accounts
+          const accountIds = item.accounts.map(acc => acc.id);
+          const existingInvTxns = await prisma.investment_transactions.findMany({
+            where: { accountId: { in: accountIds } },
+            select: { investment_transaction_id: true }
           });
+          const existingInvSet = new Set(
+            existingInvTxns.map(t => t.investment_transaction_id)
+          );
 
-          // STORE SECURITIES DATA (includes option contract details)
-          for (const security of investResponse.data.securities) {
-            const optionContract = (security as any).option_contract;
+          let offset = 0;
+          let hasMore = true;
 
-            await prisma.securities.upsert({
-              where: { securityId: security.security_id },
-              create: {
-                securityId: security.security_id,
-                isin: security.isin,
-                cusip: security.cusip,
-                sedol: security.sedol,
-                ticker_symbol: security.ticker_symbol,
-                name: security.name,
-                type: security.type,
-                close_price: security.close_price,
-                close_price_as_of: security.close_price_as_of ? new Date(security.close_price_as_of) : null,
-                option_contract_type: optionContract?.contract_type || null,
-                option_strike_price: optionContract?.strike_price || null,
-                option_expiration_date: optionContract?.expiration_date ? new Date(optionContract.expiration_date) : null,
-                option_underlying_ticker: optionContract?.underlying_security_ticker || null,
-                id: `sec_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`,
-                updatedAt: new Date()
-              },
-              update: {
-                close_price: security.close_price,
-                close_price_as_of: security.close_price_as_of ? new Date(security.close_price_as_of) : null,
-                option_contract_type: optionContract?.contract_type || null,
-                option_strike_price: optionContract?.strike_price || null,
-                option_expiration_date: optionContract?.expiration_date ? new Date(optionContract.expiration_date) : null,
-                option_underlying_ticker: optionContract?.underlying_security_ticker || null
+          while (hasMore) {
+            const investResponse = await plaidClient.investmentsTransactionsGet({
+              access_token: decryptToken(item.accessToken),
+              start_date: '2024-01-01',
+              end_date: new Date().toISOString().split('T')[0],
+              options: {
+                offset: offset,
+                count: 100
               }
             });
-            totalSecurities++;
-          }
 
-          // STORE INVESTMENT TRANSACTIONS
-          for (const txn of investResponse.data.investment_transactions) {
-            const account = item.accounts.find(acc => acc.accountId === txn.account_id);
-            if (!account) continue;
+            // STORE SECURITIES DATA (includes option contract details)
+            for (const security of investResponse.data.securities) {
+              const optionContract = (security as any).option_contract;
 
-            if (existingInvSet.has(txn.investment_transaction_id)) {
-              // Already exists — the original update clause was empty anyway, skip
-              skippedInvestmentTransactions++;
-              totalInvestmentTransactions++;
-              continue;
+              await prisma.securities.upsert({
+                where: { securityId: security.security_id },
+                create: {
+                  securityId: security.security_id,
+                  isin: security.isin,
+                  cusip: security.cusip,
+                  sedol: security.sedol,
+                  ticker_symbol: security.ticker_symbol,
+                  name: security.name,
+                  type: security.type,
+                  close_price: security.close_price,
+                  close_price_as_of: security.close_price_as_of ? new Date(security.close_price_as_of) : null,
+                  option_contract_type: optionContract?.contract_type || null,
+                  option_strike_price: optionContract?.strike_price || null,
+                  option_expiration_date: optionContract?.expiration_date ? new Date(optionContract.expiration_date) : null,
+                  option_underlying_ticker: optionContract?.underlying_security_ticker || null,
+                  id: `sec_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`,
+                  updatedAt: new Date()
+                },
+                update: {
+                  close_price: security.close_price,
+                  close_price_as_of: security.close_price_as_of ? new Date(security.close_price_as_of) : null,
+                  option_contract_type: optionContract?.contract_type || null,
+                  option_strike_price: optionContract?.strike_price || null,
+                  option_expiration_date: optionContract?.expiration_date ? new Date(optionContract.expiration_date) : null,
+                  option_underlying_ticker: optionContract?.underlying_security_ticker || null
+                }
+              });
+              totalSecurities++;
             }
 
-            await prisma.investment_transactions.create({
-              data: {
-                id: `inv_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`,
-                investment_transaction_id: txn.investment_transaction_id,
-                accountId: account.id,
-                amount: txn.amount,
-                cancel_transaction_id: txn.cancel_transaction_id,
-                date: new Date(txn.date),
-                fees: txn.fees,
-                iso_currency_code: txn.iso_currency_code,
-                name: txn.name,
-                price: txn.price,
-                quantity: txn.quantity,
-                security_id: txn.security_id,
-                subtype: txn.subtype,
-                type: txn.type,
-                unofficial_currency_code: txn.unofficial_currency_code,
-                updatedAt: new Date()
-              }
-            });
-            totalInvestmentTransactions++;
-          }
+            // STORE INVESTMENT TRANSACTIONS
+            for (const txn of investResponse.data.investment_transactions) {
+              const account = item.accounts.find(acc => acc.accountId === txn.account_id);
+              if (!account) continue;
 
-          offset += investResponse.data.investment_transactions.length;
-          hasMore = investResponse.data.total_investment_transactions > offset;
+              if (existingInvSet.has(txn.investment_transaction_id)) {
+                // Already exists — the original update clause was empty anyway, skip
+                skippedInvestmentTransactions++;
+                totalInvestmentTransactions++;
+                continue;
+              }
+
+              await prisma.investment_transactions.create({
+                data: {
+                  id: `inv_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`,
+                  investment_transaction_id: txn.investment_transaction_id,
+                  accountId: account.id,
+                  amount: txn.amount,
+                  cancel_transaction_id: txn.cancel_transaction_id,
+                  date: new Date(txn.date),
+                  fees: txn.fees,
+                  iso_currency_code: txn.iso_currency_code,
+                  name: txn.name,
+                  price: txn.price,
+                  quantity: txn.quantity,
+                  security_id: txn.security_id,
+                  subtype: txn.subtype,
+                  type: txn.type,
+                  unofficial_currency_code: txn.unofficial_currency_code,
+                  updatedAt: new Date()
+                }
+              });
+              totalInvestmentTransactions++;
+            }
+
+            offset += investResponse.data.investment_transactions.length;
+            hasMore = investResponse.data.total_investment_transactions > offset;
+          }
+        } catch (error) {
+          investmentsFailure = stageFailed('investments', error);
+          console.error('Investments stage failed:', investmentsFailure.error);
         }
-      } catch (error) {
-        console.error('Error syncing investment transactions:', summarizePlaidError(error));
       }
     }
 
-    return NextResponse.json({
-      success: true,
+    const stages = [
+      transactionsFailure ?? stageOk('transactions', { synced: totalTransactions, skipped: skippedTransactions }),
+      investmentsFailure ?? stageOk('investments', { synced: totalInvestmentTransactions, skipped: skippedInvestmentTransactions, securities: totalSecurities }),
+    ];
+    const { status, body } = syncEnvelope(stages, {
+      success: !transactionsFailure && !investmentsFailure,
       synced: {
         transactions: totalTransactions,
         investmentTransactions: totalInvestmentTransactions,
@@ -283,8 +297,10 @@ export async function POST() {
         investmentTransactions: skippedInvestmentTransactions
       }
     });
+    return NextResponse.json(body, { status });
   } catch (error) {
-    console.error('Complete sync error:', summarizePlaidError(error));
-    return NextResponse.json({ error: 'Failed to sync' }, { status: 500 });
+    const { status, body } = failureEnvelope('sync', error);
+    console.error('Complete sync error:', body.error);
+    return NextResponse.json(body, { status });
   }
 }

--- a/src/app/api/transactions/sync-full/route.ts
+++ b/src/app/api/transactions/sync-full/route.ts
@@ -8,7 +8,7 @@ import { plaidClient } from '@/lib/plaid';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { requireTabAccess } from '@/lib/auth-helpers';
 import { decryptToken } from '@/lib/secrets/tokenCipher';
-import { summarizePlaidError } from '@/lib/plaid/summarizeError';
+import { failureEnvelope, stageOk, syncEnvelope } from '@/lib/plaid/failLoud';
 
 export async function POST() {
   console.warn('DEPRECATED: /api/transactions/sync-full called — use /api/transactions/sync-complete');
@@ -94,20 +94,23 @@ export async function POST() {
           totalAdded++;
         }
       } catch (error) {
-        console.error('Error syncing item:', item.id, summarizePlaidError(error));
+        // HYG-01: STOP AND DECLARE — no further items, the failure is the response.
+        const { status, body } = failureEnvelope('transactions', error, {
+          stats: { added: totalAdded, modified: totalModified, removed: 0 },
+        });
+        console.error('Error syncing item:', item.id, body.error);
+        return NextResponse.json(body, { status });
       }
     }
 
-    return NextResponse.json({
-      success: true,
-      stats: {
-        added: totalAdded,
-        modified: totalModified,
-        removed: 0
-      }
-    });
+    const { status, body } = syncEnvelope(
+      [stageOk('transactions', { added: totalAdded, modified: totalModified, removed: 0 })],
+      { success: true, stats: { added: totalAdded, modified: totalModified, removed: 0 } },
+    );
+    return NextResponse.json(body, { status });
   } catch (error) {
-    console.error('Full sync error:', summarizePlaidError(error));
-    return NextResponse.json({ error: 'Failed to sync' }, { status: 500 });
+    const { status, body } = failureEnvelope('sync', error);
+    console.error('Full sync error:', body.error);
+    return NextResponse.json(body, { status });
   }
 }

--- a/src/app/api/transactions/sync/route.ts
+++ b/src/app/api/transactions/sync/route.ts
@@ -8,7 +8,7 @@ import { plaidClient } from '@/lib/plaid';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { requireTabAccess } from '@/lib/auth-helpers';
 import { decryptToken } from '@/lib/secrets/tokenCipher';
-import { summarizePlaidError } from '@/lib/plaid/summarizeError';
+import { failureEnvelope, stageOk, syncEnvelope } from '@/lib/plaid/failLoud';
 
 export async function POST() {
   console.warn('DEPRECATED: /api/transactions/sync called — use /api/transactions/sync-complete');
@@ -123,20 +123,23 @@ export async function POST() {
           cursor = next_cursor;
         }
       } catch (error) {
-        console.error('Error syncing transactions for item:', item.id, summarizePlaidError(error));
+        // HYG-01: STOP AND DECLARE — no further items, the failure is the response.
+        const { status, body } = failureEnvelope('transactions', error, {
+          stats: { added: totalAdded, modified: totalModified, removed: totalRemoved },
+        });
+        console.error('Error syncing transactions for item:', item.id, body.error);
+        return NextResponse.json(body, { status });
       }
     }
 
-    return NextResponse.json({
-      success: true,
-      stats: {
-        added: totalAdded,
-        modified: totalModified,
-        removed: totalRemoved
-      }
-    });
+    const { status, body } = syncEnvelope(
+      [stageOk('transactions', { added: totalAdded, modified: totalModified, removed: totalRemoved })],
+      { success: true, stats: { added: totalAdded, modified: totalModified, removed: totalRemoved } },
+    );
+    return NextResponse.json(body, { status });
   } catch (error) {
-    console.error('Transaction sync error:', summarizePlaidError(error));
-    return NextResponse.json({ error: 'Failed to sync transactions' }, { status: 500 });
+    const { status, body } = failureEnvelope('sync', error);
+    console.error('Transaction sync error:', body.error);
+    return NextResponse.json(body, { status });
   }
 }

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -6,6 +6,8 @@ import Link from 'next/link';
 import Script from 'next/script';
 import { AppLayout } from '@/components/ui';
 import { isTabLocked } from '@/lib/categoryLock';
+import { STATE } from '@/lib/ds';
+import { readSyncOutcome, type SyncOutcome } from '@/lib/plaid/failLoud';
 import SpendingTab from '@/components/dashboard/SpendingTab';
 import InvestmentsTab from '@/components/dashboard/InvestmentsTab';
 import GeneralLedger from '@/components/dashboard/GeneralLedger';
@@ -111,6 +113,12 @@ export default function Dashboard() {
   const [journalEntries, setJournalEntries] = useState<any[]>([]);
   const [loading, setLoading] = useState(true);
   const [syncing, setSyncing] = useState(false);
+  // HYG-01: the sync route's returned line; a failed core load is declared, not blank.
+  const [syncMessage, setSyncMessage] = useState<SyncOutcome | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  // HYG-01: the Investments badge counts the SAME query the commit workflow renders
+  // (/api/investment-transactions/opens · totalAll) — one source, never a disagreeing number.
+  const [investmentQueue, setInvestmentQueue] = useState<number>(0);
   const [linkToken, setLinkToken] = useState<string | null>(null);
   const [userTier, setUserTier] = useState<string>('free');
   const [currentUserId, setCurrentUserId] = useState<string>('');
@@ -145,9 +153,14 @@ export default function Dashboard() {
 
   const loadData = useCallback(async () => {
     try {
-      const [txnRes, coaRes, accRes, invRes] = await Promise.all([
-        fetch('/api/transactions'), fetch('/api/chart-of-accounts'), fetch('/api/accounts'), fetch('/api/investment-transactions')
+      const [txnRes, coaRes, accRes, invRes, opensRes] = await Promise.all([
+        fetch('/api/transactions'), fetch('/api/chart-of-accounts'), fetch('/api/accounts'), fetch('/api/investment-transactions'),
+        fetch('/api/investment-transactions/opens')
       ]);
+      // HYG-01: declare a failed core load instead of rendering the last (or empty) state as truth.
+      const failedCore = ([['transactions', txnRes], ['chart of accounts', coaRes], ['accounts', accRes], ['investment transactions', invRes], ['investment queue', opensRes]] as const)
+        .filter(([, r]) => !r.ok).map(([name, r]) => `${name} (HTTP ${r.status})`);
+      setLoadError(failedCore.length ? `Couldn't load: ${failedCore.join(', ')}. Nothing is assumed.` : null);
       if (txnRes.ok) { const data = await txnRes.json(); setTransactions(data.transactions || []); }
       if (coaRes.ok) { const data = await coaRes.json(); setCoaOptions(data.accounts || []); }
       if (accRes.ok) {
@@ -161,6 +174,12 @@ export default function Dashboard() {
         setAccounts(allAccounts);
       }
       if (invRes.ok) { const data = await invRes.json(); setInvestmentTransactions(data.transactions || data.investments || data || []); }
+      if (opensRes.ok) {
+        const data = await opensRes.json();
+        // HYG-01: a missing count is declared, never defaulted to 0.
+        if (typeof data.totalAll === 'number') setInvestmentQueue(data.totalAll);
+        else setLoadError((prev) => [prev, 'Investment queue: totalAll missing from /api/investment-transactions/opens.'].filter(Boolean).join(' '));
+      }
       
       const jeRes = await fetch('/api/journal-transactions');
       if (jeRes.ok) { const jeData = await jeRes.json(); setJournalEntries(jeData.entries || []); }
@@ -357,9 +376,15 @@ export default function Dashboard() {
 
   const syncAccounts = async () => {
     setSyncing(true);
-    await fetch('/api/transactions/sync-complete', { method: 'POST' });
-    await loadData();
-    setSyncing(false);
+    setSyncMessage(null);
+    try {
+      const res = await fetch('/api/transactions/sync-complete', { method: 'POST' });
+      // HYG-01: read the declared outcome — a failed or partial sync is shown, never swallowed.
+      setSyncMessage(await readSyncOutcome(res));
+      await loadData();
+    } finally {
+      setSyncing(false);
+    }
   };
 
   const updateAccountEntity = async (accountId: string, entityType: string) => {
@@ -408,7 +433,7 @@ export default function Dashboard() {
   // saveReconciliation, closePeriod, reopenPeriod removed — tables dropped in Phase 0
 
   const totalBalance = accounts.reduce((s, a) => s + a.balance, 0);
-  const pendingCount = uncommittedSpending.length + uncommittedInvestments.length;
+  const pendingCount = uncommittedSpending.length + investmentQueue;
   const committedCount = committedSpending.length + committedInvestments.length;
 
   const handleTaxSettingsSave = async (settings: TaxSettingsValues) => {
@@ -483,6 +508,19 @@ export default function Dashboard() {
         <div className="min-h-screen bg-bg-terminal">
           <div className="px-4 lg:px-6 pt-4 max-w-[1600px] mx-auto">
             <div className="space-y-3">
+              {loadError && (
+                <div role="alert" className={STATE.errorCard}>{loadError}</div>
+              )}
+              {syncMessage && (
+                <div
+                  role={syncMessage.tone === 'ok' ? 'status' : 'alert'}
+                  className={syncMessage.tone === 'ok'
+                    ? 'rounded-lg border border-border bg-bg-row p-3 text-xs text-text-secondary'
+                    : STATE.errorCard}
+                >
+                  {syncMessage.text}
+                </div>
+              )}
 
               {/* Tax Filing CTA — primary tax-season action */}
               <Link
@@ -577,8 +615,8 @@ export default function Dashboard() {
 
               {/* 2. CAT — Categorize */}
               <BookkeepingSection title="Categorize Transactions" pipelineKey="CAT"
-                subtitle={`${uncommittedSpending.length + uncommittedInvestments.length} pending`}
-                status={uncommittedSpending.length + uncommittedInvestments.length > 0 ? 'action-needed' : 'complete'}>
+                subtitle={`${uncommittedSpending.length + investmentQueue} pending`}
+                status={uncommittedSpending.length + investmentQueue > 0 ? 'action-needed' : 'complete'}>
                 <div>
                   <div className="flex items-center gap-3 px-3 py-1.5 border-b border-border">
                     <div className="flex items-center border border-border bg-white">
@@ -592,7 +630,7 @@ export default function Dashboard() {
                         className={`px-2 py-0.5 text-[10px] font-mono font-medium border-l border-border transition-colors ${
                           mappingTab === 'investments' ? 'bg-brand-purple-wash text-brand-purple' : 'text-text-muted hover:text-text-primary'
                         }`}>
-                        Investments <span className="font-bold text-brand-gold">{uncommittedInvestments.length}</span>
+                        Investments <span className="font-bold text-brand-gold">{investmentQueue}</span>
                       </button>
                     </div>
                   </div>

--- a/src/components/home/BooksPipeline.tsx
+++ b/src/components/home/BooksPipeline.tsx
@@ -101,6 +101,9 @@ export default function BooksPipeline() {
   const [periodCloses, setPeriodCloses] = useState<Row[]>([]);
   const [entityId, setEntityId] = useState<string | null>(null);
   const [mappingTab, setMappingTab] = useState<'spending' | 'investments'>('spending');
+  // HYG-01: the Investments badge counts the SAME query the commit workflow renders
+  // (/api/investment-transactions/opens · totalAll) — one source, never a disagreeing number.
+  const [investmentQueue, setInvestmentQueue] = useState<number>(0);
 
   // Reconciliations + period closes have their own reloaders (mirrors dashboard
   // loadReconciliations :178 / loadPeriodCloses :188). Fail-loud — throw so the
@@ -122,15 +125,16 @@ export default function BooksPipeline() {
   // Core pipe data (mirrors dashboard loadData :142 + entities effect :199).
   // Fail-loud: any non-OK response throws → 'error' state (no fabricated empty data).
   const loadData = useCallback(async () => {
-    const [txnRes, coaRes, accRes, invRes, jeRes, entRes] = await Promise.all([
+    const [txnRes, coaRes, accRes, invRes, jeRes, entRes, opensRes] = await Promise.all([
       fetch('/api/transactions'),
       fetch('/api/chart-of-accounts'),
       fetch('/api/accounts'),
       fetch('/api/investment-transactions'),
       fetch('/api/journal-transactions'),
       fetch('/api/entities'),
+      fetch('/api/investment-transactions/opens'),
     ]);
-    if (![txnRes, coaRes, accRes, invRes, jeRes, entRes].every((r) => r.ok)) {
+    if (![txnRes, coaRes, accRes, invRes, jeRes, entRes, opensRes].every((r) => r.ok)) {
       throw new Error('core books fetch failed');
     }
     const txn = await txnRes.json();
@@ -150,7 +154,14 @@ export default function BooksPipeline() {
     });
     setAccounts(flat);
     const inv = await invRes.json();
-    setInvestmentTransactions(inv.transactions || inv.investments || []);
+    // HYG-01: /api/investment-transactions returns a bare array; the old `inv.transactions ||
+    // inv.investments || []` read it as EMPTY every time (the 'Investments 0' badge above 920
+    // rows). A non-array is a contract break → error state, not a fabricated empty list.
+    if (!Array.isArray(inv)) throw new Error('investment-transactions: expected an array');
+    setInvestmentTransactions(inv);
+    const opens = await opensRes.json();
+    if (typeof opens?.totalAll !== 'number') throw new Error('investment-transactions/opens: totalAll missing');
+    setInvestmentQueue(opens.totalAll);
     const je = await jeRes.json();
     setJournalEntries(je.entries || []);
     const ent = await entRes.json();
@@ -205,7 +216,7 @@ export default function BooksPipeline() {
   // component already holds (hardcoded states forbidden; the in-card stage
   // dots' 9 hardcoded 'pending' props are the ledgered G2 anti-pattern, NEXT
   // PR, untouched here).
-  const pendingCount = uncommittedSpending.length + uncommittedInvestments.length;
+  const pendingCount = uncommittedSpending.length + investmentQueue;
   const reconciledCount = reconciliations.filter((r) => r.status === 'reconciled').length;
   const closedThisYear = periodCloses.filter((p) => p.year === year && p.status === 'closed').length;
   const closedPeriods = periodCloses.filter((p) => p.status === 'closed' && p.closedAt);
@@ -393,8 +404,8 @@ export default function BooksPipeline() {
         <SectionHeader kicker="02 / Code" right="PHASE 02 OF 06" />
       {/* 2. CAT — Categorize (dashboard :568): the COA-assignment queue. */}
       <BookkeepingSection title="Categorize Transactions" pipelineKey="CAT"
-        subtitle={`${uncommittedSpending.length + uncommittedInvestments.length} pending`}
-        status={uncommittedSpending.length + uncommittedInvestments.length > 0 ? 'action-needed' : 'complete'}>
+        subtitle={`${uncommittedSpending.length + investmentQueue} pending`}
+        status={uncommittedSpending.length + investmentQueue > 0 ? 'action-needed' : 'complete'}>
         <div>
           <div className={'flex items-center gap-3 px-3 py-1.5 border-b border-border'}>
             <div className={'flex items-center border border-border bg-white'}>
@@ -408,7 +419,7 @@ export default function BooksPipeline() {
                 className={`px-2 py-0.5 text-[10px] font-mono font-medium border-l border-border transition-colors ${
                   mappingTab === 'investments' ? 'bg-brand-purple-wash text-brand-purple' : 'text-text-muted hover:text-text-primary'
                 }`}>
-                Investments <span className="font-bold text-brand-gold">{uncommittedInvestments.length}</span>
+                Investments <span className="font-bold text-brand-gold">{investmentQueue}</span>
               </button>
             </div>
           </div>

--- a/src/components/home/ModuleLauncher.tsx
+++ b/src/components/home/ModuleLauncher.tsx
@@ -7,6 +7,7 @@ import {
   type LucideIcon,
 } from 'lucide-react';
 import { SECTION_HEADER, STATE } from '@/lib/ds';
+import { readSyncOutcome, type SyncOutcome } from '@/lib/plaid/failLoud';
 import CreateTripForm from '@/components/trips/CreateTripForm';
 import TripBookings from '@/components/trips/TripBookings';
 import UnattachedBookings from '@/components/trips/UnattachedBookings';
@@ -393,6 +394,9 @@ export default function ModuleLauncher({ onRequireAuth, onTabChange }: Props) {
     isBalanced: boolean; hasActivity: boolean; connectedAccounts: number; periodStatus: 'open' | 'closed';
   } | null>(null);
   const [booksSyncing, setBooksSyncing] = useState(false);
+  // HYG-01: the sync route's returned line (200 ok / 207 partial / non-2xx failure),
+  // rendered inline under the cockpit bar. Cleared when the next sync starts.
+  const [booksSyncMessage, setBooksSyncMessage] = useState<SyncOutcome | null>(null);
   // Plaid Link token for onLinkAccount (fetched from the auth-gated /api/plaid/link-token).
   const [booksLinkToken, setBooksLinkToken] = useState<string | null>(null);
 
@@ -455,8 +459,11 @@ export default function ModuleLauncher({ onRequireAuth, onTabChange }: Props) {
   // /api/transactions/sync-complete, then re-read the cockpit. No auth weakened.
   const booksSyncAccounts = async () => {
     setBooksSyncing(true);
+    setBooksSyncMessage(null);
     try {
-      await fetch('/api/transactions/sync-complete', { method: 'POST' });
+      const res = await fetch('/api/transactions/sync-complete', { method: 'POST' });
+      // HYG-01: read the declared outcome — a failed or partial sync is shown, never swallowed.
+      setBooksSyncMessage(await readSyncOutcome(res));
       await loadBooksCockpit();
     } finally {
       setBooksSyncing(false);
@@ -1302,6 +1309,16 @@ export default function ModuleLauncher({ onRequireAuth, onTabChange }: Props) {
                     syncing={booksSyncing}
                     onLinkAccount={booksLinkAccount}
                   />
+                )}
+                {booksSyncMessage && (
+                  <div
+                    role={booksSyncMessage.tone === 'ok' ? 'status' : 'alert'}
+                    className={booksSyncMessage.tone === 'ok'
+                      ? 'rounded-lg border border-border bg-bg-row p-3 text-xs text-text-secondary'
+                      : STATE.errorCard}
+                  >
+                    {booksSyncMessage.text}
+                  </div>
                 )}
                 {/* BOOKS-2: the full pipe below the cockpit — import → categorize/COA →
                     journal → ledger → trial balance → reconcile → adjusting → statements →

--- a/src/lib/__tests__/failLoud.test.ts
+++ b/src/lib/__tests__/failLoud.test.ts
@@ -1,0 +1,100 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  describeFailure,
+  failureEnvelope,
+  readSyncResponse,
+  stageFailed,
+  stageOk,
+  statusForFailure,
+  syncEnvelope,
+} from '../plaid/failLoud';
+import { TokenCipherKeyError } from '../secrets/tokenCipher';
+
+// HYG-01 — (a) a thrown Plaid error maps to the non-2xx envelope; (b) the
+// partial-run 207 shape carries both stages; and the client-side reader turns
+// each into the inline line the sync button renders.
+
+function plaid429() {
+  const config = {
+    headers: { 'PLAID-SECRET': 'PLAID-SECRET-VALUE' },
+    data: JSON.stringify({ access_token: 'access-production-TOKEN' }),
+  };
+  return Object.assign(new Error('Request failed with status code 429'), {
+    isAxiosError: true,
+    config,
+    response: {
+      status: 429,
+      config,
+      data: { error_type: 'RATE_LIMIT_EXCEEDED', error_code: 'TRANSACTIONS_LIMIT', error_message: 'rate limit exceeded', request_id: 'req_1' },
+    },
+  });
+}
+
+function plaid400() {
+  return Object.assign(new Error('Request failed with status code 400'), {
+    isAxiosError: true,
+    response: { status: 400, data: { error_type: 'ITEM_ERROR', error_code: 'ITEM_LOGIN_REQUIRED', error_message: 'the login details of this item have changed', request_id: 'req_2' } },
+  });
+}
+
+test('(a) a Plaid 429 maps to a 429 envelope with the summarized, user-safe body', () => {
+  const { status, body } = failureEnvelope('transactions', plaid429(), { synced: { transactions: 40 } });
+  assert.equal(status, 429);
+  assert.equal(body.ok, false);
+  assert.equal(body.stage, 'transactions');
+  assert.equal(body.message, 'Plaid: RATE_LIMIT_EXCEEDED (TRANSACTIONS_LIMIT) — try again in a few minutes');
+  assert.deepEqual(body.synced, { transactions: 40 });
+  const rendered = JSON.stringify(body);
+  assert.ok(!rendered.includes('PLAID-SECRET'));
+  assert.ok(!rendered.includes('access_token'));
+  assert.ok(!rendered.includes('access-production-TOKEN'));
+  assert.equal((body.error as { request_id?: string }).request_id, 'req_1');
+});
+
+test('(a) other upstream statuses become 502; a local throw (missing cipher key) becomes 500', () => {
+  const upstream = failureEnvelope('investments', plaid400());
+  assert.equal(upstream.status, 502);
+  assert.equal(upstream.body.message, 'Plaid: ITEM_ERROR (ITEM_LOGIN_REQUIRED) — the login details of this item have changed');
+
+  const local = failureEnvelope('transactions', new TokenCipherKeyError('TOKEN_ENCRYPTION_KEY is not set'));
+  assert.equal(local.status, 500);
+  assert.equal(local.body.message, 'TokenCipherKeyError: TOKEN_ENCRYPTION_KEY is not set');
+  assert.equal(statusForFailure(stageFailed('x', new Error('boom')).error), 500);
+  assert.equal(describeFailure({ status: 503 }), 'Plaid: HTTP 503');
+});
+
+test('(b) a partial run — transactions failed, investments succeeded — is a 207 carrying both stages', () => {
+  const stages = [stageFailed('transactions', plaid429()), stageOk('investments', { synced: 12, skipped: 3 })];
+  const { status, body } = syncEnvelope(stages, { synced: { transactions: 0, investmentTransactions: 12 } });
+  assert.equal(status, 207);
+  assert.equal(body.ok, false);
+  assert.equal(body.partial, true);
+  assert.deepEqual(body.synced, { synced: undefined, transactions: 0, investmentTransactions: 12 }.synced === undefined ? { transactions: 0, investmentTransactions: 12 } : null);
+  const declared = body.stages as Array<{ stage: string; ok: boolean }>;
+  assert.deepEqual(declared.map((s) => [s.stage, s.ok]), [['transactions', false], ['investments', true]]);
+  assert.equal(body.message, 'Partial sync — transactions: Plaid: RATE_LIMIT_EXCEEDED (TRANSACTIONS_LIMIT) — try again in a few minutes · investments: ok (12 synced, 3 skipped)');
+});
+
+test('(b) every stage failed → the first failure\'s status; zero failures → 200 with ok:true', () => {
+  const allFailed = syncEnvelope([stageFailed('transactions', plaid429()), stageFailed('investments', plaid400())]);
+  assert.equal(allFailed.status, 429);
+  assert.equal(allFailed.body.ok, false);
+  assert.equal(allFailed.body.stage, 'transactions');
+
+  const allOk = syncEnvelope([stageOk('transactions', { synced: 5, skipped: 0 }), stageOk('investments', { synced: 0, skipped: 0 })], { success: true });
+  assert.equal(allOk.status, 200);
+  assert.equal(allOk.body.ok, true);
+  assert.equal(allOk.body.success, true);
+  assert.equal(allOk.body.message, 'Synced — transactions: ok (5 synced, 0 skipped) · investments: ok (0 synced, 0 skipped)');
+  assert.throws(() => syncEnvelope([]), /no stages/);
+});
+
+test('client reader: 200 → ok line, 207 → partial line, 429 → error line, non-JSON body → HTTP fallback', () => {
+  assert.deepEqual(readSyncResponse(200, { ok: true, message: 'Synced — transactions: ok (5 synced, 0 skipped)' }), { tone: 'ok', text: 'Synced — transactions: ok (5 synced, 0 skipped)' });
+  assert.deepEqual(readSyncResponse(207, { ok: false, partial: true, message: 'Partial sync — …' }), { tone: 'partial', text: 'Partial sync — …' });
+  assert.deepEqual(readSyncResponse(429, { ok: false, message: 'Plaid: RATE_LIMIT_EXCEEDED (TRANSACTIONS_LIMIT) — try again in a few minutes' }).tone, 'error');
+  assert.deepEqual(readSyncResponse(502, null), { tone: 'error', text: 'Sync failed: HTTP 502' });
+  assert.deepEqual(readSyncResponse(401, { error: 'Unauthorized' }), { tone: 'error', text: 'Unauthorized' });
+  assert.equal(readSyncResponse(200, { ok: false, message: 'x' }).tone, 'error');
+});

--- a/src/lib/plaid/failLoud.ts
+++ b/src/lib/plaid/failLoud.ts
@@ -1,0 +1,133 @@
+/**
+ * HYG-01 — fail loud on the money paths. No silent 200.
+ *
+ * One discipline for every route that pulls from Plaid: a stage either
+ * completes or is DECLARED failed in the response, and the HTTP status says
+ * so. A partial run (one stage ok, one failed) is a 207 carrying both
+ * outcomes; a run where every stage failed carries the first failure's
+ * status; only a run with zero failures is a 200. No retries, no fallbacks —
+ * the user decides what to do next, not the code.
+ *
+ * Pure: no Next.js imports, so the same functions run in node:test and in the
+ * browser (readSyncResponse renders the returned message inline).
+ */
+import { summarizePlaidError, type PlaidErrorSummary } from './summarizeError';
+
+export interface StageOk {
+  stage: string;
+  ok: true;
+  counts: Record<string, number>;
+}
+
+export interface StageFailed {
+  stage: string;
+  ok: false;
+  error: PlaidErrorSummary;
+  message: string;
+}
+
+export type StageOutcome = StageOk | StageFailed;
+
+export interface Envelope {
+  status: number;
+  body: Record<string, unknown>;
+}
+
+/** User-safe line for a failure: provider code first, a hint for 429s, never a body. */
+export function describeFailure(error: PlaidErrorSummary): string {
+  if (error.error_type || error.error_code) {
+    const code = error.error_type && error.error_code && error.error_type !== error.error_code
+      ? `${error.error_type} (${error.error_code})`
+      : (error.error_type ?? error.error_code);
+    const rateLimited = error.status === 429 || error.error_type === 'RATE_LIMIT_EXCEEDED';
+    const hint = rateLimited
+      ? ' — try again in a few minutes'
+      : error.error_message ? ` — ${error.error_message}` : '';
+    return `Plaid: ${code}${hint}`;
+  }
+  if (typeof error.status === 'number') {
+    return `Plaid: HTTP ${error.status}${error.message ? ` — ${error.message}` : ''}`;
+  }
+  return `${error.name ?? 'Error'}: ${error.message ?? 'unknown error'}`;
+}
+
+/** 429 stays 429 (the user can act on it); any other upstream status is a 502; a local throw is a 500. */
+export function statusForFailure(error: PlaidErrorSummary): number {
+  if (error.status === 429) return 429;
+  if (typeof error.status === 'number') return 502;
+  return 500;
+}
+
+export function stageOk(stage: string, counts: Record<string, number>): StageOk {
+  return { stage, ok: true, counts };
+}
+
+export function stageFailed(stage: string, err: unknown): StageFailed {
+  const error = summarizePlaidError(err);
+  return { stage, ok: false, error, message: describeFailure(error) };
+}
+
+function line(s: StageOutcome): string {
+  if (s.ok) {
+    const parts = Object.entries(s.counts).map(([k, v]) => `${v} ${k}`);
+    return `${s.stage}: ok${parts.length ? ` (${parts.join(', ')})` : ''}`;
+  }
+  return `${s.stage}: ${s.message}`;
+}
+
+/**
+ * Fold stage outcomes into one response. `okBody` is merged in on 200 and 207
+ * so existing success keys (synced, skipped, stats) keep flowing to callers.
+ */
+export function syncEnvelope(stages: StageOutcome[], okBody: Record<string, unknown> = {}): Envelope {
+  if (stages.length === 0) throw new Error('syncEnvelope: no stages');
+  const failed = stages.filter((s): s is StageFailed => !s.ok);
+  const lines = stages.map(line).join(' · ');
+  if (failed.length === 0) {
+    return { status: 200, body: { ok: true, ...okBody, stages, message: `Synced — ${lines}` } };
+  }
+  if (failed.length === stages.length) {
+    const first = failed[0];
+    return {
+      status: statusForFailure(first.error),
+      body: { ok: false, stage: first.stage, error: first.error, message: `Sync failed — ${lines}`, stages },
+    };
+  }
+  return { status: 207, body: { ok: false, partial: true, ...okBody, stages, message: `Partial sync — ${lines}` } };
+}
+
+/** A single-stage failure, with any progress counts the caller wants to declare. */
+export function failureEnvelope(stage: string, err: unknown, progress: Record<string, unknown> = {}): Envelope {
+  const failed = stageFailed(stage, err);
+  return {
+    status: statusForFailure(failed.error),
+    body: { ok: false, stage, error: failed.error, message: failed.message, ...progress },
+  };
+}
+
+export type SyncTone = 'ok' | 'partial' | 'error';
+export interface SyncOutcome {
+  tone: SyncTone;
+  text: string;
+}
+
+/** Client side: turn a status + parsed body (or null when the body was not JSON) into one inline line. */
+export function readSyncResponse(status: number, body: unknown): SyncOutcome {
+  const b = body && typeof body === 'object' ? (body as Record<string, unknown>) : null;
+  const message = typeof b?.message === 'string' ? b.message : null;
+  if (status === 207) return { tone: 'partial', text: message ?? `Partial sync (HTTP 207)` };
+  if (status >= 200 && status < 300 && b?.ok !== false) return { tone: 'ok', text: message ?? `Synced (HTTP ${status})` };
+  const fallbackError = typeof b?.error === 'string' ? b.error : null;
+  return { tone: 'error', text: message ?? fallbackError ?? `Sync failed: HTTP ${status}` };
+}
+
+/** Client side: read a fetch Response into the inline line. Never throws on a non-JSON body. */
+export async function readSyncOutcome(res: Response): Promise<SyncOutcome> {
+  let body: unknown = null;
+  try {
+    body = await res.json();
+  } catch {
+    body = null;
+  }
+  return readSyncResponse(res.status, body);
+}


### PR DESCRIPTION
**Do not merge — Alex merges after Vercel Preview (SOC 2 gate).**

## Why

`/api/transactions/sync-complete` caught a `TokenCipherKeyError` and later a Plaid 429, logged them, and returned 200; the page showed nothing. The Categorize tab's "Investments 0" badge sat above a table of 920 rows. Truth-first: if the primary source fails, stop and declare; the user decides. Branch from main `72cbee53`.

## Audit (1) — routes on the Plaid / investments / sync path: what they returned on failure

| route | catch on main | on failure, before | after |
|---|---|---|---|
| `transactions/sync-complete/route.ts` | item loop `:166` (transactions), `:269` (investments) → continue; outer `:286` | **200** `{ success: true, synced, skipped }` with the failed stage silently missing; outer 500 `{ error }` | two stages, stop-and-declare: **200** both ok · **207** one failed, both outcomes · **429/502/500** both failed; outer → envelope |
| `transactions/sync/route.ts` (no live caller) | item `:125` → continue; outer `:138` | **200** `{ success: true, stats }` | stop at first failure → envelope + progress `stats`; 200 `ok:true` |
| `transactions/sync-full/route.ts` (no live caller) | item `:96` → continue; outer `:109` | **200** `{ success: true, stats }` | same |
| `plaid/sync/route.ts` (caller is the unmounted `ImportDataSection`) | outer `:135` only | 500 `{ error: error.message }` | envelope (429 stays 429); success adds `ok:true` |
| `investments/route.ts` (no caller in `src/`) | item `:48` → continue; outer `:54` | **200** `[]` — an empty page on a 429 | stop at the failing call: envelope with `stage: 'holdings' \| 'investments'` |
| `investments/analyze/route.ts` (no caller) | item `:48` → continue; outer `:61` | **200** `{ holdings: [], transactions: [], summary: {0,0} }` | same |
| `transactions/fix-categories/route.ts` (no caller) | item `:55` → continue; outer `:64` | **200** `{ success: true, updatedCount }` | stop + envelope with `updatedCount`; 200 `ok:true` |
| `admin/backfill-transaction-fields/route.ts` | item `:129` → continue; outer `:139` | **200** `{ success: true, updated, fieldsBackfilled }` | stop + envelope with progress |
| `transactions/resync-with-rich-data/route.ts` (no caller) | outer `:73` only | 500 `{ error: error.message }` (non-2xx, not silent) | envelope for the one discipline |
| `investment-transactions/route.ts` (the badge's own source) | `:86` | **200 `[]`** — a failed DB read rendered as "no rows" | envelope, stage `investment-transactions` |
| `plaid/exchange-token/route.ts:138`, `plaid/link-token/route.ts:48` | outer only | 500 | fine, unchanged |
| `lib/plaid-sync-fix.ts:32` | swallows per item, returns `{ success: true }` | dead: no route calls it | unchanged, reported |

## Audit (2) — the UI consumers

| consumer | on main | after |
|---|---|---|
| cockpit sync button `ModuleLauncher.tsx:456-464` (`booksSyncAccounts`) | `await fetch(...)` — never reads `res.ok` or the body; nothing rendered on any outcome | reads the declared outcome (`readSyncOutcome`) and renders it under the cockpit bar: ok / partial / error line, e.g. `Plaid: RATE_LIMIT_EXCEEDED (TRANSACTIONS_LIMIT) — try again in a few minutes` |
| legacy dashboard sync button `dashboard/page.tsx:358-363` | same; `setSyncing(false)` never ran on a throw | same inline line, `try/finally` |
| "the investments view that fetches Plaid live" | **no consumer of `/api/investments` or `/analyze` exists in `src/`** (grep, any quoting). The only live investments surface is Categorize → Investments, which reads the DB via `/api/investment-transactions/opens` in `TradeCommitWorkflow.tsx:163`, not Plaid | STOP RULE: no consumer to edit; the two routes now declare failure (non-2xx) for whoever calls them |
| Categorize badge, cockpit `BooksPipeline.tsx:411` | `uncommittedInvestments.length` from `/api/investment-transactions` read as `inv.transactions \|\| inv.investments \|\| []` — but that route returns a **bare array** (`route.ts:85`), so the badge was `0` **always**; the table beneath (`TradeCommitWorkflow.tsx:163`) counts `/opens` (`tradeNum: null` rows, 920) | badge, section subtitle, section status, and the strip's pending count all read `/api/investment-transactions/opens` · `totalAll` — the same query the workflow renders; a non-array body or missing `totalAll` throws → the pipeline's error state, never a fabricated empty list |
| Categorize badge, legacy `dashboard/page.tsx:595` | `uncommittedInvestments.length` — the array read works there (`data.transactions \|\| data.investments \|\| data`), but it is a different query from the table | same one-source badge; a failed core fetch (`if (res.ok)` used to skip silently, `:151-163`) is now declared in a banner |
| `InvestmentsTab.tsx:14` | ignores its `investmentTransactions` prop; renders `TradeCommitWorkflow` + committed table | unchanged |

## Build

- `src/lib/plaid/failLoud.ts` (pure, client-safe): `stageOk`, `stageFailed` (via `summarizePlaidError`), `describeFailure` (provider code first, a "try again in a few minutes" hint on 429, never a body), `statusForFailure` (429 → 429, other upstream → 502, local throw → 500), `syncEnvelope(stages, okBody)` (200 / 207 / first failure's status, existing success keys merged in), `failureEnvelope(stage, err, progress)`, and the client-side `readSyncResponse` / `readSyncOutcome`.
- `sync-complete` keeps its per-item bodies verbatim; each stage is wrapped in `if (!<stage>Failure)` so the first failure ends that stage for the run, and the final response is the envelope. No retries, no fallbacks.
- Response bodies on success keep every existing key (`success`, `synced`, `skipped`, `stats`, …) and add `ok: true`, `stages`, `message`.

## Verify

| check | result |
|---|---|
| `npx tsc --noEmit` | 0 |
| `npm test` | 47/47 — 5 new failLoud, 5 summarizer, 12 tokenCipher, 25 url-guard |
| eslint | 0 on the two new files (`--max-warnings 0`); per-file counts identical to main on 11 touched files, improved on two (`plaid/sync` 1e→0e, `resync` 2e→1e); the dashboard's 27e/24w pre-exist |
| `next build` | compiled, types valid; page-data collection dies at the pre-existing `/api/admin/backfill-transaction-fields` `PLAID_CLIENT_ID` assert, as on every prior PR |
| grep proof | 18 catch blocks across the 10 audited routes: every one declares (`stageFailed(` / `failureEnvelope(`), none calls `NextResponse.json(` without a status, none carries a literal 2xx — **0 violations** |
| diff scope | 10 audited routes, 3 consumers, helper + test |

### Test output
```
ok 1 · (a) a Plaid 429 maps to a 429 envelope with the summarized, user-safe body
ok 2 · (a) other upstream statuses become 502; a local throw (missing cipher key) becomes 500
ok 3 · (b) a partial run — transactions failed, investments succeeded — is a 207 carrying both stages
ok 4 · (b) every stage failed → the first failure's status; zero failures → 200 with ok:true
ok 5 · client reader: 200 → ok line, 207 → partial line, 429 → error line, non-JSON body → HTTP fallback
# tests 47 · pass 47 · fail 0
```

## Not changed, reported
- The link flow (`exchange-token` fetch at `ModuleLauncher.tsx:479`, `dashboard/page.tsx:348`) still ignores a non-2xx; the route already returns 500. Out of this task's three named consumers.
- `lib/plaid-sync-fix.ts` swallows per-item errors but no route calls it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc

---
_Generated by [Claude Code](https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc)_