### PR TITLE
HYG-03: one bank's failure never blocks another — per-item isolation in sync-complete

### DIFF
--- a/src/app/api/transactions/sync-complete/route.ts
+++ b/src/app/api/transactions/sync-complete/route.ts
@@ -4,9 +4,9 @@ import { plaidClient } from '@/lib/plaid';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { requireTabAccess } from '@/lib/auth-helpers';
 import { decryptToken } from '@/lib/secrets/tokenCipher';
-import { failureEnvelope, stageFailed, stageOk, syncEnvelope, type StageFailed } from '@/lib/plaid/failLoud';
+import { failureEnvelope, stageFailed, stageOk, sumStageCounts, syncEachItem, syncItemsEnvelope, type StageFailed, type StageOutcome } from '@/lib/plaid/failLoud';
 import { summarizePlaidError } from '@/lib/plaid/summarizeError';
-import { clearItemError, isItemError, itemFailure, recordItemError } from '@/lib/plaid/reconnect';
+import { bankName, clearItemError, isItemError, itemFailure, recordItemError } from '@/lib/plaid/reconnect';
 import { wireOf } from '@/lib/plaid/wire';
 import { prismaLanding } from '@/lib/arrivals/prismaLanding';
 import { recordFailedAnswer, runTransactionsPage, type DomainDb } from '@/lib/arrivals/plaidTransactionsPage';
@@ -33,25 +33,13 @@ export async function POST() {
     const tabGate = await requireTabAccess(user.id, 'tab:books');
     if (tabGate) return tabGate;
 
+    // HYG-03: a stable run — items by institution, then id.
     const plaidItems = await prisma.plaid_items.findMany({
       where: { userId: user.id },
-      include: { accounts: true }
+      include: { accounts: true },
+      orderBy: [{ institutionName: 'asc' }, { id: 'asc' }],
     });
-
-    let totalTransactions = 0;
-    let totalInvestmentTransactions = 0;
-    let totalSecurities = 0;
-    let skippedTransactions = 0;
-    let skippedInvestmentTransactions = 0;
-    // REBUILD-01 PR-2: the store's own counts — arrivals landed this run, and objects the
-    // table already held (linked, not re-parsed; promise 2 working).
-    let landedArrivals = 0;
-    let alreadyLanded = 0;
-    let correctedArrivals = 0;
-    // HYG-01: STOP AND DECLARE. The first failure ends its stage for the whole run;
-    // the outcome is declared in the response (200 / 207 / non-2xx), never hidden.
-    let transactionsFailure: StageFailed | null = null;
-    let investmentsFailure: StageFailed | null = null;
+    type PlaidItem = (typeof plaidItems)[number];
 
     // BANK-01: a Plaid ITEM_ERROR (ITEM_LOGIN_REQUIRED and its kin) is the ITEM's state, not
     // a one-off fault — record its code on the item (user-scoped) and name the INSTITUTION in
@@ -66,243 +54,267 @@ export async function POST() {
       return stageFailed(stage, error);
     };
 
-    for (const item of plaidItems) {
-      console.log(`Syncing ${item.institutionName || 'Bank'}...`);
+    // HYG-03: ONE BANK'S FAILURE NEVER BLOCKS ANOTHER. Each item runs both stages and
+    // declares its own outcome per stage (ok with counts | failed with the named bank and
+    // the summarized Plaid error). Nothing about item A decides whether item B runs.
+    // Inside one item a page failure still ends that item's stage and rolls that page
+    // back (PR-2, unchanged).
 
-      // Sync regular transactions — skipped once this stage has declared a failure.
-      if (!transactionsFailure) {
-        try {
-          // Batch lookup: fetch all existing transactions for this item's accounts
-          const accountIds = item.accounts.map(acc => acc.id);
-          const existingTxns = await prisma.transactions.findMany({
-            where: { accountId: { in: accountIds } },
-            select: {
-              transactionId: true,
-              personal_finance_category: true,
-              amount: true,
-              name: true,
-              date: true
-            }
-          });
-          const existingMap = new Map(
-            existingTxns.map(t => [t.transactionId, t])
-          );
-
-          let hasMore = true;
-          let offset = 0;
-          let page = 0;
-
-          while (hasMore) {
-            page += 1;
-            let response;
-            try {
-              response = await plaidClient.transactionsGet({
-                access_token: decryptToken(item.accessToken),
-                start_date: '2024-01-01',
-                end_date: new Date().toISOString().split('T')[0],
-                options: {
-                  offset: offset,
-                  count: 100,
-                  include_personal_finance_category: true
-                }
-              });
-            } catch (askError) {
-              // REBUILD-01 PR-2: a failed ask is evidence of the ask — the non-2xx answer's
-              // exact bytes land (no arrivals) before the stage declares the failure.
-              await recordFailedAnswer(prismaLanding(prisma as unknown as Prisma.TransactionClient), { userId: user.id, err: askError });
-              throw askError;
-            }
-            // REBUILD-01 PR-2: the exact wire bytes ride the response (src/lib/plaid/wire.ts);
-            // their absence is a fault, never a silent skip.
-            const wire = wireOf(response, `transactionsGet page ${page}`);
-
-            // Update balances (first iteration only)
-            if (offset === 0 && response.data.accounts) {
-              for (const plaidAccount of response.data.accounts) {
-                const dbAccount = item.accounts.find(acc => acc.accountId === plaidAccount.account_id);
-                if (dbAccount) {
-                  await prisma.accounts.update({
-                    where: { id: dbAccount.id },
-                    data: {
-                      currentBalance: plaidAccount.balances.current || 0,
-                      availableBalance: plaidAccount.balances.available || 0
-                    }
-                  });
-                }
-              }
-            }
-
-            // REBUILD-01 PR-2: raw-first, in ONE database transaction per page —
-            // provider_responses (the wire) → arrivals (one per object, promise 2 on
-            // (provider, their_id)) → the existing parser, reading the ARRIVAL payloads →
-            // transactions.arrival_id → read / status = done. A parser throw rolls this
-            // page back; earlier pages stay landed; the stage declares the failure.
-            const result = await runTransactionsPage(
-              prisma,
-              (tx) => ({ landing: prismaLanding(tx as Prisma.TransactionClient), domain: tx as unknown as DomainDb }),
-              {
-                page,
-                userId: user.id,
-                connection: item.itemId,
-                accounts: item.accounts.map((acc) => ({ id: acc.id, accountId: acc.accountId })),
-                existing: existingMap,
-                wire,
-                httpStatus: response.status,
-                transactions: response.data.transactions,
-              },
-            );
-            if (!result.ok) {
-              transactionsFailure = result.failure;
-              console.error(`Transactions stage failed on page ${page}:`, result.failure.error);
-              break;
-            }
-            totalTransactions += result.counts.synced;
-            skippedTransactions += result.counts.skipped;
-            landedArrivals += result.counts.landed;
-            alreadyLanded += result.counts.already_landed;
-            correctedArrivals += result.counts.corrected;
-
-            offset += response.data.transactions.length;
-            hasMore = response.data.total_transactions > offset;
-
-            if (!hasMore) {
-              console.log(`Synced ${response.data.total_transactions} transactions for ${item.institutionName} (${skippedTransactions} skipped — already complete)`);
-            }
+    const syncTransactions = async (item: PlaidItem): Promise<StageOutcome> => {
+      let synced = 0;
+      let skipped = 0;
+      let landed = 0;
+      let alreadyLanded = 0;
+      let corrected = 0;
+      try {
+        // Batch lookup: fetch all existing transactions for this item's accounts
+        const accountIds = item.accounts.map(acc => acc.id);
+        const existingTxns = await prisma.transactions.findMany({
+          where: { accountId: { in: accountIds } },
+          select: {
+            transactionId: true,
+            personal_finance_category: true,
+            amount: true,
+            name: true,
+            date: true
           }
-          // BANK-01: the item answered — a recorded ITEM_ERROR is over.
-          if (item.last_error_code !== null) {
-            await clearItemError(prisma, { itemRowId: item.id, userId: user.id });
-          }
-        } catch (error) {
-          transactionsFailure = await declareStageFailure('transactions', error, item);
-          console.error('Transactions stage failed:', transactionsFailure.error);
-        }
-      }
+        });
+        const existingMap = new Map(
+          existingTxns.map(t => [t.transactionId, t])
+        );
 
-      // Sync investment transactions + securities — same rule.
-      if (!investmentsFailure) {
-        try {
-          // Batch lookup: fetch all existing investment transaction IDs for this item's accounts
-          const accountIds = item.accounts.map(acc => acc.id);
-          const existingInvTxns = await prisma.investment_transactions.findMany({
-            where: { accountId: { in: accountIds } },
-            select: { investment_transaction_id: true }
-          });
-          const existingInvSet = new Set(
-            existingInvTxns.map(t => t.investment_transaction_id)
-          );
+        let hasMore = true;
+        let offset = 0;
+        let page = 0;
+        let pageFailure: StageFailed | null = null;
 
-          let offset = 0;
-          let hasMore = true;
-
-          while (hasMore) {
-            const investResponse = await plaidClient.investmentsTransactionsGet({
+        while (hasMore) {
+          page += 1;
+          let response;
+          try {
+            response = await plaidClient.transactionsGet({
               access_token: decryptToken(item.accessToken),
               start_date: '2024-01-01',
               end_date: new Date().toISOString().split('T')[0],
               options: {
                 offset: offset,
-                count: 100
+                count: 100,
+                include_personal_finance_category: true
               }
             });
-
-            // STORE SECURITIES DATA (includes option contract details)
-            for (const security of investResponse.data.securities) {
-              const optionContract = (security as any).option_contract;
-
-              await prisma.securities.upsert({
-                where: { securityId: security.security_id },
-                create: {
-                  securityId: security.security_id,
-                  isin: security.isin,
-                  cusip: security.cusip,
-                  sedol: security.sedol,
-                  ticker_symbol: security.ticker_symbol,
-                  name: security.name,
-                  type: security.type,
-                  close_price: security.close_price,
-                  close_price_as_of: security.close_price_as_of ? new Date(security.close_price_as_of) : null,
-                  option_contract_type: optionContract?.contract_type || null,
-                  option_strike_price: optionContract?.strike_price || null,
-                  option_expiration_date: optionContract?.expiration_date ? new Date(optionContract.expiration_date) : null,
-                  option_underlying_ticker: optionContract?.underlying_security_ticker || null,
-                  id: `sec_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`,
-                  updatedAt: new Date()
-                },
-                update: {
-                  close_price: security.close_price,
-                  close_price_as_of: security.close_price_as_of ? new Date(security.close_price_as_of) : null,
-                  option_contract_type: optionContract?.contract_type || null,
-                  option_strike_price: optionContract?.strike_price || null,
-                  option_expiration_date: optionContract?.expiration_date ? new Date(optionContract.expiration_date) : null,
-                  option_underlying_ticker: optionContract?.underlying_security_ticker || null
-                }
-              });
-              totalSecurities++;
-            }
-
-            // STORE INVESTMENT TRANSACTIONS
-            for (const txn of investResponse.data.investment_transactions) {
-              const account = item.accounts.find(acc => acc.accountId === txn.account_id);
-              if (!account) continue;
-
-              if (existingInvSet.has(txn.investment_transaction_id)) {
-                // Already exists — the original update clause was empty anyway, skip
-                skippedInvestmentTransactions++;
-                totalInvestmentTransactions++;
-                continue;
-              }
-
-              await prisma.investment_transactions.create({
-                data: {
-                  id: `inv_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`,
-                  investment_transaction_id: txn.investment_transaction_id,
-                  accountId: account.id,
-                  amount: txn.amount,
-                  cancel_transaction_id: txn.cancel_transaction_id,
-                  date: new Date(txn.date),
-                  fees: txn.fees,
-                  iso_currency_code: txn.iso_currency_code,
-                  name: txn.name,
-                  price: txn.price,
-                  quantity: txn.quantity,
-                  security_id: txn.security_id,
-                  subtype: txn.subtype,
-                  type: txn.type,
-                  unofficial_currency_code: txn.unofficial_currency_code,
-                  updatedAt: new Date()
-                }
-              });
-              totalInvestmentTransactions++;
-            }
-
-            offset += investResponse.data.investment_transactions.length;
-            hasMore = investResponse.data.total_investment_transactions > offset;
+          } catch (askError) {
+            // REBUILD-01 PR-2: a failed ask is evidence of the ask — the non-2xx answer's
+            // exact bytes land (no arrivals) before the stage declares the failure.
+            await recordFailedAnswer(prismaLanding(prisma as unknown as Prisma.TransactionClient), { userId: user.id, err: askError });
+            throw askError;
           }
-        } catch (error) {
-          investmentsFailure = await declareStageFailure('investments', error, item);
-          console.error('Investments stage failed:', investmentsFailure.error);
-        }
-      }
-    }
+          // REBUILD-01 PR-2: the exact wire bytes ride the response (src/lib/plaid/wire.ts);
+          // their absence is a fault, never a silent skip.
+          const wire = wireOf(response, `transactionsGet page ${page}`);
 
-    const stages = [
-      transactionsFailure ?? stageOk('transactions', { synced: totalTransactions, skipped: skippedTransactions, landed: landedArrivals, already_landed: alreadyLanded, corrected: correctedArrivals }),
-      investmentsFailure ?? stageOk('investments', { synced: totalInvestmentTransactions, skipped: skippedInvestmentTransactions, securities: totalSecurities }),
-    ];
-    const { status, body } = syncEnvelope(stages, {
-      success: !transactionsFailure && !investmentsFailure,
+          // Update balances (first iteration only)
+          if (offset === 0 && response.data.accounts) {
+            for (const plaidAccount of response.data.accounts) {
+              const dbAccount = item.accounts.find(acc => acc.accountId === plaidAccount.account_id);
+              if (dbAccount) {
+                await prisma.accounts.update({
+                  where: { id: dbAccount.id },
+                  data: {
+                    currentBalance: plaidAccount.balances.current || 0,
+                    availableBalance: plaidAccount.balances.available || 0
+                  }
+                });
+              }
+            }
+          }
+
+          // REBUILD-01 PR-2: raw-first, in ONE database transaction per page —
+          // provider_responses (the wire) → arrivals (one per object, promise 2 on
+          // (provider, their_id)) → the existing parser, reading the ARRIVAL payloads →
+          // transactions.arrival_id → read / status = done. A parser throw rolls this
+          // page back; earlier pages stay landed; this item's stage declares the failure.
+          const result = await runTransactionsPage(
+            prisma,
+            (tx) => ({ landing: prismaLanding(tx as Prisma.TransactionClient), domain: tx as unknown as DomainDb }),
+            {
+              page,
+              userId: user.id,
+              connection: item.itemId,
+              accounts: item.accounts.map((acc) => ({ id: acc.id, accountId: acc.accountId })),
+              existing: existingMap,
+              wire,
+              httpStatus: response.status,
+              transactions: response.data.transactions,
+            },
+          );
+          if (!result.ok) {
+            pageFailure = result.failure;
+            console.error(`Transactions stage failed for ${bankName(item.institutionName)} on page ${page}:`, result.failure.error);
+            break;
+          }
+          synced += result.counts.synced;
+          skipped += result.counts.skipped;
+          landed += result.counts.landed;
+          alreadyLanded += result.counts.already_landed;
+          corrected += result.counts.corrected;
+
+          offset += response.data.transactions.length;
+          hasMore = response.data.total_transactions > offset;
+
+          if (!hasMore) {
+            console.log(`Synced ${response.data.total_transactions} transactions for ${item.institutionName} (${skipped} skipped — already complete)`);
+          }
+        }
+        // BANK-01: the item answered — a recorded ITEM_ERROR is over (a page failure is
+        // local to us, not the item's state).
+        if (item.last_error_code !== null) {
+          await clearItemError(prisma, { itemRowId: item.id, userId: user.id });
+        }
+        if (pageFailure) return pageFailure;
+        return stageOk('transactions', { synced, skipped, landed, already_landed: alreadyLanded, corrected });
+      } catch (error) {
+        const failure = await declareStageFailure('transactions', error, item);
+        console.error(`Transactions stage failed for ${bankName(item.institutionName)}:`, failure.error);
+        return failure;
+      }
+    };
+
+    const syncInvestments = async (item: PlaidItem): Promise<StageOutcome> => {
+      let synced = 0;
+      let skipped = 0;
+      let securities = 0;
+      try {
+        // Batch lookup: fetch all existing investment transaction IDs for this item's accounts
+        const accountIds = item.accounts.map(acc => acc.id);
+        const existingInvTxns = await prisma.investment_transactions.findMany({
+          where: { accountId: { in: accountIds } },
+          select: { investment_transaction_id: true }
+        });
+        const existingInvSet = new Set(
+          existingInvTxns.map(t => t.investment_transaction_id)
+        );
+
+        let offset = 0;
+        let hasMore = true;
+
+        while (hasMore) {
+          const investResponse = await plaidClient.investmentsTransactionsGet({
+            access_token: decryptToken(item.accessToken),
+            start_date: '2024-01-01',
+            end_date: new Date().toISOString().split('T')[0],
+            options: {
+              offset: offset,
+              count: 100
+            }
+          });
+
+          // STORE SECURITIES DATA (includes option contract details)
+          for (const security of investResponse.data.securities) {
+            const optionContract = (security as any).option_contract;
+
+            await prisma.securities.upsert({
+              where: { securityId: security.security_id },
+              create: {
+                securityId: security.security_id,
+                isin: security.isin,
+                cusip: security.cusip,
+                sedol: security.sedol,
+                ticker_symbol: security.ticker_symbol,
+                name: security.name,
+                type: security.type,
+                close_price: security.close_price,
+                close_price_as_of: security.close_price_as_of ? new Date(security.close_price_as_of) : null,
+                option_contract_type: optionContract?.contract_type || null,
+                option_strike_price: optionContract?.strike_price || null,
+                option_expiration_date: optionContract?.expiration_date ? new Date(optionContract.expiration_date) : null,
+                option_underlying_ticker: optionContract?.underlying_security_ticker || null,
+                id: `sec_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`,
+                updatedAt: new Date()
+              },
+              update: {
+                close_price: security.close_price,
+                close_price_as_of: security.close_price_as_of ? new Date(security.close_price_as_of) : null,
+                option_contract_type: optionContract?.contract_type || null,
+                option_strike_price: optionContract?.strike_price || null,
+                option_expiration_date: optionContract?.expiration_date ? new Date(optionContract.expiration_date) : null,
+                option_underlying_ticker: optionContract?.underlying_security_ticker || null
+              }
+            });
+            securities++;
+          }
+
+          // STORE INVESTMENT TRANSACTIONS
+          for (const txn of investResponse.data.investment_transactions) {
+            const account = item.accounts.find(acc => acc.accountId === txn.account_id);
+            if (!account) continue;
+
+            if (existingInvSet.has(txn.investment_transaction_id)) {
+              // Already exists — the original update clause was empty anyway, skip
+              skipped++;
+              synced++;
+              continue;
+            }
+
+            await prisma.investment_transactions.create({
+              data: {
+                id: `inv_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`,
+                investment_transaction_id: txn.investment_transaction_id,
+                accountId: account.id,
+                amount: txn.amount,
+                cancel_transaction_id: txn.cancel_transaction_id,
+                date: new Date(txn.date),
+                fees: txn.fees,
+                iso_currency_code: txn.iso_currency_code,
+                name: txn.name,
+                price: txn.price,
+                quantity: txn.quantity,
+                security_id: txn.security_id,
+                subtype: txn.subtype,
+                type: txn.type,
+                unofficial_currency_code: txn.unofficial_currency_code,
+                updatedAt: new Date()
+              }
+            });
+            synced++;
+          }
+
+          offset += investResponse.data.investment_transactions.length;
+          hasMore = investResponse.data.total_investment_transactions > offset;
+        }
+        return stageOk('investments', { synced, skipped, securities });
+      } catch (error) {
+        const failure = await declareStageFailure('investments', error, item);
+        console.error(`Investments stage failed for ${bankName(item.institutionName)}:`, failure.error);
+        return failure;
+      }
+    };
+
+    const items = await syncEachItem(
+      plaidItems,
+      (item) => { console.log(`Syncing ${item.institutionName || 'Bank'}...`); return bankName(item.institutionName); },
+      [
+        ['transactions', syncTransactions],
+        ['investments', syncInvestments],
+      ],
+    );
+
+    // The run's totals — summed over the stages that succeeded (a failed stage has no counts).
+    const tx = sumStageCounts(items, 'transactions');
+    const inv = sumStageCounts(items, 'investments');
+    const allOk = items.every((i) => i.stages.every((s) => s.ok));
+    const { status, body } = syncItemsEnvelope(items, {
+      success: allOk,
       synced: {
-        transactions: totalTransactions,
-        investmentTransactions: totalInvestmentTransactions,
-        securities: totalSecurities
+        transactions: tx.synced ?? 0,
+        investmentTransactions: inv.synced ?? 0,
+        securities: inv.securities ?? 0
       },
       skipped: {
-        transactions: skippedTransactions,
-        investmentTransactions: skippedInvestmentTransactions
+        transactions: tx.skipped ?? 0,
+        investmentTransactions: inv.skipped ?? 0
       },
       // REBUILD-01 PR-2: the store's counts for this run.
-      landed: { arrivals: landedArrivals, already_landed: alreadyLanded, corrected: correctedArrivals }
+      landed: { arrivals: tx.landed ?? 0, already_landed: tx.already_landed ?? 0, corrected: tx.corrected ?? 0 }
     });
     return NextResponse.json(body, { status });
   } catch (error) {

--- a/src/components/home/ModuleLauncher.tsx
+++ b/src/components/home/ModuleLauncher.tsx
@@ -8,7 +8,7 @@ import {
 } from 'lucide-react';
 import { SECTION_HEADER, STATE } from '@/lib/ds';
 import FamilyNav from './FamilyNav';
-import { readSyncOutcome, type SyncOutcome } from '@/lib/plaid/failLoud';
+import { readSyncOutcome, syncLine, type SyncOutcome } from '@/lib/plaid/failLoud';
 import CreateTripForm from '@/components/trips/CreateTripForm';
 import TripBookings from '@/components/trips/TripBookings';
 import UnattachedBookings from '@/components/trips/UnattachedBookings';
@@ -506,12 +506,12 @@ export default function ModuleLauncher({ onRequireAuth, onTabChange }: Props) {
         const exit = linkExitOutcome(error, metadata ?? {}, LINK_CANCELLED);
         if (exit.kind === 'connected') return;
         if (exit.kind === 'cancelled') {
-          setBooksSyncMessage({ tone: 'ok', text: exit.note });
+          setBooksSyncMessage(syncLine('ok', exit.note));
           return;
         }
-        setBooksSyncMessage({ tone: 'error', text: exit.note });
+        setBooksSyncMessage(syncLine('error', exit.note));
         const posted = await postLinkExit(exit.report);
-        if (!posted.logged) setBooksSyncMessage({ tone: 'error', text: exit.note + notLoggedSuffix(posted.status) });
+        if (!posted.logged) setBooksSyncMessage(syncLine('error', exit.note + notLoggedSuffix(posted.status)));
       },
     }).open();
   };
@@ -1315,7 +1315,9 @@ export default function ModuleLauncher({ onRequireAuth, onTabChange }: Props) {
                       ? 'rounded-lg border border-border bg-bg-row p-3 text-xs text-text-secondary'
                       : STATE.errorCard}
                   >
-                    {booksSyncMessage.text}
+                    {/* HYG-03: one line per failed bank above one line for what succeeded —
+                        one dead bank never reads as "sync failed". */}
+                    {booksSyncMessage.lines.map((l, i) => <div key={i}>{l}</div>)}
                   </div>
                 )}
                 {/* BOOKS-2: the full pipe below the cockpit — import → categorize/COA →

--- a/src/lib/__tests__/failLoud.test.ts
+++ b/src/lib/__tests__/failLoud.test.ts
@@ -90,11 +90,12 @@ test('(b) every stage failed → the first failure\'s status; zero failures → 
   assert.throws(() => syncEnvelope([]), /no stages/);
 });
 
+// HYG-03: the reader also carries `lines` — [text] when the body sent none.
 test('client reader: 200 → ok line, 207 → partial line, 429 → error line, non-JSON body → HTTP fallback', () => {
-  assert.deepEqual(readSyncResponse(200, { ok: true, message: 'Synced — transactions: ok (5 synced, 0 skipped)' }), { tone: 'ok', text: 'Synced — transactions: ok (5 synced, 0 skipped)' });
-  assert.deepEqual(readSyncResponse(207, { ok: false, partial: true, message: 'Partial sync — …' }), { tone: 'partial', text: 'Partial sync — …' });
+  assert.deepEqual(readSyncResponse(200, { ok: true, message: 'Synced — transactions: ok (5 synced, 0 skipped)' }), { tone: 'ok', text: 'Synced — transactions: ok (5 synced, 0 skipped)', lines: ['Synced — transactions: ok (5 synced, 0 skipped)'] });
+  assert.deepEqual(readSyncResponse(207, { ok: false, partial: true, message: 'Partial sync — …' }), { tone: 'partial', text: 'Partial sync — …', lines: ['Partial sync — …'] });
   assert.deepEqual(readSyncResponse(429, { ok: false, message: 'Plaid: RATE_LIMIT_EXCEEDED (TRANSACTIONS_LIMIT) — try again in a few minutes' }).tone, 'error');
-  assert.deepEqual(readSyncResponse(502, null), { tone: 'error', text: 'Sync failed: HTTP 502' });
-  assert.deepEqual(readSyncResponse(401, { error: 'Unauthorized' }), { tone: 'error', text: 'Unauthorized' });
+  assert.deepEqual(readSyncResponse(502, null), { tone: 'error', text: 'Sync failed: HTTP 502', lines: ['Sync failed: HTTP 502'] });
+  assert.deepEqual(readSyncResponse(401, { error: 'Unauthorized' }), { tone: 'error', text: 'Unauthorized', lines: ['Unauthorized'] });
   assert.equal(readSyncResponse(200, { ok: false, message: 'x' }).tone, 'error');
 });

--- a/src/lib/__tests__/syncItems.test.ts
+++ b/src/lib/__tests__/syncItems.test.ts
@@ -1,0 +1,192 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  failedLine,
+  itemStatus,
+  readSyncResponse,
+  stageFailed,
+  stageOk,
+  successLine,
+  sumStageCounts,
+  syncEachItem,
+  syncItemsEnvelope,
+  syncLines,
+  type ItemOutcome,
+  type StageOutcome,
+  type StageRunner,
+} from '../plaid/failLoud';
+import { itemFailure } from '../plaid/reconnect';
+
+// HYG-03 — one bank's failure never blocks another: every item runs every stage; the
+// response lists each bank with its per-stage outcome; the banner reads one line per
+// failed bank above one line for what succeeded.
+
+interface Item { id: string; institutionName: string }
+const TASTY: Item = { id: 'item-tt', institutionName: 'TastyTrade' };
+const WELLS: Item = { id: 'item-wf', institutionName: 'Wells Fargo' };
+const ROBIN: Item = { id: 'item-rh', institutionName: 'Robinhood' };
+
+function loginRequired() {
+  return Object.assign(new Error('Request failed with status code 400'), {
+    isAxiosError: true,
+    config: { headers: { 'PLAID-SECRET': 'PLAID-SECRET-VALUE' }, data: JSON.stringify({ access_token: 'access-production-TOKEN' }) },
+    response: { status: 400, data: { error_type: 'ITEM_ERROR', error_code: 'ITEM_LOGIN_REQUIRED', error_message: 'the login details of this item have changed', request_id: 'req_tt' } },
+  });
+}
+
+function rateLimited() {
+  return Object.assign(new Error('Request failed with status code 429'), {
+    isAxiosError: true,
+    response: { status: 429, data: { error_type: 'RATE_LIMIT_EXCEEDED', error_code: 'TRANSACTIONS_LIMIT', error_message: 'rate limit exceeded', request_id: 'req_rl' } },
+  });
+}
+
+/** A fake pair of stage runners: per item, what each stage answers; every call is recorded. */
+function runners(plan: Record<string, { transactions: () => Promise<StageOutcome>; investments: () => Promise<StageOutcome> }>) {
+  const calls: string[] = [];
+  const stage = (name: 'transactions' | 'investments'): StageRunner<Item> => [name, async (item) => {
+    calls.push(`${item.institutionName}:${name}`);
+    return plan[item.id][name]();
+  }];
+  return { calls, runners: [stage('transactions'), stage('investments')] };
+}
+
+const okTx = (landed: number, extra: Partial<Record<'already_landed' | 'corrected' | 'synced' | 'skipped', number>> = {}) => async () =>
+  stageOk('transactions', { synced: landed, skipped: 0, landed, already_landed: 0, corrected: 0, ...extra });
+const okInv = (synced: number, securities = 0) => async () => stageOk('investments', { synced, skipped: 0, securities });
+const deadItem = (stage: string) => async () => itemFailure(stage, 'TastyTrade', loginRequired());
+
+test('(a) item A fails, item B succeeds → 207; B\'s counts present; A named', async () => {
+  const { calls, runners: r } = runners({
+    'item-tt': { transactions: deadItem('transactions'), investments: deadItem('investments') },
+    'item-wf': { transactions: okTx(14, { already_landed: 3, corrected: 1 }), investments: okInv(0) },
+  });
+  const items = await syncEachItem([TASTY, WELLS], (i) => i.institutionName, r);
+
+  // Every item ran every stage — A's failure decided nothing about B.
+  assert.deepEqual(calls, ['TastyTrade:transactions', 'TastyTrade:investments', 'Wells Fargo:transactions', 'Wells Fargo:investments']);
+  assert.deepEqual(items.map(itemStatus), ['failed', 'ok']);
+
+  const { status, body } = syncItemsEnvelope(items, { synced: { transactions: 14 } });
+  assert.equal(status, 207);
+  assert.equal(body.ok, false);
+  assert.equal(body.partial, true);
+  assert.deepEqual(body.synced, { transactions: 14 }, 'okBody rides the 207');
+  const listed = body.items as ItemOutcome[];
+  assert.equal(listed[0].institution, 'TastyTrade');
+  assert.equal(listed[0].stages[0].ok, false);
+  assert.equal(listed[1].institution, 'Wells Fargo');
+  assert.deepEqual(listed[1].stages[0], { stage: 'transactions', ok: true, counts: { synced: 14, skipped: 0, landed: 14, already_landed: 3, corrected: 1 } });
+  assert.deepEqual(body.lines, [
+    'TastyTrade — needs to be reconnected (Plaid: ITEM_LOGIN_REQUIRED)',
+    'Wells Fargo synced: 14 landed, 3 already landed, 1 corrected',
+  ], 'one line per failed bank (both dead stages collapse to one) above one for what succeeded');
+  assert.equal(body.message, 'Partial sync — TastyTrade — needs to be reconnected (Plaid: ITEM_LOGIN_REQUIRED) · Wells Fargo synced: 14 landed, 3 already landed, 1 corrected');
+  const wire = JSON.stringify(body);
+  assert.ok(!wire.includes('access-production-TOKEN') && !wire.includes('PLAID-SECRET-VALUE'), 'no secret in the body');
+
+  // The banner reads the 207 body: the same lines, partial tone.
+  const out = readSyncResponse(207, body);
+  assert.equal(out.tone, 'partial');
+  assert.deepEqual(out.lines, body.lines);
+  assert.equal(out.text, body.message);
+});
+
+test('(b) every item failed → non-2xx with the first failure\'s status', async () => {
+  const { runners: r } = runners({
+    'item-tt': { transactions: deadItem('transactions'), investments: deadItem('investments') },
+    'item-wf': { transactions: async () => stageFailed('transactions', rateLimited()), investments: async () => stageFailed('investments', rateLimited()) },
+  });
+  const items = await syncEachItem([TASTY, WELLS], (i) => i.institutionName, r);
+  assert.deepEqual(items.map(itemStatus), ['failed', 'failed']);
+  const { status, body } = syncItemsEnvelope(items, { synced: { transactions: 0 } });
+  assert.equal(status, 502, 'the first failure (TastyTrade, HTTP 400 upstream) decides: 502');
+  assert.equal(body.ok, false);
+  assert.equal(body.stage, 'transactions');
+  assert.equal(body.institution, 'TastyTrade');
+  assert.equal('synced' in body, false, 'no progress keys on a run where nothing synced');
+  assert.deepEqual(body.lines, [
+    'TastyTrade — needs to be reconnected (Plaid: ITEM_LOGIN_REQUIRED)',
+    'Wells Fargo — transactions: Plaid: RATE_LIMIT_EXCEEDED (TRANSACTIONS_LIMIT) — try again in a few minutes',
+    'Wells Fargo — investments: Plaid: RATE_LIMIT_EXCEEDED (TRANSACTIONS_LIMIT) — try again in a few minutes',
+  ]);
+  assert.equal(readSyncResponse(status, body).tone, 'error');
+
+  // Rate-limit first → 429 stays 429.
+  const swapped = syncItemsEnvelope([items[1], items[0]]);
+  assert.equal(swapped.status, 429);
+
+  // A runner that THROWS (not a declared outcome) is itself declared, and the run continues.
+  const thrower = runners({
+    'item-tt': { transactions: async () => { throw new Error('boom'); }, investments: async () => { throw new Error('boom'); } },
+    'item-wf': { transactions: async () => { throw new Error('boom'); }, investments: async () => { throw new Error('boom'); } },
+  });
+  const thrown = await syncEachItem([TASTY, WELLS], (i) => i.institutionName, thrower.runners);
+  assert.equal(thrower.calls.length, 4);
+  assert.equal(syncItemsEnvelope(thrown).status, 500, 'a local throw is a 500');
+});
+
+test('(c) every item succeeded → 200 with the totals and one success line', async () => {
+  const { calls, runners: r } = runners({
+    'item-wf': { transactions: okTx(9), investments: okInv(0) },
+    'item-rh': { transactions: okTx(5), investments: okInv(7, 2) },
+  });
+  const items = await syncEachItem([ROBIN, WELLS], (i) => i.institutionName, r);
+  assert.equal(calls.length, 4);
+  assert.deepEqual(sumStageCounts(items, 'transactions'), { synced: 14, skipped: 0, landed: 14, already_landed: 0, corrected: 0 });
+  assert.deepEqual(sumStageCounts(items, 'investments'), { synced: 7, skipped: 0, securities: 2 });
+  const { status, body } = syncItemsEnvelope(items, { synced: { transactions: 14, investmentTransactions: 7, securities: 2 } });
+  assert.equal(status, 200);
+  assert.equal(body.ok, true);
+  assert.deepEqual(body.lines, ['Robinhood, Wells Fargo synced: 14 landed, 7 investment transactions, 2 securities']);
+  assert.equal(body.message, 'Synced — Robinhood, Wells Fargo synced: 14 landed, 7 investment transactions, 2 securities');
+  assert.equal(readSyncResponse(200, body).tone, 'ok');
+
+  // No linked banks at all is still a 200, and says so.
+  const none = syncItemsEnvelope([], { synced: { transactions: 0 } });
+  assert.equal(none.status, 200);
+  assert.equal(none.body.message, 'Synced — no linked banks');
+});
+
+test('(d) a page failure inside B stops only B\'s transactions stage — B\'s investments and every other item still run', async () => {
+  // What the route returns when runTransactionsPage answers !ok on page 2: the page's
+  // failure, as PR-2 declared it (the page rolled back; earlier pages landed).
+  const pageTwo = async () => stageFailed('transactions', new Error('parser: amount is not a number'), 2);
+  const { calls, runners: r } = runners({
+    'item-wf': { transactions: okTx(9), investments: okInv(0) },
+    'item-rh': { transactions: pageTwo, investments: okInv(4) },
+    'item-tt': { transactions: okTx(2), investments: okInv(1) },
+  });
+  const items = await syncEachItem([ROBIN, TASTY, WELLS], (i) => i.institutionName, r);
+  assert.deepEqual(calls, [
+    'Robinhood:transactions', 'Robinhood:investments',
+    'TastyTrade:transactions', 'TastyTrade:investments',
+    'Wells Fargo:transactions', 'Wells Fargo:investments',
+  ], 'B\'s page failure ended B\'s transactions stage only — its investments ran, and so did every other item');
+  assert.deepEqual(items.map(itemStatus), ['partial', 'ok', 'ok']);
+  const robin = items[0];
+  assert.equal(robin.stages[0].ok, false);
+  assert.equal((robin.stages[0] as { page?: number }).page, 2);
+  assert.equal(robin.stages[1].ok, true);
+
+  const { status, body } = syncItemsEnvelope(items);
+  assert.equal(status, 207);
+  assert.deepEqual(body.lines, [
+    'Robinhood — transactions page 2: Error: parser: amount is not a number',
+    'TastyTrade, Wells Fargo synced: 11 landed, 5 investment transactions',
+  ], 'the partial item is named for its failed stage; only fully-synced banks are named as synced; counts sum every stage that succeeded');
+});
+
+test('lines: an item failure is not double-named; a stage failure names its stage; nothing succeeded → no success line', () => {
+  const dead = itemFailure('transactions', 'TastyTrade', loginRequired());
+  assert.equal(failedLine('TastyTrade', dead), 'TastyTrade — needs to be reconnected (Plaid: ITEM_LOGIN_REQUIRED)');
+  assert.equal(failedLine('A linked bank', itemFailure('investments', null, loginRequired())), 'A linked bank — needs to be reconnected (Plaid: ITEM_LOGIN_REQUIRED)');
+  assert.equal(failedLine('Wells Fargo', stageFailed('investments', rateLimited())), 'Wells Fargo — investments: Plaid: RATE_LIMIT_EXCEEDED (TRANSACTIONS_LIMIT) — try again in a few minutes');
+  assert.equal(successLine([{ institution: 'TastyTrade', stages: [dead] }]), null);
+  assert.deepEqual(syncLines([{ institution: 'TastyTrade', stages: [dead, dead] }]), ['TastyTrade — needs to be reconnected (Plaid: ITEM_LOGIN_REQUIRED)']);
+  // A partial item's successful stage counts, but the bank is not called synced.
+  assert.equal(successLine([{ institution: 'Robinhood', stages: [dead, stageOk('investments', { synced: 3, skipped: 0, securities: 0 })] }]), 'Partial progress: 0 landed, 3 investment transactions');
+  // A body without lines (link-token, reconnect-complete) still reads as one line.
+  assert.deepEqual(readSyncResponse(409, { ok: false, stage: 'reconnect', message: 'Wells Fargo still needs to be reconnected (Plaid: ITEM_LOGIN_REQUIRED)' }).lines, ['Wells Fargo still needs to be reconnected (Plaid: ITEM_LOGIN_REQUIRED)']);
+  assert.deepEqual(readSyncResponse(500, null).lines, ['Sync failed: HTTP 500']);
+});

--- a/src/lib/plaid/failLoud.ts
+++ b/src/lib/plaid/failLoud.ts
@@ -107,20 +107,164 @@ export function failureEnvelope(stage: string, err: unknown, progress: Record<st
   };
 }
 
+// ─── HYG-03: the unit of failure is the ITEM, not the stage ───────────────────
+//
+// HYG-01's stage rule ("the first failure ends its stage for the whole run") let
+// one dead bank, first in database order, stop every other bank from syncing.
+// Here every item runs every stage regardless of the others; each (item, stage)
+// declares its own outcome; the response lists each bank with its outcomes and
+// counts. Inside one item a page failure still ends that item's stage (PR-2).
+
+/** One bank's outcomes — every stage, declared. */
+export interface ItemOutcome {
+  institution: string;
+  stages: StageOutcome[];
+}
+
+export type ItemStatus = 'ok' | 'partial' | 'failed';
+
+/** ok: every stage ok · failed: every stage failed · partial: some of each. */
+export function itemStatus(item: ItemOutcome): ItemStatus {
+  const failed = item.stages.filter((s) => !s.ok).length;
+  if (failed === 0) return 'ok';
+  if (failed === item.stages.length) return 'failed';
+  return 'partial';
+}
+
+export type StageRunner<I> = readonly [stage: string, run: (item: I) => Promise<StageOutcome>];
+
+/**
+ * Run every stage for every item, in the order given, regardless of any other
+ * item's outcome. A runner declares its own outcome; a runner that THROWS is
+ * itself a declared failure of that stage (never a silent skip, never a halt).
+ */
+export async function syncEachItem<I>(items: I[], institution: (item: I) => string, runners: StageRunner<I>[]): Promise<ItemOutcome[]> {
+  const out: ItemOutcome[] = [];
+  for (const item of items) {
+    const name = institution(item);
+    const stages: StageOutcome[] = [];
+    for (const [stage, run] of runners) {
+      try {
+        stages.push(await run(item));
+      } catch (err) {
+        stages.push(stageFailed(stage, err));
+      }
+    }
+    out.push({ institution: name, stages });
+  }
+  return out;
+}
+
+/** Counts for one stage summed across every item where that stage succeeded. */
+export function sumStageCounts(items: ItemOutcome[], stage: string): Record<string, number> {
+  const sum: Record<string, number> = {};
+  for (const item of items) {
+    for (const s of item.stages) {
+      if (!s.ok || s.stage !== stage) continue;
+      for (const [k, v] of Object.entries(s.counts)) sum[k] = (sum[k] ?? 0) + v;
+    }
+  }
+  return sum;
+}
+
+/**
+ * One line per failed bank: "TastyTrade — needs to be reconnected (Plaid:
+ * ITEM_LOGIN_REQUIRED)". An item failure already names the bank (BANK-01), so
+ * that prefix is not repeated; any other failure names its stage (and page).
+ */
+export function failedLine(institution: string, failure: StageFailed): string {
+  const named = failure.message.startsWith(`${institution} `);
+  const reason = named ? failure.message.slice(institution.length + 1) : failure.message;
+  const where = named ? '' : `${failure.stage}${failure.page === undefined ? '' : ` page ${failure.page}`}: `;
+  return `${institution} — ${where}${reason}`;
+}
+
+/** "Wells Fargo, Robinhood synced: 14 landed, 2 corrected, 5 investment transactions" — null when nothing succeeded. */
+export function successLine(items: ItemOutcome[]): string | null {
+  const okItems = items.filter((i) => itemStatus(i) === 'ok').map((i) => i.institution);
+  const tx = sumStageCounts(items, 'transactions');
+  const inv = sumStageCounts(items, 'investments');
+  const anyOk = items.some((i) => i.stages.some((s) => s.ok));
+  if (!anyOk) return null;
+  const parts = [`${tx.landed ?? 0} landed`];
+  if (tx.already_landed) parts.push(`${tx.already_landed} already landed`);
+  if (tx.corrected) parts.push(`${tx.corrected} corrected`);
+  if (inv.synced) parts.push(`${inv.synced} investment transactions`);
+  if (inv.securities) parts.push(`${inv.securities} securities`);
+  const who = okItems.length ? `${okItems.join(', ')} synced` : 'Partial progress';
+  return `${who}: ${parts.join(', ')}`;
+}
+
+/** The banner's lines: one per failed bank (duplicates collapsed) above one for what succeeded. */
+export function syncLines(items: ItemOutcome[]): string[] {
+  const failed: string[] = [];
+  for (const item of items) {
+    for (const s of item.stages) {
+      if (s.ok) continue;
+      const l = failedLine(item.institution, s);
+      if (!failed.includes(l)) failed.push(l);
+    }
+  }
+  const ok = successLine(items);
+  return ok === null ? failed : [...failed, ok];
+}
+
+/**
+ * Fold per-item outcomes into one response. 200 when every stage of every
+ * item succeeded; non-2xx (the first failure's status) only when EVERY stage
+ * of EVERY item failed — nothing synced anywhere; 207 otherwise. `okBody`
+ * (synced / skipped / landed totals) rides the 200 and the 207 so existing
+ * readers keep their keys. `items` and `lines` ride every answer.
+ */
+export function syncItemsEnvelope(items: ItemOutcome[], okBody: Record<string, unknown> = {}): Envelope {
+  if (items.length === 0) {
+    return { status: 200, body: { ok: true, ...okBody, items, lines: [], message: 'Synced — no linked banks' } };
+  }
+  const lines = syncLines(items);
+  const statuses = items.map(itemStatus);
+  if (statuses.every((s) => s === 'ok')) {
+    return { status: 200, body: { ok: true, ...okBody, items, lines, message: `Synced — ${lines.join(' · ')}` } };
+  }
+  if (statuses.every((s) => s === 'failed')) {
+    const firstItem = items[0];
+    const first = firstItem.stages.find((s): s is StageFailed => !s.ok)!;
+    return {
+      status: statusForFailure(first.error),
+      body: { ok: false, stage: first.stage, institution: firstItem.institution, error: first.error, items, lines, message: `Sync failed — ${lines.join(' · ')}` },
+    };
+  }
+  return { status: 207, body: { ok: false, partial: true, ...okBody, items, lines, message: `Partial sync — ${lines.join(' · ')}` } };
+}
+
 export type SyncTone = 'ok' | 'partial' | 'error';
 export interface SyncOutcome {
   tone: SyncTone;
+  /** The one-line form (the lines joined) — every existing reader prints this. */
   text: string;
+  /** HYG-03: the banner's lines — one per failed bank above one for what succeeded; [text] when the body sent none. */
+  lines: string[];
 }
 
-/** Client side: turn a status + parsed body (or null when the body was not JSON) into one inline line. */
+/** A one-line outcome built on the client (a Link exit, a local refusal). */
+export function syncLine(tone: SyncTone, text: string): SyncOutcome {
+  return { tone, text, lines: [text] };
+}
+
+function linesOf(b: Record<string, unknown> | null): string[] | null {
+  const lines = b?.lines;
+  return Array.isArray(lines) && lines.length > 0 && lines.every((l) => typeof l === 'string') ? (lines as string[]) : null;
+}
+
+/** Client side: turn a status + parsed body (or null when the body was not JSON) into the inline line(s). */
 export function readSyncResponse(status: number, body: unknown): SyncOutcome {
   const b = body && typeof body === 'object' ? (body as Record<string, unknown>) : null;
   const message = typeof b?.message === 'string' ? b.message : null;
-  if (status === 207) return { tone: 'partial', text: message ?? `Partial sync (HTTP 207)` };
-  if (status >= 200 && status < 300 && b?.ok !== false) return { tone: 'ok', text: message ?? `Synced (HTTP ${status})` };
+  const sent = linesOf(b);
+  const withLines = (tone: SyncTone, text: string): SyncOutcome => ({ tone, text, lines: sent ?? [text] });
+  if (status === 207) return withLines('partial', message ?? `Partial sync (HTTP 207)`);
+  if (status >= 200 && status < 300 && b?.ok !== false) return withLines('ok', message ?? `Synced (HTTP ${status})`);
   const fallbackError = typeof b?.error === 'string' ? b.error : null;
-  return { tone: 'error', text: message ?? fallbackError ?? `Sync failed: HTTP ${status}` };
+  return withLines('error', message ?? fallbackError ?? `Sync failed: HTTP ${status}`);
 }
 
 /** Client side: read a fetch Response into the inline line. Never throws on a non-JSON body. */


### PR DESCRIPTION
**Do not merge — Alex merges after Vercel Preview (SOC 2 gate).**

## WHY

HYG-01 made a stage stop at its first failure. Before it, each item was tried independently and the loop continued; after it, one dead item first in database order stopped every other bank from syncing. A regression. The unit of failure is the ITEM, not the stage.

## AUDIT (read-only, before building)

| # | Finding | Where |
|---|---|---|
| 1 | **Before HYG-01** each item's transactions and investments ran in their own `try … catch (error) { console.error(…) }` and the `for` loop moved on. (Silent, but isolated.) | `675750cc:src/app/api/transactions/sync-complete/route.ts:164` (`catch` of the transactions stage), `:267` (`catch` of the investments stage) |
| 2 | **On main** the two guards skip every remaining item once any item has failed that stage: `if (!transactionsFailure) { … }` and `if (!investmentsFailure) { … }`. A TastyTrade `ITEM_LOGIN_REQUIRED` first in the (unordered) `findMany` stops Wells Fargo and Robinhood. | `main:src/app/api/transactions/sync-complete/route.ts:73`, `:183`; `findMany` without `orderBy` at `:36-39` |
| 3 | The failure variables are per STAGE, not per item; the envelope folds two stage outcomes for the whole run. | `route.ts:53-54`, `:289-292`; `src/lib/plaid/failLoud.ts:84-99` (`syncEnvelope`) |
| 4 | Inside one item, a page failure ends that item's transactions stage and rolls that page back — the rule that was right (PR-2). | `route.ts:154-158` (`if (!result.ok) { … break; }`); `src/lib/arrivals/plaidTransactionsPage.ts:218-221` (`PageResult`) |
| 5 | BANK-01's item errors are already declared per item (institution named, code recorded) — they compose directly into a per-item outcome. | `route.ts:60-67` (`declareStageFailure`), `src/lib/plaid/reconnect.ts:59-63` (`itemFailure`) |
| 6 | The banner reader turns the body into ONE line (`SyncOutcome { tone, text }`); the cockpit prints `text`. One dead bank therefore reads as one failed sync. | `failLoud.ts:110-124` (`readSyncResponse`); `src/components/home/ModuleLauncher.tsx:1295-1303` |
| 7 | Other readers of the body: `ImportDataSection.tsx:85-89` reads `data.synced.transactions` / `data.synced.investmentTransactions` on any 2xx (so those keys must ride the 207 too); BANK-01b's three link-exit calls build a `SyncOutcome` by hand. | `src/components/ImportDataSection.tsx:85-89`; `ModuleLauncher.tsx:509-514` |

## BUILD

| Piece | Change |
|---|---|
| `src/app/api/transactions/sync-complete/route.ts` | `findMany` ordered by `institutionName`, then `id` (a stable run). The two stage bodies become `syncTransactions(item)` / `syncInvestments(item)`, each returning its own `StageOutcome` — ok with **its own counts** (`synced, skipped, landed, already_landed, corrected` / `synced, skipped, securities`), or failed via `declareStageFailure` (BANK-01 item errors unchanged, still recorded on the item). `syncEachItem` runs both stages for every item, regardless of other items. Inside `syncTransactions` a page failure still ends that item's stage and rolls that page back (PR-2 unchanged) — it now returns the page's declared failure instead of setting a run-wide flag; the item's `ITEM_ERROR` is still cleared (Plaid answered; the fault is local). Totals for `synced` / `skipped` / `landed` are summed over the stages that succeeded. |
| `src/lib/plaid/failLoud.ts` (the envelope helper) | `ItemOutcome { institution, stages }`, `itemStatus` (ok / partial / failed), `syncEachItem` (a runner that THROWS is itself a declared failure of that stage — never a halt), `sumStageCounts`, `failedLine`, `successLine`, `syncLines`, `syncItemsEnvelope`, `syncLine`. `syncEnvelope` (HYG-01) is untouched. |
| `readSyncResponse` (the banner reader) | `SyncOutcome` gains `lines: string[]` — the body's `lines` when sent, else `[text]`. `text` stays the joined form, so every existing `text` reader (BooksPipeline's Reconnect row, ImportDataSection) is unchanged. |
| `src/components/home/ModuleLauncher.tsx` | The banner renders one `<div>` per line; BANK-01b's three link-exit calls use `syncLine()`. |
| `src/lib/__tests__/syncItems.test.ts` (new); `failLoud.test.ts` | Tests (a)–(d) + the line rules; HYG-01's reader expectations gain `lines`. |

### The response

| Case | Status | Body |
|---|---|---|
| every stage of every item succeeded | **200** | `{ ok:true, success, synced, skipped, landed, items, lines, message: "Synced — Wells Fargo, Robinhood synced: 14 landed, …" }` |
| some failed, something succeeded | **207** | `{ ok:false, partial:true, success:false, synced, skipped, landed, items, lines, message: "Partial sync — TastyTrade — needs to be reconnected (Plaid: ITEM_LOGIN_REQUIRED) · Wells Fargo, Robinhood synced: 14 landed" }` |
| every stage of every item failed | **first failure's status** (429 → 429, upstream → 502, local → 500) | `{ ok:false, stage, institution, error, items, lines, message: "Sync failed — …" }` |
| no linked banks | 200 | `{ ok:true, …, items: [], lines: [], message: "Synced — no linked banks" }` |

`items[]` = one entry per bank, in run order: `{ institution, stages: [ { stage, ok:true, counts } | { stage, ok:false, error, message, page? } ] }`.

**Reading of "non-2xx only when EVERY item failed":** an item counts as failed when **every** stage of it failed. An item with transactions failed and investments synced is *partial*, and a run of only such items is a 207, not a non-2xx — progress was made and the body carries it. Flagged here in case the stricter reading (any stage) was meant.

### The banner

`lines` — one line per failed bank (a bank whose two stages both failed with the same item error appears once) above one line for what succeeded:

```
TastyTrade — needs to be reconnected (Plaid: ITEM_LOGIN_REQUIRED)
Wells Fargo, Robinhood synced: 14 landed, 3 already landed, 1 corrected, 5 investment transactions
```

A non-item failure names its stage (`Wells Fargo — investments: Plaid: RATE_LIMIT_EXCEEDED (TRANSACTIONS_LIMIT) — try again in a few minutes`); a page failure names the page (`Robinhood — transactions page 2: …`). Only fully-synced banks are named as synced; a partial bank's successful stage still counts (`Partial progress: 0 landed, 3 investment transactions` when no bank is fully synced). The server sends `lines`, the client prints them — same strings, no drift.

## VERIFY

| Check | Result |
|---|---|
| `npx tsc --noEmit` | exit 0 |
| eslint, 5 touched files | 0 new — `failLoud.ts`, both tests at 0; `sync-complete/route.ts` keeps its 1 pre-existing `no-explicit-any` (`(security as any)`, 1 on main); `ModuleLauncher.tsx` keeps its 2 pre-existing unused-const warnings (2 on main) |
| `npm test` | **90 / 90 pass** (85 before + 5 new) |
| asserts + `next build` | showroom ✓ · tool registry 25/25 ✓ · reachability 60 pages ✓ · answers law ✓ · arrivals law ✓ · **BUILD EXIT 0** |
| README generator | unchanged (no new route files); byte-stable |

### Tests (node:test, `syncItems.test.ts`)

```
ok 1 - (a) item A fails, item B succeeds → 207; B's counts present; A named
ok 2 - (b) every item failed → non-2xx with the first failure's status
ok 3 - (c) every item succeeded → 200 with the totals and one success line
ok 4 - (d) a page failure inside B stops only B's transactions stage — B's investments and every other item still run
ok 5 - lines: an item failure is not double-named; a stage failure names its stage; nothing succeeded → no success line
```

- **(a)** TastyTrade's two stages fail with `ITEM_LOGIN_REQUIRED` (a real axios-shaped error carrying `PLAID-SECRET` and an access token on `config`), Wells Fargo succeeds: the recorded calls are `TastyTrade:transactions, TastyTrade:investments, Wells Fargo:transactions, Wells Fargo:investments` — A's failure decided nothing about B; 207; `items[1].stages[0].counts` = `{ synced:14, skipped:0, landed:14, already_landed:3, corrected:1 }`; `lines` = the two lines above; no secret in the body; `readSyncResponse(207, body)` → tone partial with the same lines.
- **(b)** TastyTrade dead (HTTP 400) and Wells Fargo rate-limited on both stages → **502** (the first failure's status), `institution: 'TastyTrade'`, no progress keys; the same items with the 429 first → **429**; four runners that throw → four declared failures, 500.
- **(c)** Robinhood + Wells Fargo all ok → 200, totals `{ synced:14, …, landed:14 }` / `{ synced:7, securities:2 }`, one success line; zero items → 200 "Synced — no linked banks".
- **(d)** Robinhood's transactions runner answers the page-2 failure PR-2 declares; every one of the six (item, stage) calls still ran in order; Robinhood is *partial* (`stages[0].page === 2`, `stages[1].ok`), the run is 207, lines = `Robinhood — transactions page 2: Error: parser: amount is not a number` / `TastyTrade, Wells Fargo synced: 11 landed, 5 investment transactions`.

## Diff scope

`sync-complete`, its envelope helper (`failLoud.ts`), the banner reader (`readSyncResponse`, same file) — as ruled — plus the banner's render in `ModuleLauncher.tsx` (one div per line, and BANK-01b's three calls through `syncLine`) and the two test files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc

---
_Generated by [Claude Code](https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc)_