### PR TITLE
BANK-01b: surface Plaid Link's exit error; audit redirect_uri

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Twenty-five business tools on one data pipe that ends in one Ledger and one Calendar.
 
-Source-available (BSL 1.1) · built and operated in production by its founder as User #1 · as of 2026-09-02: 114 Prisma models, 290 API route files, 121 feeds from 20 providers (counted August 24, 2026)
+Source-available (BSL 1.1) · built and operated in production by its founder as User #1 · as of 2026-09-02: 114 Prisma models, 291 API route files, 121 feeds from 20 providers (counted August 24, 2026)
 
 ## The system
 
@@ -228,7 +228,7 @@ Versions from package.json, read 2026-09-02:
 
 Observed versus authored (step 6): what the world sends is observed; what you do is authored; the blueprint keeps the two apart and matches them on one key. Today the money feeds land parsed, without a stored payload — see the gap ledger, step 14.
 
-Scale, as of 2026-09-02: 114 Prisma models, 33 enums, 290 API route files, 37 runtime dependencies, 18 dev dependencies, one test file (`npm test`).
+Scale, as of 2026-09-02: 114 Prisma models, 33 enums, 291 API route files, 37 runtime dependencies, 18 dev dependencies, one test file (`npm test`).
 
 ## Engineering discipline
 

--- a/scripts/plaid-institutions-oauth.ts
+++ b/scripts/plaid-institutions-oauth.ts
@@ -1,0 +1,52 @@
+/**
+ * BANK-01b AUDIT — which linked institutions are OAuth.
+ *
+ * A READ: one /institutions/get_by_id per distinct stored institutionId
+ * (Institution.oauth — "Indicates that the institution has an OAuth login
+ * flow", node_modules/plaid/dist/api.d.ts:12044). No link token is created,
+ * no item call is made, no access token is selected from the database.
+ *
+ * Run locally by Alex (Claude Code cannot reach Azure Postgres or Plaid):
+ *   DATABASE_URL=… PLAID_CLIENT_ID=… PLAID_SECRET=… npx tsx scripts/plaid-institutions-oauth.ts
+ *
+ * Prints one row per plaid_items row: institution, institutionId, oauth,
+ * last_error_code. Exits 1 on any failure (fail loud, no partial table).
+ */
+import { PrismaClient } from '@prisma/client';
+import { CountryCode } from 'plaid';
+import { plaidClient } from '../src/lib/plaid';
+
+async function main() {
+  if (!process.env.DATABASE_URL) throw new Error('DATABASE_URL must be set (run locally)');
+  const prisma = new PrismaClient();
+  try {
+    const items = await prisma.plaid_items.findMany({
+      select: { id: true, userId: true, institutionId: true, institutionName: true, last_error_code: true, last_error_at: true },
+      orderBy: { createdAt: 'asc' },
+    });
+    const ids = [...new Set(items.map((i) => i.institutionId).filter((v): v is string => typeof v === 'string' && v !== '' && v !== 'unknown'))];
+    const oauthById = new Map<string, boolean>();
+    for (const institution_id of ids) {
+      const res = await plaidClient.institutionsGetById({ institution_id, country_codes: [CountryCode.Us] });
+      oauthById.set(institution_id, res.data.institution.oauth);
+    }
+    const rows = items.map((i) => ({
+      item: i.id,
+      user: i.userId,
+      institution: i.institutionName ?? '(none)',
+      institutionId: i.institutionId ?? '(none)',
+      oauth: i.institutionId && oauthById.has(i.institutionId) ? oauthById.get(i.institutionId) : '(no institutionId stored)',
+      last_error_code: i.last_error_code ?? null,
+      last_error_at: i.last_error_at?.toISOString() ?? null,
+    }));
+    console.table(rows);
+    console.log(`${items.length} items · ${ids.length} distinct institutions read · ${rows.filter((r) => r.oauth === true).length} OAuth`);
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+main().catch((err) => {
+  console.error('plaid-institutions-oauth failed:', err instanceof Error ? err.message : err);
+  process.exit(1);
+});

--- a/src/app/api/plaid/link-exit/route.ts
+++ b/src/app/api/plaid/link-exit/route.ts
@@ -1,0 +1,55 @@
+import { requireTabAccess } from '@/lib/auth-helpers';
+import { NextResponse } from 'next/server';
+import { failClosedResponse } from '@/lib/http/failClosedResponse';
+import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { ownedItemOr404 } from '@/lib/plaid/reconnect';
+import { summarizeLinkExit } from '@/lib/plaid/linkExit';
+
+/**
+ * POST /api/plaid/link-exit { itemId?, error_code, error_type, error_message,
+ *                            link_session_id?, request_id?, status? }
+ * BANK-01b: Plaid Link's onExit error, as the browser saw it, written to the
+ * server log so Vercel Logs carry the reason ("Something went wrong" has a
+ * code and a request_id here). User-scoped: the caller must own `itemId`
+ * when one is given (a foreign or unknown id is a 404), and the institution
+ * comes from the owned row, not from the body. Only the named fields are
+ * read (length-capped); no token is ever in this body, and none is logged.
+ * No Plaid call, no paid call.
+ */
+export async function POST(request: Request) {
+  try {
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const user = await prisma.users.findUnique({ where: { email: userEmail } });
+    if (!user) {
+      return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    }
+
+    const tierGate = await requireTabAccess(user.id, 'tab:books');
+    if (tierGate) return tierGate;
+
+    const summary = summarizeLinkExit(await request.json().catch(() => null));
+    const item = summary.itemId === null ? null : await ownedItemOr404(prisma, user.id, summary.itemId);
+
+    console.log('[plaid/link-exit]', {
+      userId: user.id,
+      itemId: item?.id ?? null,
+      institution: item?.institutionName ?? null,
+      mode: item ? 'update' : 'new-item',
+      error_type: summary.error_type,
+      error_code: summary.error_code,
+      error_message: summary.error_message,
+      status: summary.status,
+      link_session_id: summary.link_session_id,
+      request_id: summary.request_id,
+    });
+
+    return NextResponse.json({ ok: true, stage: 'link-exit', message: 'Plaid Link exit logged' });
+  } catch (error: unknown) {
+    return failClosedResponse('api/plaid/link-exit POST', 'Failed to log the Plaid Link exit', error);
+  }
+}

--- a/src/components/home/BooksPipeline.tsx
+++ b/src/components/home/BooksPipeline.tsx
@@ -29,6 +29,8 @@ import { PIPE_PHASES } from '@/lib/pipePhases';
 // BANK-01: the HYG-01 envelope reader — the Reconnect flow reads link-token /
 // reconnect-complete answers exactly as the Sync button reads sync-complete.
 import { readSyncOutcome } from '@/lib/plaid/failLoud';
+// BANK-01b: Plaid Link's onExit is surfaced — the reason on the row, the report in the log.
+import { RECONNECT_CANCELLED, linkExitOutcome, notLoggedSuffix, postLinkExit, type LinkExitError, type LinkExitMetadata } from '@/lib/plaid/linkExit';
 
 const [PIPE_FEED, PIPE_CODE, PIPE_RECONCILE, PIPE_CLOSE, PIPE_REPORTS, PIPE_EXPORT] = PIPE_PHASES.books;
 import SectionHeader from '@/components/ui/SectionHeader';
@@ -191,7 +193,8 @@ export default function BooksPipeline() {
   // browser sees the link token only. After Link's onSuccess there is NO public-token
   // exchange — reconnect-complete asks /item/get whether the item is healthy and answers
   // with the HYG-01 envelope, which renders inline (fail-loud, never swallowed).
-  const [reconnectNote, setReconnectNote] = useState<{ itemId: string; text: string; tone: 'ok' | 'error' } | null>(null);
+  // BANK-01b: a third tone — 'note' — for a plain outcome (a cancel) that is neither ok nor an error.
+  const [reconnectNote, setReconnectNote] = useState<{ itemId: string; text: string; tone: 'ok' | 'error' | 'note' } | null>(null);
   const [reconnecting, setReconnecting] = useState<string | null>(null);
   const reconnectItem = async (itemId: string) => {
     const plaid = (window as unknown as { Plaid?: { create: (cfg: Record<string, unknown>) => { open(): void } } }).Plaid;
@@ -221,7 +224,21 @@ export default function BooksPipeline() {
           setReconnectNote({ itemId, text: out.text, tone: out.tone === 'ok' ? 'ok' : 'error' });
           await reloadAll();
         },
-        onExit: () => { setReconnecting(null); },
+        // BANK-01b: Link's exit is the only place it says why it closed. An error →
+        // the row's line ("Plaid Link: CODE — message") and the report to
+        // /api/plaid/link-exit so the log carries it; a cancel → "Reconnect cancelled".
+        onExit: async (error: LinkExitError | null, metadata: LinkExitMetadata) => {
+          setReconnecting(null);
+          const exit = linkExitOutcome(error, metadata ?? {}, RECONNECT_CANCELLED, itemId);
+          if (exit.kind === 'connected') return;
+          if (exit.kind === 'cancelled') {
+            setReconnectNote({ itemId, text: exit.note, tone: 'note' });
+            return;
+          }
+          setReconnectNote({ itemId, text: exit.note, tone: 'error' });
+          const posted = await postLinkExit(exit.report);
+          if (!posted.logged) setReconnectNote({ itemId, text: exit.note + notLoggedSuffix(posted.status), tone: 'error' });
+        },
       }).open();
     } finally {
       setReconnecting(null);
@@ -410,7 +427,7 @@ export default function BooksPipeline() {
                               </>
                             )}
                             {reconnectNote && reconnectNote.itemId === acc.itemId && (
-                              <span role={reconnectNote.tone === 'ok' ? 'status' : 'alert'} className={`text-[10px] ${reconnectNote.tone === 'ok' ? 'text-emerald-700' : 'text-rose-700'}`}>
+                              <span role={reconnectNote.tone === 'error' ? 'alert' : 'status'} className={`text-[10px] ${reconnectNote.tone === 'ok' ? 'text-emerald-700' : reconnectNote.tone === 'error' ? 'text-rose-700' : 'text-text-secondary'}`}>
                                 {reconnectNote.text}
                               </span>
                             )}

--- a/src/components/home/ModuleLauncher.tsx
+++ b/src/components/home/ModuleLauncher.tsx
@@ -65,6 +65,9 @@ import BookkeepingCockpitBar from '@/components/bookkeeping/BookkeepingCockpitBa
 // dashboard's canonical order. It owns its own data layer; the 5 BOOKS-1 drop-ins now render
 // inside it at their dashboard positions (no longer standalone here).
 import BooksPipeline from '@/components/home/BooksPipeline';
+// BANK-01b: the new-item Link's onExit is surfaced too — the reason under the cockpit
+// bar (the sync line's slot), the report to /api/plaid/link-exit for the log.
+import { LINK_CANCELLED, linkExitOutcome, notLoggedSuffix, postLinkExit, type LinkExitError, type LinkExitMetadata } from '@/lib/plaid/linkExit';
 // TAX-1: the closed-books handoff gate — shows the tax wizard only once a period is
 // closed, otherwise a "close your books first" screen that jumps to the Books tab.
 import TaxHandoffGate from '@/components/home/TaxHandoffGate';
@@ -496,7 +499,20 @@ export default function ModuleLauncher({ onRequireAuth, onTabChange }: Props) {
         });
         await loadBooksCockpit();
       },
-      onExit: () => {},
+      // BANK-01b: same wiring as the Reconnect flow — an error → the line under the
+      // cockpit bar ("Plaid Link: CODE — message") and the report to the log; a cancel →
+      // "Account link cancelled". No itemId: there is no item yet.
+      onExit: async (error: LinkExitError | null, metadata: LinkExitMetadata) => {
+        const exit = linkExitOutcome(error, metadata ?? {}, LINK_CANCELLED);
+        if (exit.kind === 'connected') return;
+        if (exit.kind === 'cancelled') {
+          setBooksSyncMessage({ tone: 'ok', text: exit.note });
+          return;
+        }
+        setBooksSyncMessage({ tone: 'error', text: exit.note });
+        const posted = await postLinkExit(exit.report);
+        if (!posted.logged) setBooksSyncMessage({ tone: 'error', text: exit.note + notLoggedSuffix(posted.status) });
+      },
     }).open();
   };
 

--- a/src/lib/__tests__/plaidLinkExit.test.ts
+++ b/src/lib/__tests__/plaidLinkExit.test.ts
@@ -1,0 +1,134 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  LINK_CANCELLED,
+  LINK_EXIT_MAX,
+  RECONNECT_CANCELLED,
+  linkExitNote,
+  linkExitOutcome,
+  linkExitReport,
+  notLoggedSuffix,
+  summarizeLinkExit,
+  type LinkExitError,
+  type LinkExitMetadata,
+} from '../plaid/linkExit';
+import { failClosed } from '../http/failClosed';
+import { ValidationError } from '../errors/ValidationError';
+
+// BANK-01b — Plaid Link's exit reaches the row and the log; the POST body carries no token.
+
+const ACCESS_TOKEN = 'access-production-1234-secret';
+const PUBLIC_TOKEN = 'public-production-5678-secret';
+const LINK_TOKEN = 'link-production-9012-secret';
+const TOKENS = [ACCESS_TOKEN, PUBLIC_TOKEN, LINK_TOKEN, 'PLAID-SECRET'];
+
+/** What Link hands onExit for "Something went wrong — Internal error occurred", with junk a test plants beside it. */
+function internalError(): LinkExitError & Record<string, unknown> {
+  return {
+    error_type: 'API_ERROR',
+    error_code: 'INTERNAL_SERVER_ERROR',
+    error_message: 'an unexpected error occurred',
+    display_message: 'Something went wrong — Internal error occurred',
+    // planted: never part of a Link error, and must never leave the browser
+    access_token: ACCESS_TOKEN,
+    link_token: LINK_TOKEN,
+  };
+}
+
+function exitMetadata(): LinkExitMetadata & Record<string, unknown> {
+  return {
+    institution: { name: 'Wells Fargo', institution_id: 'ins_127991' },
+    status: 'requires_oauth',
+    link_session_id: 'ls-abc-123',
+    request_id: 'req-link-9',
+    public_token: PUBLIC_TOKEN, // planted
+  };
+}
+
+test('an onExit error produces the row note and a report that carries no token', () => {
+  const error = internalError();
+  const metadata = exitMetadata();
+
+  assert.equal(linkExitNote(error), 'Plaid Link: INTERNAL_SERVER_ERROR — Something went wrong — Internal error occurred');
+  assert.equal(linkExitNote({ ...error, display_message: null }), 'Plaid Link: INTERNAL_SERVER_ERROR — an unexpected error occurred', 'display_message null → error_message');
+  assert.equal(linkExitNote({ ...error, display_message: '  ' }), 'Plaid Link: INTERNAL_SERVER_ERROR — an unexpected error occurred', 'blank display_message → error_message');
+
+  const out = linkExitOutcome(error, metadata, RECONNECT_CANCELLED, 'ckitemrow0001');
+  assert.equal(out.kind, 'error');
+  if (out.kind !== 'error') return;
+  assert.equal(out.note, 'Plaid Link: INTERNAL_SERVER_ERROR — Something went wrong — Internal error occurred');
+
+  // The body the browser POSTs: these keys and no others.
+  assert.deepEqual(out.report, {
+    itemId: 'ckitemrow0001',
+    error_code: 'INTERNAL_SERVER_ERROR',
+    error_type: 'API_ERROR',
+    error_message: 'an unexpected error occurred',
+    link_session_id: 'ls-abc-123',
+    request_id: 'req-link-9',
+    status: 'requires_oauth',
+  });
+  const wire = JSON.stringify(out.report);
+  for (const t of TOKENS) assert.ok(!wire.includes(t), `the report leaks ${t}`);
+  assert.ok(!wire.includes('institution'), 'the institution comes from the owned row on the server, not from the body');
+
+  // The new-item flow: no itemId key at all (not an undefined value that JSON would drop anyway).
+  const fresh = linkExitReport(error, metadata);
+  assert.equal('itemId' in fresh, false);
+  assert.equal(linkExitReport(error, {}).link_session_id, null, 'missing metadata fields are null, never fabricated');
+});
+
+test('a cancel produces the cancel note; a connected exit says nothing', () => {
+  const cancel = linkExitOutcome(null, { status: 'requires_credentials', link_session_id: 'ls-1', request_id: 'r-1' }, RECONNECT_CANCELLED, 'ckitemrow0001');
+  assert.deepEqual(cancel, { kind: 'cancelled', note: 'Reconnect cancelled' });
+  assert.deepEqual(linkExitOutcome(null, { status: null }, RECONNECT_CANCELLED), { kind: 'cancelled', note: 'Reconnect cancelled' }, 'status null is still an exit before connecting');
+  assert.deepEqual(linkExitOutcome(null, {}, LINK_CANCELLED), { kind: 'cancelled', note: 'Account link cancelled' }, 'the new-item flow has its own words');
+  assert.deepEqual(linkExitOutcome(null, { status: 'connected' }, RECONNECT_CANCELLED), { kind: 'connected' });
+  assert.equal(notLoggedSuffix(500), ' — not logged (HTTP 500)');
+  assert.equal(notLoggedSuffix(0), ' — not logged (network)');
+});
+
+test('the server admits the named fields only, length-capped; a missing field is a 400', () => {
+  const posted = {
+    itemId: 'ckitemrow0001',
+    error_code: 'INTERNAL_SERVER_ERROR',
+    error_type: 'API_ERROR',
+    error_message: 'x'.repeat(LINK_EXIT_MAX.message + 200),
+    link_session_id: 'ls-abc-123',
+    request_id: '',
+    status: 'requires_oauth',
+    // planted: a body can say anything — nothing outside the named keys is read
+    access_token: ACCESS_TOKEN,
+    public_token: PUBLIC_TOKEN,
+    institution: 'Not Wells Fargo',
+  };
+  const summary = summarizeLinkExit(posted);
+  assert.deepEqual(Object.keys(summary).sort(), ['error_code', 'error_message', 'error_type', 'itemId', 'link_session_id', 'request_id', 'status']);
+  assert.equal(summary.error_message.length, LINK_EXIT_MAX.message);
+  assert.equal(summary.request_id, null, 'an empty string is null');
+  const logged = JSON.stringify(summary);
+  for (const t of TOKENS) assert.ok(!logged.includes(t), `the summary leaks ${t}`);
+  assert.ok(!logged.includes('Not Wells Fargo'));
+
+  // The new-item flow posts no itemId.
+  assert.equal(summarizeLinkExit({ error_code: 'c', error_type: 't', error_message: 'm' }).itemId, null);
+
+  // Missing or mistyped → ValidationError 400 that the route's catch-all returns verbatim.
+  const reject = (body: unknown, message: string) => {
+    let caught: unknown;
+    try {
+      summarizeLinkExit(body);
+    } catch (e) {
+      caught = e;
+    }
+    assert.ok(caught instanceof ValidationError, `expected a ValidationError for ${JSON.stringify(body)}`);
+    assert.equal(caught.status, 400);
+    const out = failClosed('api/plaid/link-exit POST', 'Failed to log the Plaid Link exit', caught);
+    assert.equal(out.status, 400);
+    assert.equal(out.body.message, message);
+  };
+  reject(null, 'a JSON body is required');
+  reject({ error_type: 'API_ERROR', error_message: 'm' }, 'error_code is required');
+  reject({ error_code: 'c', error_type: 't', error_message: 'm', itemId: 42 }, 'itemId must be a string');
+  reject({ error_code: 'c', error_type: 't', error_message: '   ' }, 'error_message is required');
+});

--- a/src/lib/plaid/linkExit.ts
+++ b/src/lib/plaid/linkExit.ts
@@ -1,0 +1,148 @@
+/**
+ * BANK-01b — surface Plaid Link's exit. Fail loud.
+ *
+ * Plaid Link's onExit(error, metadata) is the only place Link says WHY it
+ * closed — "Something went wrong — Internal error occurred" arrives here as
+ * `{ error_type, error_code, error_message, display_message }` with the
+ * session's `link_session_id` / `request_id` (react-plaid-link
+ * src/types/index.ts:17-37; plaid.com/docs/link/web onExit). Both Link
+ * flows discarded it (BooksPipeline `onExit: () => { setReconnecting(null) }`,
+ * ModuleLauncher `onExit: () => {}`), so the reason reached neither the row
+ * nor the logs.
+ *
+ * This module is pure: the note text, the exact report body the browser
+ * POSTs to /api/plaid/link-exit, and the server-side summarizer that admits
+ * ONLY the named fields (never a token — none is ever read from the body).
+ */
+import { ValidationError } from '@/lib/errors/ValidationError';
+
+/** react-plaid-link's PlaidLinkError, structurally. */
+export interface LinkExitError {
+  error_type: string;
+  error_code: string;
+  error_message: string;
+  display_message?: string | null;
+}
+
+/** react-plaid-link's PlaidLinkOnExitMetadata, structurally. */
+export interface LinkExitMetadata {
+  institution?: { name: string; institution_id: string } | null;
+  /** "The point at which the user exited the Link flow" — requires_credentials, requires_oauth, … */
+  status?: string | null;
+  link_session_id?: string | null;
+  request_id?: string | null;
+}
+
+/** The body the browser POSTs — these keys and no others. */
+export interface LinkExitReport {
+  itemId?: string;
+  error_code: string;
+  error_type: string;
+  error_message: string;
+  link_session_id: string | null;
+  request_id: string | null;
+  /** Where Link was when it exited (metadata.status) — the field that says "requires_oauth". */
+  status: string | null;
+}
+
+export const RECONNECT_CANCELLED = 'Reconnect cancelled';
+export const LINK_CANCELLED = 'Account link cancelled';
+
+/** "Plaid Link: <error_code> — <display_message || error_message>" */
+export function linkExitNote(error: LinkExitError): string {
+  const text = error.display_message?.trim() || error.error_message;
+  return `Plaid Link: ${error.error_code} — ${text}`;
+}
+
+function str(v: unknown): string | null {
+  return typeof v === 'string' && v !== '' ? v : null;
+}
+
+export function linkExitReport(error: LinkExitError, metadata: LinkExitMetadata, itemId?: string): LinkExitReport {
+  return {
+    ...(itemId === undefined ? {} : { itemId }),
+    error_code: error.error_code,
+    error_type: error.error_type,
+    error_message: error.error_message,
+    link_session_id: str(metadata.link_session_id),
+    request_id: str(metadata.request_id),
+    status: str(metadata.status),
+  };
+}
+
+export type LinkExitOutcome =
+  | { kind: 'error'; note: string; report: LinkExitReport }
+  | { kind: 'cancelled'; note: string }
+  | { kind: 'connected' };
+
+/**
+ * error non-null → the note and the report to POST. error null with
+ * status !== 'connected' → the user cancelled (note only). Otherwise Link
+ * closed on a connected session — nothing to say.
+ */
+export function linkExitOutcome(error: LinkExitError | null, metadata: LinkExitMetadata, cancelNote: string, itemId?: string): LinkExitOutcome {
+  if (error) return { kind: 'error', note: linkExitNote(error), report: linkExitReport(error, metadata, itemId) };
+  if (metadata.status !== 'connected') return { kind: 'cancelled', note: cancelNote };
+  return { kind: 'connected' };
+}
+
+/** Browser side: POST the report; the answer says whether the server logged it. Never throws. */
+export async function postLinkExit(report: LinkExitReport): Promise<{ logged: boolean; status: number }> {
+  try {
+    const res = await fetch('/api/plaid/link-exit', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(report),
+    });
+    return { logged: res.ok, status: res.status };
+  } catch {
+    return { logged: false, status: 0 };
+  }
+}
+
+/** The row's line when the report did not land — the Plaid reason is still shown, and so is the miss. */
+export function notLoggedSuffix(status: number): string {
+  return ` — not logged (${status === 0 ? 'network' : `HTTP ${status}`})`;
+}
+
+export const LINK_EXIT_MAX = { message: 500, id: 128 } as const;
+
+export interface LinkExitSummary {
+  itemId: string | null;
+  error_code: string;
+  error_type: string;
+  error_message: string;
+  link_session_id: string | null;
+  request_id: string | null;
+  status: string | null;
+}
+
+function required(body: Record<string, unknown>, key: 'error_code' | 'error_type' | 'error_message', max: number): string {
+  const v = body[key];
+  if (typeof v !== 'string' || v.trim() === '') throw new ValidationError(`${key} is required`, { field: key });
+  return v.slice(0, max);
+}
+
+function optional(body: Record<string, unknown>, key: string, max: number): string | null {
+  const v = body[key];
+  if (v === undefined || v === null) return null;
+  if (typeof v !== 'string') throw new ValidationError(`${key} must be a string`, { field: key });
+  return v === '' ? null : v.slice(0, max);
+}
+
+/**
+ * Server side: admit the named fields only, length-capped; anything else in
+ * the body is ignored (there is no key under which a token could pass).
+ * Missing or mistyped fields are a 400 (ValidationError, verbatim).
+ */
+export function summarizeLinkExit(body: unknown): LinkExitSummary {
+  if (!body || typeof body !== 'object') throw new ValidationError('a JSON body is required');
+  const b = body as Record<string, unknown>;
+  return {
+    itemId: optional(b, 'itemId', LINK_EXIT_MAX.id),
+    error_code: required(b, 'error_code', LINK_EXIT_MAX.id),
+    error_type: required(b, 'error_type', LINK_EXIT_MAX.id),
+    error_message: required(b, 'error_message', LINK_EXIT_MAX.message),
+    link_session_id: optional(b, 'link_session_id', LINK_EXIT_MAX.id),
+    request_id: optional(b, 'request_id', LINK_EXIT_MAX.id),
+    status: optional(b, 'status', LINK_EXIT_MAX.id),
+  };
+}


### PR DESCRIPTION
**Do not merge — Alex merges after Vercel Preview (SOC 2 gate).**

## WHY

The Reconnect flow (BANK-01, #1641) opened Link in update mode and Plaid showed "Something went wrong — Internal error occurred". Both Link flows discarded `onExit`'s error, so the reason reached neither the row nor the logs. Fail loud.

## AUDIT (read-only, before building)

### The discarded exit

| # | Finding | Where |
|---|---|---|
| 1 | The Reconnect flow's `onExit` only cleared the busy flag: `onExit: () => { setReconnecting(null); }`. | `src/components/home/BooksPipeline.tsx:224` (main before this PR) |
| 2 | The "+ Account" flow's `onExit` was empty: `onExit: () => {}`. | `src/components/home/ModuleLauncher.tsx:498` (main before this PR; the flow at `:482-500`) |
| 3 | Link hands `onExit` an error `{ error_type, error_code, error_message, display_message }` and metadata `{ institution, status, link_session_id, request_id }`. | `node_modules/react-plaid-link/src/types/index.ts:17-37`; Plaid docs, Link web `onExit` |
| 4 | Plaid's documented `onExit` `status` values are `requires_questions`, `requires_mfa`, `requires_otp_selection`, `requires_otp`, `requires_credentials`, `requires_account_selection`, `requires_oauth`, `institution_not_found`, `institution_not_supported`. **`connected` is not among them**, so `error === null && status !== 'connected'` (the ruled cancel test) is every error-free exit — implemented as ruled, with `status` carried in the report so a `requires_oauth` exit is visible. | plaid.com/docs/link/web (onExit) |
| 5 | The cockpit already has one inline outcome slot (`booksSyncMessage`, a `SyncOutcome {tone,text}` rendered under the bar) — the "+ Account" exit reuses it. | `ModuleLauncher.tsx:400`, render `:1295-1303` |

### `redirect_uri` — Plaid's docs (reference data, quoted)

- **Update mode:** "If your integration uses redirect URIs normally, create the Link token with a redirect URI, as described in Configure your Link token with your redirect URI." and "Update mode can be used to request OAuth permissions: triggering update mode for an OAuth institution will cause the user to re-enter the OAuth flow." — plaid.com/docs/link/update-mode
- **OAuth guide:** "When using Link in update mode, ensure you specify your redirect URI via the `redirect_uri` field." and "After creating your redirect URI, add it to the Allowed redirect URIs" (Dashboard). Also: "OAuth flows will function properly on web even if you don't set up a redirect URI. Desktop web and mobile web integrations will always try to open the OAuth bank's website in a new pop-up window if possible" — but "not providing a redirect URI will prevent mobile web users from using your integration through a webview browser". — plaid.com/docs/link/oauth
- **Troubleshooting**, heading *"You may need to update your app", "Couldn't connect to your institution", or "Something went wrong: an internal error occurred"*: common causes are "You haven't selected a use case for Link.", "The full list of OAuth prerequisites has not been completed to enable your client ID for a given institution's OAuth connection.", "A backend error occurred during the Link flow." — plaid.com/docs/link/troubleshooting
- **SDK:** `LinkTokenCreateRequest.redirect_uri` — "used to support OAuth authentication flows when launching Link in the browser … must be an https URI … any redirect URI must also be added to the Allowed redirect URIs list in the developer dashboard" — `node_modules/plaid/dist/api.d.ts:14604-14608`.

### Does anything name a redirect URI today?

| Search | Result |
|---|---|
| `git grep -i "PLAID_REDIRECT_URI\|redirect_uri\|receivedRedirectUri\|redirectUri\|oauth_state_id"` (tracked files, lockfile excluded) | **zero hits** |
| `.env.example:21-22` | `PLAID_CLIENT_ID`, `PLAID_SECRET` only |
| `README.md:289` (env table) | `PLAID_CLIENT_ID`, `PLAID_SECRET` only |
| `src/lib/plaid.ts:6-23` | client id + secret; environment forced to `production` (`:11`) |
| `src/app/api/plaid/link-token/route.ts` (both branches) | no `redirect_uri` in either the new-item or the update-mode request |
| Link init (`BooksPipeline`, `ModuleLauncher`) | `Plaid.create({ token, onSuccess, onExit })` — no `receivedRedirectUri` |

**So:** no code path, env var, or doc names a redirect URI. Per the docs above, an update-mode token for an OAuth institution should carry one (registered in the Dashboard), and the troubleshooting page lists incomplete OAuth prerequisites as a cause of exactly the message seen. Not verified: that this is THE cause here — the log line this PR adds (`error_code`, `request_id`, `status`) is what settles it, together with Dashboard → Developers → Logs for that `request_id`.

### Which of the linked institutions are OAuth?

**Not verified here** — Claude Code cannot reach Azure Postgres or Plaid. The read is authored instead: `scripts/plaid-institutions-oauth.ts` — one `/institutions/get_by_id` per distinct stored `institutionId` (`Institution.oauth`: "Indicates that the institution has an OAuth login flow", `api.d.ts:12044`), printing `institution · institutionId · oauth · last_error_code` per `plaid_items` row. No link token, no item call, no access token selected. Alex runs locally:

```
DATABASE_URL=… PLAID_CLIENT_ID=… PLAID_SECRET=… npx tsx scripts/plaid-institutions-oauth.ts
```

`plaid_items.institutionId` is stored by exchange-token (`src/app/api/plaid/exchange-token/route.ts:48, 69`; `'unknown'` when Plaid returned none — the script skips those and says so). Report only; the OAuth build, if the read says it is needed, is BANK-01c.

## BUILD

| Piece | Change |
|---|---|
| `src/lib/plaid/linkExit.ts` (new, pure) | `linkExitOutcome(error, metadata, cancelNote, itemId?)`: error → `{ kind:'error', note: "Plaid Link: <error_code> — <display_message \|\| error_message>", report }`; `error === null && status !== 'connected'` → `{ kind:'cancelled', note }`; else `connected`. `linkExitReport` builds exactly `{ itemId?, error_code, error_type, error_message, link_session_id, request_id, status }`. `summarizeLinkExit(body)` (server) admits those named fields only, length-capped (500 / 128), `ValidationError` 400 on a missing or mistyped field. `postLinkExit` / `notLoggedSuffix` for the browser. |
| `src/app/api/plaid/link-exit/route.ts` (new) | `POST`: `getVerifiedEmail` → user → `requireTabAccess('tab:books')` → summarize → when `itemId` is given the caller must own it (`ownedItemOr404`, defensive 404) and the institution is read from the owned row, never from the body → `console.log('[plaid/link-exit]', { userId, itemId, institution, mode, error_type, error_code, error_message, status, link_session_id, request_id })` → `{ ok:true, stage:'link-exit' }`. No Plaid call, no token read, none logged. Catch-all → `failClosedResponse`. |
| `BooksPipeline.tsx` Reconnect | `onExit(error, metadata)`: error → the row's line (error tone) + the report; a report that did not land appends " — not logged (HTTP n)"; cancel → **"Reconnect cancelled"** in a new plain tone (`role=status`, secondary ink). |
| `ModuleLauncher.tsx` "+ Account" | Same wiring into the sync line's slot: error → error card; cancel → **"Account link cancelled"** (its own words — it is not a reconnect); no `itemId` (there is no item yet). |
| `scripts/plaid-institutions-oauth.ts` (new, force-added: `scripts/` is gitignored) | The audit read above. |
| `src/lib/__tests__/plaidLinkExit.test.ts` (new) | The ruled tests. |
| `README.md` | Regenerated (291 API route files); byte-stable on a second run. |

One field beyond the ruled six in the POST body: `status` (Link's `metadata.status`, e.g. `requires_oauth`) — it is the field that says where Link was when it died, which is the WHY of this PR. Flagged here; drop it if unwanted.

## VERIFY

| Check | Result |
|---|---|
| `npx tsc --noEmit` | exit 0 |
| eslint, 6 touched/new files | 0 new — `linkExit.ts`, the test, the route, `BooksPipeline.tsx`, the script at 0; `ModuleLauncher.tsx` carries its 2 pre-existing unused-const warnings (`:24`, same on main) |
| `npm test` | **85 / 85 pass** (82 before + 3 new) |
| asserts + `next build` | showroom ✓ · tool registry 25/25 ✓ · reachability 60 pages ✓ · answers law ✓ · arrivals law ✓ · **BUILD EXIT 0** |
| script | parses and imports; without `DATABASE_URL` it exits 1 with `DATABASE_URL must be set (run locally)` — fail loud, no partial table |
| README generator | regenerated; second run byte-identical |

### Tests (node:test)

```
ok 1 - an onExit error produces the row note and a report that carries no token
ok 2 - a cancel produces the cancel note; a connected exit says nothing
ok 3 - the server admits the named fields only, length-capped; a missing field is a 400
```

1. An `INTERNAL_SERVER_ERROR` Link error with planted `access_token` / `link_token` beside it and metadata with a planted `public_token`: the note is `Plaid Link: INTERNAL_SERVER_ERROR — Something went wrong — Internal error occurred` (`display_message` null or blank → `error_message`); the report deep-equals the seven named keys and its JSON contains none of the planted tokens nor the institution; the new-item report has no `itemId` key; missing metadata fields are `null`, never fabricated.
2. `error === null` with `status: 'requires_credentials'` / `null` / absent → `Reconnect cancelled` (or `Account link cancelled` for the new-item flow); `status: 'connected'` → nothing; `notLoggedSuffix` renders `HTTP 500` / `network`.
3. A body with the named fields plus planted `access_token`, `public_token`, `institution`: the summary has exactly the seven keys, `error_message` capped at 500, an empty `request_id` → `null`, no planted value in its JSON; missing `error_code` / blank `error_message` / numeric `itemId` / a non-object body → `ValidationError` 400 that `failClosed` returns verbatim.

## Notes

- Not verified: the live cause of the "Internal error occurred" — the added log line is the instrument; the OAuth read is the script above.
- Not built: `redirect_uri` on the link token / an OAuth return page / `receivedRedirectUri` — BANK-01c, after the read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc

---
_Generated by [Claude Code](https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc)_