### PR TITLE
fix(security): discoveryDailyCapUsd fails loud on a set-but-invalid A…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,7 +46,8 @@ ANTHROPIC_API_KEY="sk-ant-..."
 # (web_search + 16k output tokens, the most expensive single call in the app) is
 # refused BEFORE any paid call once today's RECORDED spend (operations_ai_usage,
 # purpose compliance_discovery) reaches the cap; the refusal is declared (429).
-# Positive number; default 10 (src/lib/discovery/discoveryGate.ts). The per-user
+# Unset → default 10 (src/lib/discovery/discoveryGate.ts). Set → must be a finite
+# positive number; anything else fails loud (DiscoveryConfigError). The per-user
 # request limiter shared by all AI routes (AI_RATE_LIMIT / AI_RATE_WINDOW) applies too.
 AI_DISCOVERY_DAILY_CAP="10"
 

--- a/src/lib/__tests__/discoveryGate.test.ts
+++ b/src/lib/__tests__/discoveryGate.test.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import {
   DEFAULT_DISCOVERY_DAILY_CAP_USD,
   DiscoveryBudgetError,
+  DiscoveryConfigError,
   discoveryDailyCapUsd,
   discoveryRefusal,
   frameUntrusted,
@@ -55,12 +56,38 @@ test('at cap exactly is refused (>= cap); under cap runs and reports the status'
   });
 });
 
-test('the cap reads AI_DISCOVERY_DAILY_CAP as a positive number; otherwise the default', () => {
-  withCap('2.5', () => assert.equal(discoveryDailyCapUsd(), 2.5));
-  withCap('0', () => assert.equal(discoveryDailyCapUsd(), DEFAULT_DISCOVERY_DAILY_CAP_USD));
-  withCap('nope', () => assert.equal(discoveryDailyCapUsd(), DEFAULT_DISCOVERY_DAILY_CAP_USD));
+test('the cap: unset → the documented default; set to a finite positive number → that number', () => {
   withCap(undefined, () => assert.equal(discoveryDailyCapUsd(), DEFAULT_DISCOVERY_DAILY_CAP_USD));
+  withCap('2.5', () => assert.equal(discoveryDailyCapUsd(), 2.5));
+  withCap(' 10 ', () => assert.equal(discoveryDailyCapUsd(), 10));
   assert.equal(DEFAULT_DISCOVERY_DAILY_CAP_USD, 10);
+});
+
+test('the cap: set but invalid → DiscoveryConfigError naming the value, never the default', async () => {
+  for (const bad of ['0', '-1', 'nope', '', '   ', '10abc', 'Infinity', 'NaN']) {
+    withCap(bad, () => {
+      assert.throws(
+        () => discoveryDailyCapUsd(),
+        (err: unknown) => {
+          assert.ok(err instanceof DiscoveryConfigError, `expected DiscoveryConfigError for ${JSON.stringify(bad)}`);
+          assert.equal(err.variable, 'AI_DISCOVERY_DAILY_CAP');
+          assert.equal(err.value, bad);
+          assert.ok(err.message.includes(JSON.stringify(bad)));
+          return true;
+        },
+      );
+    });
+  }
+  // and the budget gate propagates it (as a rejection — the gate is async): no spend
+  // is read, no call is made
+  await withCap('nope', async () => {
+    let spendRead = false;
+    await assert.rejects(
+      () => requireDiscoveryBudget('u', async () => { spendRead = true; return 0; }),
+      DiscoveryConfigError,
+    );
+    assert.equal(spendRead, false);
+  });
 });
 
 test('a rate-limited refusal is declared: 429, the envelope shape, Retry-After', () => {

--- a/src/lib/discovery/discoveryGate.ts
+++ b/src/lib/discovery/discoveryGate.ts
@@ -34,10 +34,28 @@ export class DiscoveryBudgetError extends Error {
   }
 }
 
-/** The per-user daily cap in USD. AI_DISCOVERY_DAILY_CAP env (positive number) → default. */
+/** AI_DISCOVERY_DAILY_CAP is set but is not a finite positive number. Fail loud, never default. */
+export class DiscoveryConfigError extends Error {
+  constructor(public variable: string, public value: string) {
+    super(`${variable} is set to ${JSON.stringify(value)} — it must be a finite positive number of USD per day; unset it to use the default of ${DEFAULT_DISCOVERY_DAILY_CAP_USD}`);
+    this.name = 'DiscoveryConfigError';
+  }
+}
+
+/**
+ * The per-user daily cap in USD. Unset → DEFAULT_DISCOVERY_DAILY_CAP_USD. Set →
+ * must be a finite positive number (the whole string, so "10abc" and "" are
+ * invalid); anything else throws DiscoveryConfigError naming the value — a
+ * mistyped cap must never silently become the default.
+ */
 export function discoveryDailyCapUsd(): number {
-  const env = parseFloat(process.env.AI_DISCOVERY_DAILY_CAP || '');
-  return Number.isFinite(env) && env > 0 ? env : DEFAULT_DISCOVERY_DAILY_CAP_USD;
+  const raw = process.env.AI_DISCOVERY_DAILY_CAP;
+  if (raw === undefined) return DEFAULT_DISCOVERY_DAILY_CAP_USD;
+  const value = raw.trim() === '' ? NaN : Number(raw.trim());
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new DiscoveryConfigError('AI_DISCOVERY_DAILY_CAP', raw);
+  }
+  return value;
 }
 
 function utcMidnight(now = new Date()): Date {


### PR DESCRIPTION
…I_DISCOVERY_DAILY_CAP

SEC-03 follow-up. Unset → DEFAULT_DISCOVERY_DAILY_CAP_USD (documented). Set and not a finite positive number (the whole string: "0", "-1", "nope", "", "10abc", "Infinity") → DiscoveryConfigError naming the variable and the value. A mistyped cap must never silently become the default.

Tests: test 3 split into the two branches — unset/valid → number; invalid → DiscoveryConfigError naming the value, and the async budget gate rejects before reading any spend. .env.example documents the fail-loud.

Verified: tsc 0, eslint 0 on the gate and its test, npm test 54/54.


Claude-Session: https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc