### PR TITLE
feat(schema): the arrivals store — providers.ts, provider_responses, arrivals (REBUILD-01 PR-1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Twenty-five business tools on one data pipe that ends in one Ledger and one Calendar.
 
-Source-available (BSL 1.1) · built and operated in production by its founder as User #1 · as of 2026-09-02: 112 Prisma models, 289 API route files, 121 feeds from 20 providers (counted August 24, 2026)
+Source-available (BSL 1.1) · built and operated in production by its founder as User #1 · as of 2026-09-02: 114 Prisma models, 289 API route files, 121 feeds from 20 providers (counted August 24, 2026)
 
 ## The system
 
@@ -35,7 +35,7 @@ templestuart.com teaches the full pipe with build-time proofs: every drawing der
 
 ## The data model
 
-Every shape below is extracted from the consts the deck renders from — `src/components/landing/Landing.tsx` and the leaves it imports (`src/lib/problemSheet.ts` for the sheet, `src/lib/answers.ts` for the four lenses and their inputs).
+Every shape below is extracted from the consts the deck renders from — `src/components/landing/Landing.tsx` and the leaves it imports (`src/lib/problemSheet.ts` for the sheet, `src/lib/providers.ts` for the provider menu and the rule book, `src/lib/answers.ts` for the four lenses and their inputs).
 
 ### The arrival row (step 3)
 
@@ -54,6 +54,55 @@ One row per provider answer, eleven fields:
 | WHEN AND HOW FAR | arrived | when it arrived |
 | WHEN AND HOW FAR | read | when we read it |
 | WHEN AND HOW FAR | status | pending, done, or failed |
+
+### The arrivals store (step 3, built)
+
+The arrival row above as tables — `prisma/migrations/20260903000000_arrivals/migration.sql` and the `provider_responses` / `arrivals` models in `prisma/schema.prisma`, column for column (asserted at build). Two tables: the wire (one row per HTTP answer, exact bytes, sha256) and the deck's row (one per provider object). The `arrival_provider` enum is `src/lib/providers.ts`' code set — 27 providers, every one the deck names — and `arrival_status` is the deck's pending / done / failed. Nothing writes here yet.
+
+`provider_responses` — the wire:
+
+| Column | Type | Rule |
+|---|---|---|
+| id | text | PRIMARY KEY |
+| provider | arrival_provider | NOT NULL |
+| resource | text | NOT NULL |
+| user_id | text | NULL REFERENCES users(id) |
+| guest_ref | text | NULL |
+| http_status | integer | NOT NULL |
+| body | bytea | NOT NULL |
+| body_sha256 | bytea | NOT NULL |
+| asked | timestamptz | NOT NULL |
+| arrived | timestamptz | NOT NULL |
+|  | CHECK / KEY | CHECK (octet_length(body_sha256) = 32) |
+|  | CHECK / KEY | CHECK (octet_length(body) <= 1048576) |
+|  | CHECK / KEY | CHECK (user_id IS NOT NULL OR guest_ref IS NOT NULL) |
+
+`arrivals` — the deck's row:
+
+| Column | Type | Rule |
+|---|---|---|
+| id | text | PRIMARY KEY |
+| provider | arrival_provider | NOT NULL |
+| connection | text | NULL |
+| resource | text | NOT NULL |
+| their_id | text | NOT NULL |
+| their_id_kind | their_id_kind | NOT NULL |
+| payload | jsonb | NOT NULL |
+| fingerprint | bytea | NOT NULL |
+| redactions | text[] | NOT NULL DEFAULT '{}' |
+| asked | timestamptz | NOT NULL |
+| arrived | timestamptz | NULL |
+| read | timestamptz | NULL |
+| status | arrival_status | NOT NULL DEFAULT 'pending' |
+| response_id | text | NULL REFERENCES provider_responses(id) |
+| user_id | text | NULL REFERENCES users(id) |
+| guest_ref | text | NULL |
+|  | CHECK / KEY | CHECK (octet_length(fingerprint) = 32) |
+|  | CHECK / KEY | CHECK (pg_column_size(payload) <= 1048576) |
+|  | CHECK / KEY | CHECK (user_id IS NOT NULL OR guest_ref IS NOT NULL) |
+|  | CHECK / KEY | UNIQUE (provider, their_id) |
+
+Promise 1 is a database law, not a convention: the `arrivals_promise_1` BEFORE UPDATE trigger raises if provider, connection, resource, their_id, their_id_kind, payload, fingerprint, redactions, asked, arrived, response_id, user_id or guest_ref would change — only `read` and `status` may move, each once (read from NULL, status from pending). There is no updated_at column and no DELETE policy: keep forever is the default.
 
 ### The six kinds (steps 4–5)
 
@@ -129,8 +178,8 @@ BLUEPRINT is the step's headline; TODAY is the deck's honest-state line, verbati
 
 | Step | Blueprint | Today | Gap |
 |---|---|---|---|
-| 03 | Store what arrived. Then decide what it means. | today that is 121 feeds from 20 providers — counted August 24, 2026. | feeds counted (121/20); the arrivals table that stores them word for word, fingerprinted, is not built — see 14. |
-| 04 | One rule per feed. Written down. | We classified every one of the 121 feeds — August 24, 2026 — and posting took zero. | kinds assigned in the August 24 census; rows the system applies to arrivals wait on the step-3 table — see 14. |
+| 03 | Store what arrived. Then decide what it means. | today that is 121 feeds from 20 providers — counted August 24, 2026. | feeds counted (121/20); the arrivals store that keeps them word for word, fingerprinted, is built (PR-1) and holds nothing yet — nothing lands until PR-2 — see 14. |
+| 04 | One rule per feed. Written down. | We classified every one of the 121 feeds — August 24, 2026 — and posting took zero. | kinds assigned in the August 24 census; the step-3 table is built (PR-1) and no rule row applies to it yet — see 14. |
 | 07 | Every tool runs the same four beats. Discover. Decide. Commit. Record. | This loop is the blueprint — the shape we're building every tool toward. Today, hotel bookings commit for real and an accepted task fires its build; the rest run discover → decide → draft, and commit is the beat we're wiring to the same loop, tool by tool. | commit is real for two tools (hotel bookings, accepted tasks); the other twenty-three stop at draft. |
 | 08 | One table holds everything you do. | The master table is the blueprint. Today each tool keeps its own table; one table holding every document is the shape we're building. | no master table; each tool keeps its own. |
 | 09 | The deposit meets the invoice. The fill meets the order. | (A piece of this is already alive today: card charges find their bookings and propose the match — you approve it.) | one of fourteen matches proposes today (card charge ↔ booking); the other thirteen do not. |
@@ -138,21 +187,21 @@ BLUEPRINT is the step's headline; TODAY is the deck's honest-state line, verbati
 | 11 | Every answer is math on the lines. | These four lenses are the blueprint. Today all four compute — tax and the business result from the journal entries you commit by hand, runway from Plaid's account balances against those entries, trading from the positions and lots you committed, with no live quote in the number. The rules-written lines and the live quotes the blueprint reads wait on the posting pipe. | all four compute from hand-committed lines and Plaid balances; the rules-written lines and live quotes wait on step 10. |
 | 12 | One Ledger. One Calendar. All twenty-five. | Two windows over one set of rows is the blueprint. Today the calendar window is live in the cockpit; the ledger window fills as the posting pipe lands its lines. | the Calendar window is live; the Ledger window is empty until step 10 writes. |
 | 13 | One $100.00 sale runs the machine. Then every other door opens. | Alive today: the travel match — card charges find their bookings and propose the match; you approve it. The project lane is wired end to end: a task lands for your review, and accepting it fires the build that answers it. | the travel match is alive; the project lane is wired end to end; the sale's lines and lenses wait on steps 10–11. |
-| 14 | Click any number. Walk it back. | Alive today: the fingerprint, on the rules and the audit log — every regulation pull is hashed the moment it lands, and the audit log hash-chains every entry it records; the citation re-check is written, but the hash it compares against is stored empty today, so it proves nothing yet. Today the money feeds land already parsed — no stored word-for-word payload, no fingerprint yet; the arrivals table that saves the provider's exact words and fingerprints them on arrival is the shape we're building. | fingerprints on the rules corpus and the audit log; none on money feeds — the arrivals table is not built. |
+| 14 | Click any number. Walk it back. | Alive today: the fingerprint, on the rules and the audit log — every regulation pull is hashed the moment it lands, and the audit log hash-chains every entry it records; the citation re-check is written, but the hash it compares against is stored empty today, so it proves nothing yet. Today the money feeds land already parsed — no stored word-for-word payload, no fingerprint yet; the arrivals table that saves the provider's exact words and fingerprints them on arrival is the shape we're building. | fingerprints on the rules corpus and the audit log; none on money feeds yet — the arrivals store is built (PR-1) and no feed lands in it until PR-2. |
 
 ## The nine modules
 
 | Module | What exists in code |
 |---|---|
-| Travel | stays and flights through LiteAPI, activities through Viator, visa checks through RapidAPI — public routes under src/app/api/travel (15 route files) and src/app/api/flights (3); models `trips` (schema:571) and `reservations` (schema:1327). |
-| Runway | the reservation matcher — src/app/api/runway/match/propose, queue, review (the step-9 piece alive today) — plus src/app/api/runway/route.ts; models `budgets` (schema:541) and `home_expenses` (schema:1577). |
+| Travel | stays and flights through LiteAPI, activities through Viator, visa checks through RapidAPI — public routes under src/app/api/travel (15 route files) and src/app/api/flights (3); models `trips` (schema:573) and `reservations` (schema:1329). |
+| Runway | the reservation matcher — src/app/api/runway/match/propose, queue, review (the step-9 piece alive today) — plus src/app/api/runway/route.ts; models `budgets` (schema:543) and `home_expenses` (schema:1579). |
 | Books | Plaid-synced transactions, a chart of accounts, journal and ledger entries — src/app/api/plaid/sync/route.ts:103 writes `transactions` (schema:414); `journal_entries` (schema:180), `ledger_entries` (schema:219). |
-| Trade | tastytrade connection, quotes and backtests — src/app/api/tastytrade (13 route files); models `trade_cards` (schema:1708) and `scan_snapshots` (schema:1894). |
-| Tax | scenarios, documents and the 2025 export script (`npm run tax:export:2025`) — src/app/api/tax (7 route files); models `tax_scenarios` (schema:1497) and `tax_documents` (schema:1816). |
-| Compliance | the regulatory corpus (eCFR, US Code, Federal Register, IRS bulletins) ingested by Inngest functions with sha256 on write, citations re-verified, and the hash-chained audit log — models `regulatory_sources` (schema:2207), `citations` (schema:2271), `audit_log` (schema:2437). |
-| Routines | scheduled routines evaluated by the `routine-evaluator` Inngest function — models `operations_routines` (schema:3091) and `hub_scheduled_items` (schema:3197); the deck calls the calendar window live in the cockpit (step 12 honest line). |
-| Projects | projects and tasks; accepting a pending task fires the Execute-Task Routine (src/app/api/operations/projects/[id]/tasks/[taskId]/route.ts:395-405) — models `operations_projects` (schema:2915) and `operations_project_tasks` (schema:2960). |
-| Content | scene groups, scenes, pieces and takes — model `operations_content_pieces` (schema:3324); src/app/api/operations carries 50 route files across Routines, Projects and Content. |
+| Trade | tastytrade connection, quotes and backtests — src/app/api/tastytrade (13 route files); models `trade_cards` (schema:1710) and `scan_snapshots` (schema:1896). |
+| Tax | scenarios, documents and the 2025 export script (`npm run tax:export:2025`) — src/app/api/tax (7 route files); models `tax_scenarios` (schema:1499) and `tax_documents` (schema:1818). |
+| Compliance | the regulatory corpus (eCFR, US Code, Federal Register, IRS bulletins) ingested by Inngest functions with sha256 on write, citations re-verified, and the hash-chained audit log — models `regulatory_sources` (schema:2209), `citations` (schema:2273), `audit_log` (schema:2439). |
+| Routines | scheduled routines evaluated by the `routine-evaluator` Inngest function — models `operations_routines` (schema:3093) and `hub_scheduled_items` (schema:3199); the deck calls the calendar window live in the cockpit (step 12 honest line). |
+| Projects | projects and tasks; accepting a pending task fires the Execute-Task Routine (src/app/api/operations/projects/[id]/tasks/[taskId]/route.ts:395-405) — models `operations_projects` (schema:2917) and `operations_project_tasks` (schema:2962). |
+| Content | scene groups, scenes, pieces and takes — model `operations_content_pieces` (schema:3326); src/app/api/operations carries 50 route files across Routines, Projects and Content. |
 
 ## Architecture
 
@@ -171,7 +220,7 @@ Versions from package.json, read 2026-09-02:
 
 Observed versus authored (step 6): what the world sends is observed; what you do is authored; the blueprint keeps the two apart and matches them on one key. Today the money feeds land parsed, without a stored payload — see the gap ledger, step 14.
 
-Scale, as of 2026-09-02: 112 Prisma models, 30 enums, 289 API route files, 35 runtime dependencies, 18 dev dependencies, one test file (`npm test`).
+Scale, as of 2026-09-02: 114 Prisma models, 33 enums, 289 API route files, 35 runtime dependencies, 18 dev dependencies, one test file (`npm test`).
 
 ## Engineering discipline
 
@@ -192,7 +241,7 @@ These are the written laws in `CLAUDE.md`, stated as practice:
 - Middleware: every path not in `PUBLIC_PATHS` requires the verified cookie — `src/middleware.ts:50-160, 162, 165-170`; the two Routine callbacks (`…/audit-ingest`, `…/exec-ingest`) bypass the cookie and validate a shared-secret bearer (`AUDIT_INGEST_SECRET`, `EXEC_INGEST_SECRET`) instead — `src/middleware.ts:173-187`.
 - Route gates: `getCurrentUser` (`src/lib/auth-helpers.ts:11`), `requireTier` (`:42`), `requireAdmin` (`src/lib/require-admin.ts:8`); the working law is that a paid external call is never made before the gate (CLAUDE.md, Security-first).
 - User scoping: every query is scoped to the authed user — e.g. `where: { userId: user.id }` at `src/app/api/tastytrade/connect/route.ts:54`.
-- Rate limits: a durable fixed-window limiter backed by the `rate_limit_hits` table (`src/lib/rateLimit.ts:3-15`; schema:1312), plus `src/lib/scan-rate-limit.ts` and `src/lib/ai-rate-limit.ts`; tuned by `SEARCH_/BOOK_/SCAN_/AI_RATE_LIMIT` and `_WINDOW`, with daily caps `AI_PIPE_DAILY_CAP`, `AI_EXEC_DAILY_CAP`, `AI_ROUTINE_DAILY_CAP`, `AI_DISCOVERY_DAILY_CAP` (USD, from recorded spend — `src/lib/discovery/discoveryGate.ts`), `TRAVEL_SEARCH_DAILY_CAP`, and `GOOGLE_PLACES_MONTHLY_CAP`.
+- Rate limits: a durable fixed-window limiter backed by the `rate_limit_hits` table (`src/lib/rateLimit.ts:3-15`; schema:1314), plus `src/lib/scan-rate-limit.ts` and `src/lib/ai-rate-limit.ts`; tuned by `SEARCH_/BOOK_/SCAN_/AI_RATE_LIMIT` and `_WINDOW`, with daily caps `AI_PIPE_DAILY_CAP`, `AI_EXEC_DAILY_CAP`, `AI_ROUTINE_DAILY_CAP`, `AI_DISCOVERY_DAILY_CAP` (USD, from recorded spend — `src/lib/discovery/discoveryGate.ts`), `TRAVEL_SEARCH_DAILY_CAP`, and `GOOGLE_PLACES_MONTHLY_CAP`.
 - Audit log: a hash chain — each entry stores `prev_hash` and its own sha256 `content_hash` with a `sequence_number` (`prisma/schema.prisma:2441-2443`; written at `src/lib/audit/writeAuditLog.ts:99`); `src/lib/audit/verifyAuditChain.ts:47, 80` recomputes the chain.
 - Citations: `src/lib/citations/verifyCitation.ts:97` re-fetches the source and re-hashes it against `citations.retrieved_content_hash` (`prisma/schema.prisma:2287`); the column's only writer stores an empty string today (`src/lib/discovery/materializeProposal.ts:165`), so the check is structurally dead until the arrivals rebuild lands the real hash.
 - Corpus: the four ingest persisters hash content with sha256 on write — `src/lib/corpus/ingest/ecfr-persist.ts:28`, `uscode-persist.ts:32`, `fedreg-persist.ts:31`, `irb-persist.ts:32`.

--- a/prisma/migrations/20260903000000_arrivals/migration.sql
+++ b/prisma/migrations/20260903000000_arrivals/migration.sql
@@ -1,0 +1,142 @@
+-- REBUILD-01 PR-1: THE ARRIVALS STORE — the blueprint's step 3 as tables.
+-- Every provider answer lands once, word for word, fingerprinted, before
+-- anyone decides what it means. Two tables:
+--   provider_responses — the wire: the exact bytes of one HTTP answer, sha256'd
+--   arrivals           — the deck's row: one per provider object, the eleven
+--                        fields of IMPORT_COLUMNS (src/components/landing/
+--                        Landing.tsx) plus who it belongs to and which
+--                        response it came from
+-- The ten README-desk rulings, all locked: per-object rows over a wire-exact
+-- response store; composed ids labeled (their_id_kind); secrets redacted and
+-- declared (redactions); Stripe's first feed is the webhook; guests land by
+-- reference (guest_ref); one Plaid writer (PR-2/3); no synthetic backfill;
+-- keep forever (no DELETE policy here — a purge is a future policy PR); tokens
+-- already encrypted (SEC-02); one provider vocabulary shared by deck, schema
+-- and code (src/lib/providers.ts — the enum below IS its code set, and the
+-- build asserts it).
+--
+-- SCHEMA ONLY: nothing in this PR writes a row. The generated Prisma client
+-- is not committed.
+--
+-- ADDITIVE-ONLY (the HARD-GATE posture): three types, two tables, one trigger.
+-- Zero data rewrites, zero changes to existing rows or tables.
+--
+-- Applied by Alex via psql (repo law: schema.prisma + this SQL move together;
+-- Claude Code authors the file only — it cannot reach Azure). Idempotence is
+-- deliberately NOT claimed: this file runs once; a second run fails loudly on
+-- the first CREATE TYPE.
+--
+-- id types matched to their targets (verified against schema.prisma):
+--   users.id  TEXT  (String @id; schema:494)
+-- FK posture: NO ACTION on users and on provider_responses — an arrival is
+-- kept forever, so deleting an owner or a response with arrivals behind it
+-- fails LOUDLY (the corpus foundation precedent of hash + UNIQUE columns is
+-- reused here in shape: bytea hashes, octet_length CHECKs, a UNIQUE key).
+--
+-- Constraint and index names follow Prisma's defaults (<table>_<cols>_idx /
+-- _key / _fkey / _pkey) so `prisma migrate diff` reads the database as the
+-- model describes it.
+
+BEGIN;
+
+-- STEP 1: the three vocabularies.
+-- arrival_provider: every provider the deck names (PROVIDER_MENU, today and
+-- next), alphabetical — src/lib/providers.ts PROVIDER_CODES, asserted at build.
+CREATE TYPE arrival_provider AS ENUM ('alpaca', 'amadeus', 'anthropic', 'ecfr', 'federal_register', 'finnhub', 'fred', 'google_places', 'ibkr', 'irs', 'liteapi', 'openai', 'plaid', 'polygon', 'schwab', 'sec', 'snaptrade', 'square', 'stripe', 'tastytrade', 'teller', 'tradier', 'travel_buddy', 'us_code', 'viator', 'voyage', 'xai_grok');
+CREATE TYPE arrival_status AS ENUM ('pending', 'done', 'failed');
+CREATE TYPE their_id_kind AS ENUM ('provider', 'composed');
+
+-- STEP 2: provider_responses — the wire, exact bytes, one row per HTTP answer.
+CREATE TABLE provider_responses (
+    id          text PRIMARY KEY,
+    provider    arrival_provider NOT NULL,
+    resource    text NOT NULL,
+    user_id     text NULL REFERENCES users(id),
+    guest_ref   text NULL,
+    http_status integer NOT NULL,
+    body        bytea NOT NULL,
+    body_sha256 bytea NOT NULL,
+    asked       timestamptz NOT NULL,
+    arrived     timestamptz NOT NULL,
+    CONSTRAINT provider_responses_body_sha256_len_chk CHECK (octet_length(body_sha256) = 32),
+    CONSTRAINT provider_responses_body_size_chk CHECK (octet_length(body) <= 1048576),
+    CONSTRAINT provider_responses_owner_chk CHECK (user_id IS NOT NULL OR guest_ref IS NOT NULL)
+);
+
+CREATE INDEX provider_responses_user_id_provider_arrived_idx
+    ON provider_responses (user_id, provider, arrived DESC);
+
+-- STEP 3: arrivals — the deck's row, one per provider object.
+-- id is "our id"; (provider, their_id) is unique so the same thing is never
+-- imported twice; their_id_kind says whether their_id is the provider's own
+-- id or one we composed; redactions declares every path we blanked before
+-- the payload was saved (secrets never land).
+CREATE TABLE arrivals (
+    id            text PRIMARY KEY,
+    provider      arrival_provider NOT NULL,
+    connection    text NULL,
+    resource      text NOT NULL,
+    their_id      text NOT NULL,
+    their_id_kind their_id_kind NOT NULL,
+    payload       jsonb NOT NULL,
+    fingerprint   bytea NOT NULL,
+    redactions    text[] NOT NULL DEFAULT '{}',
+    asked         timestamptz NOT NULL,
+    arrived       timestamptz NULL,
+    read          timestamptz NULL,
+    status        arrival_status NOT NULL DEFAULT 'pending',
+    response_id   text NULL REFERENCES provider_responses(id),
+    user_id       text NULL REFERENCES users(id),
+    guest_ref     text NULL,
+    CONSTRAINT arrivals_fingerprint_len_chk CHECK (octet_length(fingerprint) = 32),
+    CONSTRAINT arrivals_payload_size_chk CHECK (pg_column_size(payload) <= 1048576),
+    CONSTRAINT arrivals_owner_chk CHECK (user_id IS NOT NULL OR guest_ref IS NOT NULL),
+    CONSTRAINT arrivals_provider_their_id_key UNIQUE (provider, their_id)
+);
+
+CREATE INDEX arrivals_user_id_provider_resource_arrived_idx
+    ON arrivals (user_id, provider, resource, arrived DESC);
+CREATE INDEX arrivals_status_idx ON arrivals (status);
+CREATE INDEX arrivals_response_id_idx ON arrivals (response_id);
+
+-- STEP 4: PROMISE 1 as a database law, not a convention. An arrival never
+-- changes: every identity, payload, timing and ownership column is frozen at
+-- insert. Only `read` and `status` may move, and each exactly once — read
+-- from NULL to a time, status from 'pending' to 'done' or 'failed'. There is
+-- no updated_at column because there is no update to stamp.
+CREATE FUNCTION arrivals_promise_1() RETURNS trigger
+LANGUAGE plpgsql AS $$
+BEGIN
+    IF NEW.provider      IS DISTINCT FROM OLD.provider
+    OR NEW.connection    IS DISTINCT FROM OLD.connection
+    OR NEW.resource      IS DISTINCT FROM OLD.resource
+    OR NEW.their_id      IS DISTINCT FROM OLD.their_id
+    OR NEW.their_id_kind IS DISTINCT FROM OLD.their_id_kind
+    OR NEW.payload       IS DISTINCT FROM OLD.payload
+    OR NEW.fingerprint   IS DISTINCT FROM OLD.fingerprint
+    OR NEW.redactions    IS DISTINCT FROM OLD.redactions
+    OR NEW.asked         IS DISTINCT FROM OLD.asked
+    OR NEW.arrived       IS DISTINCT FROM OLD.arrived
+    OR NEW.response_id   IS DISTINCT FROM OLD.response_id
+    OR NEW.user_id       IS DISTINCT FROM OLD.user_id
+    OR NEW.guest_ref     IS DISTINCT FROM OLD.guest_ref THEN
+        RAISE EXCEPTION 'arrivals promise 1: an arrival never changes (id %)', OLD.id
+            USING ERRCODE = 'integrity_constraint_violation';
+    END IF;
+    IF NEW.read IS DISTINCT FROM OLD.read AND OLD.read IS NOT NULL THEN
+        RAISE EXCEPTION 'arrivals promise 1: read is set once, from NULL (id %)', OLD.id
+            USING ERRCODE = 'integrity_constraint_violation';
+    END IF;
+    IF NEW.status IS DISTINCT FROM OLD.status AND OLD.status <> 'pending' THEN
+        RAISE EXCEPTION 'arrivals promise 1: status moves once, from pending (id %)', OLD.id
+            USING ERRCODE = 'integrity_constraint_violation';
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER arrivals_promise_1
+    BEFORE UPDATE ON arrivals
+    FOR EACH ROW EXECUTE FUNCTION arrivals_promise_1();
+
+COMMIT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -536,6 +536,8 @@ model users {
   reservations            reservations[]
   commission_ledger       commission_ledger[]
   transaction_reservation_links transaction_reservation_links[]
+  provider_responses      provider_responses[]
+  arrivals                arrivals[]
 }
 
 model budgets {
@@ -3538,4 +3540,100 @@ model operations_north_star {
 
   @@index([next_review_at])
   @@map("operations_north_star")
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// THE ARRIVALS STORE (REBUILD-01 PR-1) — the blueprint's step 3
+// prisma/migrations/20260903000000_arrivals/migration.sql moves with this.
+// Column for column with the SQL — asserted at build
+// (scripts/assert-tool-registry.ts, THE ARRIVALS LAW). Nothing writes here yet.
+// ═══════════════════════════════════════════════════════════════════
+
+/// Every provider the deck names — src/lib/providers.ts PROVIDER_CODES, alphabetical.
+enum arrival_provider {
+  alpaca
+  amadeus
+  anthropic
+  ecfr
+  federal_register
+  finnhub
+  fred
+  google_places
+  ibkr
+  irs
+  liteapi
+  openai
+  plaid
+  polygon
+  schwab
+  sec
+  snaptrade
+  square
+  stripe
+  tastytrade
+  teller
+  tradier
+  travel_buddy
+  us_code
+  viator
+  voyage
+  xai_grok
+}
+
+enum arrival_status {
+  pending
+  done
+  failed
+}
+
+/// their_id is the provider's own id, or one we composed and labeled as such.
+enum their_id_kind {
+  provider
+  composed
+}
+
+/// The wire: the exact bytes of one HTTP answer, sha256'd. One row per answer.
+model provider_responses {
+  id          String           @id
+  provider    arrival_provider
+  resource    String
+  user_id     String?
+  guest_ref   String?
+  http_status Int
+  body        Bytes            @db.ByteA
+  body_sha256 Bytes            @db.ByteA
+  asked       DateTime         @db.Timestamptz(6)
+  arrived     DateTime         @db.Timestamptz(6)
+  user        users?           @relation(fields: [user_id], references: [id], onDelete: NoAction, onUpdate: NoAction)
+  arrivals    arrivals[]
+
+  @@index([user_id, provider, arrived(sort: Desc)])
+}
+
+/// The deck's row: one per provider object. Promise 1 is a BEFORE UPDATE
+/// trigger in the migration — only read and status may move, each once.
+model arrivals {
+  id            String              @id
+  provider      arrival_provider
+  connection    String?
+  resource      String
+  their_id      String
+  their_id_kind their_id_kind
+  payload       Json                @db.JsonB
+  fingerprint   Bytes               @db.ByteA
+  redactions    String[]            @default([])
+  asked         DateTime            @db.Timestamptz(6)
+  arrived       DateTime?           @db.Timestamptz(6)
+  read          DateTime?           @db.Timestamptz(6)
+  status        arrival_status      @default(pending)
+  response_id   String?
+  user_id       String?
+  guest_ref     String?
+  response      provider_responses? @relation(fields: [response_id], references: [id], onDelete: NoAction, onUpdate: NoAction)
+  user          users?              @relation(fields: [user_id], references: [id], onDelete: NoAction, onUpdate: NoAction)
+
+  @@unique([provider, their_id])
+  @@index([user_id, provider, resource, arrived(sort: Desc)])
+  @@index([status])
+  @@index([response_id])
 }

--- a/scripts/assert-tool-registry.ts
+++ b/scripts/assert-tool-registry.ts
@@ -17,6 +17,15 @@
  * navigation (its first entry); each card's home and the net-worth read are
  * doors on /answers.
  *
+ * THE ARRIVALS LAW (REBUILD-01 PR-1): the provider vocabulary's module-scope
+ * law re-run (src/lib/providers.ts — every ROUTING_RULES provider + resource
+ * pair resolves, no duplicate word or code), plus what only the texts can
+ * answer: the Prisma enum `arrival_provider` (prisma/schema.prisma, read as
+ * text) and the migration's CREATE TYPE (prisma/migrations/*_arrivals) carry
+ * the code set EXACTLY, alphabetical; and the two Prisma models agree with the
+ * migration's two CREATE TABLEs column for column — name, type, nullability,
+ * order — so schema.prisma and the SQL can never drift.
+ *
  * The assert:showroom pattern: a plain script wired into the `build` script so
  * it runs in CI / Vercel and fails the BUILD. It imports the registry (which
  * runs its module-scope law: sheet cells 25/25 both ways, LIVE/PARTIAL have a
@@ -34,6 +43,7 @@ import { PROBLEM_SHEET } from '../src/lib/problemSheet';
 import { COCKPIT_PATH, EXPECTED_STATUS_COUNTS, FAMILY_READS, TOOL_REGISTRY, registryLaw, statusCounts } from '../src/lib/toolRegistry';
 import { OWNER_UTILITIES } from '../src/lib/shellMenu';
 import { ANSWERS_HOME, ANSWER_READS, ANSWER_ROWS, NET_WORTH_READ, answersLaw } from '../src/lib/answers';
+import { PROVIDERS, PROVIDER_CODES, ROUTING_RULES, providersLaw } from '../src/lib/providers';
 
 /**
  * Routes whose door is outside the app map: the front door and its marketing
@@ -210,6 +220,68 @@ for (const r of rows) console.log(r);
 const counts = statusCounts();
 console.log(`counts: LIVE ${counts.LIVE} · PARTIAL ${counts.PARTIAL} · NOT_BUILT ${counts.NOT_BUILT} (census ${EXPECTED_STATUS_COUNTS.LIVE}/${EXPECTED_STATUS_COUNTS.PARTIAL}/${EXPECTED_STATUS_COUNTS.NOT_BUILT}) · sheet cells ${PROBLEM_SHEET.flatMap((f) => f.tools).length}`);
 
+// ── THE ARRIVALS LAW (REBUILD-01 PR-1) ──────────────────────────────────────
+violations.push(...providersLaw({ throwOnFail: false }));
+const schemaText = readFileSync(resolve(ROOT, 'prisma/schema.prisma'), 'utf8');
+const migrationDir = readdirSync(resolve(ROOT, 'prisma/migrations')).find((d) => d.endsWith('_arrivals'));
+const migrationSql = migrationDir ? readFileSync(resolve(ROOT, 'prisma/migrations', migrationDir, 'migration.sql'), 'utf8') : '';
+if (!migrationDir) violations.push('arrivals: no prisma/migrations/*_arrivals/migration.sql');
+
+const enumBlock = schemaText.match(/enum arrival_provider \{\n([\s\S]*?)\n\}/);
+const enumValues = enumBlock ? enumBlock[1].split('\n').map((l) => l.trim()).filter(Boolean) : [];
+if (enumValues.join(',') !== PROVIDER_CODES.join(',')) violations.push(`arrivals: enum arrival_provider [${enumValues.join(' ')}] ≠ providers.ts codes [${PROVIDER_CODES.join(' ')}]`);
+const typeValues = migrationSql.match(/CREATE TYPE arrival_provider AS ENUM \((.*?)\);/)?.[1].split(', ').map((v) => v.replace(/^'|'$/g, '')) ?? [];
+if (typeValues.join(',') !== PROVIDER_CODES.join(',')) violations.push(`arrivals: migration CREATE TYPE arrival_provider [${typeValues.join(' ')}] ≠ providers.ts codes`);
+
+/** SQL column → { name, type, nullable } from a CREATE TABLE body; constraints and indexes are skipped. */
+function sqlColumns(table: string): Array<{ name: string; type: string; nullable: boolean }> {
+  const m = migrationSql.match(new RegExp(`CREATE TABLE ${table} \\(\\n([\\s\\S]*?)\\n\\);`));
+  if (!m) return [];
+  return m[1].split('\n').map((l) => l.trim().replace(/,$/, '')).filter((l) => l && !/^CONSTRAINT /.test(l)).map((l) => {
+    const [name, type] = l.split(/\s+/);
+    const nullable = !/NOT NULL|PRIMARY KEY/.test(l);
+    return { name, type, nullable };
+  });
+}
+/** Prisma scalar field → the SQL shape it must match. Relation fields (a model type) are skipped. */
+const PRISMA_TO_SQL: Record<string, string> = { String: 'text', Int: 'integer', 'Bytes@db.ByteA': 'bytea', 'Json@db.JsonB': 'jsonb', 'DateTime@db.Timestamptz(6)': 'timestamptz', 'String[]': 'text[]' };
+function modelColumns(model: string): Array<{ name: string; type: string; nullable: boolean }> {
+  const m = schemaText.match(new RegExp(`model ${model} \\{\\n([\\s\\S]*?)\\n\\}`));
+  if (!m) return [];
+  const out: Array<{ name: string; type: string; nullable: boolean }> = [];
+  for (const raw of m[1].split('\n')) {
+    const l = raw.trim();
+    if (!l || l.startsWith('@@') || l.startsWith('//')) continue;
+    const [name, typeTok, ...rest] = l.split(/\s+/);
+    if (rest.some((t) => t.startsWith('@relation')) || /^(users|provider_responses|arrivals)\??(\[\])?$/.test(typeTok)) continue;
+    const nullable = typeTok.endsWith('?');
+    const base = typeTok.replace(/\?$/, '');
+    const native = rest.find((t) => t.startsWith('@db.')) ?? '';
+    const key = base + native;
+    const type = PRISMA_TO_SQL[key] ?? (['arrival_provider', 'arrival_status', 'their_id_kind'].includes(base) ? base : `?${key}`);
+    out.push({ name, type, nullable });
+  }
+  return out;
+}
+const arrivalsRows: string[] = [];
+for (const [table] of [['provider_responses'], ['arrivals']]) {
+  const sql = sqlColumns(table);
+  const model = modelColumns(table);
+  if (sql.length === 0) violations.push(`arrivals: CREATE TABLE ${table} not found in the migration`);
+  if (model.length === 0) violations.push(`arrivals: model ${table} not found in schema.prisma`);
+  const n = Math.max(sql.length, model.length);
+  for (let i = 0; i < n; i++) {
+    const a = sql[i]; const b = model[i];
+    const same = a && b && a.name === b.name && a.type === b.type && a.nullable === b.nullable;
+    arrivalsRows.push(`${table.padEnd(19)} ${(a ? `${a.name} ${a.type}${a.nullable ? ' NULL' : ' NOT NULL'}` : '—').padEnd(44)} ${(b ? `${b.name} ${b.type}${b.nullable ? ' NULL' : ' NOT NULL'}` : '—').padEnd(44)} ${same ? '=' : '≠'}`);
+    if (!same) violations.push(`arrivals: ${table} column ${i + 1} differs — SQL ${a ? `${a.name} ${a.type}${a.nullable ? '' : ' NOT NULL'}` : '(none)'} vs model ${b ? `${b.name} ${b.type}${b.nullable ? '' : ' NOT NULL'}` : '(none)'}`);
+  }
+}
+console.log('THE ARRIVALS STORE — migration SQL vs schema.prisma, column for column');
+console.log(`${'table'.padEnd(19)} ${'migration.sql'.padEnd(44)} ${'schema.prisma'.padEnd(44)}`);
+for (const r of arrivalsRows) console.log(r);
+console.log(`providers: ${PROVIDERS.length} (${PROVIDERS.filter((p) => p.today).length} today) · rule-book pairs ${ROUTING_RULES.length} · enum values ${enumValues.length} · CREATE TYPE values ${typeValues.length}`);
+
 if (violations.length) {
   console.error('\n✖ TOOL REGISTRY LAW FAILED:');
   for (const v of violations) console.error(`  ${v}`);
@@ -218,3 +290,4 @@ if (violations.length) {
 console.log('✔ Tool registry law passed — 25/25 cells, homes resolve to page files, counts match the census.');
 console.log(`✔ Reachability law passed — ${pages.length} pages, every one has a door.`);
 console.log(`✔ The answers law passed — ${ANSWER_ROWS.length}/4 questions on ${ANSWERS_HOME}, every number sourced.`);
+console.log(`✔ The arrivals law passed — ${PROVIDERS.length} providers, enum === codes, ${arrivalsRows.length} columns agree with the migration.`);

--- a/src/components/landing/Landing.tsx
+++ b/src/components/landing/Landing.tsx
@@ -182,6 +182,7 @@ import LandingFooter from './LandingFooter';
 import GuestTripStrip from './GuestTripStrip';
 import { PROBLEM_SHEET } from '@/lib/problemSheet';
 import { ANSWER_ROWS, ANSWER_INPUTS } from '@/lib/answers';
+import { PROVIDER_MENU, ROUTING_RULES } from '@/lib/providers';
 // PR-ELEV-1: the coming-soon tiles became badged "Soon" chips INSIDE the
 // booking strip (travelStripModes) — the separate tile row is gone.
 
@@ -301,21 +302,10 @@ const PROBLEM_SHEET_SM = [
 // edit here (a provider is just rows in a table — added, never built).
 // PR-S2: the menu renders ONCE PER BREAKPOINT — the walk's right panel
 // on desktop, the full-width DECK.table on mobile.
-const PROVIDER_MENU = [
-  ['banks & accounts', 'plaid', 'teller'],
-  ['card money', 'stripe', 'square'],
-  ['trades & market data', 'tastytrade', 'schwab · ibkr · alpaca · tradier · snaptrade'],
-  ['company numbers', 'finnhub', 'polygon'],
-  ['the economy', 'fred', '—'],
-  ['filings', 'sec', '—'],
-  ['flights', 'liteapi', 'amadeus'],
-  ['hotels', 'liteapi', 'amadeus'],
-  ['activities', 'viator', '—'],
-  ['locations', 'google places', '—'],
-  ['visas', 'travel buddy', '—'],
-  ['our AI', 'anthropic · openai · xai grok · voyage', '—'],
-  ['the law itself', 'ecfr · us code · federal register · irs', '—'],
-] as const;
+// REBUILD-01: PROVIDER_MENU (step 2's menu — [job, today, next]) lives in the
+// shared leaf src/lib/providers.ts now — one vocabulary for the deck, the
+// schema and the code. Imported at the top; byte-identical; the S2 laws below
+// are unchanged.
 
 // ── PR-S2 / THE WALK. Step 2's visual: the walk from Step 1's finished
 // table to the provider menu, DRAWN, not listed (SHOW DON'T ECHO, Deck
@@ -545,28 +535,9 @@ const s3FieldIndex = (b: number, r: number) => IMPORT_COLUMNS.slice(0, b).reduce
 // THE POINT:
 // nothing ever arrives as a posting — the system writes postings from events.
 // Do not add a POSTING row here to make the two lists match.
-const ROUTING_RULES = [
-  ['plaid', 'transaction', 'EVENT', 'something that happened'],
-  ['plaid', 'account', 'REGISTRY', 'one of your accounts'],
-  ['plaid', 'holding', 'SNAPSHOT', 'how things stood at one moment'],
-  ['stripe', 'payout', 'EVENT', ''],
-  ['tastytrade', 'quote', 'REFERENCE', 'a fact about the world'],
-  ['finnhub', 'fundamentals', 'REFERENCE', ''],
-  ['fred', 'series', 'REFERENCE', ''],
-  ['sec', 'filing', 'REFERENCE', ''],
-  ['liteapi', 'booking', 'EVENT', ''],
-  ['viator', 'activity', 'REFERENCE', ''],
-  ['google places', 'place', 'REFERENCE', ''],
-  ['travel buddy', 'visa', 'REFERENCE', ''],
-  ['anthropic', 'classification', 'DERIVED', 'math we did — never a source'],
-  ['openai', 'insight', 'DERIVED', ''],
-  ['xai grok', 'sentiment', 'DERIVED', ''],
-  ['voyage', 'embedding', 'DERIVED', ''],
-  ['ecfr', 'title', 'REFERENCE', ''],
-  ['us code', 'title', 'REFERENCE', ''],
-  ['federal register', 'document', 'REFERENCE', ''],
-  ['irs', 'bulletin', 'REFERENCE', ''],
-] as const;
+// REBUILD-01: ROUTING_RULES (step 4's rule book) lives in the shared leaf
+// src/lib/providers.ts now, beside PROVIDER_MENU. Imported at the top;
+// byte-identical; the S4 / S5 laws below are unchanged.
 
 // PR-S4: ROUTING_DERIVED_ROW retired — the old table's anthropic emphasis
 // died with the table; the rule book's rows are peers, and DERIVED's

--- a/src/lib/__tests__/providers.test.ts
+++ b/src/lib/__tests__/providers.test.ts
@@ -1,0 +1,57 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { PROVIDERS, PROVIDER_CODES, PROVIDER_MENU, ROUTING_RULES, providerByCode, providerByDeck, providerCode, providersLaw } from '../providers';
+
+// REBUILD-01 PR-1 — the provider vocabulary. Deck words ↔ codes round-trip, no
+// duplicates, every rule-book pair resolves, and the schema's enum carries the
+// code set exactly (read as text — the generated client is not committed).
+
+const ROOT = resolve(__dirname, '../../..');
+
+test('the vocabulary passes its own law and derives from the deck consts', () => {
+  assert.deepEqual(providersLaw({ throwOnFail: false }), []);
+  const menuWords = PROVIDER_MENU.flatMap(([, today, next]) => [today, next]).filter((c) => c !== '—').flatMap((c) => c.split(' · '));
+  assert.deepEqual([...new Set(menuWords)].sort(), PROVIDERS.map((p) => p.deck).sort());
+  assert.equal(PROVIDERS.length, 27);
+  assert.equal(PROVIDERS.filter((p) => p.today).length, 18);
+});
+
+test('deck words and codes round-trip both ways, with no duplicate on either side', () => {
+  for (const p of PROVIDERS) {
+    assert.equal(providerCode(p.deck), p.code);
+    assert.equal(providerByCode(p.code)?.deck, p.deck);
+    assert.equal(providerByDeck(p.deck)?.code, p.code);
+    assert.match(p.code, /^[a-z][a-z0-9_]*$/);
+  }
+  assert.equal(new Set(PROVIDERS.map((p) => p.deck)).size, PROVIDERS.length);
+  assert.equal(new Set(PROVIDERS.map((p) => p.code)).size, PROVIDERS.length);
+  assert.deepEqual(PROVIDER_CODES, [...PROVIDER_CODES].sort());
+  assert.equal(providerCode('google places'), 'google_places');
+  assert.equal(providerByCode('federal_register')?.deck, 'federal register');
+});
+
+test('every ROUTING_RULES provider + resource pair resolves, spelled as the deck spells it', () => {
+  for (const [provider, resource] of ROUTING_RULES) {
+    const p = providerByDeck(provider);
+    assert.ok(p, `${provider} is a menu provider`);
+    assert.ok(p.resources.includes(resource), `${provider} ${resource}`);
+  }
+  assert.equal(PROVIDERS.flatMap((p) => p.resources).length, ROUTING_RULES.length);
+  assert.deepEqual(providerByDeck('plaid')?.resources, ['transaction', 'account', 'holding']);
+  assert.deepEqual(providerByDeck('teller')?.resources, []);
+});
+
+test("the Prisma enum arrival_provider and the migration's CREATE TYPE carry the code set exactly, alphabetical", () => {
+  const schema = readFileSync(resolve(ROOT, 'prisma/schema.prisma'), 'utf8');
+  const enumBlock = schema.match(/enum arrival_provider \{\n([\s\S]*?)\n\}/);
+  assert.ok(enumBlock, 'enum arrival_provider exists');
+  const enumValues = enumBlock[1].split('\n').map((l) => l.trim()).filter(Boolean);
+  assert.deepEqual(enumValues, PROVIDER_CODES);
+  const dir = readdirSync(resolve(ROOT, 'prisma/migrations')).find((d) => d.endsWith('_arrivals'));
+  assert.ok(dir, 'the arrivals migration exists');
+  const sql = readFileSync(resolve(ROOT, 'prisma/migrations', dir, 'migration.sql'), 'utf8');
+  const typeValues = sql.match(/CREATE TYPE arrival_provider AS ENUM \((.*?)\);/)?.[1].split(', ').map((v) => v.replace(/^'|'$/g, ''));
+  assert.deepEqual(typeValues, PROVIDER_CODES);
+});

--- a/src/lib/providers.ts
+++ b/src/lib/providers.ts
@@ -1,0 +1,132 @@
+/**
+ * REBUILD-01 PR-1 — THE PROVIDER VOCABULARY. One list of the providers the
+ * deck names and the resources each one sends, shared by the deck, the schema
+ * and the code (ruling 10 of the README desk). The two deck consts below moved
+ * out of Landing.tsx BYTE-IDENTICAL (the PROBLEM_SHEET / ANSWER_ROWS precedent):
+ * PROVIDER_MENU is step 2's menu — [job, today, next] — and ROUTING_RULES is
+ * step 4's rule book — [provider, resource, KIND, means]. The deck imports them;
+ * nothing here is retyped.
+ *
+ * PROVIDERS derives from them: one entry per provider word the menu names
+ * (today and next; '—' is deck content, not a provider; a ' · ' cell lists
+ * several), `code` = the deck word with spaces as underscores — the value the
+ * Prisma enum `arrival_provider` carries — and `resources` = the provider's
+ * ROUTING_RULES rows, spelled as the deck spells them.
+ *
+ * THE LAW (module scope; re-run at build by scripts/assert-tool-registry.ts,
+ * which adds the check only the schema text can answer — enum values === the
+ * code set): deck words and codes unique; every ROUTING_RULES provider is a
+ * menu provider and every (provider, resource) pair resolves; codes are
+ * snake_case identifiers.
+ *
+ * Zero imports: server- and client-safe.
+ */
+
+export const PROVIDER_MENU = [
+  ['banks & accounts', 'plaid', 'teller'],
+  ['card money', 'stripe', 'square'],
+  ['trades & market data', 'tastytrade', 'schwab · ibkr · alpaca · tradier · snaptrade'],
+  ['company numbers', 'finnhub', 'polygon'],
+  ['the economy', 'fred', '—'],
+  ['filings', 'sec', '—'],
+  ['flights', 'liteapi', 'amadeus'],
+  ['hotels', 'liteapi', 'amadeus'],
+  ['activities', 'viator', '—'],
+  ['locations', 'google places', '—'],
+  ['visas', 'travel buddy', '—'],
+  ['our AI', 'anthropic · openai · xai grok · voyage', '—'],
+  ['the law itself', 'ecfr · us code · federal register · irs', '—'],
+] as const;
+
+export const ROUTING_RULES = [
+  ['plaid', 'transaction', 'EVENT', 'something that happened'],
+  ['plaid', 'account', 'REGISTRY', 'one of your accounts'],
+  ['plaid', 'holding', 'SNAPSHOT', 'how things stood at one moment'],
+  ['stripe', 'payout', 'EVENT', ''],
+  ['tastytrade', 'quote', 'REFERENCE', 'a fact about the world'],
+  ['finnhub', 'fundamentals', 'REFERENCE', ''],
+  ['fred', 'series', 'REFERENCE', ''],
+  ['sec', 'filing', 'REFERENCE', ''],
+  ['liteapi', 'booking', 'EVENT', ''],
+  ['viator', 'activity', 'REFERENCE', ''],
+  ['google places', 'place', 'REFERENCE', ''],
+  ['travel buddy', 'visa', 'REFERENCE', ''],
+  ['anthropic', 'classification', 'DERIVED', 'math we did — never a source'],
+  ['openai', 'insight', 'DERIVED', ''],
+  ['xai grok', 'sentiment', 'DERIVED', ''],
+  ['voyage', 'embedding', 'DERIVED', ''],
+  ['ecfr', 'title', 'REFERENCE', ''],
+  ['us code', 'title', 'REFERENCE', ''],
+  ['federal register', 'document', 'REFERENCE', ''],
+  ['irs', 'bulletin', 'REFERENCE', ''],
+] as const;
+
+export interface Provider {
+  /** The deck's word — PROVIDER_MENU / ROUTING_RULES spelling. */
+  deck: string;
+  /** The schema's word — the `arrival_provider` enum value. */
+  code: string;
+  /** Named in the menu's TODAY column (true) or its NEXT column (false). */
+  today: boolean;
+  /** The resources this provider sends, as ROUTING_RULES spells them (empty until the rule book names one). */
+  resources: readonly string[];
+}
+
+/** deck word → enum code: spaces become underscores; nothing else changes. */
+export function providerCode(deck: string): string {
+  return deck.replace(/ /g, '_');
+}
+
+const menuWords = (cell: string): string[] => (cell === '—' ? [] : cell.split(' · '));
+
+/** Every provider the deck names, menu order (a row's TODAY word before its NEXT words), each once. */
+export const PROVIDERS: readonly Provider[] = (() => {
+  const out: Provider[] = [];
+  for (const [, today, next] of PROVIDER_MENU) {
+    for (const [words, isToday] of [[menuWords(today), true], [menuWords(next), false]] as const) {
+      for (const deck of words) {
+        if (out.some((p) => p.deck === deck)) continue;
+        out.push({
+          deck,
+          code: providerCode(deck),
+          today: isToday,
+          resources: ROUTING_RULES.filter(([p]) => p === deck).map(([, r]) => r),
+        });
+      }
+    }
+  }
+  return out;
+})();
+
+/** The enum's values, alphabetical — the order the migration's CREATE TYPE lists them. */
+export const PROVIDER_CODES: readonly string[] = [...PROVIDERS.map((p) => p.code)].sort();
+
+export function providerByDeck(deck: string): Provider | undefined {
+  return PROVIDERS.find((p) => p.deck === deck);
+}
+
+export function providerByCode(code: string): Provider | undefined {
+  return PROVIDERS.find((p) => p.code === code);
+}
+
+/** THE LAW. Throws on the first violation; returns the violations list when asked not to throw. */
+export function providersLaw(opts: { throwOnFail?: boolean } = {}): string[] {
+  const violations: string[] = [];
+  const decks = PROVIDERS.map((p) => p.deck);
+  const codes = PROVIDERS.map((p) => p.code);
+  if (new Set(decks).size !== decks.length) violations.push('PROVIDERS: a deck word repeats');
+  if (new Set(codes).size !== codes.length) violations.push('PROVIDERS: a code repeats');
+  for (const p of PROVIDERS) {
+    if (!/^[a-z][a-z0-9_]*$/.test(p.code)) violations.push(`${p.deck}: code "${p.code}" is not a snake_case identifier`);
+    if (providerCode(p.deck) !== p.code) violations.push(`${p.deck}: code "${p.code}" is not the deck word`);
+  }
+  for (const [provider, resource] of ROUTING_RULES) {
+    const p = providerByDeck(provider);
+    if (!p) violations.push(`ROUTING_RULES: "${provider}" is not a provider the menu names`);
+    else if (!p.resources.includes(resource)) violations.push(`ROUTING_RULES: ${provider} ${resource} does not resolve`);
+  }
+  if (violations.length && opts.throwOnFail !== false) throw new Error(`PROVIDER VOCABULARY LAW failed:\n  ${violations.join('\n  ')}`);
+  return violations;
+}
+
+providersLaw();


### PR DESCRIPTION
**Do not merge — Alex merges after Vercel Preview (SOC 2 gate).**

**HARD GATE — migration-bearing.** Alex runs the SQL via psql before merge; `prisma/schema.prisma` and `prisma/migrations/20260903000000_arrivals/migration.sql` move together. Nothing in this PR writes a row. Branch from current main (`24b1dfab`).

REBUILD-01 PR-1 — the blueprint's first open gap (step 3): every provider answer lands once, word for word, fingerprinted, before anyone decides what it means. This PR ships the store and nothing that writes to it. The ten README-desk rulings are locked and cited in the migration header.

## Audit (read-only, before the build)

| Question | Finding (file:line on main) |
|---|---|
| The deck's provider words | `PROVIDER_MENU` at `src/components/landing/Landing.tsx:304-318` — 13 rows `[job, today, next]`; `ROUTING_RULES` at `:548-569` — 20 rows `[provider, resource, KIND, means]`, 18 distinct providers; `IMPORT_ARRIVALS` at `:502-521` (the deck's sample rows) uses the same words. Both consts were module-local (`const`, not exported); the deck's S2 / S4 / S5 layout laws read them. |
| IMPORT_COLUMNS' eleven fields | `Landing.tsx:453-485`: provider · connection · resource · their id · our id · payload · fingerprint · asked · arrived · read · status — four bands, glosses verbatim (README "The arrival row"). |
| The latest migration's SQL style | `prisma/migrations/20260805000000_transaction_reservation_links/migration.sql`: a header block stating the arc, ADDITIVE-ONLY, "applied by Alex via psql", the id types verified against `schema.prisma` with line cites, FK posture with precedents, then `CREATE TABLE` + named constraints + `ALTER TABLE … ADD CONSTRAINT … FOREIGN KEY` + `CREATE [UNIQUE] INDEX` with Prisma-default names. (The undated `add_robinhood_reconciliation` directory is bare `ALTER TABLE` lines — not the style followed.) |
| How `users` is keyed | `prisma/schema.prisma:494` — `id String @id` → SQL `text`, no default (the app supplies ids). Both new FKs target it as `text`. |
| The corpus foundation migration | `prisma/migrations/20260503000000_pr_f_corpus_foundation/migration.sql:36-56, :73-89` — `content_hash bytea NOT NULL`, `raw_hash bytea NOT NULL`, `text_hash bytea NOT NULL`, `retrieved_at timestamptz NOT NULL`, `metadata jsonb`, named `UNIQUE (citation_key, version)` / `(document_id, ordinal)`, `BEGIN … COMMIT`. Its tables are SQL-only (no Prisma model — `grep Bytes prisma/schema.prisma` is empty), so the column *shapes* are reused (bytea hashes with `octet_length` CHECKs, timestamptz, jsonb, a named UNIQUE key, a transaction), not its location or `IF NOT EXISTS` idempotence. |
| Schema style precedents | `@db.Timestamptz(6)` (`schema.prisma:742, :2848`), `@db.JsonB` (`:2924`), `@@index([… (sort: Desc)])` (`:1298, :2860`), lowercase snake_case enums beside their models (`:2157`), a section banner before a model family (`:562`). |
| Local Postgres for the dry run | `/usr/lib/postgresql/16` with a stopped `main` cluster — started, used for a throwaway `arrivals_dry` database, dropped and stopped again after. |

## Build

- **`src/lib/providers.ts`** — ONE vocabulary. `PROVIDER_MENU` (621 B) and `ROUTING_RULES` (1,008 B) moved out of `Landing.tsx` **byte-identical** (only `export` prefixed; the deck imports them; all 10 module-scope law blocks in Landing.tsx unchanged byte-for-byte — proof script in the scratchpad). `PROVIDERS` derives from them: one entry per provider word the menu names, today and next (`'—'` is deck content; a `' · '` cell lists several), `code = deck word with spaces as underscores`, `resources` = the provider's ROUTING_RULES rows as the deck spells them. 27 providers (18 today, 9 next), 20 resource pairs. `PROVIDER_CODES` is the alphabetical code list; `providerCode / providerByDeck / providerByCode`; `providersLaw()` at module scope (words and codes unique; snake_case codes; every ROUTING_RULES provider is a menu provider and every pair resolves).
- **`prisma/migrations/20260903000000_arrivals/migration.sql`** — verbatim below.
- **`prisma/schema.prisma`** — enums `arrival_provider` (27 values = `PROVIDER_CODES`), `arrival_status`, `their_id_kind`; models `provider_responses` and `arrivals` (`Bytes @db.ByteA`, `Json @db.JsonB`, `DateTime @db.Timestamptz(6)`, `String[] @default([])`); `users` gains `provider_responses provider_responses[]` and `arrivals arrivals[]`; both FKs declared `onDelete: NoAction, onUpdate: NoAction` to match the SQL's bare `REFERENCES` (keep forever: deleting an owner or a response with arrivals behind it fails loudly). `npx prisma validate` passes; `npx prisma generate` run (client in `node_modules`, not committed).
- **`scripts/assert-tool-registry.ts`** — THE ARRIVALS LAW: re-runs `providersLaw`; reads `schema.prisma` as text and requires `enum arrival_provider` === `PROVIDER_CODES` (values and order); reads the `*_arrivals` migration and requires `CREATE TYPE arrival_provider` === `PROVIDER_CODES`; and compares the two `CREATE TABLE`s with the two models **column for column** (name, SQL type ↔ Prisma type + native attribute, nullability, order) — 26 columns, printed as a table at build. Wired into `build` through the existing assert.
- **`src/lib/__tests__/providers.test.ts`** — 4 tests: the law passes and PROVIDERS derives from the menu words (27 / 18 today); deck ↔ code round-trip both ways with no duplicates; every ROUTING_RULES pair resolves (plaid → transaction, account, holding; teller → none); the Prisma enum and the migration's CREATE TYPE carry the code set exactly, alphabetical.
- **README** — "The arrivals store (step 3, built)" under the data model: both tables' columns and rules extracted verbatim from the migration SQL by the generator, the promise-1 trigger in words, the enum = `providers.ts` code set; the shapes line names `src/lib/providers.ts`; gap-ledger row 03 TODAY unchanged, its GAP now "…the arrivals store … is built (PR-1) and holds nothing yet — nothing lands until PR-2"; rows 04 and 14 GAP say the same (the step-3 table exists; no rule row applies to it; no feed lands). The generator's row-04 census guard now requires the only arrival-shaped model to be `arrivals` (a kinds / rules table would still trip it). Model / enum counts follow the schema (114 / 33). README regenerates byte-stable.

**Not in this PR:** any writer (PR-2/3), any backfill, any DELETE policy, `IF NOT EXISTS` idempotence (the file runs once; a second run fails loudly on the first `CREATE TYPE`). One design note for PR-2: `payload` is `NOT NULL`, so a failed ask (the deck's viator row) must land what came back — an error body or `{}` — with `status = 'failed'`; the store does not decide that.

## The migration, verbatim

```sql
-- REBUILD-01 PR-1: THE ARRIVALS STORE — the blueprint's step 3 as tables.
-- Every provider answer lands once, word for word, fingerprinted, before
-- anyone decides what it means. Two tables:
--   provider_responses — the wire: the exact bytes of one HTTP answer, sha256'd
--   arrivals           — the deck's row: one per provider object, the eleven
--                        fields of IMPORT_COLUMNS (src/components/landing/
--                        Landing.tsx) plus who it belongs to and which
--                        response it came from
-- The ten README-desk rulings, all locked: per-object rows over a wire-exact
-- response store; composed ids labeled (their_id_kind); secrets redacted and
-- declared (redactions); Stripe's first feed is the webhook; guests land by
-- reference (guest_ref); one Plaid writer (PR-2/3); no synthetic backfill;
-- keep forever (no DELETE policy here — a purge is a future policy PR); tokens
-- already encrypted (SEC-02); one provider vocabulary shared by deck, schema
-- and code (src/lib/providers.ts — the enum below IS its code set, and the
-- build asserts it).
--
-- SCHEMA ONLY: nothing in this PR writes a row. The generated Prisma client
-- is not committed.
--
-- ADDITIVE-ONLY (the HARD-GATE posture): three types, two tables, one trigger.
-- Zero data rewrites, zero changes to existing rows or tables.
--
-- Applied by Alex via psql (repo law: schema.prisma + this SQL move together;
-- Claude Code authors the file only — it cannot reach Azure). Idempotence is
-- deliberately NOT claimed: this file runs once; a second run fails loudly on
-- the first CREATE TYPE.
--
-- id types matched to their targets (verified against schema.prisma):
--   users.id  TEXT  (String @id; schema:494)
-- FK posture: NO ACTION on users and on provider_responses — an arrival is
-- kept forever, so deleting an owner or a response with arrivals behind it
-- fails LOUDLY (the corpus foundation precedent of hash + UNIQUE columns is
-- reused here in shape: bytea hashes, octet_length CHECKs, a UNIQUE key).
--
-- Constraint and index names follow Prisma's defaults (<table>_<cols>_idx /
-- _key / _fkey / _pkey) so `prisma migrate diff` reads the database as the
-- model describes it.

BEGIN;

-- STEP 1: the three vocabularies.
-- arrival_provider: every provider the deck names (PROVIDER_MENU, today and
-- next), alphabetical — src/lib/providers.ts PROVIDER_CODES, asserted at build.
CREATE TYPE arrival_provider AS ENUM ('alpaca', 'amadeus', 'anthropic', 'ecfr', 'federal_register', 'finnhub', 'fred', 'google_places', 'ibkr', 'irs', 'liteapi', 'openai', 'plaid', 'polygon', 'schwab', 'sec', 'snaptrade', 'square', 'stripe', 'tastytrade', 'teller', 'tradier', 'travel_buddy', 'us_code', 'viator', 'voyage', 'xai_grok');
CREATE TYPE arrival_status AS ENUM ('pending', 'done', 'failed');
CREATE TYPE their_id_kind AS ENUM ('provider', 'composed');

-- STEP 2: provider_responses — the wire, exact bytes, one row per HTTP answer.
CREATE TABLE provider_responses (
    id          text PRIMARY KEY,
    provider    arrival_provider NOT NULL,
    resource    text NOT NULL,
    user_id     text NULL REFERENCES users(id),
    guest_ref   text NULL,
    http_status integer NOT NULL,
    body        bytea NOT NULL,
    body_sha256 bytea NOT NULL,
    asked       timestamptz NOT NULL,
    arrived     timestamptz NOT NULL,
    CONSTRAINT provider_responses_body_sha256_len_chk CHECK (octet_length(body_sha256) = 32),
    CONSTRAINT provider_responses_body_size_chk CHECK (octet_length(body) <= 1048576),
    CONSTRAINT provider_responses_owner_chk CHECK (user_id IS NOT NULL OR guest_ref IS NOT NULL)
);

CREATE INDEX provider_responses_user_id_provider_arrived_idx
    ON provider_responses (user_id, provider, arrived DESC);

-- STEP 3: arrivals — the deck's row, one per provider object.
-- id is "our id"; (provider, their_id) is unique so the same thing is never
-- imported twice; their_id_kind says whether their_id is the provider's own
-- id or one we composed; redactions declares every path we blanked before
-- the payload was saved (secrets never land).
CREATE TABLE arrivals (
    id            text PRIMARY KEY,
    provider      arrival_provider NOT NULL,
    connection    text NULL,
    resource      text NOT NULL,
    their_id      text NOT NULL,
    their_id_kind their_id_kind NOT NULL,
    payload       jsonb NOT NULL,
    fingerprint   bytea NOT NULL,
    redactions    text[] NOT NULL DEFAULT '{}',
    asked         timestamptz NOT NULL,
    arrived       timestamptz NULL,
    read          timestamptz NULL,
    status        arrival_status NOT NULL DEFAULT 'pending',
    response_id   text NULL REFERENCES provider_responses(id),
    user_id       text NULL REFERENCES users(id),
    guest_ref     text NULL,
    CONSTRAINT arrivals_fingerprint_len_chk CHECK (octet_length(fingerprint) = 32),
    CONSTRAINT arrivals_payload_size_chk CHECK (pg_column_size(payload) <= 1048576),
    CONSTRAINT arrivals_owner_chk CHECK (user_id IS NOT NULL OR guest_ref IS NOT NULL),
    CONSTRAINT arrivals_provider_their_id_key UNIQUE (provider, their_id)
);

CREATE INDEX arrivals_user_id_provider_resource_arrived_idx
    ON arrivals (user_id, provider, resource, arrived DESC);
CREATE INDEX arrivals_status_idx ON arrivals (status);
CREATE INDEX arrivals_response_id_idx ON arrivals (response_id);

-- STEP 4: PROMISE 1 as a database law, not a convention. An arrival never
-- changes: every identity, payload, timing and ownership column is frozen at
-- insert. Only `read` and `status` may move, and each exactly once — read
-- from NULL to a time, status from 'pending' to 'done' or 'failed'. There is
-- no updated_at column because there is no update to stamp.
CREATE FUNCTION arrivals_promise_1() RETURNS trigger
LANGUAGE plpgsql AS $$
BEGIN
    IF NEW.provider      IS DISTINCT FROM OLD.provider
    OR NEW.connection    IS DISTINCT FROM OLD.connection
    OR NEW.resource      IS DISTINCT FROM OLD.resource
    OR NEW.their_id      IS DISTINCT FROM OLD.their_id
    OR NEW.their_id_kind IS DISTINCT FROM OLD.their_id_kind
    OR NEW.payload       IS DISTINCT FROM OLD.payload
    OR NEW.fingerprint   IS DISTINCT FROM OLD.fingerprint
    OR NEW.redactions    IS DISTINCT FROM OLD.redactions
    OR NEW.asked         IS DISTINCT FROM OLD.asked
    OR NEW.arrived       IS DISTINCT FROM OLD.arrived
    OR NEW.response_id   IS DISTINCT FROM OLD.response_id
    OR NEW.user_id       IS DISTINCT FROM OLD.user_id
    OR NEW.guest_ref     IS DISTINCT FROM OLD.guest_ref THEN
        RAISE EXCEPTION 'arrivals promise 1: an arrival never changes (id %)', OLD.id
            USING ERRCODE = 'integrity_constraint_violation';
    END IF;
    IF NEW.read IS DISTINCT FROM OLD.read AND OLD.read IS NOT NULL THEN
        RAISE EXCEPTION 'arrivals promise 1: read is set once, from NULL (id %)', OLD.id
            USING ERRCODE = 'integrity_constraint_violation';
    END IF;
    IF NEW.status IS DISTINCT FROM OLD.status AND OLD.status <> 'pending' THEN
        RAISE EXCEPTION 'arrivals promise 1: status moves once, from pending (id %)', OLD.id
            USING ERRCODE = 'integrity_constraint_violation';
    END IF;
    RETURN NEW;
END;
$$;

CREATE TRIGGER arrivals_promise_1
    BEFORE UPDATE ON arrivals
    FOR EACH ROW EXECUTE FUNCTION arrivals_promise_1();

COMMIT;
```

## Column-for-column proof (the assert's own output, run at build)

```
table               migration.sql                                schema.prisma
provider_responses  id text NOT NULL                             id text NOT NULL                             =
provider_responses  provider arrival_provider NOT NULL           provider arrival_provider NOT NULL           =
provider_responses  resource text NOT NULL                       resource text NOT NULL                       =
provider_responses  user_id text NULL                            user_id text NULL                            =
provider_responses  guest_ref text NULL                          guest_ref text NULL                          =
provider_responses  http_status integer NOT NULL                 http_status integer NOT NULL                 =
provider_responses  body bytea NOT NULL                          body bytea NOT NULL                          =
provider_responses  body_sha256 bytea NOT NULL                   body_sha256 bytea NOT NULL                   =
provider_responses  asked timestamptz NOT NULL                   asked timestamptz NOT NULL                   =
provider_responses  arrived timestamptz NOT NULL                 arrived timestamptz NOT NULL                 =
arrivals            id text NOT NULL                             id text NOT NULL                             =
arrivals            provider arrival_provider NOT NULL           provider arrival_provider NOT NULL           =
arrivals            connection text NULL                         connection text NULL                         =
arrivals            resource text NOT NULL                       resource text NOT NULL                       =
arrivals            their_id text NOT NULL                       their_id text NOT NULL                       =
arrivals            their_id_kind their_id_kind NOT NULL         their_id_kind their_id_kind NOT NULL         =
arrivals            payload jsonb NOT NULL                       payload jsonb NOT NULL                       =
arrivals            fingerprint bytea NOT NULL                   fingerprint bytea NOT NULL                   =
arrivals            redactions text[] NOT NULL                   redactions text[] NOT NULL                   =
arrivals            asked timestamptz NOT NULL                   asked timestamptz NOT NULL                   =
arrivals            arrived timestamptz NULL                     arrived timestamptz NULL                     =
arrivals            read timestamptz NULL                        read timestamptz NULL                        =
arrivals            status arrival_status NOT NULL               status arrival_status NOT NULL               =
arrivals            response_id text NULL                        response_id text NULL                        =
arrivals            user_id text NULL                            user_id text NULL                            =
arrivals            guest_ref text NULL                          guest_ref text NULL                          =
providers: 27 (18 today) · rule-book pairs 20 · enum values 27 · CREATE TYPE values 27
✔ The arrivals law passed — 27 providers, enum === codes, 26 columns agree with the migration.
```

Type mapping the assert applies: `String`→`text`, `Int`→`integer`, `Bytes @db.ByteA`→`bytea`, `Json @db.JsonB`→`jsonb`, `DateTime @db.Timestamptz(6)`→`timestamptz`, `String[]`→`text[]`, enum → its name; `?` ↔ `NULL`; defaults (`'{}'`, `'pending'`) are declared in both texts and checked by eye: `@default([])` ↔ `DEFAULT '{}'`, `@default(pending)` ↔ `DEFAULT 'pending'`. Relation fields (`user`, `response`, `arrivals[]`) carry no column and are skipped. Indexes and the unique key are declared in both texts with Prisma's default names (`arrivals_provider_their_id_key`, `arrivals_user_id_provider_resource_arrived_idx`, `arrivals_status_idx`, `arrivals_response_id_idx`, `provider_responses_user_id_provider_arrived_idx`).

## The SQL was executed — on a throwaway local Postgres 16

Cluster `16/main` started, database `arrivals_dry` created with a stub `users (id text PRIMARY KEY)`, the migration applied with `-v ON_ERROR_STOP=1` (clean: 3 types, 2 tables, 4 indexes, 1 function, 1 trigger, COMMIT), then fifteen probes — every one behaved as designed:

| Probe | Result |
|---|---|
| insert a response and an arrival (user-owned) | ok |
| the same (provider, their_id) twice | `duplicate key … arrivals_provider_their_id_key` |
| 1-byte fingerprint | `violates check constraint arrivals_fingerprint_len_chk` |
| no user_id and no guest_ref | `violates check constraint arrivals_owner_chk` |
| a guest arrival by `guest_ref` only | ok |
| `read` NULL → now() | ok |
| `read` a second time | `arrivals promise 1: read is set once, from NULL` |
| `status` pending → done | ok |
| `status` done → failed | `arrivals promise 1: status moves once, from pending` |
| change `payload` / `fingerprint` / `their_id` / `user_id` / `redactions` | `arrivals promise 1: an arrival never changes` (each) |
| a no-op UPDATE (same values) | ok |
| DELETE the owner with arrivals behind it | `violates foreign key constraint provider_responses_user_id_fkey` (NO ACTION) |
| DELETE the response with arrivals behind it | `violates foreign key constraint arrivals_response_id_fkey` (NO ACTION) |
| an unknown provider (`'robinhood'`) | `invalid input value for enum arrival_provider` |

The database was dropped and the cluster stopped afterwards. Azure has not been touched — Alex's run is the first there.

## What Alex runs (file path only)

```
psql -v ON_ERROR_STOP=1 -f prisma/migrations/20260903000000_arrivals/migration.sql
```

against the Azure database, then merge; `prisma migrate deploy` at deploy will see the migration as applied only if Alex also records it — if the repo's convention is to let `migrate deploy` apply it at deploy instead, run nothing by hand and merge (either way the file is the same; state which so the migration table matches).

## Verified

- `npx tsc --noEmit` — 0.
- eslint — 0 / 0 on `src/lib/providers.ts` and the test; `Landing.tsx` and the assert unchanged from main (0 / 0).
- Byte-identity: `PROVIDER_MENU` and `ROUTING_RULES` in `providers.ts` === the main literals with only `export` added; the 10 module-scope law blocks in `Landing.tsx` unchanged byte-for-byte; the whole `Landing.tsx` diff is +8 (one import, two pointer comments) / −37 (the two moved blocks).
- `npm test` — 68/68 (64 + 4 new).
- `npx prisma validate` — valid; `npx prisma generate` — client generated to `node_modules` (not committed; `git status` shows only the seven intended files).
- The four build-time laws (registry, reachability, answers, arrivals) pass; `next build` — exit 0, 263/263 pages.
- README regenerated twice, byte-stable; the generator's census guards (row 03 / 04) pass.
- Diff: `src/lib/providers.ts`, `src/lib/__tests__/providers.test.ts`, `scripts/assert-tool-registry.ts`, `prisma/migrations/20260903000000_arrivals/migration.sql`, `prisma/schema.prisma`, `src/components/landing/Landing.tsx` (the move), `README.md`. The generated client is not committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc

---
_Generated by [Claude Code](https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc)_