### PR TITLE
BANK-01: reconnect a bank (Plaid Link update mode) — and name the bank in the failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Twenty-five business tools on one data pipe that ends in one Ledger and one Calendar.
 
-Source-available (BSL 1.1) · built and operated in production by its founder as User #1 · as of 2026-09-02: 114 Prisma models, 289 API route files, 121 feeds from 20 providers (counted August 24, 2026)
+Source-available (BSL 1.1) · built and operated in production by its founder as User #1 · as of 2026-09-02: 114 Prisma models, 290 API route files, 121 feeds from 20 providers (counted August 24, 2026)
 
 ## The system
 
@@ -201,15 +201,15 @@ BLUEPRINT is the step's headline; TODAY is the deck's honest-state line, verbati
 
 | Module | What exists in code |
 |---|---|
-| Travel | stays and flights through LiteAPI, activities through Viator, visa checks through RapidAPI — public routes under src/app/api/travel (15 route files) and src/app/api/flights (3); models `trips` (schema:578) and `reservations` (schema:1334). |
-| Runway | the reservation matcher — src/app/api/runway/match/propose, queue, review (the step-9 piece alive today) — plus src/app/api/runway/route.ts; models `budgets` (schema:548) and `home_expenses` (schema:1584). |
-| Books | Plaid-synced transactions, a chart of accounts, journal and ledger entries — src/app/api/plaid/sync/route.ts:103 writes `transactions` (schema:414); `journal_entries` (schema:180), `ledger_entries` (schema:219). |
-| Trade | tastytrade connection, quotes and backtests — src/app/api/tastytrade (13 route files); models `trade_cards` (schema:1715) and `scan_snapshots` (schema:1901). |
-| Tax | scenarios, documents and the 2025 export script (`npm run tax:export:2025`) — src/app/api/tax (7 route files); models `tax_scenarios` (schema:1504) and `tax_documents` (schema:1823). |
-| Compliance | the regulatory corpus (eCFR, US Code, Federal Register, IRS bulletins) ingested by Inngest functions with sha256 on write, citations re-verified, and the hash-chained audit log — models `regulatory_sources` (schema:2214), `citations` (schema:2278), `audit_log` (schema:2444). |
-| Routines | scheduled routines evaluated by the `routine-evaluator` Inngest function — models `operations_routines` (schema:3098) and `hub_scheduled_items` (schema:3204); the deck calls the calendar window live in the cockpit (step 12 honest line). |
-| Projects | projects and tasks; accepting a pending task fires the Execute-Task Routine (src/app/api/operations/projects/[id]/tasks/[taskId]/route.ts:395-405) — models `operations_projects` (schema:2922) and `operations_project_tasks` (schema:2967). |
-| Content | scene groups, scenes, pieces and takes — model `operations_content_pieces` (schema:3331); src/app/api/operations carries 50 route files across Routines, Projects and Content. |
+| Travel | stays and flights through LiteAPI, activities through Viator, visa checks through RapidAPI — public routes under src/app/api/travel (15 route files) and src/app/api/flights (3); models `trips` (schema:581) and `reservations` (schema:1337). |
+| Runway | the reservation matcher — src/app/api/runway/match/propose, queue, review (the step-9 piece alive today) — plus src/app/api/runway/route.ts; models `budgets` (schema:551) and `home_expenses` (schema:1587). |
+| Books | Plaid-synced transactions, a chart of accounts, journal and ledger entries — src/app/api/plaid/sync/route.ts:103 writes `transactions` (schema:417); `journal_entries` (schema:180), `ledger_entries` (schema:219). |
+| Trade | tastytrade connection, quotes and backtests — src/app/api/tastytrade (13 route files); models `trade_cards` (schema:1718) and `scan_snapshots` (schema:1904). |
+| Tax | scenarios, documents and the 2025 export script (`npm run tax:export:2025`) — src/app/api/tax (7 route files); models `tax_scenarios` (schema:1507) and `tax_documents` (schema:1826). |
+| Compliance | the regulatory corpus (eCFR, US Code, Federal Register, IRS bulletins) ingested by Inngest functions with sha256 on write, citations re-verified, and the hash-chained audit log — models `regulatory_sources` (schema:2217), `citations` (schema:2281), `audit_log` (schema:2447). |
+| Routines | scheduled routines evaluated by the `routine-evaluator` Inngest function — models `operations_routines` (schema:3101) and `hub_scheduled_items` (schema:3207); the deck calls the calendar window live in the cockpit (step 12 honest line). |
+| Projects | projects and tasks; accepting a pending task fires the Execute-Task Routine (src/app/api/operations/projects/[id]/tasks/[taskId]/route.ts:395-405) — models `operations_projects` (schema:2925) and `operations_project_tasks` (schema:2970). |
+| Content | scene groups, scenes, pieces and takes — model `operations_content_pieces` (schema:3334); src/app/api/operations carries 50 route files across Routines, Projects and Content. |
 
 ## Architecture
 
@@ -228,7 +228,7 @@ Versions from package.json, read 2026-09-02:
 
 Observed versus authored (step 6): what the world sends is observed; what you do is authored; the blueprint keeps the two apart and matches them on one key. Today the money feeds land parsed, without a stored payload — see the gap ledger, step 14.
 
-Scale, as of 2026-09-02: 114 Prisma models, 33 enums, 289 API route files, 37 runtime dependencies, 18 dev dependencies, one test file (`npm test`).
+Scale, as of 2026-09-02: 114 Prisma models, 33 enums, 290 API route files, 37 runtime dependencies, 18 dev dependencies, one test file (`npm test`).
 
 ## Engineering discipline
 
@@ -249,7 +249,7 @@ These are the written laws in `CLAUDE.md`, stated as practice:
 - Middleware: every path not in `PUBLIC_PATHS` requires the verified cookie — `src/middleware.ts:50-160, 162, 165-170`; the two Routine callbacks (`…/audit-ingest`, `…/exec-ingest`) bypass the cookie and validate a shared-secret bearer (`AUDIT_INGEST_SECRET`, `EXEC_INGEST_SECRET`) instead — `src/middleware.ts:173-187`.
 - Route gates: `getCurrentUser` (`src/lib/auth-helpers.ts:11`), `requireTier` (`:42`), `requireAdmin` (`src/lib/require-admin.ts:8`); the working law is that a paid external call is never made before the gate (CLAUDE.md, Security-first).
 - User scoping: every query is scoped to the authed user — e.g. `where: { userId: user.id }` at `src/app/api/tastytrade/connect/route.ts:54`.
-- Rate limits: a durable fixed-window limiter backed by the `rate_limit_hits` table (`src/lib/rateLimit.ts:3-15`; schema:1319), plus `src/lib/scan-rate-limit.ts` and `src/lib/ai-rate-limit.ts`; tuned by `SEARCH_/BOOK_/SCAN_/AI_RATE_LIMIT` and `_WINDOW`, with daily caps `AI_PIPE_DAILY_CAP`, `AI_EXEC_DAILY_CAP`, `AI_ROUTINE_DAILY_CAP`, `AI_DISCOVERY_DAILY_CAP` (USD, from recorded spend — `src/lib/discovery/discoveryGate.ts`), `TRAVEL_SEARCH_DAILY_CAP`, and `GOOGLE_PLACES_MONTHLY_CAP`.
+- Rate limits: a durable fixed-window limiter backed by the `rate_limit_hits` table (`src/lib/rateLimit.ts:3-15`; schema:1322), plus `src/lib/scan-rate-limit.ts` and `src/lib/ai-rate-limit.ts`; tuned by `SEARCH_/BOOK_/SCAN_/AI_RATE_LIMIT` and `_WINDOW`, with daily caps `AI_PIPE_DAILY_CAP`, `AI_EXEC_DAILY_CAP`, `AI_ROUTINE_DAILY_CAP`, `AI_DISCOVERY_DAILY_CAP` (USD, from recorded spend — `src/lib/discovery/discoveryGate.ts`), `TRAVEL_SEARCH_DAILY_CAP`, and `GOOGLE_PLACES_MONTHLY_CAP`.
 - Audit log: a hash chain — each entry stores `prev_hash` and its own sha256 `content_hash` with a `sequence_number` (`prisma/schema.prisma:2441-2443`; written at `src/lib/audit/writeAuditLog.ts:99`); `src/lib/audit/verifyAuditChain.ts:47, 80` recomputes the chain.
 - Citations: `src/lib/citations/verifyCitation.ts:97` re-fetches the source and re-hashes it against `citations.retrieved_content_hash` (`prisma/schema.prisma:2287`); the column's only writer stores an empty string today (`src/lib/discovery/materializeProposal.ts:165`), so the check is structurally dead until the arrivals rebuild lands the real hash.
 - Corpus: the four ingest persisters hash content with sha256 on write — `src/lib/corpus/ingest/ecfr-persist.ts:28`, `uscode-persist.ts:32`, `fedreg-persist.ts:31`, `irb-persist.ts:32`.

--- a/prisma/migrations/20260903150000_plaid_items_last_error/migration.sql
+++ b/prisma/migrations/20260903150000_plaid_items_last_error/migration.sql
@@ -1,0 +1,12 @@
+-- BANK-01: plaid_items.last_error_code / last_error_at — the item's last Plaid
+-- ITEM_ERROR (ITEM_LOGIN_REQUIRED and its kin), recorded by sync-complete when
+-- Plaid refuses the item and cleared by reconnect-complete once /item/get
+-- reports the item healthy again (Plaid Link update mode). The Books page reads
+-- them to offer Reconnect on the rows that need it. The code, never the message
+-- and never a token: the error text stays in the server log.
+--
+-- ADDITIVE-ONLY: two nullable columns. Zero data rewrites. Applied by
+-- `prisma migrate deploy` at deploy (schema.prisma moves with it).
+
+ALTER TABLE plaid_items ADD COLUMN last_error_code text NULL;
+ALTER TABLE plaid_items ADD COLUMN last_error_at timestamptz NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -317,6 +317,9 @@ model plaid_items {
   updatedAt       DateTime
   accountCode     String?
   subAccount      String?
+  /// BANK-01: the item's last Plaid ITEM_ERROR code (e.g. ITEM_LOGIN_REQUIRED) and when; NULL when healthy.
+  last_error_code String?
+  last_error_at   DateTime?  @db.Timestamptz(6)
   accounts        accounts[]
   users           users      @relation(fields: [userId], references: [id], onDelete: NoAction, onUpdate: NoAction)
 }

--- a/src/app/api/accounts/route.ts
+++ b/src/app/api/accounts/route.ts
@@ -32,6 +32,9 @@ export async function GET(request: NextRequest) {
     const transformedItems = items.map(item => ({
       id: item.id,
       institutionName: item.institutionName,
+      // BANK-01: the item's last Plaid ITEM_ERROR, so the Books page can offer Reconnect.
+      lastErrorCode: item.last_error_code,
+      lastErrorAt: item.last_error_at,
       accounts: item.accounts.map(account => ({
         id: account.id,
         name: account.name,

--- a/src/app/api/plaid/link-token/route.ts
+++ b/src/app/api/plaid/link-token/route.ts
@@ -6,8 +6,23 @@ import { plaidClient } from '@/lib/plaid';
 import { Products, CountryCode } from 'plaid';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { summarizePlaidError } from '@/lib/plaid/summarizeError';
+import { decryptToken } from '@/lib/secrets/tokenCipher';
+import { RateLimitError, rateLimit } from '@/lib/rateLimit';
+import { ownedItemOr404, rateLimitedEnvelope, updateModeLinkRequest } from '@/lib/plaid/reconnect';
 
-export async function POST() {
+const CLIENT_NAME = 'Temple Stuart, LLC';
+
+/**
+ * POST /api/plaid/link-token
+ *   {}           → a link token for a NEW item (products, history), as before.
+ *   { itemId }   → BANK-01: a link token in UPDATE MODE for the caller's own
+ *                  existing item (plaid_items.id, user-scoped; a foreign or
+ *                  unknown id is a 404). The stored access token is decrypted
+ *                  server-side (SEC-02) and handed to Plaid only; the browser
+ *                  receives the link token and nothing else. No products are
+ *                  requested in update mode. Rate-limited per user.
+ */
+export async function POST(request: Request) {
   try {
     const userEmail = await getVerifiedEmail();
 
@@ -27,11 +42,36 @@ export async function POST() {
     const tierGate = await requireTabAccess(user.id, 'tab:books');
     if (tierGate) return tierGate;
 
+    // BANK-01: per-user burst defense before any paid call (the repo's durable limiter).
+    try {
+      await rateLimit(`plaid-link-token:${user.id}`, { limit: 10, windowSeconds: 60 });
+    } catch (limited) {
+      if (limited instanceof RateLimitError) {
+        const { status, body, retryAfterSeconds } = rateLimitedEnvelope('link-token', limited);
+        return NextResponse.json(body, { status, headers: { 'Retry-After': String(retryAfterSeconds) } });
+      }
+      throw limited;
+    }
+
+    const body = (await request.json().catch(() => ({}))) as { itemId?: unknown };
+
+    if (body.itemId !== undefined) {
+      const item = await ownedItemOr404(prisma, user.id, body.itemId);
+      const createTokenResponse = await plaidClient.linkTokenCreate(
+        updateModeLinkRequest({ userId: user.id, clientName: CLIENT_NAME, accessToken: decryptToken(item.accessToken) }),
+      );
+      return NextResponse.json({
+        link_token: createTokenResponse.data.link_token,
+        expiration: createTokenResponse.data.expiration,
+        mode: 'update',
+      });
+    }
+
     const configs = {
       user: {
         client_user_id: user.id,
       },
-      client_name: 'Temple Stuart, LLC',
+      client_name: CLIENT_NAME,
       products: [Products.Transactions, Products.Investments],
       country_codes: [CountryCode.Us],
       language: 'en',
@@ -46,7 +86,7 @@ export async function POST() {
       link_token: createTokenResponse.data.link_token,
       expiration: createTokenResponse.data.expiration 
     });
-  } catch (error: any) {
+  } catch (error: unknown) {
     console.error('Error creating link token:', summarizePlaidError(error));
     return failClosedResponse('api/plaid/link-token POST', 'Failed to create link token', error);
   }

--- a/src/app/api/plaid/reconnect-complete/route.ts
+++ b/src/app/api/plaid/reconnect-complete/route.ts
@@ -1,0 +1,58 @@
+import { requireTabAccess } from '@/lib/auth-helpers';
+import { NextResponse } from 'next/server';
+import { failClosedResponse } from '@/lib/http/failClosedResponse';
+import { prisma } from '@/lib/prisma';
+import { plaidClient } from '@/lib/plaid';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { summarizePlaidError } from '@/lib/plaid/summarizeError';
+import { decryptToken } from '@/lib/secrets/tokenCipher';
+import { RateLimitError, rateLimit } from '@/lib/rateLimit';
+import { ownedItemOr404, rateLimitedEnvelope, reconcileItemHealth, reconnectEnvelope } from '@/lib/plaid/reconnect';
+
+/**
+ * POST /api/plaid/reconnect-complete { itemId }
+ * BANK-01: after Plaid Link's onSuccess in UPDATE MODE. The item keeps its id
+ * and its access token, so there is NO public-token exchange here — the only
+ * question is whether the item is healthy now: /item/get with the stored token
+ * (decrypted server-side, SEC-02). Healthy → last_error_* cleared, 200; still
+ * erroring → recorded again, 409. Both answers are the HYG-01 envelope and name
+ * the institution, never the Plaid item id or a token. User-scoped; a foreign
+ * or unknown id is a 404. Rate-limited per user.
+ */
+export async function POST(request: Request) {
+  try {
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const user = await prisma.users.findUnique({ where: { email: userEmail } });
+    if (!user) {
+      return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    }
+
+    const tierGate = await requireTabAccess(user.id, 'tab:books');
+    if (tierGate) return tierGate;
+
+    try {
+      await rateLimit(`plaid-reconnect:${user.id}`, { limit: 10, windowSeconds: 60 });
+    } catch (limited) {
+      if (limited instanceof RateLimitError) {
+        const { status, body, retryAfterSeconds } = rateLimitedEnvelope('reconnect', limited);
+        return NextResponse.json(body, { status, headers: { 'Retry-After': String(retryAfterSeconds) } });
+      }
+      throw limited;
+    }
+
+    const body = (await request.json().catch(() => ({}))) as { itemId?: unknown };
+    const item = await ownedItemOr404(prisma, user.id, body.itemId);
+
+    const got = await plaidClient.itemGet({ access_token: decryptToken(item.accessToken) });
+    const health = await reconcileItemHealth(prisma, item, got.data.item);
+    const { status, body: envelope } = reconnectEnvelope(item.institutionName, health);
+    return NextResponse.json(envelope, { status });
+  } catch (error: unknown) {
+    console.error('Reconnect complete error:', summarizePlaidError(error));
+    return failClosedResponse('api/plaid/reconnect-complete POST', 'Failed to confirm the reconnection', error);
+  }
+}

--- a/src/app/api/transactions/sync-complete/route.ts
+++ b/src/app/api/transactions/sync-complete/route.ts
@@ -5,6 +5,8 @@ import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { requireTabAccess } from '@/lib/auth-helpers';
 import { decryptToken } from '@/lib/secrets/tokenCipher';
 import { failureEnvelope, stageFailed, stageOk, syncEnvelope, type StageFailed } from '@/lib/plaid/failLoud';
+import { summarizePlaidError } from '@/lib/plaid/summarizeError';
+import { clearItemError, isItemError, itemFailure, recordItemError } from '@/lib/plaid/reconnect';
 import { wireOf } from '@/lib/plaid/wire';
 import { prismaLanding } from '@/lib/arrivals/prismaLanding';
 import { recordFailedAnswer, runTransactionsPage, type DomainDb } from '@/lib/arrivals/plaidTransactionsPage';
@@ -50,6 +52,19 @@ export async function POST() {
     // the outcome is declared in the response (200 / 207 / non-2xx), never hidden.
     let transactionsFailure: StageFailed | null = null;
     let investmentsFailure: StageFailed | null = null;
+
+    // BANK-01: a Plaid ITEM_ERROR (ITEM_LOGIN_REQUIRED and its kin) is the ITEM's state, not
+    // a one-off fault — record its code on the item (user-scoped) and name the INSTITUTION in
+    // the declared failure; never the Plaid item id, never a token. Any other error is
+    // declared as before.
+    const declareStageFailure = async (stage: string, error: unknown, item: { id: string; institutionName: string | null }): Promise<StageFailed> => {
+      const summary = summarizePlaidError(error);
+      if (isItemError(summary)) {
+        await recordItemError(prisma, { itemRowId: item.id, userId: user.id, code: summary.error_code ?? 'ITEM_ERROR', at: new Date() });
+        return itemFailure(stage, item.institutionName, error);
+      }
+      return stageFailed(stage, error);
+    };
 
     for (const item of plaidItems) {
       console.log(`Syncing ${item.institutionName || 'Bank'}...`);
@@ -154,8 +169,12 @@ export async function POST() {
               console.log(`Synced ${response.data.total_transactions} transactions for ${item.institutionName} (${skippedTransactions} skipped — already complete)`);
             }
           }
+          // BANK-01: the item answered — a recorded ITEM_ERROR is over.
+          if (item.last_error_code !== null) {
+            await clearItemError(prisma, { itemRowId: item.id, userId: user.id });
+          }
         } catch (error) {
-          transactionsFailure = stageFailed('transactions', error);
+          transactionsFailure = await declareStageFailure('transactions', error, item);
           console.error('Transactions stage failed:', transactionsFailure.error);
         }
       }
@@ -261,7 +280,7 @@ export async function POST() {
             hasMore = investResponse.data.total_investment_transactions > offset;
           }
         } catch (error) {
-          investmentsFailure = stageFailed('investments', error);
+          investmentsFailure = await declareStageFailure('investments', error, item);
           console.error('Investments stage failed:', investmentsFailure.error);
         }
       }

--- a/src/components/home/BooksPipeline.tsx
+++ b/src/components/home/BooksPipeline.tsx
@@ -26,6 +26,9 @@ import StageStrip, { type StagePhase } from '@/components/ui/StageStrip';
 // construction. Keys, derived states, the handler, and the 13-stage →
 // 6-phase nesting map stay HERE (the config carries phase data only).
 import { PIPE_PHASES } from '@/lib/pipePhases';
+// BANK-01: the HYG-01 envelope reader — the Reconnect flow reads link-token /
+// reconnect-complete answers exactly as the Sync button reads sync-complete.
+import { readSyncOutcome } from '@/lib/plaid/failLoud';
 
 const [PIPE_FEED, PIPE_CODE, PIPE_RECONCILE, PIPE_CLOSE, PIPE_REPORTS, PIPE_EXPORT] = PIPE_PHASES.books;
 import SectionHeader from '@/components/ui/SectionHeader';
@@ -160,6 +163,8 @@ export default function BooksPipeline() {
           id: a.id, name: a.name, mask: a.mask, type: a.type,
           balance: a.balance || 0, institutionName: item.institutionName || 'Unknown',
           entityType: a.entityType || null,
+          // BANK-01: the item this account rides on, and its recorded Plaid error (null when healthy).
+          itemId: item.id, lastErrorCode: item.lastErrorCode ?? null,
         });
       });
     });
@@ -180,6 +185,48 @@ export default function BooksPipeline() {
     const def = entities.find((e: Row) => e.is_default) || entities[0];
     setEntityId(def?.id ?? null);
   }, []);
+
+  // BANK-01: Reconnect a bank — Plaid Link in UPDATE MODE for the existing item. The
+  // server mints the update-mode token from the stored (encrypted) access token; the
+  // browser sees the link token only. After Link's onSuccess there is NO public-token
+  // exchange — reconnect-complete asks /item/get whether the item is healthy and answers
+  // with the HYG-01 envelope, which renders inline (fail-loud, never swallowed).
+  const [reconnectNote, setReconnectNote] = useState<{ itemId: string; text: string; tone: 'ok' | 'error' } | null>(null);
+  const [reconnecting, setReconnecting] = useState<string | null>(null);
+  const reconnectItem = async (itemId: string) => {
+    const plaid = (window as unknown as { Plaid?: { create: (cfg: Record<string, unknown>) => { open(): void } } }).Plaid;
+    if (!plaid) {
+      setReconnectNote({ itemId, text: 'Plaid Link has not loaded yet — try again in a moment.', tone: 'error' });
+      return;
+    }
+    setReconnecting(itemId);
+    setReconnectNote(null);
+    try {
+      const res = await fetch('/api/plaid/link-token', {
+        method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ itemId }),
+      });
+      if (!res.ok) {
+        const out = await readSyncOutcome(res);
+        setReconnectNote({ itemId, text: out.text, tone: 'error' });
+        return;
+      }
+      const { link_token: token } = (await res.json()) as { link_token: string };
+      plaid.create({
+        token,
+        onSuccess: async () => {
+          const done = await fetch('/api/plaid/reconnect-complete', {
+            method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ itemId }),
+          });
+          const out = await readSyncOutcome(done);
+          setReconnectNote({ itemId, text: out.text, tone: out.tone === 'ok' ? 'ok' : 'error' });
+          await reloadAll();
+        },
+        onExit: () => { setReconnecting(null); },
+      }).open();
+    } finally {
+      setReconnecting(null);
+    }
+  };
 
   const reloadAll = useCallback(async () => {
     setState('loading');
@@ -341,8 +388,35 @@ export default function BooksPipeline() {
                     : et === 'trading' ? 'bg-green-100 text-green-700'
                     : 'bg-orange-100 text-orange-700';
                   return (
-                    <tr key={acc.id} className={'hover:bg-brand-purple-wash/40'}>
-                      <td className={'px-3 py-2 font-medium text-text-primary'}>{acc.institutionName}</td>
+                    <tr key={acc.id} className={'hover:bg-brand-purple-wash/40'} data-item-error={acc.lastErrorCode ?? undefined}>
+                      <td className={'px-3 py-2 font-medium text-text-primary'}>
+                        {acc.institutionName}
+                        {/* BANK-01: only a row whose item carries a recorded Plaid error offers Reconnect.
+                            The outcome line stays on the row after the refetch — a reconnected item
+                            loses the button, not the "reconnected" answer. */}
+                        {(acc.lastErrorCode || (reconnectNote && reconnectNote.itemId === acc.itemId)) && (
+                          <div className="mt-1 flex flex-wrap items-center gap-2">
+                            {acc.lastErrorCode && (
+                              <>
+                                <span className="font-mono text-[10px] uppercase tracking-wider text-rose-700">needs reconnecting · {acc.lastErrorCode}</span>
+                                <button
+                                  type="button"
+                                  onClick={() => reconnectItem(acc.itemId)}
+                                  disabled={reconnecting === acc.itemId}
+                                  className="rounded border border-brand-purple px-2 py-0.5 font-mono text-[10px] uppercase tracking-wider text-brand-purple hover:bg-brand-purple-wash disabled:opacity-60"
+                                >
+                                  {reconnecting === acc.itemId ? 'Opening…' : 'Reconnect'}
+                                </button>
+                              </>
+                            )}
+                            {reconnectNote && reconnectNote.itemId === acc.itemId && (
+                              <span role={reconnectNote.tone === 'ok' ? 'status' : 'alert'} className={`text-[10px] ${reconnectNote.tone === 'ok' ? 'text-emerald-700' : 'text-rose-700'}`}>
+                                {reconnectNote.text}
+                              </span>
+                            )}
+                          </div>
+                        )}
+                      </td>
                       <td className={'px-3 py-2 text-text-secondary font-mono'}>{'••••'} {acc.mask || '----'}</td>
                       <td className="px-3 py-2"><span className={'px-2 py-0.5 bg-bg-row text-text-secondary text-[10px] uppercase'}>{acc.type}</span></td>
                       <td className="px-3 py-2">

--- a/src/lib/__tests__/plaidReconnect.test.ts
+++ b/src/lib/__tests__/plaidReconnect.test.ts
@@ -1,0 +1,241 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  bankName,
+  clearItemError,
+  isItemError,
+  itemFailure,
+  ownedItemOr404,
+  rateLimitedEnvelope,
+  recordItemError,
+  reconcileItemHealth,
+  reconnectEnvelope,
+  updateModeLinkRequest,
+  type ItemDb,
+  type OwnedItem,
+} from '../plaid/reconnect';
+import { stageOk, syncEnvelope } from '../plaid/failLoud';
+import { failClosed } from '../http/failClosed';
+import { ValidationError } from '../errors/ValidationError';
+import type { RateLimitError } from '../rateLimit';
+
+// BANK-01 — reconnect a bank (Plaid Link update mode), and name the bank in the failure.
+
+// Secrets and identifiers that must never reach a response body.
+const ITEM_ROW_ID = 'ckitemrow0001';
+const PLAID_ITEM_ID = 'plaid-item-9Xy';
+const CIPHERTEXT = 'v1:ciphertext-of-the-access-token';
+const ACCESS_TOKEN = 'access-sandbox-1234-secret';
+const PLAID_SECRET = 'plaid-secret-abcdef';
+const LEAKS = [ITEM_ROW_ID, PLAID_ITEM_ID, CIPHERTEXT, ACCESS_TOKEN, PLAID_SECRET, 'PLAID-SECRET'];
+
+function assertLeaksNothing(body: unknown, label: string) {
+  const text = JSON.stringify(body);
+  for (const secret of LEAKS) assert.ok(!text.includes(secret), `${label} leaks ${secret}`);
+}
+
+/** An axios 0.21 error the way plaid 11 throws it: the whole request rides on `config`. */
+function plaidItemLoginRequired(): Error {
+  return Object.assign(new Error('Request failed with status code 400'), {
+    config: {
+      headers: { 'PLAID-CLIENT-ID': 'client', 'PLAID-SECRET': PLAID_SECRET },
+      data: JSON.stringify({ access_token: ACCESS_TOKEN, item_id: PLAID_ITEM_ID }),
+    },
+    response: {
+      status: 400,
+      data: {
+        error_type: 'ITEM_ERROR',
+        error_code: 'ITEM_LOGIN_REQUIRED',
+        error_message: "the login details of this item have changed (credentials, MFA, or required user action) and a user login is required to update this information. use Link's update mode to restore the item to a good state",
+        request_id: 'req-item-1',
+        item_id: PLAID_ITEM_ID,
+      },
+    },
+  });
+}
+
+const OWNER = 'user-a';
+const STRANGER = 'user-b';
+
+function ownedItem(overrides: Partial<OwnedItem> = {}): OwnedItem {
+  return {
+    id: ITEM_ROW_ID,
+    userId: OWNER,
+    itemId: PLAID_ITEM_ID,
+    accessToken: CIPHERTEXT,
+    institutionName: 'Wells Fargo',
+    last_error_code: 'ITEM_LOGIN_REQUIRED',
+    last_error_at: new Date('2026-09-01T00:00:00Z'),
+    ...overrides,
+  };
+}
+
+type UpdateCall = { where: { id: string; userId: string }; data: { last_error_code: string | null; last_error_at: Date | null } };
+
+/** A fake plaid_items table holding ONE row owned by user-a; every lookup must carry (id, userId). */
+function fakeDb(row: OwnedItem | null = ownedItem()) {
+  const finds: { id: string; userId: string }[] = [];
+  const updates: UpdateCall[] = [];
+  const db: ItemDb = {
+    plaid_items: {
+      async findFirst({ where }) {
+        finds.push(where);
+        return row && row.id === where.id && row.userId === where.userId ? row : null;
+      },
+      async updateMany(args) {
+        updates.push(args);
+        return { count: row && row.id === args.where.id && row.userId === args.where.userId ? 1 : 0 };
+      },
+    },
+  };
+  return { db, finds, updates };
+}
+
+test('(a) the envelope names the institution and carries no item id and no token', () => {
+  const err = plaidItemLoginRequired();
+  assert.equal(isItemError({ error_type: 'ITEM_ERROR', error_code: 'ITEM_LOGIN_REQUIRED' }), true);
+  assert.equal(isItemError({ error_type: 'RATE_LIMIT_EXCEEDED', error_code: 'TRANSACTIONS_LIMIT' }), false);
+
+  const failure = itemFailure('transactions', 'Wells Fargo', err);
+  assert.equal(failure.ok, false);
+  assert.equal(failure.stage, 'transactions');
+  assert.equal(failure.message, 'Wells Fargo needs to be reconnected (Plaid: ITEM_LOGIN_REQUIRED)');
+  assert.equal(failure.error.error_type, 'ITEM_ERROR');
+  assert.equal(failure.error.error_code, 'ITEM_LOGIN_REQUIRED');
+  assert.equal(failure.error.status, 400);
+  assert.equal('page' in failure, false);
+  assertLeaksNothing(failure, 'the stage failure');
+
+  // Through the HYG-01 sync envelope — the shape sync-complete actually returns.
+  const partial = syncEnvelope([failure, stageOk('investments', { securities: 3 })], { synced: 0 });
+  assert.equal(partial.status, 207);
+  assert.equal(partial.body.message, 'Partial sync — transactions: Wells Fargo needs to be reconnected (Plaid: ITEM_LOGIN_REQUIRED) · investments: ok (3 securities)');
+  assertLeaksNothing(partial.body, 'the 207 envelope');
+
+  const whole = syncEnvelope([failure]);
+  assert.equal(whole.status, 502, 'a 400 from Plaid is an upstream failure, declared as 502');
+  assert.equal(whole.body.message, 'Sync failed — transactions: Wells Fargo needs to be reconnected (Plaid: ITEM_LOGIN_REQUIRED)');
+  assertLeaksNothing(whole.body, 'the 502 envelope');
+
+  // The bank the user knows, never an id; an item stored without a name reads as a bank, not as 'Unknown'.
+  assert.equal(bankName(null), 'A linked bank');
+  assert.equal(bankName(undefined), 'A linked bank');
+  assert.equal(bankName('Unknown'), 'A linked bank');
+  assert.equal(bankName('  Chase '), 'Chase');
+  assert.equal(itemFailure('investments', 'Unknown', err, 2).message, 'A linked bank needs to be reconnected (Plaid: ITEM_LOGIN_REQUIRED)');
+  assert.equal(itemFailure('investments', 'Unknown', err, 2).page, 2);
+});
+
+test("(b) link-token with another user's itemId is a 404 envelope that confirms nothing", async () => {
+  const { db, finds } = fakeDb();
+
+  // The owner gets the row; the query carried both the id and the caller.
+  const mine = await ownedItemOr404(db, OWNER, ITEM_ROW_ID);
+  assert.equal(mine.accessToken, CIPHERTEXT, 'the ciphertext, to be decrypted at the point of use only');
+  assert.deepEqual(finds.at(-1), { id: ITEM_ROW_ID, userId: OWNER });
+
+  // A stranger naming the same row: the same query, user-scoped, finds nothing → ValidationError 404.
+  await assert.rejects(ownedItemOr404(db, STRANGER, ITEM_ROW_ID), (e: unknown) => {
+    assert.ok(e instanceof ValidationError);
+    assert.equal(e.status, 404);
+    assert.equal(e.message, 'Bank connection not found');
+    assert.equal(e.field, 'itemId');
+    return true;
+  });
+  assert.deepEqual(finds.at(-1), { id: ITEM_ROW_ID, userId: STRANGER }, 'the lookup is WHERE id AND userId — never id alone');
+
+  // What the route's catch-all turns that into: the guidance verbatim at 404, nothing about the row.
+  let caught: unknown;
+  try {
+    await ownedItemOr404(db, STRANGER, ITEM_ROW_ID);
+  } catch (e) {
+    caught = e;
+  }
+  const out = failClosed('api/plaid/link-token POST', 'Failed to create link token', caught);
+  assert.equal(out.status, 404);
+  assert.deepEqual(out.body, { ok: false, stage: 'api/plaid/link-token POST', error: 'Bank connection not found', message: 'Bank connection not found', field: 'itemId' });
+  assertLeaksNothing(out.body, 'the 404 envelope');
+
+  // An unknown id for the owner is the SAME answer as a foreign id — a 404 confirms nothing.
+  await assert.rejects(ownedItemOr404(db, OWNER, 'ckdoesnotexist'), (e: unknown) => e instanceof ValidationError && e.status === 404 && e.message === 'Bank connection not found');
+
+  // No itemId at all is a 400, not a lookup.
+  const before = finds.length;
+  await assert.rejects(ownedItemOr404(db, OWNER, undefined), (e: unknown) => e instanceof ValidationError && e.status === 400 && e.message === 'itemId is required');
+  await assert.rejects(ownedItemOr404(db, OWNER, '   '), (e: unknown) => e instanceof ValidationError && e.status === 400);
+  await assert.rejects(ownedItemOr404(db, OWNER, 42), (e: unknown) => e instanceof ValidationError && e.status === 400);
+  assert.equal(finds.length, before, 'a missing id never reaches the table');
+
+  // Update mode: the existing item's access token, no products, no history request.
+  const req = updateModeLinkRequest({ userId: OWNER, clientName: 'Temple Stuart, LLC', accessToken: ACCESS_TOKEN });
+  assert.equal(req.access_token, ACCESS_TOKEN);
+  assert.equal(req.user.client_user_id, OWNER);
+  assert.equal(req.client_name, 'Temple Stuart, LLC');
+  assert.equal('products' in req, false);
+  assert.equal('transactions' in req, false);
+});
+
+test('(c) reconnect-complete leaves last_error_* null only when /item/get reports no error', async () => {
+  const now = new Date('2026-09-03T15:00:00Z');
+
+  // Healthy: the item answered with error null → the recorded error is cleared, user-scoped.
+  {
+    const { db, updates } = fakeDb();
+    const health = await reconcileItemHealth(db, ownedItem(), { error: null }, now);
+    assert.deepEqual(health, { healthy: true });
+    assert.equal(updates.length, 1);
+    assert.deepEqual(updates[0], { where: { id: ITEM_ROW_ID, userId: OWNER }, data: { last_error_code: null, last_error_at: null } });
+    const env = reconnectEnvelope('Wells Fargo', health);
+    assert.equal(env.status, 200);
+    assert.deepEqual(env.body, { ok: true, stage: 'reconnect', message: 'Wells Fargo reconnected' });
+  }
+
+  // Still erroring: /item/get carries the error → recorded again (code + when), nothing cleared, 409.
+  {
+    const { db, updates } = fakeDb();
+    const health = await reconcileItemHealth(
+      db,
+      ownedItem(),
+      { error: { error_type: 'ITEM_ERROR', error_code: 'ITEM_LOGIN_REQUIRED', error_message: 'still needs a login', request_id: 'req-item-2' } },
+      now,
+    );
+    assert.equal(health.healthy, false);
+    assert.equal(updates.length, 1);
+    assert.deepEqual(updates[0], { where: { id: ITEM_ROW_ID, userId: OWNER }, data: { last_error_code: 'ITEM_LOGIN_REQUIRED', last_error_at: now } });
+    const env = reconnectEnvelope('Wells Fargo', health);
+    assert.equal(env.status, 409);
+    assert.equal(env.body.ok, false);
+    assert.equal(env.body.stage, 'reconnect');
+    assert.equal(env.body.message, 'Wells Fargo still needs to be reconnected (Plaid: ITEM_LOGIN_REQUIRED)');
+    assert.deepEqual(env.body.error, { error_type: 'ITEM_ERROR', error_code: 'ITEM_LOGIN_REQUIRED', error_message: 'still needs a login', request_id: 'req-item-2' });
+    assertLeaksNothing(env.body, 'the 409 envelope');
+  }
+
+  // A different item error (ITEM_LOCKED) is recorded as itself — the code is Plaid's, not a constant.
+  {
+    const { db, updates } = fakeDb();
+    const health = await reconcileItemHealth(db, ownedItem(), { error: { error_type: 'ITEM_ERROR', error_code: 'ITEM_LOCKED', error_message: 'locked' } }, now);
+    assert.equal(health.healthy, false);
+    assert.equal(updates[0].data.last_error_code, 'ITEM_LOCKED');
+    assert.equal(reconnectEnvelope(null, health).body.message, 'A linked bank still needs to be reconnected (Plaid: ITEM_LOCKED)');
+  }
+
+  // The two writers sync-complete uses: both address the row by (id, userId).
+  {
+    const { db, updates } = fakeDb();
+    await recordItemError(db, { itemRowId: ITEM_ROW_ID, userId: OWNER, code: 'ITEM_LOGIN_REQUIRED', at: now });
+    await clearItemError(db, { itemRowId: ITEM_ROW_ID, userId: OWNER });
+    assert.deepEqual(updates.map(u => u.where), [{ id: ITEM_ROW_ID, userId: OWNER }, { id: ITEM_ROW_ID, userId: OWNER }]);
+    assert.deepEqual(updates.map(u => u.data.last_error_code), ['ITEM_LOGIN_REQUIRED', null]);
+  }
+});
+
+test('a rate-limited Plaid route answers 429 with the envelope and a Retry-After', () => {
+  const limited = Object.assign(new Error('Rate limit exceeded for plaid-link-token:user-a — 11/10 in window'), {
+    name: 'RateLimitError', key: 'plaid-link-token:user-a', count: 11, limit: 10, retryAfterSeconds: 42,
+  }) as RateLimitError;
+  const out = rateLimitedEnvelope('link-token', limited);
+  assert.equal(out.status, 429);
+  assert.equal(out.retryAfterSeconds, 42);
+  assert.deepEqual(out.body, { ok: false, stage: 'link-token', error: 'Too many link-token requests — try again in 42s', message: 'Too many link-token requests — try again in 42s' });
+});

--- a/src/lib/plaid/reconnect.ts
+++ b/src/lib/plaid/reconnect.ts
@@ -1,0 +1,124 @@
+/**
+ * BANK-01 — reconnect a bank (Plaid Link update mode), and name the bank in
+ * the failure.
+ *
+ * A Plaid Item that falls into ITEM_LOGIN_REQUIRED (or any ITEM_ERROR) is
+ * restored with a link token created FOR THE EXISTING ITEM — `access_token`
+ * on /link/token/create (node_modules/plaid/dist/api.d.ts:14596: "Used when
+ * launching Link in update mode") — after which Link's onSuccess public_token
+ * is NOT exchanged: the Item keeps its id and its access token. /item/get
+ * (ItemGetResponse.item.error, api.d.ts:13046) says whether it is healthy.
+ *
+ * Security-first: the access token is decrypted server-side only (SEC-02) and
+ * used to mint the link token; the browser sees the link token and nothing
+ * else. Every lookup is user-scoped; a foreign or unknown item is a defensive
+ * 404. Messages name the INSTITUTION — never the Plaid item id, never a token.
+ *
+ * Pure over two small ports (the item rows; the Plaid answer) so node:test
+ * drives it with fakes; the routes bind Prisma and the Plaid client.
+ */
+import { CountryCode, type LinkTokenCreateRequest } from 'plaid';
+import { ValidationError } from '@/lib/errors/ValidationError';
+import type { RateLimitError } from '@/lib/rateLimit';
+import { summarizePlaidError, type PlaidErrorSummary } from './summarizeError';
+import type { Envelope, StageFailed } from './failLoud';
+
+export interface OwnedItem {
+  id: string;
+  userId: string;
+  itemId: string;
+  /** SEC-02 ciphertext — decrypt only at the point of use. */
+  accessToken: string;
+  institutionName: string | null;
+  last_error_code: string | null;
+  last_error_at: Date | null;
+}
+
+/** The port: the plaid_items rows, always addressed by (id, userId). */
+export interface ItemDb {
+  plaid_items: {
+    findFirst(args: { where: { id: string; userId: string } }): Promise<OwnedItem | null>;
+    updateMany(args: { where: { id: string; userId: string }; data: { last_error_code: string | null; last_error_at: Date | null } }): Promise<unknown>;
+  };
+}
+
+/** Plaid's error_type for anything wrong with the Item itself (ITEM_LOGIN_REQUIRED, ITEM_LOCKED, …). */
+export const ITEM_ERROR = 'ITEM_ERROR';
+
+export function isItemError(summary: PlaidErrorSummary): boolean {
+  return summary.error_type === ITEM_ERROR;
+}
+
+/** The name the user knows — never an id. An item stored without a name (exchange-token's 'Unknown') reads as "A linked bank". */
+export function bankName(institution: string | null | undefined): string {
+  const name = institution?.trim();
+  return name && name !== 'Unknown' ? name : 'A linked bank';
+}
+
+/** The stage failure for an Item error: the institution named, the code declared, nothing internal. */
+export function itemFailure(stage: string, institution: string | null | undefined, err: unknown, page?: number): StageFailed {
+  const error = summarizePlaidError(err);
+  const code = error.error_code ?? error.error_type ?? ITEM_ERROR;
+  return { stage, ok: false, error, message: `${bankName(institution)} needs to be reconnected (Plaid: ${code})`, ...(page === undefined ? {} : { page }) };
+}
+
+export async function recordItemError(db: ItemDb, input: { itemRowId: string; userId: string; code: string; at: Date }): Promise<void> {
+  await db.plaid_items.updateMany({ where: { id: input.itemRowId, userId: input.userId }, data: { last_error_code: input.code, last_error_at: input.at } });
+}
+
+export async function clearItemError(db: ItemDb, input: { itemRowId: string; userId: string }): Promise<void> {
+  await db.plaid_items.updateMany({ where: { id: input.itemRowId, userId: input.userId }, data: { last_error_code: null, last_error_at: null } });
+}
+
+/** The user's own item, or a defensive 404 (never confirms a foreign item exists). */
+export async function ownedItemOr404(db: ItemDb, userId: string, itemRowId: unknown): Promise<OwnedItem> {
+  if (typeof itemRowId !== 'string' || itemRowId.trim() === '') throw new ValidationError('itemId is required', { field: 'itemId' });
+  const item = await db.plaid_items.findFirst({ where: { id: itemRowId, userId } });
+  if (!item) throw new ValidationError('Bank connection not found', { status: 404, field: 'itemId' });
+  return item;
+}
+
+/** Link update mode: the existing item's access token, no products (Plaid: products are not set in update mode unless adding one). */
+export function updateModeLinkRequest(input: { userId: string; clientName: string; accessToken: string }): LinkTokenCreateRequest {
+  return {
+    user: { client_user_id: input.userId },
+    client_name: input.clientName,
+    country_codes: [CountryCode.Us],
+    language: 'en',
+    access_token: input.accessToken,
+  };
+}
+
+/** What /item/get says about the Item — the SDK's `PlaidError | null` on `item.error`. */
+export interface ItemGetItem {
+  error: { error_type: string; error_code: string; error_message: string; request_id?: string } | null;
+}
+
+export type ItemHealth = { healthy: true } | { healthy: false; error: PlaidErrorSummary };
+
+/** After Link's update-mode onSuccess: healthy → clear last_error_*; still erroring → record it. Nothing else moves. */
+export async function reconcileItemHealth(db: ItemDb, item: OwnedItem, got: ItemGetItem, now: Date = new Date()): Promise<ItemHealth> {
+  if (got.error === null) {
+    await clearItemError(db, { itemRowId: item.id, userId: item.userId });
+    return { healthy: true };
+  }
+  const error: PlaidErrorSummary = { error_type: got.error.error_type, error_code: got.error.error_code, error_message: got.error.error_message, request_id: got.error.request_id };
+  await recordItemError(db, { itemRowId: item.id, userId: item.userId, code: got.error.error_code, at: now });
+  return { healthy: false, error };
+}
+
+/** The HYG-01 envelope for reconnect-complete. */
+export function reconnectEnvelope(institution: string | null | undefined, health: ItemHealth): Envelope {
+  const bank = bankName(institution);
+  if (health.healthy) return { status: 200, body: { ok: true, stage: 'reconnect', message: `${bank} reconnected` } };
+  return {
+    status: 409,
+    body: { ok: false, stage: 'reconnect', error: health.error, message: `${bank} still needs to be reconnected (Plaid: ${health.error.error_code ?? ITEM_ERROR})` },
+  };
+}
+
+/** A rate-limited Plaid route answers 429 with the envelope and Retry-After. */
+export function rateLimitedEnvelope(stage: string, err: RateLimitError): Envelope & { retryAfterSeconds: number } {
+  const message = `Too many ${stage} requests — try again in ${err.retryAfterSeconds}s`;
+  return { status: 429, retryAfterSeconds: err.retryAfterSeconds, body: { ok: false, stage, error: message, message } };
+}


### PR DESCRIPTION
**Do not merge — Alex merges after Vercel Preview (SOC 2 gate).**

**Migration-bearing PR — extra human scrutiny.** Two nullable columns on `plaid_items`; SQL below; Alex applies it via `psql` (the repo holds no `DATABASE_URL`).

## WHY

A Plaid item in `ITEM_LOGIN_REQUIRED` had no way back: the Books page offered "+ Account" and "Sync" only, and the sync failure never said which institution. Plaid's fix is **Link update mode** — a link token created for the EXISTING item — which restores it without a new item or a new access token.

## AUDIT (read-only, before building)

| # | Finding | Where |
|---|---|---|
| 1 | The Books cockpit's only Plaid affordances are the new-item token fetched on mount, Sync, and a Link flow that ends in `exchange-token` (the NEW-item path). | `src/components/home/ModuleLauncher.tsx:453` (link-token POST, no body), `:465` (sync-complete), `:483-487` (`Plaid.create` → `/api/plaid/exchange-token`) |
| 2 | The pipe's Source Accounts section lists accounts and defers linking to the cockpit — the natural home for a per-row Reconnect. | `src/components/home/BooksPipeline.tsx:61-65` |
| 3 | A sync failure was declared as `Plaid: ITEM_ERROR (ITEM_LOGIN_REQUIRED) — <plaid text>` — the code, never the bank. | `src/lib/plaid/failLoud.ts:38-52` (`describeFailure`); `sync-complete/route.ts:157` and `:264` (both catches called `stageFailed(stage, error)`) |
| 4 | Plaid's error body carries no `item_id`; the item is known from the loop the failure happens in. | `node_modules/plaid/dist/api.d.ts:19658-19706` (`PlaidError`); `sync-complete/route.ts:54` (`for (const item of plaidItems)`) |
| 5 | `plaid_items` had no place to keep an item's error state, so the page could not know which row to offer Reconnect on. | `prisma/schema.prisma` model `plaid_items` (no error columns before this PR) |
| 6 | `link-token` built only the new-item config (products, `days_requested: 730`). Update mode is the same call with `access_token` set. | `src/app/api/plaid/link-token/route.ts` (before); `api.d.ts:14596` — `LinkTokenCreateRequest.access_token`: "Used when launching Link in update mode" |
| 7 | Whether an item is healthy is `/item/get`'s `item.error: PlaidError \| null`. | `api.d.ts:13046` (`Item.error`), `:13339-13351` (`ItemGetResponse`), `:34779` (`itemGet`) |
| 8 | The access token is SEC-02 ciphertext at rest and decrypted only at the point of use. | `src/lib/secrets/tokenCipher.ts` (`decryptToken`); used by `sync-complete/route.ts` |
| 9 | **No Plaid route was rate-limited.** The repo's durable limiter was used by two routes only. | `src/lib/rateLimit.ts:57` (`rateLimit`); usages `places/category-search/route.ts:112`, `auth/register/route.ts:17` |
| 10 | `/api/accounts` is user-scoped and already exposes `plaid_items.id` as each item's `id` — the handle the client posts as `itemId`. | `src/app/api/accounts/route.ts:25-33` |
| 11 | Every `/api/plaid/*` and sync route gates `getVerifiedEmail` → user → `requireTabAccess('tab:books')` before any Plaid call. | `link-token/route.ts:27-43`, `sync-complete/route.ts:17-34` |

## BUILD

| Piece | Change |
|---|---|
| `src/app/api/transactions/sync-complete/route.ts` | `declareStageFailure(stage, error, item)`: a Plaid `ITEM_ERROR` records `last_error_code` / `last_error_at` on the item (`updateMany WHERE id AND userId`) and declares `itemFailure(...)` — **"Wells Fargo needs to be reconnected (Plaid: ITEM_LOGIN_REQUIRED)"** — never the item id, never a token. Any other error → `stageFailed` exactly as before. A clean transactions pass clears a recorded error. |
| `src/app/api/plaid/link-token/route.ts` | `POST { itemId }` → `ownedItemOr404` (`findFirst WHERE id AND userId`; foreign/unknown → `ValidationError` 404 "Bank connection not found") → `linkTokenCreate(updateModeLinkRequest(...))` with `access_token: decryptToken(item.accessToken)` — no products, no history request → `{ link_token, expiration, mode: 'update' }`. Without `itemId`: today's config, byte-for-byte. Per-user `rateLimit('plaid-link-token:<id>', 10/60s)` before any Plaid call → 429 envelope + `Retry-After`. Catch-all → `failClosedResponse`. |
| `src/app/api/plaid/reconnect-complete/route.ts` (new) | `POST { itemId }`: same gates + limiter → `ownedItemOr404` → `itemGet({ access_token: decryptToken(...) })` → `reconcileItemHealth`: `item.error === null` → clear `last_error_*`, **200 "Wells Fargo reconnected"**; else record it again, **409 "Wells Fargo still needs to be reconnected (Plaid: CODE)"**. **No `exchange-token`** — update mode keeps the item and its token. |
| `src/lib/plaid/reconnect.ts` (new) | Pure helpers over an `ItemDb` port: `isItemError`, `bankName` (`'A linked bank'` for null/`'Unknown'`), `itemFailure`, `recordItemError`, `clearItemError`, `ownedItemOr404`, `updateModeLinkRequest`, `reconcileItemHealth`, `reconnectEnvelope`, `rateLimitedEnvelope`. |
| `src/app/api/accounts/route.ts` | Each item carries `lastErrorCode` / `lastErrorAt`. |
| `src/components/home/BooksPipeline.tsx` | Rows flatten `itemId` + `lastErrorCode`. A row whose item carries an error shows **`needs reconnecting · CODE`** + **Reconnect** → `POST link-token { itemId }` → `window.Plaid.create({ token, onSuccess, onExit }).open()` → `POST reconnect-complete { itemId }` → the envelope's line inline (`role=status` / `role=alert`) → `reloadAll()`. The outcome line stays on the row after the refetch (a reconnected item loses the button, not the answer). Rows without an error render nothing new. `window.Plaid` absent → a declared line, no throw. |
| `prisma/migrations/20260903150000_plaid_items_last_error/migration.sql` + `prisma/schema.prisma` | Two nullable columns, lockstep (`prisma validate` ✓, client generated). |
| `src/lib/__tests__/plaidReconnect.test.ts` (new) | Tests (a) (b) (c) + the 429 envelope. |
| `README.md` | Regenerated by the generator (byte-stable on a second run): 290 API route files; schema line cites +3. |

### Migration SQL (verbatim — Alex runs it; this PR only authors the file)

```sql
ALTER TABLE plaid_items ADD COLUMN last_error_code text NULL;
ALTER TABLE plaid_items ADD COLUMN last_error_at timestamptz NULL;
```

Additive only; zero data rewrites. Apply with the migration file (connection from the local environment, never in the repo):

```
psql -f prisma/migrations/20260903150000_plaid_items_last_error/migration.sql
```

`prisma/schema.prisma` gains `last_error_code String?` and `last_error_at DateTime? @db.Timestamptz(6)` on `plaid_items` in the same commit.

## SECURITY (HARD GATE items, reported)

- **Auth:** both Plaid routes gate `getVerifiedEmail` → `prisma.users.findUnique` → `requireTabAccess('tab:books')` → limiter **before** any Plaid call (401/403/429 spend no Plaid token).
- **User scoping:** every item read/write is `WHERE id AND userId`; a foreign or unknown id is a **defensive 404** (`Bank connection not found`), the same answer for both, and the tests prove the fake table was queried with both keys.
- **Secrets:** the access token is decrypted server-side only and appears in the Plaid request only; the browser receives `link_token` / `expiration` / `mode`. Envelopes carry `institutionName` and Plaid's `error_code`; test (a) asserts the serialized bodies contain no item row id, Plaid item id, ciphertext, access token, or `PLAID-SECRET`.
- **Cost:** rate limit 10 / 60 s per user per route via the durable `rate_limit_hits` limiter — the first Plaid routes in the repo to carry one.
- **No new fallbacks:** `ITEM_ERROR` is recorded, not swallowed; a non-item error is declared as before; `window.Plaid` missing is a declared line.

## VERIFY

| Check | Result |
|---|---|
| `npx tsc --noEmit` | exit 0 |
| eslint on the 7 touched/new files | 0 new — `reconnect.ts`, `plaidReconnect.test.ts`, `link-token`, `reconnect-complete`, `BooksPipeline.tsx` at 0; `link-token` went 1 → 0. Pre-existing, unchanged: `sync-complete/route.ts:211` `no-explicit-any` (1, on main), `accounts/route.ts:6` unused `request` warning (1, on main). |
| `npm test` | **82 / 82 pass** (78 before + 4 new) |
| asserts + `next build` | showroom ✓ · tool registry 25/25 ✓ · reachability 60 pages ✓ · answers law ✓ · arrivals law 27 providers / 26 columns ✓ · **BUILD EXIT 0** |
| `npx prisma validate` | valid; client generated |
| README generator | regenerated; second run byte-identical |

### Tests (node:test)

```
ok 1 - (a) the envelope names the institution and carries no item id and no token
ok 2 - (b) link-token with another user's itemId is a 404 envelope that confirms nothing
ok 3 - (c) reconnect-complete leaves last_error_* null only when /item/get reports no error
ok 4 - a rate-limited Plaid route answers 429 with the envelope and a Retry-After
```

(a) `itemFailure('transactions', 'Wells Fargo', <axios ITEM_LOGIN_REQUIRED error carrying PLAID-SECRET + access_token on config>)` → message `Wells Fargo needs to be reconnected (Plaid: ITEM_LOGIN_REQUIRED)`; through `syncEnvelope` → 207 `Partial sync — transactions: Wells Fargo needs to be reconnected (Plaid: ITEM_LOGIN_REQUIRED) · investments: ok (3 securities)` and 502 when it is the only stage; no secret string in either body; `bankName` null/`'Unknown'` → `A linked bank`.
(b) owner's lookup returns the row (query `{ id, userId: 'user-a' }`); stranger's → `ValidationError` 404 (query `{ id, userId: 'user-b' }`); `failClosed(...)` → `{ status: 404, body: { ok:false, stage, error:'Bank connection not found', message:'Bank connection not found', field:'itemId' } }`; unknown id for the owner → the same 404; missing/blank/non-string `itemId` → 400 without touching the table; `updateModeLinkRequest` carries `access_token` and no `products`.
(c) `error: null` → exactly one `updateMany` `{ last_error_code: null, last_error_at: null }` WHERE `{ id, userId }` → 200 `Wells Fargo reconnected`; `ITEM_LOGIN_REQUIRED` → recorded with `at = now` → 409 `Wells Fargo still needs to be reconnected (Plaid: ITEM_LOGIN_REQUIRED)`; `ITEM_LOCKED` is recorded as `ITEM_LOCKED`.

### Screenshot (in the session report)

`/books` under `next dev` with every API answer mocked at the network layer (no DB, no Plaid; a fake `window.Plaid` that records `create()` and fires `onSuccess`):

- **Before:** the two Wells Fargo rows (`data-item-error="ITEM_LOGIN_REQUIRED"`) show `needs reconnecting · ITEM_LOGIN_REQUIRED` + **Reconnect**; the Chase row shows nothing new.
- **Click Reconnect:** the client posted `{"itemId":"item-wf-1"}` to `/api/plaid/link-token`; `Plaid.create` received `link-sandbox-mock-update-token` with keys `onExit, onSuccess, token`; `onSuccess` posted `{"itemId":"item-wf-1"}` to `/api/plaid/reconnect-complete`; **`/api/plaid/exchange-token` was never called.**
- **After:** the button is gone and `Wells Fargo reconnected` (`role=status`) stays on both rows; Chase unchanged.

## Notes

- Not in this PR: `README.md:253-254` cite `prisma/schema.prisma:2441-2443` / `:2287` for the audit-log hash fields and `retrieved_content_hash`; both cites were already stale on `main` (those lines are `citations` fields) and the generator does not own them — one concept per PR.
- Not verified here: a live Plaid update-mode round trip (no Plaid credentials in this environment). The Preview deployment is the first real `linkTokenCreate` with `access_token`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc

---
_Generated by [Claude Code](https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc)_