### PR TITLE
feat(answers): THE ANSWERS — the app's front page is step 11 (NAV-01c)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ templestuart.com teaches the full pipe with build-time proofs: every drawing der
 
 ## The data model
 
-Every shape below is extracted from `src/components/landing/Landing.tsx` — the same consts the deck renders from.
+Every shape below is extracted from the consts the deck renders from — `src/components/landing/Landing.tsx` and the leaves it imports (`src/lib/problemSheet.ts` for the sheet, `src/lib/answers.ts` for the four lenses and their inputs).
 
 ### The arrival row (step 3)
 

--- a/scripts/assert-tool-registry.ts
+++ b/scripts/assert-tool-registry.ts
@@ -8,6 +8,15 @@
  * target has a door. A child page is reached through its parent (segment-prefix
  * rule: /agenda/[id] through /agenda). A page with no door fails the build.
  *
+ * THE ANSWERS LAW (NAV-01c): the module-scope law of src/lib/answers.ts re-run
+ * here (ANSWER_READS keys === ANSWER_ROWS questions 4/4 in order; a computed
+ * read declares its source line — a card with a number and no source fails the
+ * build), plus what only the filesystem can answer: /answers has a page file,
+ * and its client derives the four cards from ANSWER_ROWS (imports the leaf,
+ * maps ANSWER_ROWS, retypes no question). /answers is a door in the family
+ * navigation (its first entry); each card's home and the net-worth read are
+ * doors on /answers.
+ *
  * The assert:showroom pattern: a plain script wired into the `build` script so
  * it runs in CI / Vercel and fails the BUILD. It imports the registry (which
  * runs its module-scope law: sheet cells 25/25 both ways, LIVE/PARTIAL have a
@@ -22,8 +31,9 @@ import { existsSync, readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { readdirSync, statSync } from 'node:fs';
 import { PROBLEM_SHEET } from '../src/lib/problemSheet';
-import { EXPECTED_STATUS_COUNTS, FAMILY_READS, TOOL_REGISTRY, registryLaw, statusCounts } from '../src/lib/toolRegistry';
+import { COCKPIT_PATH, EXPECTED_STATUS_COUNTS, FAMILY_READS, TOOL_REGISTRY, registryLaw, statusCounts } from '../src/lib/toolRegistry';
 import { OWNER_UTILITIES } from '../src/lib/shellMenu';
+import { ANSWERS_HOME, ANSWER_READS, ANSWER_ROWS, NET_WORTH_READ, answersLaw } from '../src/lib/answers';
 
 /**
  * Routes whose door is outside the app map: the front door and its marketing
@@ -45,11 +55,6 @@ const GUEST_ROUTES: ReadonlyArray<{ route: string; why: string }> = [
   { route: '/trips/rsvp', why: 'the RSVP invite link sent to participants (src/app/trips/rsvp/RSVPClient.tsx)' },
   { route: '/trips/[id]', why: 'linked from the RSVP flow — RSVPClient.tsx:72, :87, :136' },
 ];
-
-const COCKPIT_PATH: Record<string, string> = {
-  calendar: '/runway', travel: '/travel', routines: '/routines', projects: '/projects',
-  content: '/content', trade: '/trade', books: '/books', tax: '/tax', compliance: '/?tab=compliance',
-};
 
 function pageRoutes(): Array<{ route: string; file: string }> {
   const out: Array<{ route: string; file: string }> = [];
@@ -139,6 +144,10 @@ for (const t of TOOL_REGISTRY) {
 for (const [family, reads] of Object.entries(FAMILY_READS)) for (const r of reads ?? []) doors.push({ route: r.href as string, kind: 'family read', via: `${family} · "${r.label}"` });
 for (const u of OWNER_UTILITIES) doors.push({ route: u.href, kind: 'utilities menu', via: u.label });
 for (const g of GUEST_ROUTES) doors.push({ route: g.route, kind: 'listed route', via: g.why });
+// NAV-01c: THE ANSWERS is the family navigation's first entry; each card opens its lens's home.
+doors.push({ route: ANSWERS_HOME, kind: 'family nav', via: 'THE ANSWERS · first entry' });
+for (const [q, r] of Object.entries(ANSWER_READS)) if (r.computed) doors.push({ route: r.home, kind: 'answers', via: `"${q}" · Open · ${r.home}` });
+doors.push({ route: NET_WORTH_READ.home, kind: 'answers', via: `Net worth · Open · ${NET_WORTH_READ.home}` });
 
 const pages = pageRoutes();
 const reach = new Map<string, Door | null>();
@@ -175,6 +184,26 @@ for (const d of doors) {
 }
 console.log(`pages: ${pages.length} · doors: ${doors.length}`);
 
+// ── THE ANSWERS LAW (NAV-01c) ───────────────────────────────────────────────
+violations.push(...answersLaw({ throwOnFail: false }));
+const ANSWERS_PAGE = `src/app${ANSWERS_HOME}/page.tsx`;
+const ANSWERS_CLIENT = 'src/components/answers/AnswersClient.tsx';
+if (!existsSync(resolve(ROOT, ANSWERS_PAGE))) violations.push(`${ANSWERS_HOME} has no page file (${ANSWERS_PAGE})`);
+const clientSrc = existsSync(resolve(ROOT, ANSWERS_CLIENT)) ? readFileSync(resolve(ROOT, ANSWERS_CLIENT), 'utf8') : '';
+if (!clientSrc) violations.push(`${ANSWERS_CLIENT} is missing — /answers renders nothing`);
+if (clientSrc && !/from '@\/lib\/answers'/.test(clientSrc)) violations.push(`${ANSWERS_CLIENT} must import the answers from src/lib/answers.ts`);
+if (clientSrc && !clientSrc.includes('ANSWER_ROWS.map(')) violations.push(`${ANSWERS_CLIENT} must derive its cards from ANSWER_ROWS — never a retyped list`);
+for (const [q] of ANSWER_ROWS) {
+  if (clientSrc.includes(`'${q}'`) || clientSrc.includes(`"${q}"`)) violations.push(`${ANSWERS_CLIENT} retypes the question "${q}" — the four questions come from ANSWER_ROWS only`);
+}
+console.log('THE ANSWERS — four cards, ANSWER_ROWS order, then the read');
+for (const [q, segs] of ANSWER_ROWS) {
+  const r = ANSWER_READS[q];
+  console.log(`${q.padEnd(28)} ${segs.map(([t]) => t).join('')}`);
+  console.log(`${''.padEnd(28)} ${r === undefined ? 'NO READ' : r.computed ? `NUMBER · ${r.endpoint} → ${r.home}\n${''.padEnd(28)} source: ${r.source}` : `HONEST · ${r.honest}`}`);
+}
+console.log(`${'Net worth'.padEnd(28)} NUMBER · ${NET_WORTH_READ.endpoint} → ${NET_WORTH_READ.home}\n${''.padEnd(28)} source: ${NET_WORTH_READ.source}`);
+
 console.log('TOOL REGISTRY — 25 rows, sheet order');
 console.log('#   tool          family        status    beats                                  home            page file');
 for (const r of rows) console.log(r);
@@ -188,3 +217,4 @@ if (violations.length) {
 }
 console.log('✔ Tool registry law passed — 25/25 cells, homes resolve to page files, counts match the census.');
 console.log(`✔ Reachability law passed — ${pages.length} pages, every one has a door.`);
+console.log(`✔ The answers law passed — ${ANSWER_ROWS.length}/4 questions on ${ANSWERS_HOME}, every number sourced.`);

--- a/src/app/answers/page.tsx
+++ b/src/app/answers/page.tsx
@@ -1,0 +1,22 @@
+import { getVerifiedEmail } from '@/lib/cookie-auth';
+import AnswersClient from '@/components/answers/AnswersClient';
+
+/**
+ * NAV-01c — /answers, THE ANSWERS: the app's front page and the post-login
+ * front door (LoginBox, /login and /hub all land here). The deck's step 11 on
+ * the viewer's own lines — four cards in ANSWER_ROWS order, then Net worth as
+ * a read (src/lib/answers.ts).
+ *
+ * Auth: a protected path — middleware (src/middleware.ts) bounces an
+ * unverified visitor to '/' before this renders; every read a card makes is
+ * user-scoped and cookie-gated in its own route (401/403 print as the card's
+ * declared state, never a number). The verified cookie names the viewer for
+ * the shell bar; nothing here touches the database, so the page renders for a
+ * signed cookie alone — the NAV-01c verification shape.
+ */
+export const dynamic = 'force-dynamic';
+
+export default async function AnswersPage() {
+  const viewer = await getVerifiedEmail();
+  return <AnswersClient viewer={viewer ?? ''} />;
+}

--- a/src/app/hub/page.tsx
+++ b/src/app/hub/page.tsx
@@ -1,8 +1,9 @@
 import { redirect } from 'next/navigation';
 
 // NAV-01b (ONE SHELL): the old hub cockpit — its calendar lives in the Runway section of the cockpit
-// (HubCalendar, ModuleLauncher.tsx).
+// (HubCalendar, ModuleLauncher.tsx). NAV-01c: /hub was the post-login door, so it
+// lands where login lands now — THE ANSWERS.
 // The URL keeps resolving for anyone who linked or bookmarked it.
 export default function HubRedirect() {
-  redirect('/runway');
+  redirect('/answers');
 }

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -25,7 +25,8 @@ export default function LoginPage() {
 
       if (response.ok) {
         // Force full page navigation to ensure cookie is picked up
-        window.location.href = '/hub';
+        // NAV-01c: the post-login front door is /answers.
+        window.location.href = '/answers';
       } else {
         setError(data.error || 'Login failed');
       }

--- a/src/components/LoginBox.tsx
+++ b/src/components/LoginBox.tsx
@@ -11,7 +11,8 @@ interface LoginBoxProps {
   initialMode?: 'login' | 'register';
 }
 
-export default function LoginBox({ onClose, onSuccess, redirectTo = '/hub', initialMode = 'login' }: LoginBoxProps) {
+// NAV-01c: the post-login front door is /answers (src/lib/answers.ts ANSWERS_HOME).
+export default function LoginBox({ onClose, onSuccess, redirectTo = '/answers', initialMode = 'login' }: LoginBoxProps) {
   const [mode, setMode] = useState<'login' | 'register'>(initialMode);
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');

--- a/src/components/answers/AnswersClient.tsx
+++ b/src/components/answers/AnswersClient.tsx
@@ -1,0 +1,301 @@
+'use client';
+
+/**
+ * NAV-01c — THE ANSWERS, the app's front page: the deck's step 11 on the
+ * viewer's own lines. Four cards in ANSWER_ROWS order — the question and the
+ * math line verbatim from the deck (money words ink gold, as there) — and the
+ * NUMBER when a computation exists in the code today, with its SOURCE LINE
+ * beside it (ANSWER_READS, src/lib/answers.ts; a number with no source fails
+ * the build). Below the four: Net worth as a READ, sourced the same way.
+ *
+ * Fail loud (HYG-01): a read that fails prints its HTTP status and the
+ * route's own error, never a number; an empty ledger prints the empty state in
+ * words, never $0 as if it were a sum. No retry, no fallback, no placeholder.
+ *
+ * The shell is the one shell (NAV-01b): ShellBar + the family navigation in
+ * link mode (THE ANSWERS is its first entry). Mobile: cards stack; ≥10px.
+ */
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useSession, signOut } from 'next-auth/react';
+import ShellBar from '@/components/ui/ShellBar';
+import FamilyNav from '@/components/home/FamilyNav';
+import { deriveRunwayReceipts } from '@/components/hub/RunwayBudgetPanel';
+import { ANSWER_ROWS, ANSWER_READS, NET_WORTH_READ, type AnswerRead, type ComputedRead } from '@/lib/answers';
+
+type Read<T> = { status: 'reading' } | { status: 'failed'; message: string } | { status: 'ok'; data: T };
+
+/** One cookie-gated GET. A non-2xx answer or a network failure is a declared failure — never retried, never defaulted. */
+async function readJson<T>(endpoint: string): Promise<Read<T>> {
+  try {
+    const res = await fetch(endpoint, { cache: 'no-store' });
+    if (!res.ok) {
+      let detail = '';
+      try {
+        const body = (await res.json()) as { error?: unknown };
+        if (typeof body.error === 'string') detail = body.error;
+      } catch {
+        detail = 'no error body';
+      }
+      return { status: 'failed', message: `HTTP ${res.status}${detail ? ` · ${detail}` : ''}` };
+    }
+    return { status: 'ok', data: (await res.json()) as T };
+  } catch (e) {
+    return { status: 'failed', message: `network — ${e instanceof Error ? e.message : String(e)}` };
+  }
+}
+
+function useRead<T>(endpoint: string): Read<T> {
+  const [read, setRead] = useState<Read<T>>({ status: 'reading' });
+  useEffect(() => {
+    let live = true;
+    readJson<T>(endpoint).then((r) => { if (live) setRead(r); });
+    return () => { live = false; };
+  }, [endpoint]);
+  return read;
+}
+
+const usd = (n: number) => `$${Math.abs(n).toLocaleString('en-US', { minimumFractionDigits: 0, maximumFractionDigits: 0 })}`;
+const signed = (n: number) => `${n < 0 ? '−' : '+'}${usd(n)}`;
+const niceDate = (ymd: string) => new Date(`${ymd}T00:00:00`).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+const YEAR = new Date().getFullYear();
+
+/** What a card shows once its read resolved: a number (with its detail), or the declared state in words. */
+type Figure = { kind: 'number'; value: string; tone: 'pos' | 'neg' | 'flat'; detail: string; note?: string } | { kind: 'state'; text: string; detail?: string };
+
+// ── the four lenses + the read, each a pure map from the route's own answer to a Figure ──
+
+interface TaxAnswer {
+  tax_year: number;
+  disclaimer: string;
+  form_1040_full: { line9: number; totalTax: number; totalPayments: number; amountOwed: number; filingStatus: string };
+}
+function taxFigure(d: TaxAnswer): Figure {
+  const f = d.form_1040_full;
+  if (f.line9 === 0) return { kind: 'state', text: `No income on the lines for ${d.tax_year} — nothing to tax yet.`, detail: `${f.filingStatus} · ${d.disclaimer}` };
+  return {
+    kind: 'number',
+    value: `${f.amountOwed < 0 ? 'refund ' : 'owe '}${usd(f.amountOwed)}`,
+    tone: f.amountOwed > 0 ? 'neg' : 'pos',
+    detail: `tax year ${d.tax_year} · income ${usd(f.line9)} · total tax ${usd(f.totalTax)} · paid or withheld ${usd(f.totalPayments)} · ${f.filingStatus}`,
+    note: d.disclaimer,
+  };
+}
+
+type RunwayAnswer = Parameters<typeof deriveRunwayReceipts>[0];
+function runwayFigure(d: RunwayAnswer): Figure {
+  const r = deriveRunwayReceipts(d);
+  const w = d.windows[0];
+  const basis = `cash ${r.cash ?? 'no bank linked'} (${r.accountsLinked} linked account${r.accountsLinked === 1 ? '' : 's'}) · burn ${r.burnLine ?? '—'} over the trailing ${w.months} full months · as of ${d.asOf}`;
+  if (r.runwayValue === null || w.state !== 'ok') return { kind: 'state', text: r.runwayEmpty, detail: basis };
+  return { kind: 'number', value: r.runwayValue, tone: 'flat', detail: `zero date ${niceDate(w.zeroDate as string)} · ${basis}` };
+}
+
+interface TradingAnswer { summary: { totalRealizedPL: number; openPositions: number; closedPositions: number; winRate: number } }
+function tradingFigure(d: TradingAnswer): Figure {
+  const s = d.summary;
+  if (s.closedPositions === 0 && s.openPositions === 0) return { kind: 'state', text: 'No trades committed yet — nothing to score.' };
+  return {
+    kind: 'number',
+    value: `${signed(s.totalRealizedPL)} realized`,
+    tone: s.totalRealizedPL < 0 ? 'neg' : 'pos',
+    detail: `${s.closedPositions} closed · win rate ${s.winRate}% · ${s.openPositions} open (counted, not priced)`,
+  };
+}
+
+interface EntitiesAnswer { entities: Array<{ id: string; name: string; entity_type: string }> }
+interface StatementsAnswer { accounts: Array<{ accountType: string; debits: number; credits: number; entityName: string | null }> }
+/** Money in minus money out for the sole-prop entity, from the statements read (ledger cents → dollars). */
+function businessFigure(entities: EntitiesAnswer['entities'], statements: ReadonlyArray<StatementsAnswer>): Figure {
+  if (entities.length === 0) return { kind: 'state', text: 'No business (sole-prop) entity on your books — nothing to sum.' };
+  const rows = statements.flatMap((s) => s.accounts);
+  if (rows.length === 0) return { kind: 'state', text: `No journal entries committed for ${YEAR} on ${entities.map((e) => e.name).join(', ')}.` };
+  let moneyIn = 0;
+  let moneyOut = 0;
+  for (const a of rows) {
+    if (a.accountType === 'revenue') moneyIn += (a.credits - a.debits) / 100;
+    else if (a.accountType === 'expense') moneyOut += (a.debits - a.credits) / 100;
+  }
+  const net = moneyIn - moneyOut;
+  return {
+    kind: 'number',
+    value: `${signed(net)} net`,
+    tone: net < 0 ? 'neg' : 'pos',
+    detail: `money in ${usd(moneyIn)} − money out ${usd(moneyOut)} · ${YEAR} · ${entities.map((e) => e.name).join(', ')}`,
+  };
+}
+
+interface NetWorthAnswer { summary: { totalAssets: number; totalDebt: number; netWorth: number }; assets: unknown[]; debt: unknown[] }
+function netWorthFigure(d: NetWorthAnswer): Figure {
+  if (d.assets.length === 0 && d.debt.length === 0) return { kind: 'state', text: 'No asset or debt lines from your linked accounts yet.' };
+  return {
+    kind: 'number',
+    value: `${d.summary.netWorth < 0 ? '−' : ''}${usd(d.summary.netWorth)}`,
+    tone: d.summary.netWorth < 0 ? 'neg' : 'pos',
+    detail: `assets ${usd(d.summary.totalAssets)} − debt ${usd(d.summary.totalDebt)}`,
+  };
+}
+
+// ── rendering ──
+
+const TONE: Record<'pos' | 'neg' | 'flat', string> = { pos: 'text-emerald-700', neg: 'text-rose-700', flat: 'text-text-primary' };
+
+function FigureBlock({ read, figure }: { read: Read<unknown>; figure: (d: never) => Figure }) {
+  if (read.status === 'reading') return <p className="font-mono text-xs text-text-faint" data-read="reading">Reading…</p>;
+  if (read.status === 'failed') return <p role="alert" className="font-mono text-xs text-rose-700" data-read="failed">Could not read — {read.message}</p>;
+  const f = figure(read.data as never);
+  if (f.kind === 'state') {
+    return (
+      <div data-read="state">
+        <p className="font-mono text-sm text-text-secondary">{f.text}</p>
+        {f.detail && <p className="mt-1 text-[10px] text-text-faint">{f.detail}</p>}
+      </div>
+    );
+  }
+  return (
+    <div data-read="number">
+      <p className={`font-mono text-2xl sm:text-3xl tracking-tight tabular-nums ${TONE[f.tone]}`}>{f.value}</p>
+      <p className="mt-1 text-[10px] text-text-faint">{f.detail}</p>
+      {f.note && <p className="mt-1 text-[10px] text-text-faint italic">{f.note}</p>}
+    </div>
+  );
+}
+
+/** The card frame: the question, the math line, the read (number or state), and — for a computed read — its source line. */
+function AnswerCard({ question, math, read, children }: { question: string; math: ReadonlyArray<readonly [string, boolean]>; read: AnswerRead; children: React.ReactNode }) {
+  return (
+    <article className="flex flex-col gap-2 rounded border border-border bg-white p-4 sm:p-5" data-answer={question}>
+      <h2 className="text-base sm:text-lg font-semibold tracking-tight text-text-primary">{question}</h2>
+      <p className="font-mono text-[11px] sm:text-xs uppercase tracking-wider text-text-secondary" data-math>
+        {math.map(([text, gold], i) => (gold ? <span key={i} className="text-brand-gold">{text}</span> : <span key={i}>{text}</span>))}
+      </p>
+      <div className="mt-1 min-h-[3rem]">{children}</div>
+      {read.computed ? (
+        <>
+          <p className="text-[10px] leading-relaxed text-text-muted" data-source>
+            <span className="font-mono uppercase tracking-wider text-text-faint">Source · </span>
+            {read.source}
+          </p>
+          <Link href={read.home} className="self-start rounded border border-brand-purple px-2.5 py-1 font-mono text-[10px] uppercase tracking-wider text-brand-purple hover:bg-brand-purple-wash">
+            Open · {read.home}
+          </Link>
+        </>
+      ) : (
+        <p className="text-[10px] leading-relaxed text-text-muted" data-honest>{read.honest}</p>
+      )}
+    </article>
+  );
+}
+
+function TaxCard({ question, math, read }: { question: string; math: ReadonlyArray<readonly [string, boolean]>; read: ComputedRead }) {
+  const r = useRead<TaxAnswer>(`${read.endpoint}?year=${YEAR}`);
+  return <AnswerCard question={question} math={math} read={read}><FigureBlock read={r} figure={taxFigure} /></AnswerCard>;
+}
+function RunwayCard({ question, math, read }: { question: string; math: ReadonlyArray<readonly [string, boolean]>; read: ComputedRead }) {
+  const r = useRead<RunwayAnswer>(read.endpoint);
+  return <AnswerCard question={question} math={math} read={read}><FigureBlock read={r} figure={runwayFigure} /></AnswerCard>;
+}
+function TradingCard({ question, math, read }: { question: string; math: ReadonlyArray<readonly [string, boolean]>; read: ComputedRead }) {
+  const r = useRead<TradingAnswer>(read.endpoint);
+  return <AnswerCard question={question} math={math} read={read}><FigureBlock read={r} figure={tradingFigure} /></AnswerCard>;
+}
+function BusinessCard({ question, math, read }: { question: string; math: ReadonlyArray<readonly [string, boolean]>; read: ComputedRead }) {
+  // Two reads, one source: the sole-prop entity (entities), then its statements for the year.
+  const [r, setR] = useState<Read<{ entities: EntitiesAnswer['entities']; statements: StatementsAnswer[] }>>({ status: 'reading' });
+  useEffect(() => {
+    let live = true;
+    (async () => {
+      const ents = await readJson<EntitiesAnswer>('/api/entities');
+      if (ents.status !== 'ok') { if (live) setR(ents); return; }
+      const business = ents.data.entities.filter((e) => e.entity_type === 'sole_prop');
+      const statements: StatementsAnswer[] = [];
+      for (const e of business) {
+        const s = await readJson<StatementsAnswer>(`${read.endpoint}?year=${YEAR}&entityId=${encodeURIComponent(e.id)}`);
+        if (s.status !== 'ok') { if (live) setR(s); return; }
+        statements.push(s.data);
+      }
+      if (live) setR({ status: 'ok', data: { entities: business, statements } });
+    })();
+    return () => { live = false; };
+  }, [read.endpoint]);
+  return (
+    <AnswerCard question={question} math={math} read={read}>
+      <FigureBlock read={r} figure={(d: { entities: EntitiesAnswer['entities']; statements: StatementsAnswer[] }) => businessFigure(d.entities, d.statements)} />
+    </AnswerCard>
+  );
+}
+
+/** Which card renders which lens — keyed by the read's endpoint, so the questions themselves come from ANSWER_ROWS only. */
+const CARD_BY_ENDPOINT: Record<string, typeof TaxCard> = {
+  '/api/tax/calculate': TaxCard,
+  '/api/runway': RunwayCard,
+  '/api/positions/summary': TradingCard,
+  '/api/statements': BusinessCard,
+};
+
+export default function AnswersClient({ viewer }: { viewer: string }) {
+  const router = useRouter();
+  const { data: session } = useSession();
+  const [isAdmin, setIsAdmin] = useState(false);
+  const [profileError, setProfileError] = useState<string | null>(null);
+
+  // The utilities menu is admin-only (the same /api/auth/me flag both headers read). A failed
+  // profile read is declared, never swallowed: no menu, and the failure printed under the bar.
+  useEffect(() => {
+    let live = true;
+    readJson<{ user: { isAdmin?: boolean } }>('/api/auth/me').then((r) => {
+      if (!live) return;
+      if (r.status === 'ok') setIsAdmin(Boolean(r.data.user.isAdmin));
+      else if (r.status === 'failed') setProfileError(r.message);
+    });
+    return () => { live = false; };
+  }, []);
+
+  const handleSignOut = async () => {
+    document.cookie = 'userEmail=; path=/; max-age=0';
+    if (session) {
+      await signOut({ callbackUrl: '/' });
+    } else {
+      await fetch('/api/auth/logout', { method: 'POST' });
+      router.push('/');
+    }
+  };
+
+  const netWorth = useRead<NetWorthAnswer>(NET_WORTH_READ.endpoint);
+
+  return (
+    <div className="min-h-screen bg-bg-terminal flex flex-col">
+      <ShellBar userLabel={viewer.split('@')[0]} isAdmin={isAdmin} onSignOut={handleSignOut} />
+      <FamilyNav />
+      <main className="max-w-7xl mx-auto w-full px-4 lg:px-8 py-6 sm:py-8">
+        {profileError && (
+          <p role="alert" className="mb-4 font-mono text-[10px] text-rose-700">Profile read failed — {profileError}. Utilities hidden.</p>
+        )}
+        <header className="mb-5 sm:mb-6">
+          <p className="font-mono text-[10px] sm:text-xs uppercase tracking-[0.2em] text-text-faint">The answers</p>
+          <h1 className="mt-1 text-xl sm:text-2xl font-semibold tracking-tight text-text-primary">Every answer is math on the lines.</h1>
+          <p className="mt-1 text-xs text-text-muted">Four questions, each a number with its source, or the honest state in words.</p>
+        </header>
+
+        {/* The four, ANSWER_ROWS order. Cards stack on a phone, two-up from sm. */}
+        <section aria-label="The four answers" className="grid grid-cols-1 gap-3 sm:grid-cols-2 sm:gap-4" data-answers>
+          {ANSWER_ROWS.map(([question, math]) => {
+            const read = ANSWER_READS[question];
+            if (!read.computed) return <AnswerCard key={question} question={question} math={math} read={read}><p className="font-mono text-sm text-text-secondary">{read.honest}</p></AnswerCard>;
+            const Card = CARD_BY_ENDPOINT[read.endpoint];
+            if (!Card) throw new Error(`THE ANSWERS: no card renders ${read.endpoint} ("${question}")`);
+            return <Card key={question} question={question} math={math} read={read} />;
+          })}
+        </section>
+
+        {/* Below the four: Net worth as a read. */}
+        <section aria-label="Net worth" className="mt-5 sm:mt-6" data-net-worth>
+          <AnswerCard question="Net worth" math={[['Assets', true], [' minus ', false], ['debt', true], ['; a read.', false]]} read={NET_WORTH_READ}>
+            <FigureBlock read={netWorth} figure={netWorthFigure} />
+          </AnswerCard>
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/src/components/home/FamilyNav.tsx
+++ b/src/components/home/FamilyNav.tsx
@@ -9,21 +9,29 @@
  * existing section in place (the same selectTab funnel the old tabs used, so
  * the URL keeps being written as today); an off-cockpit tool is a plain link.
  * A NOT_BUILT row is exactly that — no screen, no mock, no "coming soon" copy.
- * THE ANSWERS is reserved (NAV-01c) and is not rendered.
+ *
+ * NAV-01c — THE ANSWERS is the first entry of the row: a link to /answers, the
+ * app's front page (src/lib/answers.ts ANSWERS_HOME), current when you are on
+ * it. Off the cockpit (no selectTab funnel — /answers), the nav runs in LINK
+ * MODE: a cockpit-hosted tool is a plain link to the URL the cockpit writes
+ * for its section (COCKPIT_PATH, one source with the reachability law), and
+ * the tool list opens only when a family is picked.
  *
  * Mobile: the family row scrolls horizontally; tool rows stack; nothing under
  * 10px type.
  */
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
-import { FAMILIES, FAMILY_READS, COCKPIT_PRIMARY_TOOL, TOOL_REGISTRY, toolsOf, type Beats, type ToolEntry, type ToolStatus } from '@/lib/toolRegistry';
+import { usePathname } from 'next/navigation';
+import { COCKPIT_PATH, FAMILIES, FAMILY_READS, COCKPIT_PRIMARY_TOOL, TOOL_REGISTRY, toolsOf, type Beats, type ToolEntry, type ToolStatus } from '@/lib/toolRegistry';
+import { ANSWERS_HOME } from '@/lib/answers';
 import type { FamilyName } from '@/lib/problemSheet';
 
 interface Props {
-  /** The cockpit's active section key (ModuleLauncher activeModule). */
-  activeModule: string;
-  /** The cockpit's selectTab funnel — sets the section AND writes the URL. */
-  onSelectModule: (key: string) => void;
+  /** The cockpit's active section key (ModuleLauncher activeModule). Absent off the cockpit. */
+  activeModule?: string;
+  /** The cockpit's selectTab funnel — sets the section AND writes the URL. Absent off the cockpit (link mode). */
+  onSelectModule?: (key: string) => void;
 }
 
 const STATUS_LABEL: Record<ToolStatus, string> = { LIVE: 'LIVE', PARTIAL: 'PARTIAL', NOT_BUILT: 'NOT BUILT' };
@@ -33,15 +41,22 @@ const STATUS_CLASS: Record<ToolStatus, string> = {
   NOT_BUILT: 'border-border text-text-faint',
 };
 const BEATS: ReadonlyArray<[keyof Beats, string]> = [['discover', 'discover'], ['decide', 'decide'], ['commit', 'commit'], ['record', 'record']];
+const CHIP = 'shrink-0 border-b-2 px-3 sm:px-4 py-3 font-mono text-[10px] sm:text-xs uppercase tracking-wider transition-colors';
+const CHIP_ON = 'border-brand-purple text-brand-purple';
+const CHIP_OFF = 'border-transparent text-text-muted hover:text-text-primary';
 
-function familyOfModule(key: string): FamilyName | null {
+function familyOfModule(key: string | undefined): FamilyName | null {
+  if (!key) return null;
   const name = COCKPIT_PRIMARY_TOOL[key];
   if (!name) return null;
   return TOOL_REGISTRY.find((t) => t.name === name)?.family ?? null;
 }
 
 export default function FamilyNav({ activeModule, onSelectModule }: Props) {
-  const [family, setFamily] = useState<FamilyName>(() => familyOfModule(activeModule) ?? FAMILIES[0]);
+  const pathname = usePathname();
+  const onAnswers = pathname === ANSWERS_HOME;
+  // Cockpit mode opens a family at once (the section's own); link mode opens none until picked.
+  const [family, setFamily] = useState<FamilyName | null>(() => familyOfModule(activeModule) ?? (onSelectModule ? FAMILIES[0] : null));
 
   // A deep link or the path restore lands on a cockpit section → open its family.
   useEffect(() => {
@@ -49,36 +64,46 @@ export default function FamilyNav({ activeModule, onSelectModule }: Props) {
     if (f) setFamily(f);
   }, [activeModule]);
 
-  const tools = toolsOf(family);
-  const reads = FAMILY_READS[family] ?? [];
+  const tools = family ? toolsOf(family) : [];
+  const reads = family ? (FAMILY_READS[family] ?? []) : [];
 
   return (
     <nav aria-label="Tool families" className="border-b border-border bg-white">
       <div className="max-w-7xl mx-auto px-4 lg:px-8">
-        {/* The six families — one row, horizontal scroll on a phone. */}
-        <div role="tablist" className="flex overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-          {FAMILIES.map((f) => (
-            <button
-              key={f}
-              type="button"
-              role="tab"
-              aria-selected={family === f}
-              onClick={() => setFamily(f)}
-              className={`shrink-0 border-b-2 px-3 sm:px-4 py-3 font-mono text-[10px] sm:text-xs uppercase tracking-wider transition-colors ${
-                family === f ? 'border-brand-purple text-brand-purple' : 'border-transparent text-text-muted hover:text-text-primary'
-              }`}
-            >
-              {f}
-            </button>
-          ))}
+        {/* THE ANSWERS first, then the six families — one row, horizontal scroll on a phone. */}
+        <div className="flex overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+          <Link
+            href={ANSWERS_HOME}
+            aria-current={onAnswers ? 'page' : undefined}
+            data-answers
+            className={`${CHIP} ${onAnswers ? CHIP_ON : CHIP_OFF}`}
+          >
+            THE ANSWERS
+          </Link>
+          <div role="tablist" className="flex">
+            {FAMILIES.map((f) => (
+              <button
+                key={f}
+                type="button"
+                role="tab"
+                aria-selected={family === f}
+                onClick={() => setFamily(f)}
+                className={`${CHIP} ${family === f ? CHIP_ON : CHIP_OFF}`}
+              >
+                {f}
+              </button>
+            ))}
+          </div>
         </div>
 
         {/* The family's tools, sheet order. */}
-        <ul role="tabpanel" className="divide-y divide-border">
-          {tools.map((t) => (
-            <ToolRow key={t.slug} tool={t} activeModule={activeModule} onSelectModule={onSelectModule} />
-          ))}
-        </ul>
+        {family !== null && (
+          <ul role="tabpanel" className="divide-y divide-border">
+            {tools.map((t) => (
+              <ToolRow key={t.slug} tool={t} activeModule={activeModule} onSelectModule={onSelectModule} />
+            ))}
+          </ul>
+        )}
         {/* NAV-01b: family-level reads — pages that read across the family's tools. */}
         {reads.length > 0 && (
           <div className="flex flex-wrap items-center gap-x-3 gap-y-1 border-t border-border py-2 font-mono text-[10px] uppercase tracking-wider">
@@ -95,8 +120,10 @@ export default function FamilyNav({ activeModule, onSelectModule }: Props) {
   );
 }
 
-function ToolRow({ tool, activeModule, onSelectModule }: { tool: ToolEntry; activeModule: string; onSelectModule: (key: string) => void }) {
-  const isOpen = tool.cockpitKey !== undefined && tool.cockpitKey === activeModule;
+function ToolRow({ tool, activeModule, onSelectModule }: { tool: ToolEntry; activeModule?: string; onSelectModule?: (key: string) => void }) {
+  const isOpen = onSelectModule !== undefined && tool.cockpitKey !== undefined && tool.cockpitKey === activeModule;
+  const openClass = 'rounded border px-2.5 py-1 font-mono text-[10px] uppercase tracking-wider transition-colors';
+  const linkClass = 'font-mono text-[10px] text-text-muted underline-offset-2 hover:text-text-primary hover:underline';
   return (
     <li className="flex flex-col gap-2 py-2.5 sm:flex-row sm:items-center sm:gap-4" data-tool={tool.slug} data-status={tool.status}>
       <div className="flex items-center gap-3 sm:w-64">
@@ -120,39 +147,36 @@ function ToolRow({ tool, activeModule, onSelectModule }: { tool: ToolEntry; acti
       {/* A way in — only when a home exists. NOT_BUILT renders nothing here. */}
       {tool.home !== null && (
         <div className="flex flex-wrap items-center gap-x-3 gap-y-1 sm:ml-auto">
-          {tool.cockpitKey ? (
+          {tool.cockpitKey && onSelectModule ? (
             <button
               type="button"
               onClick={() => onSelectModule(tool.cockpitKey as string)}
               aria-current={isOpen ? 'page' : undefined}
-              className={`rounded border px-2.5 py-1 font-mono text-[10px] uppercase tracking-wider transition-colors ${
-                isOpen ? 'border-brand-purple bg-brand-purple text-white' : 'border-brand-purple text-brand-purple hover:bg-brand-purple-wash'
-              }`}
+              className={`${openClass} ${isOpen ? 'border-brand-purple bg-brand-purple text-white' : 'border-brand-purple text-brand-purple hover:bg-brand-purple-wash'}`}
             >
               {isOpen ? 'Open below' : `Open · ${tool.home}`}
             </button>
           ) : (
             <Link
-              href={tool.home}
-              className="rounded border border-brand-purple px-2.5 py-1 font-mono text-[10px] uppercase tracking-wider text-brand-purple transition-colors hover:bg-brand-purple-wash"
+              href={tool.cockpitKey ? COCKPIT_PATH[tool.cockpitKey] : tool.home}
+              className={`${openClass} border-brand-purple text-brand-purple hover:bg-brand-purple-wash`}
             >
-              Open · {tool.home}
+              Open · {tool.cockpitKey ? COCKPIT_PATH[tool.cockpitKey] : tool.home}
             </Link>
           )}
           {(tool.links ?? []).map((l) =>
             l.href ? (
-              <Link key={l.label} href={l.href} className="font-mono text-[10px] text-text-muted underline-offset-2 hover:text-text-primary hover:underline">
+              <Link key={l.label} href={l.href} className={linkClass}>
                 {l.label}
               </Link>
-            ) : (
-              <button
-                key={l.label}
-                type="button"
-                onClick={() => onSelectModule(l.cockpitKey as string)}
-                className="font-mono text-[10px] text-text-muted underline-offset-2 hover:text-text-primary hover:underline"
-              >
+            ) : onSelectModule ? (
+              <button key={l.label} type="button" onClick={() => onSelectModule(l.cockpitKey as string)} className={linkClass}>
                 {l.label}
               </button>
+            ) : (
+              <Link key={l.label} href={COCKPIT_PATH[l.cockpitKey as string]} className={linkClass}>
+                {l.label}
+              </Link>
             ),
           )}
         </div>

--- a/src/components/home/HomeClient.tsx
+++ b/src/components/home/HomeClient.tsx
@@ -31,9 +31,9 @@ export default function HomeClient() {
   // tabs and reports the active one via onTabChange; this mirror drives the hero copy.
   // Default 'calendar' matches ModuleLauncher's initial tab (no flash, no mismatch).
   const [activeTab, setActiveTab] = useState('calendar');
-  // PR-Auth-Home: login from the home page lands back on the home tabs (in logged-in
-  // mode), not the old /hub cockpit. (Other /hub entry points are a separate retire PR.)
-  const [loginRedirect] = useState('/');
+  // PR-Auth-Home → NAV-01c: login from the home page lands on THE ANSWERS (/answers),
+  // the post-login front door — the same door the /login page and /hub use.
+  const [loginRedirect] = useState('/answers');
   const [loginMode, setLoginMode] = useState<'login' | 'register'>('login');
 
   // PR-Auth-Home: the home shell now learns who's logged in (same /api/auth/me check the
@@ -349,7 +349,7 @@ export default function HomeClient() {
           <div className="relative z-10">
             <LoginBox
               onClose={() => setShowLogin(false)}
-              onSuccess={() => { window.location.href = '/'; }}
+              onSuccess={() => { window.location.href = loginRedirect; }}
               redirectTo={loginRedirect}
               initialMode={loginMode}
             />

--- a/src/components/landing/Landing.tsx
+++ b/src/components/landing/Landing.tsx
@@ -181,6 +181,7 @@ import LandingFooter from './LandingFooter';
 // only on the FD-2 verified-guest branch).
 import GuestTripStrip from './GuestTripStrip';
 import { PROBLEM_SHEET } from '@/lib/problemSheet';
+import { ANSWER_ROWS, ANSWER_INPUTS } from '@/lib/answers';
 // PR-ELEV-1: the coming-soon tiles became badged "Soon" chips INSIDE the
 // booking strip (travelStripModes) — the separate tile row is gone.
 
@@ -1122,33 +1123,11 @@ const S10_LAYOUT = (() => {
 })();
 const S10_H = S10_GEOM.HEAD + S10_LAYOUT.rows.length * S10_GEOM.ROW_H;
 
-// DECK-11: four questions and their math, the math pre-split so the deck's
-// money words ink gold. Row 3 has no money word and that is the deck's own
-// shape, not an omission.
-const ANSWER_ROWS: ReadonlyArray<readonly [string, ReadonlyArray<readonly [string, boolean]>]> = [
-  ['What do I owe in tax?', [['Income', true], [' so far × the rules.', false]]],
-  ['How long can I last?', [['Cash', true], [' ÷ what I burn each month.', false]]],
-  ['How is my trading doing?', [['Wins, losses, and open risk; from fills, positions, and live quotes.', false]]],
-  ['How is my business doing?', [['Money in', true], [' minus ', false], ['money out', true], ['.', false]]],
-];
-
-// S11-INPUTS (PR-S11-DATAFLOW): the lines each answer reads, keyed by
-// the answer's question, in ANSWER_ROWS order — Alex's product logic; he
-// tunes on Preview. Accounts are verbatim POSTING_RULES debit/credit
-// strings; feeds are verbatim ROUTING_RULES provider+resource pairs; the
-// S11_LAYOUT law throws on anything that resolves to neither. A line
-// under more than one answer is CORRECT — same line, many lenses; it
-// renders once per group. NOTE: the ruling named a tastytrade position
-// feed, which ROUTING_RULES does not carry (tastytrade has only quote);
-// plaid holding is the rule book's positions feed (SNAPSHOT — how things
-// stood at one moment), so it rides here and the kept math's 'fills,
-// positions, and live quotes' stays drawn 3-for-3.
-const ANSWER_INPUTS: Readonly<Record<string, readonly string[]>> = {
-  'What do I owe in tax?': ['Revenue', 'Expense', 'Wages + employer taxes', 'irs bulletin', 'us code title'],
-  'How long can I last?': ['Cash', 'Expense', 'Travel', 'Wages + employer taxes', 'A/P'],
-  'How is my trading doing?': ['Investments', 'plaid holding', 'tastytrade quote'],
-  'How is my business doing?': ['Revenue', 'Expense', 'Travel', 'Wages + employer taxes', 'Filing Fees'],
-};
+// NAV-01c: ANSWER_ROWS (the four questions and their math lines) and
+// ANSWER_INPUTS (the lines each answer reads) moved to the shared leaf
+// src/lib/answers.ts — one source, as PROBLEM_SHEET moved (NAV-01a): the deck
+// renders them, /answers renders them, the build-time law reads them. Imported
+// at the top beside PROBLEM_SHEET; the S11 / S13 / S14 laws below are unchanged.
 
 // S11-GEOM: the lines (grouped by answer), THE MATH pull-out (one lens
 // per group, spanning its rows), the four answer cards. Rows on one

--- a/src/lib/__tests__/answers.test.ts
+++ b/src/lib/__tests__/answers.test.ts
@@ -1,0 +1,61 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { ANSWERS_HOME, ANSWER_INPUTS, ANSWER_READS, ANSWER_ROWS, NET_WORTH_READ, answersLaw, type AnswerRead } from '../answers';
+
+// NAV-01c — THE ANSWERS LAW. Hermetic: rows / reads are injected for the failing shapes;
+// the real constants must pass the law as the module already ran it at import.
+
+test('the real constants pass: four questions, four reads in order, every number sourced', () => {
+  assert.deepEqual(answersLaw({ throwOnFail: false }), []);
+  assert.equal(ANSWER_ROWS.length, 4);
+  assert.deepEqual(Object.keys(ANSWER_READS), ANSWER_ROWS.map(([q]) => q));
+  assert.deepEqual(Object.keys(ANSWER_INPUTS), ANSWER_ROWS.map(([q]) => q));
+  for (const read of [...Object.values(ANSWER_READS), NET_WORTH_READ]) {
+    if (read.computed) {
+      assert.ok(read.source.length > 0);
+      assert.match(read.endpoint, /^\/api\//);
+      assert.match(read.citation, /\.ts:\d+/);
+      assert.match(read.home, /^\//);
+    }
+  }
+  assert.equal(ANSWERS_HOME, '/answers');
+});
+
+test('a card with a number and no source line fails the law', () => {
+  const reads: Record<string, AnswerRead> = Object.fromEntries(Object.entries(ANSWER_READS));
+  const [first] = ANSWER_ROWS[0];
+  const r = reads[first];
+  assert.ok(r.computed);
+  reads[first] = { ...r, source: '   ' };
+  const v = answersLaw({ throwOnFail: false, reads });
+  assert.equal(v.length, 1);
+  assert.match(v[0], /a card with a number must declare its source line/);
+  assert.throws(() => answersLaw({ reads }), /THE ANSWERS LAW failed/);
+});
+
+test('the reads must cover ANSWER_ROWS 4/4, in order — a missing, extra, or reordered question fails', () => {
+  const entries = Object.entries(ANSWER_READS);
+  const missing = Object.fromEntries(entries.slice(0, 3));
+  assert.match(answersLaw({ throwOnFail: false, reads: missing })[0], /4\/4 in order/);
+  const reordered = Object.fromEntries([entries[1], entries[0], ...entries.slice(2)]);
+  assert.match(answersLaw({ throwOnFail: false, reads: reordered })[0], /4\/4 in order/);
+  const extra = Object.fromEntries([...entries, ['Is this a fifth question?', { computed: false, honest: 'no' }]]);
+  assert.match(answersLaw({ throwOnFail: false, reads: extra })[0], /4\/4 in order/);
+});
+
+test("an un-computed card carries the deck's honest words and reads nothing", () => {
+  const reads: Record<string, AnswerRead> = Object.fromEntries(Object.entries(ANSWER_READS));
+  const [q] = ANSWER_ROWS[3];
+  reads[q] = { computed: false, honest: '' };
+  assert.match(answersLaw({ throwOnFail: false, reads })[0], /must carry the deck's honest words/);
+  reads[q] = { computed: false, honest: 'waits on the posting pipe' };
+  assert.deepEqual(answersLaw({ throwOnFail: false, reads }), []);
+  const leaking = { computed: false, honest: 'waits', endpoint: '/api/x' } as unknown as AnswerRead;
+  reads[q] = leaking;
+  assert.match(answersLaw({ throwOnFail: false, reads })[0], /reads nothing and prints no source/);
+});
+
+test('the net-worth read is held to the same law', () => {
+  const v = answersLaw({ throwOnFail: false, netWorth: { ...NET_WORTH_READ, source: '' } });
+  assert.deepEqual(v, ['Net worth: a card with a number must declare its source line']);
+});

--- a/src/lib/answers.ts
+++ b/src/lib/answers.ts
@@ -1,0 +1,157 @@
+/**
+ * NAV-01c — THE ANSWERS. The deck's step-11 constants, moved out of
+ * Landing.tsx into a shared LEAF (the PROBLEM_SHEET precedent, NAV-01a — zero
+ * imports, server- and client-safe): ONE source for the four questions, their
+ * math lines, and the lines each answer reads. The deck renders them
+ * (Landing.tsx), the app's front page renders them (/answers), and the
+ * build-time law reads them (scripts/assert-tool-registry.ts). The two literals
+ * are byte-identical to the deck's; never a retyped second copy.
+ *
+ * ANSWER_READS (below) is NAV-01c's own fact table: per question, whether a
+ * COMPUTATION EXISTS in the code today and, when it does, the SOURCE LINE — one
+ * clause from the NAV-01c audit — the card prints beside its number. THE LAW
+ * (module scope, the deck's LAYOUT LAW idiom; re-run at build by the assert):
+ *   1. ANSWER_READS keys === ANSWER_ROWS questions, 4/4, in order;
+ *   2. a computed read declares a non-empty source, an /api endpoint, a
+ *      file:line citation, and a home — a card with a number and no source
+ *      FAILS THE BUILD;
+ *   3. an un-computed read carries the deck's honest words and reads nothing.
+ */
+
+// DECK-11: four questions and their math, the math pre-split so the deck's
+// money words ink gold. Row 3 has no money word and that is the deck's own
+// shape, not an omission.
+export const ANSWER_ROWS: ReadonlyArray<readonly [string, ReadonlyArray<readonly [string, boolean]>]> = [
+  ['What do I owe in tax?', [['Income', true], [' so far × the rules.', false]]],
+  ['How long can I last?', [['Cash', true], [' ÷ what I burn each month.', false]]],
+  ['How is my trading doing?', [['Wins, losses, and open risk; from fills, positions, and live quotes.', false]]],
+  ['How is my business doing?', [['Money in', true], [' minus ', false], ['money out', true], ['.', false]]],
+];
+
+// S11-INPUTS (PR-S11-DATAFLOW): the lines each answer reads, keyed by
+// the answer's question, in ANSWER_ROWS order — Alex's product logic; he
+// tunes on Preview. Accounts are verbatim POSTING_RULES debit/credit
+// strings; feeds are verbatim ROUTING_RULES provider+resource pairs; the
+// S11_LAYOUT law throws on anything that resolves to neither. A line
+// under more than one answer is CORRECT — same line, many lenses; it
+// renders once per group. NOTE: the ruling named a tastytrade position
+// feed, which ROUTING_RULES does not carry (tastytrade has only quote);
+// plaid holding is the rule book's positions feed (SNAPSHOT — how things
+// stood at one moment), so it rides here and the kept math's 'fills,
+// positions, and live quotes' stays drawn 3-for-3.
+export const ANSWER_INPUTS: Readonly<Record<string, readonly string[]>> = {
+  'What do I owe in tax?': ['Revenue', 'Expense', 'Wages + employer taxes', 'irs bulletin', 'us code title'],
+  'How long can I last?': ['Cash', 'Expense', 'Travel', 'Wages + employer taxes', 'A/P'],
+  'How is my trading doing?': ['Investments', 'plaid holding', 'tastytrade quote'],
+  'How is my business doing?': ['Revenue', 'Expense', 'Travel', 'Wages + employer taxes', 'Filing Fees'],
+};
+
+/** The app's front page — the post-login front door (NAV-01c). */
+export const ANSWERS_HOME = '/answers';
+
+/** A lens whose computation EXISTS in the code today: the card reads `endpoint` and prints the number WITH `source`. */
+export interface ComputedRead {
+  computed: true;
+  /** The user-scoped route the card reads (cookie-gated in the route; a failed read prints its status, never a number). */
+  endpoint: string;
+  /** ONE clause — where the number comes from, from the NAV-01c audit. Printed beside the number. */
+  source: string;
+  /** file:line of the computation (the NAV-01c audit). */
+  citation: string;
+  /** Where the lens lives — the card's door. */
+  home: string;
+}
+
+/** A lens with NO computation in the code: the card prints the deck's honest words — no number, no placeholder. */
+export interface HonestRead {
+  computed: false;
+  /** The honest state in the deck's words (Landing.tsx, step 11). */
+  honest: string;
+}
+
+export type AnswerRead = ComputedRead | HonestRead;
+
+/**
+ * The four reads, keyed by the question, in ANSWER_ROWS order. Every source
+ * line is one clause from the NAV-01c audit of the route it names; the
+ * citation is the computation's file:line on main at the audit.
+ */
+export const ANSWER_READS: Readonly<Record<string, AnswerRead>> = {
+  'What do I owe in tax?': {
+    computed: true,
+    endpoint: '/api/tax/calculate',
+    source: 'from the ledger entries you committed for the tax year on your sole-prop accounts, plus the tax documents you entered — Form 1040 line by line',
+    citation: 'src/app/api/tax/calculate/route.ts:63 (tax_documents) · :101-107 (ledger_entries per Schedule C account, entity sole_prop) · src/lib/form-1040-service.ts:508 (totalTax) · :532 (amountOwed)',
+    home: '/tax',
+  },
+  'How long can I last?': {
+    computed: true,
+    endpoint: '/api/runway',
+    source: 'cash from the account balances Plaid last synced (operating accounts, trading excluded), divided by the net burn from the ledger entries you committed over the trailing full months',
+    citation: 'src/app/api/runway/route.ts:101-104 (SUM accounts.currentBalance) · :150-160 (expense debits and revenue credits from ledger_entries) · :200-212 (state, runway months, zero date)',
+    home: '/runway',
+  },
+  'How is my trading doing?': {
+    computed: true,
+    endpoint: '/api/positions/summary',
+    source: 'realized wins and losses from the trades you committed (stored option positions and stock lots); open positions are counted, not priced — no live quote in this read',
+    citation: 'src/app/api/positions/summary/route.ts:31-41 (trading_positions) · :44-68 (stock_lots + dispositions) · :182-199 (summary)',
+    home: '/trade',
+  },
+  'How is my business doing?': {
+    computed: true,
+    endpoint: '/api/statements',
+    source: 'revenue minus expense over the journal entries you committed this year on your sole-prop entity — the statements read, per account',
+    citation: 'src/app/api/entities/route.ts:19-23 (entity_type) · src/app/api/statements/route.ts:53-71 (ledger_entries × journal_entries × chart_of_accounts, per year and entity)',
+    home: '/books',
+  },
+};
+
+/** Net worth — a READ below the four (NAV-01c), its /net-worth source stated the same way. */
+export const NET_WORTH_READ: ComputedRead = {
+  computed: true,
+  endpoint: '/api/net-worth',
+  source: 'assets minus debt, each the sum of your Plaid-synced transactions by chart-of-accounts code (personal entity) — not account balances, not ledger entries',
+  citation: 'src/app/api/net-worth/route.ts:33-40 (chart_of_accounts modules assets / debt / equity) · :45-56 (transactions summed by accountCode) · :73-85 (totals)',
+  home: '/net-worth',
+};
+
+/** THE LAW. Throws on the first violation; returns the violations list when asked not to throw. Rows / reads are injectable for tests. */
+export function answersLaw(opts: {
+  throwOnFail?: boolean;
+  rows?: typeof ANSWER_ROWS;
+  reads?: Readonly<Record<string, AnswerRead>>;
+  netWorth?: AnswerRead;
+} = {}): string[] {
+  const rows = opts.rows ?? ANSWER_ROWS;
+  const reads = opts.reads ?? ANSWER_READS;
+  const violations: string[] = [];
+  const questions = rows.map(([q]) => q);
+  const keys = Object.keys(reads);
+  if (questions.length !== 4) violations.push(`ANSWER_ROWS has ${questions.length} questions, expected 4`);
+  if (keys.length !== questions.length || keys.some((k, i) => k !== questions[i])) {
+    violations.push(`ANSWER_READS keys must equal ANSWER_ROWS questions 4/4 in order — got [${keys.join(' | ')}]`);
+  }
+  for (const [q, segs] of rows) {
+    if (segs.length === 0 || segs.some(([text]) => text.length === 0)) violations.push(`"${q}": the math line must not be empty`);
+  }
+  const check = (label: string, r: AnswerRead) => {
+    if (r.computed) {
+      if (r.source.trim() === '') violations.push(`${label}: a card with a number must declare its source line`);
+      if (!r.endpoint.startsWith('/api/')) violations.push(`${label}: endpoint "${r.endpoint}" is not an /api route`);
+      if (r.citation.trim() === '') violations.push(`${label}: a computed read must cite its file:line`);
+      if (!r.home.startsWith('/')) violations.push(`${label}: home "${r.home}" is not a route`);
+    } else {
+      if (r.honest.trim() === '') violations.push(`${label}: an un-computed card must carry the deck's honest words`);
+      if ('endpoint' in r || 'source' in r) violations.push(`${label}: an un-computed card reads nothing and prints no source`);
+    }
+  };
+  for (const q of questions) if (q in reads) check(`"${q}"`, reads[q]);
+  check('Net worth', opts.netWorth ?? NET_WORTH_READ);
+  if (violations.length && opts.throwOnFail !== false) {
+    throw new Error(`THE ANSWERS LAW failed:\n  ${violations.join('\n  ')}`);
+  }
+  return violations;
+}
+
+answersLaw();

--- a/src/lib/toolRegistry.ts
+++ b/src/lib/toolRegistry.ts
@@ -167,12 +167,13 @@ export const FAMILIES: readonly FamilyName[] = PROBLEM_SHEET.map((f) => f.header
 
 /**
  * NAV-01b: family-level READS — pages that read across a family's tools and
- * belong to no single tool. Net worth is reserved for THE ANSWERS (NAV-01c);
- * until then it is a read under WHAT YOU OWN. Income is a read under MONEY IN.
+ * belong to no single tool. Income is a read under MONEY IN; net worth is a
+ * read under WHAT YOU OWN and, since NAV-01c, the read below the four answers
+ * on /answers (src/lib/answers.ts NET_WORTH_READ names the same page).
  */
 export const FAMILY_READS: Readonly<Partial<Record<FamilyName, readonly ToolLink[]>>> = {
   'MONEY IN': [{ label: 'Income · a read', href: '/income' }],
-  'WHAT YOU OWN': [{ label: 'Net worth · a read (THE ANSWERS, NAV-01c)', href: '/net-worth' }],
+  'WHAT YOU OWN': [{ label: 'Net worth · a read', href: '/net-worth' }],
 };
 
 /** The 25 tools in sheet order, each joined to its census facts. */
@@ -184,6 +185,18 @@ export const TOOL_REGISTRY: readonly ToolEntry[] = PROBLEM_SHEET.flatMap((f) =>
 export const COCKPIT_PRIMARY_TOOL: Readonly<Record<string, ToolName>> = {
   projects: 'Tasks', content: 'Time', travel: 'Travel', calendar: 'Budget', routines: 'Calendar',
   books: 'Bookkeeping', trade: 'Brokerage', tax: 'Tax', compliance: 'Compliance',
+};
+
+/**
+ * NAV-01c: cockpit section key → the URL the cockpit writes for it
+ * (ModuleLauncher writeTabParam; src/app/[tab]/page.tsx TAB_PATHS; the
+ * compliance carve-out keeps its legacy /?tab= URL). ONE source: the family
+ * navigation's link mode (off the cockpit, a cockpit tool is a plain link here)
+ * and the build-time reachability law (scripts/assert-tool-registry.ts).
+ */
+export const COCKPIT_PATH: Readonly<Record<string, string>> = {
+  calendar: '/runway', travel: '/travel', routines: '/routines', projects: '/projects',
+  content: '/content', trade: '/trade', books: '/books', tax: '/tax', compliance: '/?tab=compliance',
 };
 
 export function toolsOf(family: FamilyName): readonly ToolEntry[] {
@@ -230,6 +243,11 @@ export function registryLaw(opts: { throwOnFail?: boolean } = {}): string[] {
   }
   for (const [key, name] of Object.entries(COCKPIT_PRIMARY_TOOL)) {
     if (!(name in FACTS)) violations.push(`COCKPIT_PRIMARY_TOOL[${key}] names unknown tool "${name}"`);
+    if (!(key in COCKPIT_PATH)) violations.push(`COCKPIT_PRIMARY_TOOL key "${key}" has no COCKPIT_PATH`);
+  }
+  for (const t of TOOL_REGISTRY) {
+    if (t.cockpitKey && !(t.cockpitKey in COCKPIT_PATH)) violations.push(`${t.name}: cockpitKey "${t.cockpitKey}" has no COCKPIT_PATH`);
+    for (const l of t.links ?? []) if (l.cockpitKey && !(l.cockpitKey in COCKPIT_PATH)) violations.push(`${t.name}: link "${l.label}" cockpit key "${l.cockpitKey}" has no COCKPIT_PATH`);
   }
   for (const [family, reads] of Object.entries(FAMILY_READS)) {
     if (!FAMILIES.includes(family as FamilyName)) violations.push(`FAMILY_READS names unknown family "${family}"`);


### PR DESCRIPTION
**Do not merge — Alex merges after Vercel Preview (SOC 2 gate).**

NAV-01c — THE ANSWERS: the app's front page is step 11. `/answers` is the post-login front door (LoginBox, `/login` and `/hub` all land there); the family navigation gets THE ANSWERS as its first entry; four cards in ANSWER_ROWS order — the question, the math line, the number with its source line — then Net worth as a read. The deck's step-11 constants moved to one source, byte-identical. A card with a number and no source fails the build.

## Audit — the four lenses, where each number comes from (read-only, before the build)

| Lens | Computation exists? | Where it computes | What it reads | Auth gate in the route |
|---|---|---|---|---|
| What do I owe in tax? | **yes** | `src/app/api/tax/calculate/route.ts:58-60` (year param, default 2025) → `src/lib/form-1040-service.ts:346` generateForm1040; totalTax `:508`, amountOwed `:532` | `tax_documents` for the year (`route.ts:63`); `ledger_entries` per Schedule C account on the `sole_prop` entity (`:101-107`); Schedule D from stored positions / lot dispositions (`generateForm8949`); bracket tables hardcoded `form-1040-service.ts:13-51` (2025 + 2026) | `getVerifiedEmail` `:47` → user `:50` → `requireTabAccess('tab:tax')` `:56` |
| How long can I last? | **yes** | `src/app/api/runway/route.ts:200-212` (state → runway months → zero date); windows `[3, 6]` `:235` | cash = `SUM(accounts.currentBalance)`, trading entity excluded (`:101-104`, Plaid-synced stored balance); burn = expense debits and revenue credits from `ledger_entries` over the trailing full months (`:150-160`); explicit no-number states `no_cash` / `insufficient_history` / `cashflow_positive` (`:67`) | `getVerifiedEmail` `:71` → user `:76` |
| How is my trading doing? | **yes** | `src/app/api/positions/summary/route.ts:182-199` (totalRealizedPL, open / closed counts, win rate) | `trading_positions` (`:31-41`), `stock_lots` + dispositions (`:44-68`) — stored, DB-only. No live quote: `src/app/api/tastytrade/positions/route.ts:5-18` and `balances` are `requireAdmin` reads of the shared firm account, not the viewer's lens | `getVerifiedEmail` (route head) → user |
| How is my business doing? | **yes** | client sum of the statements read: revenue credits − debits, expense debits − credits, per account (`src/app/api/statements/route.ts:53-71`), for the `sole_prop` entity from `src/app/api/entities/route.ts:19-23` (the vocabulary the tax route `:102`, `chart-of-accounts/page.tsx:32` and `SpendingDashboard.tsx:57` call "Business") | `ledger_entries × journal_entries × chart_of_accounts`, non-reversed, per year and entity | `getVerifiedEmail` `:9` → user `:14` → `requireTabAccess('tab:books')` `:20` |
| Net worth (a read) | **yes** | `src/app/api/net-worth/route.ts:73-85` | `chart_of_accounts` modules assets / debt / equity, `entity_type: 'personal'` (`:33-40`); balance per code = Σ `transactions.amount` (Plaid-synced, categorized) (`:45-56`) — not account balances, not ledger entries | `getVerifiedEmail` `:7` → user `:12` |

Login chain before this PR: `LoginBox.tsx:14` default `redirectTo = '/hub'`; `login/page.tsx:28` `window.location.href = '/hub'`; `HomeClient.tsx:36` `loginRedirect = '/'` and the modal's `onSuccess` (`:353`) pushed `/`; `hub/page.tsx` redirected to `/runway` (NAV-01b). NextAuth sign-in sets the same signed `userEmail` cookie (`api/auth/[...nextauth]/route.ts:49-51`), so one cookie gate covers both login paths.

## Each card's source line (verbatim from `src/lib/answers.ts` ANSWER_READS — printed beside the number)

| Card | Endpoint | Source line | Door |
|---|---|---|---|
| What do I owe in tax? | `/api/tax/calculate?year=<this year>` | from the ledger entries you committed for the tax year on your sole-prop accounts, plus the tax documents you entered — Form 1040 line by line | `/tax` |
| How long can I last? | `/api/runway` | cash from the account balances Plaid last synced (operating accounts, trading excluded), divided by the net burn from the ledger entries you committed over the trailing full months | `/runway` |
| How is my trading doing? | `/api/positions/summary` | realized wins and losses from the trades you committed (stored option positions and stock lots); open positions are counted, not priced — no live quote in this read | `/trade` |
| How is my business doing? | `/api/entities` → `/api/statements?year=&entityId=` | revenue minus expense over the journal entries you committed this year on your sole-prop entity — the statements read, per account | `/books` |
| Net worth | `/api/net-worth` | assets minus debt, each the sum of your Plaid-synced transactions by chart-of-accounts code (personal entity) — not account balances, not ledger entries | `/net-worth` |

Every card is computed today, so every card shows a number when the read succeeds. Empty inputs render the empty state in words, never $0 as a sum: tax with total income 0 → "No income on the lines for <year> — nothing to tax yet"; runway reuses `deriveRunwayReceipts` (`RunwayBudgetPanel.tsx:134`) so the no-number states print the panel's own wording ("No bank linked", "Need 3 full months", "Cash-flow positive"); trading with no positions → "No trades committed yet"; business with no sole-prop entity or no entries this year → says so; net worth with no asset or debt lines → says so. A failed read prints `Could not read — HTTP <status> · <the route's own error>` and no number; no retry, no fallback, no placeholder.

## Where the code and the deck's honest lines disagree (for truing the deck — reported, not papered over)

1. **Step 11 honest line** (`Landing.tsx:4041`; README row 11): "Today the trading lens reads live; tax, runway, and the business result wait on the posting pipe."
   - The code says **more**: `/api/tax/calculate`, `/api/runway` and `/api/statements` compute today from committed ledger / journal entries (cites above). The computations exist; what may be empty is the lines. On `/answers` an empty ledger renders the declared empty state — so "wait on the posting pipe" is true of the data, not of the lenses.
   - The code says **less**: the viewer's trading lens does not read live. `/api/positions/summary` and `/api/trading/realized-pnl` are stored-data reads; the live tastytrade positions / balances routes are `requireAdmin` on the shared firm account. README row 11 GAP "one lens live (trading); three wait on step 10" inherits both.
2. **Step 11 math, trading** — "from fills, positions, and live quotes": no live quote reaches the number; open positions are counted, not priced. The card says so.
3. **Step 11 inputs, runway** — ANSWER_INPUTS reads the `Cash` posting line; the code's numerator is the Plaid-synced `accounts.currentBalance` (`runway/route.ts:101-104`), not the ledger's Cash account.
4. **Step 11 inputs, tax** — ANSWER_INPUTS lists the `irs bulletin` and `us code title` feeds; the code's rules are hardcoded bracket and deduction tables (`form-1040-service.ts:13-51`), no feed is read.
5. **Step 12 honest line** (`Landing.tsx:4254`; README rows 139 and 153): "the calendar window is live at /hub" — `/hub` has been a redirect since NAV-01b (→ `/runway`) and now lands on `/answers`; the calendar lives in the Runway section of the cockpit.

None of these lines were edited here — the ruling is the deck's to true.

## What changed

- **`src/lib/answers.ts`** (new): `ANSWER_ROWS` and `ANSWER_INPUTS` moved out of `Landing.tsx:1128-1151` **byte-identical** (494 B + 462 B; only `export ` prefixed), with their two comment blocks; `Landing.tsx` imports them beside `PROBLEM_SHEET`. Adds `ANSWERS_HOME`, `ANSWER_READS` (per question: `computed`, `endpoint`, `source`, `citation`, `home` — or `honest` in the deck's words), `NET_WORTH_READ`, and `answersLaw()` at module scope: keys === ANSWER_ROWS questions 4/4 in order; a computed read declares a non-empty source, an `/api` endpoint, a citation and a home; an un-computed read carries honest words and reads nothing.
- **`src/app/answers/page.tsx`** + **`src/components/answers/AnswersClient.tsx`** (new): the page. Server component (`force-dynamic`) reads the verified cookie for the viewer label only — no database on the page, so it renders for a signed cookie alone; middleware is the gate (a guest 307s to `/`, proved below). Client: ShellBar + FamilyNav (link mode) + the four cards mapped from `ANSWER_ROWS` (the questions are never retyped — the assert checks) + the Net worth read. Cards are keyed to their lens by endpoint. The utilities menu shows for an admin via `/api/auth/me`; a failed profile read is declared under the bar, never swallowed.
- **`src/components/home/FamilyNav.tsx`**: THE ANSWERS is the first entry (a link to `/answers`, `aria-current` on it). `activeModule` / `onSelectModule` are optional: without the cockpit's selectTab funnel the nav runs in link mode — a cockpit tool is a plain link to the URL the cockpit writes for its section, and the tool list opens when a family is picked. Cockpit behaviour unchanged (screenshot in chat).
- **`src/lib/toolRegistry.ts`**: `COCKPIT_PATH` moves in from the assert (one source for the nav's link mode and the reachability law; the law now checks every cockpit key has a path). The net-worth read drops its "reserved for NAV-01c" label.
- **Redirects**: `LoginBox` default `redirectTo` → `/answers`; `/login` → `/answers`; the home modal's `loginRedirect` and `onSuccess` → `/answers`; `/hub` stub → `/answers`.
- **`scripts/assert-tool-registry.ts`**: THE ANSWERS LAW — re-runs `answersLaw`, checks `/answers` has a page file, that the client imports the leaf, maps `ANSWER_ROWS` and retypes no question; adds `/answers` (family nav, first entry) and each card's home + `/net-worth` (answers) as doors; prints the four cards with their sources. 62 pages, every one has a door.
- **`src/lib/__tests__/answers.test.ts`** (new, 5 tests): the real constants pass; a number with a blank source fails; missing / extra / reordered questions fail; an un-computed card must carry honest words and may not read; the net-worth read is held to the same law.
- **README.md**: one line (38) — the shapes are extracted from the deck's consts in `Landing.tsx` and the leaves it imports (`problemSheet.ts`, `answers.ts`); the generator now reads the lenses from `answers.ts` and the rest of the README is byte-identical.

Not touched: auth logic, migrations, paid calls, any route. `/` stays the cockpit for a signed-in arrival (not ruled).

## Verified

- `npx tsc --noEmit` — 0.
- eslint — 0 errors / 0 warnings on every new file; identical counts to `origin/main` on every touched file (`HomeClient.tsx` keeps its pre-existing 2 / 1).
- `npm test` — 59/59 (54 + 5 new).
- `npx tsx scripts/assert-tool-registry.ts` — registry law, reachability law (62 pages), answers law all pass.
- Byte-identity (`nav01c-proof.py`, scratchpad): `ANSWER_ROWS` and `ANSWER_INPUTS` in `answers.ts` === the `origin/main` literals with only `export ` added; the S11_LAYOUT (2,397 B), S13 (11,578 B) and S14 (1,206 B) law chunks are unchanged byte-for-byte; the whole `Landing.tsx` diff is +6 (the import and a 5-line pointer comment) / −27 (the moved block). Guest `/` renders the deck (200) — the module-scope laws ran.
- `next build` — exit 0 — compiled (84s), types valid, 265/265 static pages generated, `/answers` listed as a dynamic route (ƒ), `/hub` as a static redirect stub. (Run with placeholder `PLAID_CLIENT_ID` / `PLAID_SECRET` in the env, so the backfill route's module assert that stopped page-data on earlier PRs did not fire; no Plaid call is made at build.)
- Live, dev server, signed dev cookie (`userEmail=<email>.<hmac>`): guest `/answers` → 307 `/`; cookie `/answers` → 200; cookie `/hub` → 307 `/answers`; guest `/hub` → 307 `/`. SSR carries the four questions, five source lines, five doors (`/tax /runway /trade /books /net-worth`), THE ANSWERS current in the nav.
- Screenshots (desktop 1280, mobile 390): every card reads `Could not read — HTTP 500 · <route error>` because this environment has no database — the declared failure state, no number; smallest computed type on both viewports 10px; no horizontal overflow; cards two-up on desktop, stacked on mobile. The cockpit's family nav shows THE ANSWERS first with the tool rows unchanged. (`answers-desktop.png`, `answers-mobile.png`, `cockpit-nav-desktop.png` — sent in chat.)
- Not verifiable here: the numbers themselves (no Azure reach) — verify on Preview that each card's source line matches the route it reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc

---
_Generated by [Claude Code](https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc)_