### PR TITLE
BANK-01c fix-up: every outcome the OAuth return page builds carries `lines`

### DIFF
--- a/src/app/plaid/oauth-return/page.tsx
+++ b/src/app/plaid/oauth-return/page.tsx
@@ -41,7 +41,8 @@ import {
   type LinkExitError,
   type LinkExitMetadata,
 } from '@/lib/plaid/linkExit';
-import type { SyncOutcome } from '@/lib/plaid/failLoud';
+// HYG-03: every outcome carries `lines`; a page-built one is the one-line form, like the link-exit notes.
+import { syncLine, type SyncOutcome } from '@/lib/plaid/failLoud';
 
 const PLAID_LINK_SCRIPT = 'https://cdn.plaid.com/link/v2/stable/link-initialize.js';
 
@@ -108,11 +109,11 @@ export default function PlaidOauthReturnPage() {
         const exit = linkExitOutcome(error, metadata ?? {}, flow.kind === 'reconnect' ? RECONNECT_CANCELLED : LINK_CANCELLED, itemId);
         if (exit.kind === 'connected') return;
         if (exit.kind === 'cancelled') {
-          finish({ tone: flow.kind === 'reconnect' ? 'partial' : 'ok', text: exit.note });
+          finish(syncLine(flow.kind === 'reconnect' ? 'partial' : 'ok', exit.note));
           return;
         }
         const posted = await postLinkExit(exit.report);
-        finish({ tone: 'error', text: posted.logged ? exit.note : exit.note + notLoggedSuffix(posted.status) });
+        finish(syncLine('error', posted.logged ? exit.note : exit.note + notLoggedSuffix(posted.status)));
       },
     }).open();
   }, [phase, plaidReady, router]);

--- a/src/lib/__tests__/plaidOauth.test.ts
+++ b/src/lib/__tests__/plaidOauth.test.ts
@@ -16,6 +16,7 @@ import {
   type KeyValueStore,
 } from '../plaid/oauth';
 import { updateModeLinkRequest } from '../plaid/reconnect';
+import { syncLine } from '../plaid/failLoud';
 
 // BANK-01c — Plaid OAuth: the redirect URI on every link token, and the return page's round trip.
 
@@ -117,22 +118,22 @@ test("the 'reconnect' flow calls reconnect-complete, never exchange-token; 'new'
   const r = await completeOauthReturn({ kind: 'reconnect', itemId: 'ckitemrow0001', institution: 'tastytrade' }, 'public-production-x', { institution: { name: 'tastytrade', institution_id: 'ins_116995' } }, reconnect.post);
   assert.equal(r.endpoint, '/api/plaid/reconnect-complete');
   assert.deepEqual(reconnect.calls, [{ path: '/api/plaid/reconnect-complete', body: { itemId: 'ckitemrow0001' } }], 'one call, no public token, no exchange');
-  assert.deepEqual(r.outcome, { tone: 'ok', text: 'tastytrade reconnected' });
+  assert.deepEqual(r.outcome, { tone: 'ok', text: 'tastytrade reconnected', lines: ['tastytrade reconnected'] });
   assert.ok(!JSON.stringify(reconnect.calls).includes('public-production-x'), 'the public token never leaves the browser in update mode');
 
   const still = fakePost({ '/api/plaid/reconnect-complete': { status: 409, body: { ok: false, stage: 'reconnect', message: 'tastytrade still needs to be reconnected (Plaid: ITEM_LOGIN_REQUIRED)' } } });
   const s = await completeOauthReturn({ kind: 'reconnect', itemId: 'ckitemrow0001', institution: 'tastytrade' }, 'public-production-x', null, still.post);
-  assert.deepEqual(s.outcome, { tone: 'error', text: 'tastytrade still needs to be reconnected (Plaid: ITEM_LOGIN_REQUIRED)' });
+  assert.deepEqual(s.outcome, { tone: 'error', text: 'tastytrade still needs to be reconnected (Plaid: ITEM_LOGIN_REQUIRED)', lines: ['tastytrade still needs to be reconnected (Plaid: ITEM_LOGIN_REQUIRED)'] });
 
   const fresh = fakePost({ '/api/plaid/exchange-token': { status: 200, body: { success: true } } });
   const n = await completeOauthReturn({ kind: 'new' }, 'public-production-y', { institution: { name: 'tastytrade', institution_id: 'ins_116995' } }, fresh.post);
   assert.equal(n.endpoint, '/api/plaid/exchange-token');
   assert.deepEqual(fresh.calls, [{ path: '/api/plaid/exchange-token', body: { publicToken: 'public-production-y', institutionId: 'ins_116995', institutionName: 'tastytrade', entityId: 'personal' } }], 'the exact body the cockpit sends today');
-  assert.deepEqual(n.outcome, { tone: 'ok', text: 'tastytrade linked' });
+  assert.deepEqual(n.outcome, { tone: 'ok', text: 'tastytrade linked', lines: ['tastytrade linked'] }, 'HYG-03: the renamed line moves its `lines` with it');
 
   const failed = fakePost({ '/api/plaid/exchange-token': { status: 500, body: { ok: false, stage: 'api/plaid/exchange-token POST', error: 'Failed to link account', message: 'Failed to link account' } } });
   const f = await completeOauthReturn({ kind: 'new' }, 'public-production-y', null, failed.post);
-  assert.deepEqual(f.outcome, { tone: 'error', text: 'Failed to link account' });
+  assert.deepEqual(f.outcome, { tone: 'error', text: 'Failed to link account', lines: ['Failed to link account'] });
 });
 
 test('a return with no kept state renders the declared error — and so do a missing state id, a corrupt entry, and an expired token', () => {
@@ -167,11 +168,11 @@ test('a return with no kept state renders the declared error — and so do a mis
 
 test('the outcome line rides back to Books and is consumed by the reader of its flow kind', () => {
   const store = memoryStore();
-  keepReturnOutcome(store, { flow: { kind: 'reconnect', itemId: 'ckitemrow0001', institution: 'tastytrade' }, outcome: { tone: 'ok', text: 'tastytrade reconnected' }, now: NOW });
+  keepReturnOutcome(store, { flow: { kind: 'reconnect', itemId: 'ckitemrow0001', institution: 'tastytrade' }, outcome: syncLine('ok', 'tastytrade reconnected'), now: NOW });
   assert.equal(takeReturnOutcome(store, 'new'), null, "the cockpit banner reads 'new' outcomes only — the row's outcome stays for the row");
   assert.ok(store.getItem(OUTCOME_KEY), 'still kept');
   const taken = takeReturnOutcome(store, 'reconnect');
-  assert.deepEqual(taken, { flow: { kind: 'reconnect', itemId: 'ckitemrow0001', institution: 'tastytrade' }, outcome: { tone: 'ok', text: 'tastytrade reconnected' }, at: NOW.toISOString() });
+  assert.deepEqual(taken, { flow: { kind: 'reconnect', itemId: 'ckitemrow0001', institution: 'tastytrade' }, outcome: { tone: 'ok', text: 'tastytrade reconnected', lines: ['tastytrade reconnected'] }, at: NOW.toISOString() });
   assert.equal(store.getItem(OUTCOME_KEY), null, 'consumed');
   assert.equal(takeReturnOutcome(store, 'reconnect'), null);
 

--- a/src/lib/plaid/oauth.ts
+++ b/src/lib/plaid/oauth.ts
@@ -15,7 +15,7 @@
  * key-value port (localStorage in the browser, a Map in tests).
  */
 import { CountryCode, Products, type LinkTokenCreateRequest } from 'plaid';
-import { readSyncResponse, type SyncOutcome } from './failLoud';
+import { readSyncResponse, syncLine, type SyncOutcome } from './failLoud';
 
 // ─── the redirect URI ─────────────────────────────────────────────────────────
 
@@ -191,7 +191,8 @@ export async function completeOauthReturn(flow: LinkFlow, publicToken: string, m
   // exchange-token's success body carries no `message`; name the bank instead of "Synced (HTTP 200)".
   const b = body && typeof body === 'object' ? (body as Record<string, unknown>) : null;
   const text = read.tone === 'ok' && typeof b?.message !== 'string' ? `${institutionName ?? 'Account'} linked` : read.text;
-  return { endpoint: '/api/plaid/exchange-token', outcome: { ...read, text } };
+  // HYG-03: `lines` moves with the text — the banner renders lines, not text.
+  return { endpoint: '/api/plaid/exchange-token', outcome: text === read.text ? read : syncLine(read.tone, text) };
 }
 
 // ─── the outcome line, carried back to Books ──────────────────────────────────
@@ -219,7 +220,7 @@ export function takeReturnOutcome(store: KeyValueStore, kind: LinkFlow['kind']):
     }
     if (v.flow.kind !== kind) return null;
     store.removeItem(OUTCOME_KEY);
-    return { flow: v.flow, outcome: { tone: outcome.tone as SyncOutcome['tone'], text: outcome.text }, at: v.at };
+    return { flow: v.flow, outcome: syncLine(outcome.tone as SyncOutcome['tone'], outcome.text), at: v.at };
   } catch {
     store.removeItem(OUTCOME_KEY);
     return null;


### PR DESCRIPTION
**Do not merge — Alex merges after Vercel Preview (SOC 2 gate).**

## WHY

`main` at `e9d43ddc` fails type-check: `src/app/plaid/oauth-return/page.tsx:111` calls `finish({ tone, text })` without `lines`, required on `SyncOutcome` since HYG-03 (#1643) landed beside BANK-01c (#1644).

## AUDIT — every site, not just :111

`npx tsc --noEmit` on `main` reports four errors, all the same missing field:

| # | Site | What it built |
|---|---|---|
| 1 | `src/app/plaid/oauth-return/page.tsx:111` — the onExit **cancel** | `finish({ tone: 'partial' \| 'ok', text })` |
| 2 | `src/app/plaid/oauth-return/page.tsx:115` — the onExit **error** | `finish({ tone: 'error', text })` |
| 3 | `src/lib/plaid/oauth.ts:222` — `takeReturnOutcome` rebuilding the stored outcome for Books | `{ tone, text }` |
| 4 | `src/lib/__tests__/plaidOauth.test.ts:170` — the `keepReturnOutcome` fixture | `{ tone: 'ok', text }` |

The page's third `finish(` (`:105`, onSuccess) already received a full outcome from `completeOauthReturn`, but that function had a fifth gap tsc could not see: on an exchange-token success it renames `text` to "`<bank> linked`" with `{ ...read, text }`, leaving `lines: ['Synced (HTTP 200)']` beside the new text — the banner renders `lines`, so it would have shown the old line.

## BUILD

| File | Change |
|---|---|
| `src/app/plaid/oauth-return/page.tsx` | Both onExit outcomes go through **`syncLine(tone, text)`** — the one-line constructor HYG-03 routes the link-exit notes through (`lines: [text]`) — so the banner renders them like every other outcome. Every `finish(` call now carries `lines`. |
| `src/lib/plaid/oauth.ts` | `takeReturnOutcome` rebuilds through `syncLine`; `completeOauthReturn` returns `read` unchanged when the text stands, else `syncLine(read.tone, text)` — the renamed line moves its `lines` with it. |
| `src/lib/__tests__/plaidOauth.test.ts` | The six BANK-01c tests assert `lines` on every outcome (four `deepEqual`s + the fixture). |

## VERIFY

| Check | Result |
|---|---|
| `npx tsc --noEmit` (the gate the build failed) | **exit 0** |
| eslint, 3 touched files | 0 |
| `npm test` | **96 / 96 pass**; the six BANK-01c tests pass with `lines` asserted |
| asserts + `next build` | showroom ✓ · tool registry ✓ · reachability 61 pages ✓ · answers law ✓ · arrivals law ✓ · **BUILD EXIT 0** |

```
ok 1 - both link tokens carry redirect_uri; the new-item token keeps Transactions + Investments
ok 2 - an unset, non-HTTPS, or query-carrying PLAID_REDIRECT_URI fails loud with a named error — no no-OAuth path
ok 3 - the return page re-opens Link with the kept token and the received URI
ok 4 - the 'reconnect' flow calls reconnect-complete, never exchange-token; 'new' exchanges as the cockpit does
ok 5 - a return with no kept state renders the declared error — and so do a missing state id, a corrupt entry, and an expired token
ok 6 - the outcome line rides back to Books and is consumed by the reader of its flow kind
```

Diff: 3 files, +15 / −12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc

---
_Generated by [Claude Code](https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc)_