### PR TITLE
fix(api): user guidance is not a fault — ValidationError passes throu…

### DIFF
--- a/src/app/api/admin/fix-entity-assignment/route.ts
+++ b/src/app/api/admin/fix-entity-assignment/route.ts
@@ -1,6 +1,8 @@
 import { randomUUID } from 'crypto';
 import { NextRequest, NextResponse } from 'next/server';
 import { failClosedResponse } from '@/lib/http/failClosedResponse';
+import { summarizeError, userFacingMessage } from '@/lib/http/failClosed';
+import { ValidationError } from '@/lib/errors/ValidationError';
 import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { ADMIN_USER_ID } from '@/lib/tiers';
@@ -227,9 +229,9 @@ export async function POST(request: NextRequest) {
           errors.push(`Txn ${txn.id}: ${err.message}`);
           continue;
         }
-        const msg = err instanceof Error ? err.message : 'Unknown error';
-        console.error(`Fix entity error for txn ${txn.id}:`, err);
-        errors.push(`Txn ${txn.id}: ${msg}`);
+        // HYG-02: a ValidationError's guidance reaches the body verbatim; a fault stays on the server.
+        if (!(err instanceof ValidationError)) console.error(`[Fix entity assignment] txn ${txn.id} failed:`, summarizeError(err));
+        errors.push(`Txn ${txn.id}: ${userFacingMessage(err, 'Fix failed')}`);
       }
     }
 

--- a/src/app/api/investments/assignment-exercise/route.ts
+++ b/src/app/api/investments/assignment-exercise/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { ValidationError } from '@/lib/errors/ValidationError';
 import { failClosedResponse } from '@/lib/http/failClosedResponse';
 import { prisma } from '@/lib/prisma';
 import { positionTrackerService } from '@/lib/position-tracker-service';
@@ -53,7 +54,7 @@ export async function POST(request: Request) {
       ]);
 
       if (!transferTxn || !stockTxn) {
-        throw new Error(`Transaction not found or not owned: ${transferId} or ${stockId}`);
+        throw new ValidationError(`Transaction not found or not owned: ${transferId} or ${stockId}`, { status: 404 });
       }
 
       const result = await positionTrackerService.handleAssignmentExercise({

--- a/src/app/api/stock-lots/commit/route.ts
+++ b/src/app/api/stock-lots/commit/route.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'crypto';
+import { ValidationError } from '@/lib/errors/ValidationError';
 import { NextResponse } from 'next/server';
 import { failClosedResponse } from '@/lib/http/failClosedResponse';
 import { prisma } from '@/lib/prisma';
@@ -103,7 +104,7 @@ export async function POST(request: Request) {
         // Reorder based on user selection
         sortedLots = selectedLots.map(sel => {
           const lot = lots.find(l => l.id === sel.lotId);
-          if (!lot) throw new Error(`Lot not found: ${sel.lotId}`);
+          if (!lot) throw new ValidationError(`Lot not found: ${sel.lotId}`, { status: 404, field: 'selectedLots' });
           return { ...lot, requestedQty: sel.quantity };
         });
         break;
@@ -192,7 +193,7 @@ export async function POST(request: Request) {
       }
 
       if (remaining > 0.01) {
-        throw new Error(`Could not match all shares: ${remaining.toFixed(4)} remaining`);
+        throw new ValidationError(`Could not match all shares: ${remaining.toFixed(4)} remaining`);
       }
 
       // Save tax scenario record
@@ -247,7 +248,7 @@ export async function POST(request: Request) {
       const plAccount = accounts.find(a => a.code === PL_ACCOUNT);
 
       if (!cashAccount || !stockAccount || !plAccount) {
-        throw new Error(`Missing required accounts: ${TRADING_CASH}, ${STOCK_POSITION}, ${PL_ACCOUNT}`);
+        throw new ValidationError(`Missing required accounts: ${TRADING_CASH}, ${STOCK_POSITION}, ${PL_ACCOUNT}`);
       }
 
       // Create journal entry

--- a/src/app/api/trading/commit-to-ledger/route.ts
+++ b/src/app/api/trading/commit-to-ledger/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { ValidationError } from '@/lib/errors/ValidationError';
 import { failClosedResponse } from '@/lib/http/failClosedResponse';
+import { summarizeError, userFacingMessage } from '@/lib/http/failClosed';
 import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { assertPeriodOpen, PeriodClosedError } from '@/lib/period-close-guard';
@@ -231,8 +233,9 @@ export async function POST(request: NextRequest) {
           skipped++;
           continue;
         }
-        console.error(`Error committing trade #${tradeNum}:`, err);
-        errors.push(`Trade #${tradeNum}: ${message}`);
+        // HYG-02: a ValidationError's guidance reaches the body verbatim; a fault stays on the server.
+        if (!(err instanceof ValidationError)) console.error(`[Trade commit] trade #${tradeNum} failed:`, summarizeError(err));
+        errors.push(`Trade #${tradeNum}: ${userFacingMessage(err, 'Commit failed')}`);
       }
     }
 

--- a/src/app/api/transactions/commit-to-ledger/route.ts
+++ b/src/app/api/transactions/commit-to-ledger/route.ts
@@ -1,6 +1,8 @@
 import { randomUUID } from 'crypto';
+import { ValidationError } from '@/lib/errors/ValidationError';
 import { NextRequest, NextResponse } from 'next/server';
 import { failClosedResponse } from '@/lib/http/failClosedResponse';
+import { summarizeError, userFacingMessage } from '@/lib/http/failClosed';
 import { prisma } from '@/lib/prisma';
 import { commitPlaidTransaction, type CommitLink } from '@/lib/journal-entry-service';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
@@ -362,8 +364,9 @@ export async function POST(request: NextRequest) {
           continue;
         }
 
-        console.error('Error committing transaction:', txnId, error);
-        errors.push({ txnId, error: message });
+        // HYG-02: a ValidationError's guidance reaches the body verbatim; a fault stays on the server.
+        if (!(error instanceof ValidationError)) console.error('[Commit] transaction failed:', txnId, summarizeError(error));
+        errors.push({ txnId, error: userFacingMessage(error, 'Commit failed') });
       }
     }
 

--- a/src/app/api/transactions/uncommit/route.ts
+++ b/src/app/api/transactions/uncommit/route.ts
@@ -1,7 +1,8 @@
 import { randomUUID } from 'crypto';
+import { ValidationError } from '@/lib/errors/ValidationError';
 import { NextResponse } from 'next/server';
 import { failClosedResponse } from '@/lib/http/failClosedResponse';
-import { summarizeError } from '@/lib/http/failClosed';
+import { summarizeError, userFacingMessage } from '@/lib/http/failClosed';
 import { prisma } from '@/lib/prisma';
 import { reversePlaidTransaction } from '@/lib/journal-entry-service';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
@@ -82,9 +83,9 @@ export async function POST(request: Request) {
         if (error instanceof PeriodClosedError) {
           return NextResponse.json({ error: error.message }, { status: 409 });
         }
-        // HYG-02: the thrown text stays on the server; the body says which transaction failed, not why internally.
-        console.error('[Uncommit] transaction failed:', txn.id, summarizeError(error));
-        errors.push({ txnId: txn.id, error: 'Uncommit failed' });
+        // HYG-02: a ValidationError's guidance reaches the body verbatim; a fault stays on the server.
+        if (!(error instanceof ValidationError)) console.error('[Uncommit] transaction failed:', txn.id, summarizeError(error));
+        errors.push({ txnId: txn.id, error: userFacingMessage(error, 'Uncommit failed') });
       }
     }
 

--- a/src/app/api/trips/[id]/ai-assistant/route.ts
+++ b/src/app/api/trips/[id]/ai-assistant/route.ts
@@ -1,4 +1,5 @@
 import { requireTier } from '@/lib/auth-helpers';
+import { ValidationError } from '@/lib/errors/ValidationError';
 import { NextRequest, NextResponse } from 'next/server';
 import { failClosedResponse } from '@/lib/http/failClosedResponse';
 import { prisma } from '@/lib/prisma';
@@ -257,7 +258,7 @@ export async function POST(
         select: { startDate: true, endDate: true },
       });
       if (!trip?.startDate || !trip?.endDate) {
-        throw new Error('Trip dates required for hotel search — set Start/End on the trip first');
+        throw new ValidationError('Trip dates required for hotel search — set Start/End on the trip first');
       }
       const participantCount = await prisma.trip_participants.count({ where: { tripId } });
       const adults = Math.max(1, participantCount);
@@ -348,7 +349,7 @@ export async function POST(
       if (!process.env.VIATOR_API_KEY) {
         // Fail loud — Viator categories must come from Viator. A missing key
         // is a config issue the user needs to see, not silently routed to Google.
-        throw new Error('VIATOR_API_KEY is not configured');
+        throw new MissingViatorKeyError();
       }
       console.log(`[Viator] ${category}: Using Viator API for ${city}, ${country}`);
       try {

--- a/src/app/api/trips/[id]/vendor-commit/route.ts
+++ b/src/app/api/trips/[id]/vendor-commit/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { ValidationError } from '@/lib/errors/ValidationError';
 import { failClosedResponse } from '@/lib/http/failClosedResponse';
 import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
@@ -37,7 +38,7 @@ async function getOptionDetails(
       // divisor. The outer catch surfaces this as a 500 with the message.
       const totalPrice = Number(opt.total_price);
       if (!Number.isFinite(totalPrice) || totalPrice <= 0) {
-        throw new Error(
+        throw new ValidationError(
           `Lodging option ${optionId} has no total_price — refusing to substitute one night's ` +
           `price_per_night as the whole-stay amount. Re-save the stay with a total.`,
         );
@@ -226,7 +227,7 @@ export async function POST(request: Request, { params }: { params: Promise<{ id:
       const details = (optionType === 'flight' || isSyntheticLodging || isSyntheticActivity)
         ? { title: notes || (isSyntheticLodging ? 'Lodging' : isSyntheticActivity ? 'Place' : 'Flight'), amount: Number(requestAmount || 0), tripId: id }
         : await getOptionDetails(tx, optionType, optionId, id);
-      if (!details) throw new Error('Vendor option not found');
+      if (!details) throw new ValidationError('Vendor option not found', { status: 404 });
 
       // A. Update vendor option status to committed (only for real option rows —
       // flights, synthetic lodging, and synthetic activity have none to update).

--- a/src/lib/__tests__/failClosed.test.ts
+++ b/src/lib/__tests__/failClosed.test.ts
@@ -1,6 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { failClosed, summarizeError } from '../http/failClosed';
+import { failClosed, summarizeError, userFacingMessage } from '../http/failClosed';
+import { ValidationError } from '../errors/ValidationError';
 
 // HYG-02 — no raw database or runtime error text to the client. Hermetic: a
 // Prisma-shaped error is thrown by hand; console.error is captured.
@@ -66,4 +67,31 @@ test('status and extra keys pass through; extra can never override the fixed key
     assert.equal(bad.status, 502);
   });
   assert.equal(logs.length, 2);
+});
+
+test('a ValidationError reaches the body verbatim at 400 (or its own status) with no error log', () => {
+  const guidance = 'Trip dates required for hotel search — set Start/End on the trip first';
+  const logs = capture(() => {
+    const e = failClosed('Travel scan', 'Search failed', new ValidationError(guidance), 500, { category: 'accommodation' });
+    assert.equal(e.status, 400);
+    assert.deepEqual(e.body, { category: 'accommodation', ok: false, stage: 'Travel scan', error: guidance, message: guidance });
+    const nf = failClosed('Stock lots commit', 'Failed to commit sale', new ValidationError('Lot not found: lot-9', { status: 404, field: 'selectedLots' }));
+    assert.equal(nf.status, 404);
+    assert.equal(nf.body.error, 'Lot not found: lot-9');
+    assert.equal(nf.body.field, 'selectedLots');
+  });
+  assert.equal(logs.length, 0);
+  assert.equal(userFacingMessage(new ValidationError('Cannot reverse a reversal entry'), 'Uncommit failed'), 'Cannot reverse a reversal entry');
+});
+
+test('a Prisma-shaped error still never reaches the body, even beside a ValidationError path', () => {
+  const err = new PrismaClientInitializationError(PRISMA_TEXT);
+  const logs = capture(() => {
+    const e = failClosed('Stock lots commit', 'Failed to commit sale', err);
+    assert.equal(e.status, 500);
+    assert.equal(e.body.error, 'Failed to commit sale');
+    assert.ok(!JSON.stringify(e.body).includes('prisma'));
+    assert.equal(userFacingMessage(err, 'Commit failed'), 'Commit failed');
+  });
+  assert.equal(logs.length, 1);
 });

--- a/src/lib/batch-trade-processor.ts
+++ b/src/lib/batch-trade-processor.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'crypto';
+import { ValidationError } from '@/lib/errors/ValidationError';
 import { prisma } from '@/lib/prisma';
 import { positionTrackerService } from '@/lib/position-tracker-service';
 
@@ -978,7 +979,7 @@ export async function processStockSells(
           const plAccount = accounts.find((a: { code: string }) => a.code === PL_ACCOUNT);
 
           if (!cashAccount || !stockAccount || !plAccount) {
-            throw new Error(`Missing required accounts: ${TRADING_CASH}, ${STOCK_POSITION}, ${PL_ACCOUNT}`);
+            throw new ValidationError(`Missing required accounts: ${TRADING_CASH}, ${STOCK_POSITION}, ${PL_ACCOUNT}`);
           }
 
           const journalEntry = await tx.journal_entries.create({
@@ -1220,7 +1221,7 @@ export async function processDividends(
           const divAccount = accounts.find((a: { code: string }) => a.code === DIVIDEND_INCOME);
 
           if (!cashAccount || !divAccount) {
-            throw new Error(`Missing COA accounts: ${TRADING_CASH} or ${DIVIDEND_INCOME}. Ensure trading entity has dividend income account (4300).`);
+            throw new ValidationError(`Missing COA accounts: ${TRADING_CASH} or ${DIVIDEND_INCOME}. Ensure trading entity has dividend income account (4300).`);
           }
 
           // DR Trading Cash, CR Dividend Income

--- a/src/lib/errors/ValidationError.ts
+++ b/src/lib/errors/ValidationError.ts
@@ -1,0 +1,28 @@
+/**
+ * HYG-02 follow-up — user guidance is not an internal fault.
+ *
+ * A route's catch-all answers a thrown error with a FIXED line (failClosed);
+ * the thrown text stays on the server. That is right for a database or
+ * runtime fault and wrong for a message written FOR the user — "Trip dates
+ * required for hotel search — set Start/End on the trip first" tells them
+ * what to change. Throw one of these instead of a plain Error and failClosed
+ * passes the text through VERBATIM at its status (400 by default; 404 for a
+ * record the caller named that does not exist for them) with no error log —
+ * a refusal is not a fault.
+ *
+ * Zero imports: services (journal entries, positions, rrule) throw it too.
+ */
+export type ValidationStatus = 400 | 404 | 409 | 422;
+
+export class ValidationError extends Error {
+  readonly status: ValidationStatus;
+  /** The input field the guidance is about, when there is one. */
+  readonly field?: string;
+
+  constructor(message: string, opts: { status?: ValidationStatus; field?: string } = {}) {
+    super(message);
+    this.name = 'ValidationError';
+    this.status = opts.status ?? 400;
+    this.field = opts.field;
+  }
+}

--- a/src/lib/http/failClosed.ts
+++ b/src/lib/http/failClosed.ts
@@ -9,10 +9,15 @@
  * discipline) and RETURNS the HYG-01 envelope with a FIXED, user-safe message.
  * The thrown message never reaches the body.
  *
+ * The one exception is user guidance: a ValidationError (src/lib/errors) is
+ * text written FOR the user — it passes through VERBATIM at its own status
+ * (400 / 404 …) and is not logged as an error. Everything else is a fault.
+ *
  * Pure (no Next.js import) so it runs in node:test; failClosedResponse.ts is
  * the one-line NextResponse wrapper routes call.
  */
 import type { Envelope } from '../plaid/failLoud';
+import { ValidationError } from '../errors/ValidationError';
 
 export interface FailureSummary {
   name?: string;
@@ -50,6 +55,13 @@ export interface FailClosedBody {
   /** The fixed, user-safe line — the same text in both keys so every existing reader (`error` or `message`) prints it. */
   error: string;
   message: string;
+  /** Set only for a ValidationError that names its input field. */
+  field?: string;
+}
+
+/** The text a client may print for a thrown error: a ValidationError's own words, else the fixed line. */
+export function userFacingMessage(err: unknown, fixed: string): string {
+  return err instanceof ValidationError ? err.message : fixed;
 }
 
 /**
@@ -60,6 +72,13 @@ export interface FailClosedBody {
  * anything derived from the thrown error.
  */
 export function failClosed(stage: string, userMessage: string, err: unknown, status = 500, extra: Record<string, unknown> = {}): Envelope & { body: FailClosedBody } {
+  if (err instanceof ValidationError) {
+    // User guidance, verbatim, at its own status; a refusal is not a fault, so no error log.
+    return {
+      status: err.status,
+      body: { ...extra, ok: false, stage, error: err.message, message: err.message, ...(err.field ? { field: err.field } : {}) },
+    };
+  }
   console.error(`[${stage}] ${userMessage}`, summarizeError(err));
   return { status, body: { ...extra, ok: false, stage, error: userMessage, message: userMessage } };
 }

--- a/src/lib/journal-entry-service.ts
+++ b/src/lib/journal-entry-service.ts
@@ -1,4 +1,5 @@
 import { PrismaClient, journal_entries } from '@prisma/client';
+import { ValidationError } from '@/lib/errors/ValidationError';
 import { assertPeriodOpen } from '@/lib/period-close-guard';
 
 type Tx = Omit<PrismaClient, '$connect' | '$disconnect' | '$on' | '$transaction' | '$use' | '$extends'>;
@@ -95,7 +96,7 @@ export async function commitPlaidTransaction(
       },
     });
     if (!expenseOrIncomeAccount) {
-      throw new Error(
+      throw new ValidationError(
         `COA account not found: code=${accountCode}, entityId=${entityId}, userId=${userId}`
       );
     }
@@ -110,7 +111,7 @@ export async function commitPlaidTransaction(
       },
     });
     if (!bankAccount) {
-      throw new Error(
+      throw new ValidationError(
         `Bank COA account not found: code=${bankAccountCode}, entityId=${resolvedBankEntityId}, userId=${userId}`
       );
     }
@@ -239,7 +240,7 @@ export async function reversePlaidTransaction(
     });
 
     if (!original) {
-      throw new Error(`Journal entry not found: ${journalEntryId}`);
+      throw new ValidationError(`Journal entry not found: ${journalEntryId}`, { status: 404 });
     }
 
     if (original.userId !== userId) {
@@ -247,11 +248,11 @@ export async function reversePlaidTransaction(
     }
 
     if (original.reversed_by_entry_id) {
-      throw new Error('Journal entry has already been reversed');
+      throw new ValidationError('Journal entry has already been reversed');
     }
 
     if (original.is_reversal) {
-      throw new Error('Cannot reverse a reversal entry');
+      throw new ValidationError('Cannot reverse a reversal entry');
     }
 
     // Period close enforcement — reversals are dated today

--- a/src/lib/operations/rruleHelpers.ts
+++ b/src/lib/operations/rruleHelpers.ts
@@ -14,6 +14,7 @@
  */
 
 import { RRule, RRuleSet, rrulestr, Frequency } from 'rrule';
+import { ValidationError } from '@/lib/errors/ValidationError';
 import type { CadenceGroup, CadenceMode, RoutineForm, WeekDay } from '@/components/workbench/operations/routines/types';
 
 /**
@@ -30,7 +31,7 @@ export function compileFormToRRule(form: RoutineForm): string {
   if (form.cadence_mode === 'custom') {
     const trimmed = form.custom_rrule.trim();
     if (trimmed.length === 0) {
-      throw new Error('custom RRULE is required when cadence_mode=custom');
+      throw new ValidationError('custom RRULE is required when cadence_mode=custom', { field: 'custom_rrule' });
     }
     // Validate it parses; rrulestr throws on malformed input.
     rrulestr(trimmed.startsWith('RRULE:') ? trimmed : `RRULE:${trimmed}`);
@@ -43,7 +44,7 @@ export function compileFormToRRule(form: RoutineForm): string {
     parts.push('FREQ=DAILY');
   } else if (form.cadence_mode === 'weekly') {
     if (form.weekly_byday.length === 0) {
-      throw new Error('weekly cadence requires at least one weekday selection');
+      throw new ValidationError('weekly cadence requires at least one weekday selection', { field: 'weekdays' });
     }
     parts.push('FREQ=WEEKLY');
     parts.push(`BYDAY=${form.weekly_byday.join(',')}`);
@@ -53,7 +54,7 @@ export function compileFormToRRule(form: RoutineForm): string {
     parts.push(`BYMONTHDAY=${dom}`);
   } else if (form.cadence_mode === 'monthly_nth_weekday') {
     const nth = parseIntStrict(form.monthly_nth, -5, 5);
-    if (nth === 0) throw new Error('monthly_nth must be non-zero');
+    if (nth === 0) throw new ValidationError('monthly_nth must be non-zero', { field: 'monthly_nth' });
     parts.push('FREQ=MONTHLY');
     parts.push(`BYDAY=${nth}${form.monthly_weekday}`);
   }
@@ -121,7 +122,7 @@ export function rruleFromString(rruleString: string): RRule {
     dtstart: new Date(Date.UTC(1971, 0, 1, 0, 0, 0)),
   });
   if (parsed instanceof RRuleSet) {
-    throw new Error('RRuleSet not supported; provide a single RRULE');
+    throw new ValidationError('RRuleSet not supported; provide a single RRULE', { field: 'schedule_rrule' });
   }
   return parsed;
 }
@@ -233,7 +234,7 @@ function addYears(d: Date, n: number): Date {
 function parseIntStrict(value: string, min: number, max: number): number {
   const n = parseInt(value, 10);
   if (!Number.isInteger(n) || n < min || n > max) {
-    throw new Error(`invalid integer: "${value}" must be between ${min} and ${max}`);
+    throw new ValidationError(`invalid integer: "${value}" must be between ${min} and ${max}`);
   }
   return n;
 }

--- a/src/lib/position-tracker-service.ts
+++ b/src/lib/position-tracker-service.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'crypto';
+import { ValidationError } from '@/lib/errors/ValidationError';
 import { PrismaClient } from '@prisma/client';
 import { prisma } from '@/lib/prisma';
 
@@ -220,7 +221,7 @@ export class PositionTrackerService {
 
     // Skip quantity validation for exercise/assignment (qty is shares, not contracts)
     if (!isExerciseOrAssignment && closeQty > remainingQty) {
-      throw new Error(`Cannot close ${closeQty} contracts - only ${remainingQty} remaining`);
+      throw new ValidationError(`Cannot close ${closeQty} contracts - only ${remainingQty} remaining`);
     }
 
     // For normal closes, use leg qty; for exercise/assignment, close full position
@@ -594,7 +595,7 @@ export class PositionTrackerService {
     const accounts = await db.chart_of_accounts.findMany({ where: { code: { in: uniqueAccountCodes }, userId, entity_id: entityId } });
     if (accounts.length !== uniqueAccountCodes.length) {
       const missing = uniqueAccountCodes.filter(code => !accounts.find(a => a.code === code));
-      throw new Error(`Account codes not found: ${missing.join(', ')}`);
+      throw new ValidationError(`Account codes not found: ${missing.join(', ')}`);
     }
 
     // Create journal entry


### PR DESCRIPTION
…gh verbatim at 400 (HYG-02 follow-up)

HYG-02 follow-up. trips/[id]/ai-assistant/route.ts:260 threw a plain Error whose text tells the user what to change ("Trip dates required for hotel search — set Start/End on the trip first"); the fail-closed catch-all turned it into "Search failed". A refusal with guidance is not an internal fault.

- src/lib/errors/ValidationError.ts (zero imports): message + status (400 default; 404 for a record the caller named that does not exist for them)
  + optional field. failClosed() recognizes it BEFORE the fixed-message branch: the authored text reaches the body verbatim at its status, with no error log. userFacingMessage(err, fixed) is the same rule for per-item arrays. A Prisma error still never reaches the body (test).
- Sweep of the 134 fixed routes and the 72 lib modules they import: every plain Error whose text tells the user what to change now throws ValidationError — 21 sites: ai-assistant:260; vendor-commit:40 (re-save the stay with a total), :229 (vendor option not found → 404); stock-lots/commit:106 (lot not found → 404), :195 (could not match all shares), :250 (missing required accounts); assignment-exercise:56 (not found or not owned → 404); journal-entry-service:98, :113 (COA account not found), :242 (journal entry not found → 404), :250 (already reversed), :254 (cannot reverse a reversal); position-tracker-service:223 (cannot close N contracts), :597 (account codes not found); batch-trade-processor:981, :1223 (missing accounts, "ensure …"); rruleHelpers:33, :46, :56, :124, :236 (cadence validation, with field).
- ai-assistant:351 threw a plain Error for a missing VIATOR_API_KEY while the route already has a typed MissingViatorKeyError branch (:510): it throws the typed error now and takes that branch (500, kind missing_key).
- Four per-item error arrays the first audit missed (array pushes, not response calls) carried the raw thrown text into a 200 body: transactions/commit-to-ledger:366, trading/commit-to-ledger:235, admin/fix-entity-assignment:232, and transactions/uncommit:87 (fixed line before) — each now userFacingMessage(err, fixed) with the summary logged.
- Left as faults, by judgment: "No response from AI" / "Failed to parse", "disappeared mid-transaction", unbalanced-entry invariants, missing server env (JWT_SECRET, PLAID_*, TT_*, EXEC_ROUTINE_*), "Cannot extract strike from", lib/time invariants, the admin repair diagnostics, and journal-entry-service:246 "does not belong to this user" (a cross-user probe stays a fixed 500, never a confirmation).

Verified: tsc 0, eslint 0 on the new files and no touched file worse than main, npm test 64/64 (2 new), the asserts pass, next build exit 0.


Claude-Session: https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc