### PR TITLE
BANK-01c: Plaid OAuth — the redirect URI on every link token and the return page

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,11 @@ NEXTAUTH_URL="http://localhost:3000"
 # ═══════════════════════════════════════════════════════════════
 PLAID_CLIENT_ID="your-client-id"
 PLAID_SECRET="your-secret"
+# BANK-01c: the OAuth return URL — HTTPS, no query string, an EXACT entry in the Plaid
+# Dashboard's "Allowed redirect URIs". Sent on every link token (new item and update
+# mode); no link token is created without it (fail loud). The page lives at
+# src/app/plaid/oauth-return/page.tsx.
+PLAID_REDIRECT_URI="https://www.templestuart.com/plaid/oauth-return"
 # Note: App forces production environment for real data
 
 # ═══════════════════════════════════════════════════════════════

--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ You need Node (the code is typed against `@types/node ^20`), PostgreSQL, and a h
 |---|---|---|
 | Core | `DATABASE_URL` (read by Prisma, `prisma/schema.prisma:7`), `JWT_SECRET`, `NEXTAUTH_SECRET`, `OWNER_EMAIL`, `NEXT_PUBLIC_OWNER_EMAIL`, `NEXT_PUBLIC_APP_URL`, `NEXT_PUBLIC_BASE_URL` | Required |
 | Set by the platform | `NODE_ENV`, `VERCEL`, `NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA` | Provided by Vercel / Node; nothing to set |
-| Plaid (bank sync) | `PLAID_CLIENT_ID`, `PLAID_SECRET` | Required unless Books sync is disabled |
+| Plaid (bank sync) | `PLAID_CLIENT_ID`, `PLAID_SECRET`, `PLAID_REDIRECT_URI` (the OAuth return URL, `src/lib/plaid/oauth.ts`) | Required unless Books sync is disabled — no link token is created without the redirect URI |
 | Provider tokens at rest | `TOKEN_ENCRYPTION_KEY` (base64 of 32 bytes), `TOKEN_ENCRYPTION_KEY_ID` (`src/lib/secrets/tokenCipher.ts`) | Required — every Plaid and tastytrade token read or write fails loud without both |
 | Stripe (payments) | `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY`, `STRIPE_PRO_PRICE_ID`, `STRIPE_PRO_PLUS_PRICE_ID`; per entitlement `STRIPE_TAB_<KEY>_PRICE_ID`, `STRIPE_CAT_<KEY>_PRICE_ID`, `STRIPE_BUNDLE_ALL_PRICE_ID` (`src/lib/stripe.ts:49-55`) | Required to sell modules; skip to run everything unlocked |
 | Flights and stays (LiteAPI) | `LITEAPI_SANDBOX_KEY`, `LITEAPI_PRODUCTION_KEY`, `LITEAPI_MODE`, `FLIGHTS_LANE` (set to `liteapi`; `src/lib/flightsLane.ts:20`) | Required unless travel is disabled |

--- a/scripts/assert-tool-registry.ts
+++ b/scripts/assert-tool-registry.ts
@@ -62,6 +62,7 @@ const GUEST_ROUTES: ReadonlyArray<{ route: string; why: string }> = [
   { route: '/work-with-me', why: 'the deck (Landing.tsx), PUBLIC_PATHS' },
   { route: '/modules/[pillar]', why: 'the deck PILLAR_CARDS and ModulePointerCard.tsx' },
   { route: '/booking/confirm', why: 'the LiteAPI checkout return URL (CheckoutPanel.tsx returnUrl), PUBLIC_PATHS' },
+  { route: '/plaid/oauth-return', why: 'the Plaid OAuth return URL — PLAID_REDIRECT_URI on every link token (src/lib/plaid/oauth.ts), registered in the Plaid Dashboard; the bank sends the signed-in user here, the app never links to it' },
   { route: '/trips/rsvp', why: 'the RSVP invite link sent to participants (src/app/trips/rsvp/RSVPClient.tsx)' },
   { route: '/trips/[id]', why: 'linked from the RSVP flow — RSVPClient.tsx:72, :87, :136' },
 ];

--- a/src/app/api/plaid/link-token/route.ts
+++ b/src/app/api/plaid/link-token/route.ts
@@ -3,14 +3,14 @@ import { NextResponse } from 'next/server';
 import { failClosedResponse } from '@/lib/http/failClosedResponse';
 import { prisma } from '@/lib/prisma';
 import { plaidClient } from '@/lib/plaid';
-import { Products, CountryCode } from 'plaid';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { summarizePlaidError } from '@/lib/plaid/summarizeError';
 import { decryptToken } from '@/lib/secrets/tokenCipher';
 import { RateLimitError, rateLimit } from '@/lib/rateLimit';
 import { ownedItemOr404, rateLimitedEnvelope, updateModeLinkRequest } from '@/lib/plaid/reconnect';
-
-const CLIENT_NAME = 'Temple Stuart, LLC';
+// BANK-01c: the OAuth return URL on EVERY link token, read before any Plaid call —
+// unset → a named throw, never a token without it.
+import { CLIENT_NAME, newItemLinkRequest, plaidRedirectUri } from '@/lib/plaid/oauth';
 
 /**
  * POST /api/plaid/link-token
@@ -21,6 +21,8 @@ const CLIENT_NAME = 'Temple Stuart, LLC';
  *                  server-side (SEC-02) and handed to Plaid only; the browser
  *                  receives the link token and nothing else. No products are
  *                  requested in update mode. Rate-limited per user.
+ *   Both carry redirect_uri = PLAID_REDIRECT_URI (BANK-01c) — the OAuth return
+ *   URL registered in the Plaid Dashboard; unset → a named 500, no token.
  */
 export async function POST(request: Request) {
   try {
@@ -53,12 +55,17 @@ export async function POST(request: Request) {
       throw limited;
     }
 
+    // BANK-01c: the registered OAuth return URL — read BEFORE any Plaid call. Unset or
+    // malformed → PlaidRedirectUriMissingError → the catch-all's 500 (the name in the
+    // log); there is no link token without it.
+    const redirectUri = plaidRedirectUri();
+
     const body = (await request.json().catch(() => ({}))) as { itemId?: unknown };
 
     if (body.itemId !== undefined) {
       const item = await ownedItemOr404(prisma, user.id, body.itemId);
       const createTokenResponse = await plaidClient.linkTokenCreate(
-        updateModeLinkRequest({ userId: user.id, clientName: CLIENT_NAME, accessToken: decryptToken(item.accessToken) }),
+        updateModeLinkRequest({ userId: user.id, clientName: CLIENT_NAME, accessToken: decryptToken(item.accessToken), redirectUri }),
       );
       return NextResponse.json({
         link_token: createTokenResponse.data.link_token,
@@ -67,24 +74,14 @@ export async function POST(request: Request) {
       });
     }
 
-    const configs = {
-      user: {
-        client_user_id: user.id,
-      },
-      client_name: CLIENT_NAME,
-      products: [Products.Transactions, Products.Investments],
-      country_codes: [CountryCode.Us],
-      language: 'en',
-      transactions: {
-        days_requested: 730  // Request 2 years of history
-      }
-    };
+    // The new-item token: Transactions + Investments, two years of history, the return URL.
+    const createTokenResponse = await plaidClient.linkTokenCreate(
+      newItemLinkRequest({ userId: user.id, clientName: CLIENT_NAME, redirectUri }),
+    );
 
-    const createTokenResponse = await plaidClient.linkTokenCreate(configs);
-    
-    return NextResponse.json({ 
+    return NextResponse.json({
       link_token: createTokenResponse.data.link_token,
-      expiration: createTokenResponse.data.expiration 
+      expiration: createTokenResponse.data.expiration
     });
   } catch (error: unknown) {
     console.error('Error creating link token:', summarizePlaidError(error));

--- a/src/app/plaid/oauth-return/page.tsx
+++ b/src/app/plaid/oauth-return/page.tsx
@@ -1,0 +1,150 @@
+'use client';
+
+/**
+ * /plaid/oauth-return — Plaid's OAuth return URL (BANK-01c).
+ *
+ * The link token carried PLAID_REDIRECT_URI; an OAuth institution sends the
+ * user back here with `?oauth_state_id=…`. Per Plaid's OAuth guide the page
+ * retrieves the link_token kept before Link opened (localStorage, same
+ * browser session) and re-opens Link with the SAME token and
+ * `receivedRedirectUri` = the full received URL (window.location.href).
+ *
+ *   onSuccess → 'new'       → /api/plaid/exchange-token (as the cockpit does)
+ *             → 'reconnect' → /api/plaid/reconnect-complete (NO exchange — update
+ *                              mode keeps the item, its accounts and history)
+ *   onExit    → the BANK-01b handling: the reason shown here, the report to
+ *               /api/plaid/link-exit, then back to Books with the line.
+ *
+ * Missing, unknown, or expired kept state is a DECLARED error on this page —
+ * never a silent redirect. Not in PUBLIC_PATHS: the middleware requires the
+ * signed-in cookie (SameSite=Lax rides the bank's top-level redirect).
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import Script from 'next/script';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import {
+  completeOauthReturn,
+  forgetLinkFlow,
+  keepReturnOutcome,
+  linkReopenConfig,
+  planOauthReturn,
+  type OauthReturnPlan,
+} from '@/lib/plaid/oauth';
+import {
+  LINK_CANCELLED,
+  RECONNECT_CANCELLED,
+  linkExitOutcome,
+  notLoggedSuffix,
+  postLinkExit,
+  type LinkExitError,
+  type LinkExitMetadata,
+} from '@/lib/plaid/linkExit';
+import type { SyncOutcome } from '@/lib/plaid/failLoud';
+
+const PLAID_LINK_SCRIPT = 'https://cdn.plaid.com/link/v2/stable/link-initialize.js';
+
+type Phase =
+  | { kind: 'reading' }
+  | { kind: 'error'; message: string }
+  | { kind: 'reopening'; plan: Extract<OauthReturnPlan, { kind: 'reopen' }> }
+  | { kind: 'done'; outcome: SyncOutcome };
+
+interface PlaidLinkHandler { open(): void }
+interface PlaidGlobal { create(config: Record<string, unknown>): PlaidLinkHandler }
+
+const ERROR_CARD = 'rounded-lg border border-status-danger/30 bg-status-danger/10 p-3 text-xs text-status-danger';
+const NOTE_CARD = 'rounded-lg border border-border bg-bg-row p-3 text-xs text-text-secondary';
+
+const postJson = (path: string, body: Record<string, unknown>) =>
+  fetch(path, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
+
+function flowLabel(plan: Extract<OauthReturnPlan, { kind: 'reopen' }>): string {
+  return plan.flow.kind === 'reconnect' ? `reconnecting ${plan.flow.institution}` : 'linking a new account';
+}
+
+export default function PlaidOauthReturnPage() {
+  const router = useRouter();
+  const [phase, setPhase] = useState<Phase>({ kind: 'reading' });
+  const [plaidReady, setPlaidReady] = useState(false);
+  const opened = useRef(false);
+
+  // Step 1 — read oauth_state_id and the kept link_token + flow. Declared errors, no redirect.
+  useEffect(() => {
+    const plan = planOauthReturn(window.location.href, window.localStorage);
+    if (plan.kind === 'error') {
+      setPhase({ kind: 'error', message: plan.message });
+      return;
+    }
+    setPhase({ kind: 'reopening', plan });
+    if ((window as unknown as { Plaid?: PlaidGlobal }).Plaid) setPlaidReady(true);
+  }, []);
+
+  // Step 2 — re-open Link with the SAME token and the received URI, once the script is here.
+  useEffect(() => {
+    if (phase.kind !== 'reopening' || !plaidReady || opened.current) return;
+    const plaid = (window as unknown as { Plaid?: PlaidGlobal }).Plaid;
+    if (!plaid) return;
+    opened.current = true;
+    const { plan } = phase;
+    const { flow, linkToken } = plan;
+    const itemId = flow.kind === 'reconnect' ? flow.itemId : undefined;
+
+    const finish = (outcome: SyncOutcome) => {
+      forgetLinkFlow(window.localStorage, linkToken);
+      keepReturnOutcome(window.localStorage, { flow, outcome });
+      setPhase({ kind: 'done', outcome });
+      router.replace('/books');
+    };
+
+    plaid.create({
+      ...linkReopenConfig(plan),
+      onSuccess: async (publicToken: string, metadata: { institution?: { name?: string | null; institution_id?: string | null } | null }) => {
+        const { outcome } = await completeOauthReturn(flow, publicToken, metadata, postJson);
+        finish(outcome);
+      },
+      onExit: async (error: LinkExitError | null, metadata: LinkExitMetadata) => {
+        const exit = linkExitOutcome(error, metadata ?? {}, flow.kind === 'reconnect' ? RECONNECT_CANCELLED : LINK_CANCELLED, itemId);
+        if (exit.kind === 'connected') return;
+        if (exit.kind === 'cancelled') {
+          finish({ tone: flow.kind === 'reconnect' ? 'partial' : 'ok', text: exit.note });
+          return;
+        }
+        const posted = await postLinkExit(exit.report);
+        finish({ tone: 'error', text: posted.logged ? exit.note : exit.note + notLoggedSuffix(posted.status) });
+      },
+    }).open();
+  }, [phase, plaidReady, router]);
+
+  return (
+    <main className="mx-auto max-w-xl p-6 space-y-4">
+      <Script src={PLAID_LINK_SCRIPT} strategy="afterInteractive" onLoad={() => setPlaidReady(true)} onError={() => setPhase({ kind: 'error', message: 'Plaid Link\'s script did not load, so the OAuth return cannot resume. Open Books and start again.' })} />
+      <h1 className="font-mono text-[10px] uppercase tracking-wider text-text-secondary">Plaid · OAuth return</h1>
+
+      {phase.kind === 'reading' && <p className={NOTE_CARD} role="status">Reading the return…</p>}
+
+      {phase.kind === 'reopening' && (
+        <p className={NOTE_CARD} role="status" data-flow={phase.plan.flow.kind}>
+          Resuming Plaid Link — {flowLabel(phase.plan)}. Finish in the Plaid window.
+        </p>
+      )}
+
+      {phase.kind === 'done' && (
+        <p className={phase.outcome.tone === 'error' ? ERROR_CARD : NOTE_CARD} role={phase.outcome.tone === 'error' ? 'alert' : 'status'}>
+          {phase.outcome.text} — returning to Books.
+        </p>
+      )}
+
+      {phase.kind === 'error' && (
+        <div className={ERROR_CARD} role="alert" data-oauth-return="error">
+          <p>{phase.message}</p>
+        </div>
+      )}
+
+      <p className="text-xs">
+        <Link href="/books" className="underline text-brand-purple">Back to Books</Link>
+      </p>
+    </main>
+  );
+}

--- a/src/components/home/BooksPipeline.tsx
+++ b/src/components/home/BooksPipeline.tsx
@@ -31,6 +31,10 @@ import { PIPE_PHASES } from '@/lib/pipePhases';
 import { readSyncOutcome } from '@/lib/plaid/failLoud';
 // BANK-01b: Plaid Link's onExit is surfaced — the reason on the row, the report in the log.
 import { RECONNECT_CANCELLED, linkExitOutcome, notLoggedSuffix, postLinkExit, type LinkExitError, type LinkExitMetadata } from '@/lib/plaid/linkExit';
+// BANK-01c: the OAuth round trip — the update-mode token and the reconnect flow (item +
+// bank) are kept before Link opens so /plaid/oauth-return re-opens Link with the SAME
+// token; the return page's outcome line lands on the row.
+import { forgetLinkFlow, keepLinkFlow, takeReturnOutcome } from '@/lib/plaid/oauth';
 
 const [PIPE_FEED, PIPE_CODE, PIPE_RECONCILE, PIPE_CLOSE, PIPE_REPORTS, PIPE_EXPORT] = PIPE_PHASES.books;
 import SectionHeader from '@/components/ui/SectionHeader';
@@ -196,7 +200,14 @@ export default function BooksPipeline() {
   // BANK-01b: a third tone — 'note' — for a plain outcome (a cancel) that is neither ok nor an error.
   const [reconnectNote, setReconnectNote] = useState<{ itemId: string; text: string; tone: 'ok' | 'error' | 'note' } | null>(null);
   const [reconnecting, setReconnecting] = useState<string | null>(null);
-  const reconnectItem = async (itemId: string) => {
+  // BANK-01c: a reconnect that went through the OAuth return page left its outcome line
+  // for this row (ok / error / a cancel as the plain tone).
+  useEffect(() => {
+    const back = takeReturnOutcome(window.localStorage, 'reconnect');
+    if (!back || back.flow.kind !== 'reconnect') return;
+    setReconnectNote({ itemId: back.flow.itemId, text: back.outcome.text, tone: back.outcome.tone === 'ok' ? 'ok' : back.outcome.tone === 'error' ? 'error' : 'note' });
+  }, []);
+  const reconnectItem = async (itemId: string, institution: string) => {
     const plaid = (window as unknown as { Plaid?: { create: (cfg: Record<string, unknown>) => { open(): void } } }).Plaid;
     if (!plaid) {
       setReconnectNote({ itemId, text: 'Plaid Link has not loaded yet — try again in a moment.', tone: 'error' });
@@ -213,10 +224,18 @@ export default function BooksPipeline() {
         setReconnectNote({ itemId, text: out.text, tone: 'error' });
         return;
       }
-      const { link_token: token } = (await res.json()) as { link_token: string };
+      const { link_token: token, expiration } = (await res.json()) as { link_token: string; expiration?: unknown };
+      if (typeof expiration !== 'string') {
+        setReconnectNote({ itemId, text: 'The link token answer carried no expiration — not opening Plaid Link.', tone: 'error' });
+        return;
+      }
+      // BANK-01c: keep the token + the reconnect flow for the OAuth return page before Link
+      // opens (Plaid's guide: the same link_token must re-open Link after the bank's redirect).
+      keepLinkFlow(window.localStorage, { linkToken: token, flow: { kind: 'reconnect', itemId, institution }, expiresAt: expiration });
       plaid.create({
         token,
         onSuccess: async () => {
+          forgetLinkFlow(window.localStorage, token);
           const done = await fetch('/api/plaid/reconnect-complete', {
             method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ itemId }),
           });
@@ -229,6 +248,7 @@ export default function BooksPipeline() {
         // /api/plaid/link-exit so the log carries it; a cancel → "Reconnect cancelled".
         onExit: async (error: LinkExitError | null, metadata: LinkExitMetadata) => {
           setReconnecting(null);
+          forgetLinkFlow(window.localStorage, token);
           const exit = linkExitOutcome(error, metadata ?? {}, RECONNECT_CANCELLED, itemId);
           if (exit.kind === 'connected') return;
           if (exit.kind === 'cancelled') {
@@ -418,7 +438,7 @@ export default function BooksPipeline() {
                                 <span className="font-mono text-[10px] uppercase tracking-wider text-rose-700">needs reconnecting · {acc.lastErrorCode}</span>
                                 <button
                                   type="button"
-                                  onClick={() => reconnectItem(acc.itemId)}
+                                  onClick={() => reconnectItem(acc.itemId, acc.institutionName)}
                                   disabled={reconnecting === acc.itemId}
                                   className="rounded border border-brand-purple px-2 py-0.5 font-mono text-[10px] uppercase tracking-wider text-brand-purple hover:bg-brand-purple-wash disabled:opacity-60"
                                 >

--- a/src/components/home/ModuleLauncher.tsx
+++ b/src/components/home/ModuleLauncher.tsx
@@ -68,6 +68,10 @@ import BooksPipeline from '@/components/home/BooksPipeline';
 // BANK-01b: the new-item Link's onExit is surfaced too — the reason under the cockpit
 // bar (the sync line's slot), the report to /api/plaid/link-exit for the log.
 import { LINK_CANCELLED, linkExitOutcome, notLoggedSuffix, postLinkExit, type LinkExitError, type LinkExitMetadata } from '@/lib/plaid/linkExit';
+// BANK-01c: the OAuth round trip — the link token and the flow are kept before Link
+// opens (Plaid's guide: local storage, same browser session) so /plaid/oauth-return can
+// re-open Link with the SAME token; the return page's outcome line lands here.
+import { forgetLinkFlow, keepLinkFlow, takeReturnOutcome } from '@/lib/plaid/oauth';
 // TAX-1: the closed-books handoff gate — shows the tax wizard only once a period is
 // closed, otherwise a "close your books first" screen that jumps to the Books tab.
 import TaxHandoffGate from '@/components/home/TaxHandoffGate';
@@ -403,6 +407,8 @@ export default function ModuleLauncher({ onRequireAuth, onTabChange }: Props) {
   const [booksSyncMessage, setBooksSyncMessage] = useState<SyncOutcome | null>(null);
   // Plaid Link token for onLinkAccount (fetched from the auth-gated /api/plaid/link-token).
   const [booksLinkToken, setBooksLinkToken] = useState<string | null>(null);
+  // BANK-01c: Plaid's `expiration` for that token — the kept round-trip entry expires with it.
+  const [booksLinkExpiration, setBooksLinkExpiration] = useState<string | null>(null);
 
   const loadBooksCockpit = useCallback(async () => {
     setBooksState('loading');
@@ -453,9 +459,20 @@ export default function ModuleLauncher({ onRequireAuth, onTabChange }: Props) {
   useEffect(() => {
     if (booksLocked) return;
     loadBooksCockpit();
+    // BANK-01c: an OAuth round trip that ended on /plaid/oauth-return left its outcome line
+    // for this banner (the 'new' flow; a reconnect's line goes to its row in the pipe).
+    const back = takeReturnOutcome(window.localStorage, 'new');
+    if (back) setBooksSyncMessage(back.outcome);
     fetch('/api/plaid/link-token', { method: 'POST' })
       .then((r) => (r.ok ? r.json() : null))
-      .then((d) => { if (d?.link_token) setBooksLinkToken(d.link_token); })
+      .then((d) => {
+        // BANK-01c: the token is usable only with its expiration — the round-trip entry
+        // must expire with it; a token without one is a contract break, not a link.
+        if (d?.link_token && typeof d.expiration === 'string') {
+          setBooksLinkToken(d.link_token);
+          setBooksLinkExpiration(d.expiration);
+        }
+      })
       .catch(() => { /* no token → onLinkAccount guards on it, fail-loud (button no-ops until ready) */ });
   }, [booksLocked, loadBooksCockpit]);
 
@@ -483,10 +500,14 @@ export default function ModuleLauncher({ onRequireAuth, onTabChange }: Props) {
   // token, so this button no-ops. Guards on token + window.Plaid exactly like the
   // dashboard (no fallback).
   const booksLinkAccount = () => {
-    if (!booksLinkToken || !(window as any).Plaid) return; // eslint-disable-line @typescript-eslint/no-explicit-any
+    if (!booksLinkToken || !booksLinkExpiration || !(window as any).Plaid) return; // eslint-disable-line @typescript-eslint/no-explicit-any
+    // BANK-01c: keep the token + flow for the OAuth return page before Link opens (Plaid's
+    // guide: the same link_token must re-open Link after the bank's redirect).
+    keepLinkFlow(window.localStorage, { linkToken: booksLinkToken, flow: { kind: 'new' }, expiresAt: booksLinkExpiration });
     (window as any).Plaid.create({ // eslint-disable-line @typescript-eslint/no-explicit-any
       token: booksLinkToken,
       onSuccess: async (publicToken: string, metadata: any) => { // eslint-disable-line @typescript-eslint/no-explicit-any
+        forgetLinkFlow(window.localStorage, booksLinkToken);
         await fetch('/api/plaid/exchange-token', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
@@ -503,6 +524,7 @@ export default function ModuleLauncher({ onRequireAuth, onTabChange }: Props) {
       // cockpit bar ("Plaid Link: CODE — message") and the report to the log; a cancel →
       // "Account link cancelled". No itemId: there is no item yet.
       onExit: async (error: LinkExitError | null, metadata: LinkExitMetadata) => {
+        forgetLinkFlow(window.localStorage, booksLinkToken);
         const exit = linkExitOutcome(error, metadata ?? {}, LINK_CANCELLED);
         if (exit.kind === 'connected') return;
         if (exit.kind === 'cancelled') {

--- a/src/lib/__tests__/plaidOauth.test.ts
+++ b/src/lib/__tests__/plaidOauth.test.ts
@@ -1,0 +1,181 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  LATEST_KEY,
+  OUTCOME_KEY,
+  PlaidRedirectUriMissingError,
+  completeOauthReturn,
+  forgetLinkFlow,
+  keepLinkFlow,
+  keepReturnOutcome,
+  linkReopenConfig,
+  newItemLinkRequest,
+  planOauthReturn,
+  plaidRedirectUri,
+  takeReturnOutcome,
+  type KeyValueStore,
+} from '../plaid/oauth';
+import { updateModeLinkRequest } from '../plaid/reconnect';
+
+// BANK-01c — Plaid OAuth: the redirect URI on every link token, and the return page's round trip.
+
+const REDIRECT = 'https://www.templestuart.com/plaid/oauth-return';
+const RETURN_HREF = `${REDIRECT}?oauth_state_id=9d5feadd-a873-43eb-97ba-422f35ce849b`;
+const LINK_TOKEN = 'link-production-11111111-2222-3333-4444-555555555555';
+const ACCESS_TOKEN = 'access-production-secret';
+const NOW = new Date('2026-09-03T15:00:00Z');
+const EXPIRES = '2026-09-03T19:00:00Z';
+
+function memoryStore(): KeyValueStore & { dump(): Record<string, string> } {
+  const m = new Map<string, string>();
+  return {
+    getItem: (k) => m.get(k) ?? null,
+    setItem: (k, v) => { m.set(k, v); },
+    removeItem: (k) => { m.delete(k); },
+    dump: () => Object.fromEntries(m),
+  };
+}
+
+/** A fake fetch: records every POST and answers per path. */
+function fakePost(answers: Record<string, { status: number; body: unknown }>) {
+  const calls: { path: string; body: Record<string, unknown> }[] = [];
+  const post = async (path: string, body: Record<string, unknown>) => {
+    calls.push({ path, body });
+    const a = answers[path];
+    if (!a) throw new Error(`unexpected POST ${path}`);
+    return { status: a.status, json: async () => a.body };
+  };
+  return { calls, post };
+}
+
+test('both link tokens carry redirect_uri; the new-item token keeps Transactions + Investments', () => {
+  const fresh = newItemLinkRequest({ userId: 'user-a', clientName: 'Temple Stuart, LLC', redirectUri: REDIRECT });
+  assert.equal(fresh.redirect_uri, REDIRECT);
+  assert.deepEqual(fresh.products, ['transactions', 'investments'], 'tastytrade supports both — the new-item path keeps requesting both');
+  assert.equal(fresh.transactions.days_requested, 730);
+  assert.equal(fresh.client_name, 'Temple Stuart, LLC');
+  assert.equal(fresh.user.client_user_id, 'user-a');
+  assert.equal('access_token' in fresh, false);
+
+  const update = updateModeLinkRequest({ userId: 'user-a', clientName: 'Temple Stuart, LLC', accessToken: ACCESS_TOKEN, redirectUri: REDIRECT });
+  assert.equal(update.redirect_uri, REDIRECT, 'Plaid: update mode needs the redirect URI too');
+  assert.equal(update.access_token, ACCESS_TOKEN);
+  assert.equal('products' in update, false);
+});
+
+test('an unset, non-HTTPS, or query-carrying PLAID_REDIRECT_URI fails loud with a named error — no no-OAuth path', () => {
+  assert.equal(plaidRedirectUri({ PLAID_REDIRECT_URI: REDIRECT }), REDIRECT);
+  assert.equal(plaidRedirectUri({ PLAID_REDIRECT_URI: `  ${REDIRECT}  ` }), REDIRECT, 'trimmed');
+  const named = (env: { PLAID_REDIRECT_URI?: string }, includes: string) => {
+    assert.throws(() => plaidRedirectUri(env), (e: unknown) => {
+      assert.ok(e instanceof PlaidRedirectUriMissingError);
+      assert.equal(e.name, 'PlaidRedirectUriMissingError');
+      assert.ok(e.message.includes(includes), e.message);
+      return true;
+    });
+  };
+  named({}, 'PLAID_REDIRECT_URI is not set');
+  named({ PLAID_REDIRECT_URI: '' }, 'PLAID_REDIRECT_URI is not set');
+  named({ PLAID_REDIRECT_URI: '   ' }, 'PLAID_REDIRECT_URI is not set');
+  named({ PLAID_REDIRECT_URI: 'http://www.templestuart.com/plaid/oauth-return' }, 'must be an https URI');
+  named({ PLAID_REDIRECT_URI: `${REDIRECT}?x=1` }, 'no query string');
+  named({ PLAID_REDIRECT_URI: `${REDIRECT}#/return` }, 'no query string');
+});
+
+test('the return page re-opens Link with the kept token and the received URI', () => {
+  const store = memoryStore();
+  const kept = keepLinkFlow(store, { linkToken: LINK_TOKEN, flow: { kind: 'reconnect', itemId: 'ckitemrow0001', institution: 'tastytrade' }, expiresAt: EXPIRES, now: NOW });
+  assert.equal(kept.keptAt, NOW.toISOString());
+  assert.equal(store.getItem(LATEST_KEY), LINK_TOKEN, 'keyed by the link token, with a pointer to the latest');
+  assert.ok(store.getItem(`plaid-link:${LINK_TOKEN}`));
+
+  const plan = planOauthReturn(RETURN_HREF, store, NOW);
+  assert.equal(plan.kind, 'reopen');
+  if (plan.kind !== 'reopen') return;
+  assert.equal(plan.oauthStateId, '9d5feadd-a873-43eb-97ba-422f35ce849b');
+  assert.equal(plan.linkToken, LINK_TOKEN, 'the SAME link_token');
+  assert.equal(plan.receivedRedirectUri, RETURN_HREF, 'the FULL received URL, query string included');
+  assert.deepEqual(plan.flow, { kind: 'reconnect', itemId: 'ckitemrow0001', institution: 'tastytrade' });
+  assert.deepEqual(linkReopenConfig(plan), { token: LINK_TOKEN, receivedRedirectUri: RETURN_HREF });
+
+  // Finished → forgotten; the pointer goes with it.
+  forgetLinkFlow(store, LINK_TOKEN);
+  assert.deepEqual(store.dump(), {});
+
+  // A newer keep replaces the pointer; forgetting an older token leaves the newer pointer alone.
+  keepLinkFlow(store, { linkToken: 'link-1', flow: { kind: 'new' }, expiresAt: EXPIRES, now: NOW });
+  keepLinkFlow(store, { linkToken: 'link-2', flow: { kind: 'new' }, expiresAt: EXPIRES, now: NOW });
+  forgetLinkFlow(store, 'link-1');
+  assert.equal(store.getItem(LATEST_KEY), 'link-2');
+});
+
+test("the 'reconnect' flow calls reconnect-complete, never exchange-token; 'new' exchanges as the cockpit does", async () => {
+  const reconnect = fakePost({
+    '/api/plaid/reconnect-complete': { status: 200, body: { ok: true, stage: 'reconnect', message: 'tastytrade reconnected' } },
+    '/api/plaid/exchange-token': { status: 500, body: { ok: false, error: 'must never be called' } },
+  });
+  const r = await completeOauthReturn({ kind: 'reconnect', itemId: 'ckitemrow0001', institution: 'tastytrade' }, 'public-production-x', { institution: { name: 'tastytrade', institution_id: 'ins_116995' } }, reconnect.post);
+  assert.equal(r.endpoint, '/api/plaid/reconnect-complete');
+  assert.deepEqual(reconnect.calls, [{ path: '/api/plaid/reconnect-complete', body: { itemId: 'ckitemrow0001' } }], 'one call, no public token, no exchange');
+  assert.deepEqual(r.outcome, { tone: 'ok', text: 'tastytrade reconnected' });
+  assert.ok(!JSON.stringify(reconnect.calls).includes('public-production-x'), 'the public token never leaves the browser in update mode');
+
+  const still = fakePost({ '/api/plaid/reconnect-complete': { status: 409, body: { ok: false, stage: 'reconnect', message: 'tastytrade still needs to be reconnected (Plaid: ITEM_LOGIN_REQUIRED)' } } });
+  const s = await completeOauthReturn({ kind: 'reconnect', itemId: 'ckitemrow0001', institution: 'tastytrade' }, 'public-production-x', null, still.post);
+  assert.deepEqual(s.outcome, { tone: 'error', text: 'tastytrade still needs to be reconnected (Plaid: ITEM_LOGIN_REQUIRED)' });
+
+  const fresh = fakePost({ '/api/plaid/exchange-token': { status: 200, body: { success: true } } });
+  const n = await completeOauthReturn({ kind: 'new' }, 'public-production-y', { institution: { name: 'tastytrade', institution_id: 'ins_116995' } }, fresh.post);
+  assert.equal(n.endpoint, '/api/plaid/exchange-token');
+  assert.deepEqual(fresh.calls, [{ path: '/api/plaid/exchange-token', body: { publicToken: 'public-production-y', institutionId: 'ins_116995', institutionName: 'tastytrade', entityId: 'personal' } }], 'the exact body the cockpit sends today');
+  assert.deepEqual(n.outcome, { tone: 'ok', text: 'tastytrade linked' });
+
+  const failed = fakePost({ '/api/plaid/exchange-token': { status: 500, body: { ok: false, stage: 'api/plaid/exchange-token POST', error: 'Failed to link account', message: 'Failed to link account' } } });
+  const f = await completeOauthReturn({ kind: 'new' }, 'public-production-y', null, failed.post);
+  assert.deepEqual(f.outcome, { tone: 'error', text: 'Failed to link account' });
+});
+
+test('a return with no kept state renders the declared error — and so do a missing state id, a corrupt entry, and an expired token', () => {
+  const empty = memoryStore();
+  const none = planOauthReturn(RETURN_HREF, empty, NOW);
+  assert.equal(none.kind, 'error');
+  if (none.kind === 'error') assert.match(none.message, /No Plaid Link session was kept in this browser .*9d5feadd/);
+
+  const noState = planOauthReturn(REDIRECT, memoryStore(), NOW);
+  assert.equal(noState.kind, 'error');
+  if (noState.kind === 'error') assert.match(noState.message, /carries no oauth_state_id/);
+
+  const corrupt = memoryStore();
+  corrupt.setItem(LATEST_KEY, LINK_TOKEN);
+  corrupt.setItem(`plaid-link:${LINK_TOKEN}`, '{not json');
+  const c = planOauthReturn(RETURN_HREF, corrupt, NOW);
+  assert.equal(c.kind, 'error');
+  if (c.kind === 'error') assert.match(c.message, /missing or unreadable/);
+
+  const dangling = memoryStore();
+  dangling.setItem(LATEST_KEY, LINK_TOKEN);
+  assert.equal(planOauthReturn(RETURN_HREF, dangling, NOW).kind, 'error');
+
+  const expired = memoryStore();
+  keepLinkFlow(expired, { linkToken: LINK_TOKEN, flow: { kind: 'new' }, expiresAt: '2026-09-03T14:00:00Z', now: new Date('2026-09-03T10:00:00Z') });
+  const e = planOauthReturn(RETURN_HREF, expired, NOW);
+  assert.equal(e.kind, 'error');
+  if (e.kind === 'error') assert.match(e.message, /expired at 2026-09-03T14:00:00Z/);
+
+  assert.equal(planOauthReturn('not a url', memoryStore(), NOW).kind, 'error');
+});
+
+test('the outcome line rides back to Books and is consumed by the reader of its flow kind', () => {
+  const store = memoryStore();
+  keepReturnOutcome(store, { flow: { kind: 'reconnect', itemId: 'ckitemrow0001', institution: 'tastytrade' }, outcome: { tone: 'ok', text: 'tastytrade reconnected' }, now: NOW });
+  assert.equal(takeReturnOutcome(store, 'new'), null, "the cockpit banner reads 'new' outcomes only — the row's outcome stays for the row");
+  assert.ok(store.getItem(OUTCOME_KEY), 'still kept');
+  const taken = takeReturnOutcome(store, 'reconnect');
+  assert.deepEqual(taken, { flow: { kind: 'reconnect', itemId: 'ckitemrow0001', institution: 'tastytrade' }, outcome: { tone: 'ok', text: 'tastytrade reconnected' }, at: NOW.toISOString() });
+  assert.equal(store.getItem(OUTCOME_KEY), null, 'consumed');
+  assert.equal(takeReturnOutcome(store, 'reconnect'), null);
+
+  store.setItem(OUTCOME_KEY, '{"flow":{"kind":"new"},"outcome":{"tone":"ok"}}');
+  assert.equal(takeReturnOutcome(store, 'new'), null, 'a malformed outcome is dropped, not rendered');
+  assert.equal(store.getItem(OUTCOME_KEY), null);
+});

--- a/src/lib/__tests__/plaidReconnect.test.ts
+++ b/src/lib/__tests__/plaidReconnect.test.ts
@@ -167,8 +167,9 @@ test("(b) link-token with another user's itemId is a 404 envelope that confirms 
   assert.equal(finds.length, before, 'a missing id never reaches the table');
 
   // Update mode: the existing item's access token, no products, no history request.
-  const req = updateModeLinkRequest({ userId: OWNER, clientName: 'Temple Stuart, LLC', accessToken: ACCESS_TOKEN });
+  const req = updateModeLinkRequest({ userId: OWNER, clientName: 'Temple Stuart, LLC', accessToken: ACCESS_TOKEN, redirectUri: 'https://www.templestuart.com/plaid/oauth-return' });
   assert.equal(req.access_token, ACCESS_TOKEN);
+  assert.equal(req.redirect_uri, 'https://www.templestuart.com/plaid/oauth-return', 'BANK-01c: update mode carries the OAuth return URL');
   assert.equal(req.user.client_user_id, OWNER);
   assert.equal(req.client_name, 'Temple Stuart, LLC');
   assert.equal('products' in req, false);

--- a/src/lib/plaid/oauth.ts
+++ b/src/lib/plaid/oauth.ts
@@ -1,0 +1,227 @@
+/**
+ * BANK-01c — Plaid OAuth: the redirect URI on every link token, and the
+ * return page's round trip.
+ *
+ * Plaid's OAuth guide (plaid.com/docs/link/oauth): the link token carries
+ * `redirect_uri` (HTTPS, an exact entry in the Dashboard's Allowed redirect
+ * URIs, no query parameters — and update mode needs it too); the bank sends
+ * the user back to that URI with `?oauth_state_id=…`; the app re-opens Link
+ * with the SAME link_token and `receivedRedirectUri` = the full received URL;
+ * in the same browser session the link_token is kept "in a cookie or local
+ * storage" across the redirect.
+ *
+ * This module is pure: the env read (fail loud — no link token without the
+ * redirect URI), both link-token request builders, and the round trip over a
+ * key-value port (localStorage in the browser, a Map in tests).
+ */
+import { CountryCode, Products, type LinkTokenCreateRequest } from 'plaid';
+import { readSyncResponse, type SyncOutcome } from './failLoud';
+
+// ─── the redirect URI ─────────────────────────────────────────────────────────
+
+export class PlaidRedirectUriMissingError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'PlaidRedirectUriMissingError';
+  }
+}
+
+/**
+ * The registered OAuth return URL, from PLAID_REDIRECT_URI. Unset, non-HTTPS,
+ * or carrying a query string → a named throw: there is no no-OAuth path.
+ */
+export function plaidRedirectUri(env: Record<string, string | undefined> = { PLAID_REDIRECT_URI: process.env.PLAID_REDIRECT_URI }): string {
+  const value = env.PLAID_REDIRECT_URI?.trim();
+  if (!value) {
+    throw new PlaidRedirectUriMissingError(
+      'PLAID_REDIRECT_URI is not set — every Plaid link token needs the OAuth return URL registered in the Plaid Dashboard (Allowed redirect URIs); no link token is created without it',
+    );
+  }
+  if (!/^https:\/\//i.test(value)) {
+    throw new PlaidRedirectUriMissingError(`PLAID_REDIRECT_URI must be an https URI (Plaid: "Redirect URIs must use HTTPS"); got "${value.slice(0, 48)}"`);
+  }
+  if (value.includes('?') || value.includes('#')) {
+    throw new PlaidRedirectUriMissingError('PLAID_REDIRECT_URI must carry no query string or fragment (Plaid: "Do not use query parameters when specifying the redirect_uri"; hash routing is not supported)');
+  }
+  return value;
+}
+
+export const CLIENT_NAME = 'Temple Stuart, LLC';
+
+/** plaid 11.0.0's LinkTokenCreateRequest does not type `transactions.days_requested`; the API accepts it (the route sent it untyped before). */
+export type NewItemLinkRequest = LinkTokenCreateRequest & { transactions: { days_requested: number } };
+
+/** The NEW-item link token: Transactions + Investments (tastytrade supports both), two years of history, the OAuth return URL. */
+export function newItemLinkRequest(input: { userId: string; clientName: string; redirectUri: string }): NewItemLinkRequest {
+  return {
+    user: { client_user_id: input.userId },
+    client_name: input.clientName,
+    products: [Products.Transactions, Products.Investments],
+    country_codes: [CountryCode.Us],
+    language: 'en',
+    transactions: { days_requested: 730 },
+    redirect_uri: input.redirectUri,
+  };
+}
+
+// ─── the round trip ───────────────────────────────────────────────────────────
+
+/** localStorage / sessionStorage, structurally. */
+export interface KeyValueStore {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+}
+
+export type LinkFlow =
+  | { kind: 'new' }
+  | { kind: 'reconnect'; itemId: string; institution: string };
+
+/** What the browser keeps before opening Link, keyed by the link token. */
+export interface KeptLink {
+  linkToken: string;
+  flow: LinkFlow;
+  /** Plaid's `expiration` for the link token (link-token route), ISO. */
+  expiresAt: string;
+  keptAt: string;
+}
+
+const keyOf = (linkToken: string) => `plaid-link:${linkToken}`;
+export const LATEST_KEY = 'plaid-link:latest';
+export const OUTCOME_KEY = 'plaid-link:outcome';
+
+/** Before opening Link, in both flows: keep the token and the flow for the return page. */
+export function keepLinkFlow(store: KeyValueStore, input: { linkToken: string; flow: LinkFlow; expiresAt: string; now?: Date }): KeptLink {
+  const kept: KeptLink = { linkToken: input.linkToken, flow: input.flow, expiresAt: input.expiresAt, keptAt: (input.now ?? new Date()).toISOString() };
+  store.setItem(keyOf(input.linkToken), JSON.stringify(kept));
+  store.setItem(LATEST_KEY, input.linkToken);
+  return kept;
+}
+
+/** After Link finished (success or exit) in either the original page or the return page. */
+export function forgetLinkFlow(store: KeyValueStore, linkToken: string): void {
+  store.removeItem(keyOf(linkToken));
+  if (store.getItem(LATEST_KEY) === linkToken) store.removeItem(LATEST_KEY);
+}
+
+function isFlow(v: unknown): v is LinkFlow {
+  if (!v || typeof v !== 'object') return false;
+  const f = v as Record<string, unknown>;
+  if (f.kind === 'new') return true;
+  return f.kind === 'reconnect' && typeof f.itemId === 'string' && typeof f.institution === 'string';
+}
+
+function parseKept(raw: string | null): KeptLink | null {
+  if (!raw) return null;
+  try {
+    const v = JSON.parse(raw) as Record<string, unknown>;
+    if (typeof v.linkToken !== 'string' || typeof v.expiresAt !== 'string' || typeof v.keptAt !== 'string' || !isFlow(v.flow)) return null;
+    return { linkToken: v.linkToken, flow: v.flow, expiresAt: v.expiresAt, keptAt: v.keptAt };
+  } catch {
+    return null;
+  }
+}
+
+export type OauthReturnPlan =
+  | { kind: 'reopen'; oauthStateId: string; linkToken: string; flow: LinkFlow; receivedRedirectUri: string }
+  | { kind: 'error'; message: string };
+
+/**
+ * The return page's first step: read `oauth_state_id` from the URL, retrieve
+ * the kept token + flow. Missing, unknown, corrupt, or expired state is a
+ * DECLARED error for the page — never a silent redirect.
+ */
+export function planOauthReturn(href: string, store: KeyValueStore, now: Date = new Date()): OauthReturnPlan {
+  let url: URL;
+  try {
+    url = new URL(href);
+  } catch {
+    return { kind: 'error', message: `The return URL could not be read (${href.slice(0, 64)}).` };
+  }
+  const oauthStateId = url.searchParams.get('oauth_state_id');
+  if (!oauthStateId) {
+    return { kind: 'error', message: 'This is the Plaid OAuth return page, but the URL carries no oauth_state_id — there is no Link session to resume. Open Books and start the link or reconnect again.' };
+  }
+  const latest = store.getItem(LATEST_KEY);
+  if (!latest) {
+    return { kind: 'error', message: `No Plaid Link session was kept in this browser for this return (state ${oauthStateId}). The link must be started and finished in the same browser — open Books and start again.` };
+  }
+  const kept = parseKept(store.getItem(keyOf(latest)));
+  if (!kept) {
+    return { kind: 'error', message: `The kept Plaid Link session for this return (state ${oauthStateId}) is missing or unreadable. Open Books and start again.` };
+  }
+  if (new Date(kept.expiresAt).getTime() <= now.getTime()) {
+    return { kind: 'error', message: `The kept Plaid Link session expired at ${kept.expiresAt} (Plaid link tokens are short-lived). Open Books and start again.` };
+  }
+  return { kind: 'reopen', oauthStateId, linkToken: kept.linkToken, flow: kept.flow, receivedRedirectUri: href };
+}
+
+/** What Plaid.create receives on the return page: the SAME token, the full received URL. */
+export function linkReopenConfig(plan: Extract<OauthReturnPlan, { kind: 'reopen' }>): { token: string; receivedRedirectUri: string } {
+  return { token: plan.linkToken, receivedRedirectUri: plan.receivedRedirectUri };
+}
+
+export type PostJson = (path: string, body: Record<string, unknown>) => Promise<{ status: number; json(): Promise<unknown> }>;
+
+export interface LinkSuccessMetadata {
+  institution?: { name?: string | null; institution_id?: string | null } | null;
+}
+
+/**
+ * Link's onSuccess on the return page: 'new' → exchange-token, exactly as the
+ * cockpit does; 'reconnect' → reconnect-complete, and NEVER exchange-token
+ * (update mode keeps the item and its token). Returns which endpoint ran and
+ * the outcome line for Books.
+ */
+export async function completeOauthReturn(flow: LinkFlow, publicToken: string, metadata: LinkSuccessMetadata | null | undefined, post: PostJson): Promise<{ endpoint: string; outcome: SyncOutcome }> {
+  if (flow.kind === 'reconnect') {
+    const res = await post('/api/plaid/reconnect-complete', { itemId: flow.itemId });
+    const body = await res.json().catch(() => null);
+    return { endpoint: '/api/plaid/reconnect-complete', outcome: readSyncResponse(res.status, body) };
+  }
+  const institutionName = metadata?.institution?.name ?? null;
+  const res = await post('/api/plaid/exchange-token', {
+    publicToken,
+    institutionId: metadata?.institution?.institution_id ?? null,
+    institutionName,
+    entityId: 'personal',
+  });
+  const body = await res.json().catch(() => null);
+  const read = readSyncResponse(res.status, body);
+  // exchange-token's success body carries no `message`; name the bank instead of "Synced (HTTP 200)".
+  const b = body && typeof body === 'object' ? (body as Record<string, unknown>) : null;
+  const text = read.tone === 'ok' && typeof b?.message !== 'string' ? `${institutionName ?? 'Account'} linked` : read.text;
+  return { endpoint: '/api/plaid/exchange-token', outcome: { ...read, text } };
+}
+
+// ─── the outcome line, carried back to Books ──────────────────────────────────
+
+export interface ReturnOutcome {
+  flow: LinkFlow;
+  outcome: SyncOutcome;
+  at: string;
+}
+
+export function keepReturnOutcome(store: KeyValueStore, input: { flow: LinkFlow; outcome: SyncOutcome; now?: Date }): void {
+  store.setItem(OUTCOME_KEY, JSON.stringify({ flow: input.flow, outcome: input.outcome, at: (input.now ?? new Date()).toISOString() } satisfies ReturnOutcome));
+}
+
+/** Books reads (and consumes) the outcome of the flow kind it renders: the cockpit banner for 'new', the row for 'reconnect'. */
+export function takeReturnOutcome(store: KeyValueStore, kind: LinkFlow['kind']): ReturnOutcome | null {
+  const raw = store.getItem(OUTCOME_KEY);
+  if (!raw) return null;
+  try {
+    const v = JSON.parse(raw) as Record<string, unknown>;
+    const outcome = v.outcome as Record<string, unknown> | undefined;
+    if (!isFlow(v.flow) || !outcome || typeof outcome.text !== 'string' || typeof outcome.tone !== 'string' || typeof v.at !== 'string') {
+      store.removeItem(OUTCOME_KEY);
+      return null;
+    }
+    if (v.flow.kind !== kind) return null;
+    store.removeItem(OUTCOME_KEY);
+    return { flow: v.flow, outcome: { tone: outcome.tone as SyncOutcome['tone'], text: outcome.text }, at: v.at };
+  } catch {
+    store.removeItem(OUTCOME_KEY);
+    return null;
+  }
+}

--- a/src/lib/plaid/reconnect.ts
+++ b/src/lib/plaid/reconnect.ts
@@ -78,14 +78,20 @@ export async function ownedItemOr404(db: ItemDb, userId: string, itemRowId: unkn
   return item;
 }
 
-/** Link update mode: the existing item's access token, no products (Plaid: products are not set in update mode unless adding one). */
-export function updateModeLinkRequest(input: { userId: string; clientName: string; accessToken: string }): LinkTokenCreateRequest {
+/**
+ * Link update mode: the existing item's access token, no products (Plaid: products are
+ * not set in update mode unless adding one). BANK-01c: the OAuth return URL rides here
+ * too — Plaid: "If you're using Link in update mode, ensure you specify your redirect
+ * URI via the redirect_uri field."
+ */
+export function updateModeLinkRequest(input: { userId: string; clientName: string; accessToken: string; redirectUri: string }): LinkTokenCreateRequest {
   return {
     user: { client_user_id: input.userId },
     client_name: input.clientName,
     country_codes: [CountryCode.Us],
     language: 'en',
     access_token: input.accessToken,
+    redirect_uri: input.redirectUri,
   };
 }
 


### PR DESCRIPTION
**Do not merge — Alex merges after Vercel Preview (SOC 2 gate).**

**Needs an env var on the Preview and in Production:** `PLAID_REDIRECT_URI=https://www.templestuart.com/plaid/oauth-return` (the exact Dashboard entry). Without it every link-token request answers a named 500 — by design.

## WHY

tastytrade (ins_116995) is supported by Plaid, yet Link update mode refuses the item with `INSTITUTION_NO_LONGER_SUPPORTED`. Plaid's documented causes for that code are "The financial institution is no longer supported on Plaid's platform" and **"The institution has switched from supporting non-OAuth-based connections to requiring OAuth-based connections."** This integration had never sent a `redirect_uri` or handled an OAuth return. The redirect URI is now registered in the Dashboard; this PR builds the OAuth round trip so Reconnect restores the SAME item, accounts, and history.

## AUDIT (read-only, before building)

### Plaid's rules (reference data, quoted — plaid.com/docs/link/oauth unless noted)

| Rule | Quote |
|---|---|
| HTTPS | "Redirect URIs must use HTTPS. The only exception is on Sandbox, where, for testing purposes, redirect URIs pointing to localhost are allowed over HTTP." |
| Exact match, no wildcard in the call | Redirect URIs must precisely match the Dashboard "Allowed redirect URIs" entry; "Do not enter a wildcard (*) when specifying a `redirect_uri` in the call to /link/token/create." |
| No query string, no hash | "Do not use query parameters when specifying the `redirect_uri`." / "Redirect URIs do not support hash routing, so your URI cannot contain a '#' symbol." |
| How the user comes back | "The received redirect URI is your redirect URI appended with an OAuth state ID parameter." e.g. `https://example.com/oauth-page.html?oauth_state_id=9d5feadd-…` |
| Re-open with the SAME token | "When reinitializing Link, configure it using the same Link token you used when initializing Link the first time." |
| receivedRedirectUri | "You should configure it with the `receivedRedirectUri` field and pass in the full received redirect URI… You can retrieve it using `window.location.href`." |
| Keeping the token across the round trip | "If Link is reinitialized in the _same_ browser session as the first Link initialization, you can store the Link token in a cookie or local storage in the browser for easy access when reinitializing Link." (A different session → a server-side mapping.) |
| Update mode | "If you're using Link in update mode, ensure you specify your redirect URI via the `redirect_uri` field." |
| The error seen | plaid.com/docs/errors/institution — `INSTITUTION_NO_LONGER_SUPPORTED`: error_message "this institution is no longer supported"; common causes as quoted above. |
| SDK | `LinkTokenCreateRequest.redirect_uri` — "used to support OAuth authentication flows when launching Link in the browser… must be an https URI… any redirect URI must also be added to the Allowed redirect URIs list in the developer dashboard" (`node_modules/plaid/dist/api.d.ts:14604-14608`). |

### This repo, before

| # | Finding | Where |
|---|---|---|
| 1 | No code path, env var, or doc named a redirect URI: `git grep -i "PLAID_REDIRECT_URI\|redirect_uri\|receivedRedirectUri\|redirectUri\|oauth_state_id"` → zero hits (lockfile excluded). `.env.example:21-22` and `README.md:289` list `PLAID_CLIENT_ID` / `PLAID_SECRET` only. | whole tree |
| 2 | **New-item link token** — an untyped literal with `products: [Transactions, Investments]`, `transactions.days_requested: 730`, no `redirect_uri`. | `src/app/api/plaid/link-token/route.ts:70-83` (main) |
| 3 | **Update-mode link token** — `user, client_name, country_codes, language, access_token`; no `redirect_uri`. | `src/lib/plaid/reconnect.ts:82-90` (main) |
| 4 | **Link init, new item** — `Plaid.create({ token, onSuccess → exchange-token, onExit })`; nothing kept before opening; no `receivedRedirectUri` anywhere. | `src/components/home/ModuleLauncher.tsx:482-518` (main) |
| 5 | **Link init, reconnect** — `plaid.create({ token, onSuccess → reconnect-complete, onExit })`; same. | `src/components/home/BooksPipeline.tsx:199-241` (main) |
| 6 | The link-token route answers `{ link_token, expiration }` — Plaid's `expiration` is exactly what a kept round-trip entry should expire with. | `link-token/route.ts:63-67, :85-88` |
| 7 | **Middleware:** every non-public path requires the verified `userEmail` cookie (or a NextAuth token) and otherwise redirects to `/`; the cookie is set `sameSite: 'lax'`, which a top-level GET navigation from the bank's site carries. So the return page is reachable for a signed-in user with PUBLIC_PATHS untouched. | `src/middleware.ts:162, :192-202`; `src/app/api/auth/login/route.ts:57-59` |
| 8 | **Reachability law:** listed flow routes carry a cited door (`GUEST_ROUTES`); `/booking/confirm` is the precedent for a provider return URL. | `scripts/assert-tool-registry.ts:54-66` |
| 9 | **README env table** is generated with a hard drift check: every `process.env.NAME` read in `src` must be documented and vice versa. | generator (scratchpad) `readme-gen.py:163-167, :277-280` |
| 10 | **Product coverage:** tastytrade supports Investments and Transactions per the coverage page cited in the ruling. **Not verified by me** — `plaid.com/institutions/tastytrade/` answers 404 to this environment; the ruling's statement is taken as given. The new-item path keeps requesting both. | ruling; `newItemLinkRequest` |

## BUILD

| Piece | Change |
|---|---|
| `src/lib/plaid/oauth.ts` (new, pure) | `plaidRedirectUri()` reads `process.env.PLAID_REDIRECT_URI` — unset / blank, non-HTTPS, or carrying `?`/`#` → **`PlaidRedirectUriMissingError`** (named). `newItemLinkRequest` (Transactions + Investments, 730 days, `redirect_uri`). The round trip over a key-value port: `keepLinkFlow` (keyed `plaid-link:<token>` + a `plaid-link:latest` pointer, with Plaid's `expiration`), `forgetLinkFlow`, `planOauthReturn(href, store, now)` → `reopen { linkToken, flow, receivedRedirectUri: href }` or a declared `error`, `linkReopenConfig`, `completeOauthReturn(flow, publicToken, metadata, post)` ('new' → exchange-token with the cockpit's exact body; 'reconnect' → reconnect-complete, never exchange-token), `keepReturnOutcome` / `takeReturnOutcome(store, kind)`. |
| `src/lib/plaid/reconnect.ts` | `updateModeLinkRequest` gains `redirectUri` → `redirect_uri`. |
| `src/app/api/plaid/link-token/route.ts` | `plaidRedirectUri()` is read **before any Plaid call** (after the gates and the limiter); both branches build through the two builders; the untyped literal is gone. Unset env → the catch-all's fixed 500 with the error's name in the server log. |
| `ModuleLauncher.tsx` ("+ Account") | The mount fetch keeps the token only with its `expiration`; `booksLinkAccount` calls `keepLinkFlow(localStorage, { token, flow: 'new', expiresAt })` before `Plaid.create`, `forgetLinkFlow` on success and on exit; on mount it takes a `'new'` return outcome into the banner. |
| `BooksPipeline.tsx` (Reconnect) | `reconnectItem(itemId, institution)`; keeps `{ reconnect, itemId, institution }` with the token before opening; forgets on success and exit; a link-token answer without `expiration` is a declared row error, not a link; on mount it takes a `'reconnect'` return outcome onto the row (ok / error / a cancel as the plain tone). |
| `src/app/plaid/oauth-return/page.tsx` (new, client) | Reads `oauth_state_id` from the URL, retrieves the kept token + flow, loads Link's script, re-opens Link with `{ token, receivedRedirectUri: window.location.href, onSuccess, onExit }`. onSuccess → `completeOauthReturn`; onExit → the BANK-01b handling (`linkExitOutcome` → `postLinkExit`, "Reconnect cancelled" / "Account link cancelled"). Either way: forget the kept entry, keep the outcome line, `router.replace('/books')`. Missing / unknown / corrupt / expired state → a declared error card with a Back-to-Books link, never a redirect. |
| `src/middleware.ts` | **Unchanged** — PUBLIC_PATHS untouched; the page requires the signed-in cookie. |
| `scripts/assert-tool-registry.ts` | `/plaid/oauth-return` listed as a flow route: "the Plaid OAuth return URL — PLAID_REDIRECT_URI on every link token, registered in the Plaid Dashboard; the bank sends the signed-in user here, the app never links to it". Reachability law: 61 pages. |
| `.env.example`, `README.md` | `PLAID_REDIRECT_URI` documented; the README env row regenerated (drift check clean, byte-stable on a second run). |
| `src/lib/__tests__/plaidOauth.test.ts` (new); `plaidReconnect.test.ts` | The ruled tests; BANK-01's builder test passes the new argument and asserts it. |

## VERIFY

| Check | Result |
|---|---|
| `npx tsc --noEmit` | exit 0 |
| eslint, 9 touched/new files | 0 new — all at 0 except `ModuleLauncher.tsx`'s 2 pre-existing unused-const warnings (2 on main) |
| `npm test` | **91 / 91 pass** (85 before + 6 new) |
| asserts + `next build` | showroom ✓ · tool registry 25/25 ✓ · **reachability 61 pages ✓** (`/plaid/oauth-return` listed route) · answers law ✓ · arrivals law ✓ · **BUILD EXIT 0**; the page prerenders (`○ /plaid/oauth-return`) |
| README generator | env drift check passes; regenerated; second run byte-identical |

### Tests (node:test, `plaidOauth.test.ts`)

```
ok 1 - both link tokens carry redirect_uri; the new-item token keeps Transactions + Investments
ok 2 - an unset, non-HTTPS, or query-carrying PLAID_REDIRECT_URI fails loud with a named error — no no-OAuth path
ok 3 - the return page re-opens Link with the kept token and the received URI
ok 4 - the 'reconnect' flow calls reconnect-complete, never exchange-token; 'new' exchanges as the cockpit does
ok 5 - a return with no kept state renders the declared error — and so do a missing state id, a corrupt entry, and an expired token
ok 6 - the outcome line rides back to Books and is consumed by the reader of its flow kind
```

1. `newItemLinkRequest(...).redirect_uri` and `updateModeLinkRequest(...).redirect_uri` both equal the registered URI; the new-item request keeps `products: ['transactions','investments']` and `days_requested: 730`.
2. `{}`, `''`, `'   '` → `PlaidRedirectUriMissingError` "PLAID_REDIRECT_URI is not set"; `http://…` → "must be an https URI"; `…?x=1` / `…#/return` → "no query string".
3. `keepLinkFlow` then `planOauthReturn('https://www.templestuart.com/plaid/oauth-return?oauth_state_id=9d5feadd-…')` → `reopen` with the SAME token and `receivedRedirectUri` equal to the full URL; `linkReopenConfig` → `{ token, receivedRedirectUri }`; forgetting clears the entry and the pointer.
4. A recording fake fetch: the reconnect flow makes exactly one call, `POST /api/plaid/reconnect-complete { itemId }`, the public token never appears in any call; the 'new' flow posts the cockpit's exact exchange-token body; a 409 from reconnect-complete reads as the error line.
5. Empty store → "No Plaid Link session was kept in this browser for this return (state 9d5feadd-…)"; no `oauth_state_id` → "carries no oauth_state_id"; a corrupt entry → "missing or unreadable"; an expired token → "expired at 2026-09-03T14:00:00Z"; an unparsable href → error.
6. The banner reader (`'new'`) leaves a reconnect outcome for the row; the row reader consumes it; a malformed outcome is dropped, not rendered.

## Not verified here — say it plainly

- **No live Plaid OAuth round trip is possible in this environment** (no Plaid credentials, no browser to a bank). The Vercel Preview with `PLAID_REDIRECT_URI` set is the first real test: press Reconnect on tastytrade, complete the bank's OAuth page, land on `/plaid/oauth-return`, see "tastytrade reconnected" on the row.
- The kept state lives in the browser's localStorage for the origin that opened Link, so the registered `https://www.templestuart.com/…` must be the same host the app runs on (apex vs `www` would be two origins).
- The tastytrade coverage page could not be fetched from here (404 to this environment); its product list is taken from the ruling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc

---
_Generated by [Claude Code](https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc)_