### PR TITLE
PERF-01: land a page's domain writes in one statement per kind, not one per row

### DIFF
--- a/src/app/api/transactions/sync-complete/route.ts
+++ b/src/app/api/transactions/sync-complete/route.ts
@@ -9,7 +9,9 @@ import { summarizePlaidError } from '@/lib/plaid/summarizeError';
 import { bankName, clearItemError, isItemError, itemFailure, recordItemError } from '@/lib/plaid/reconnect';
 import { wireOf } from '@/lib/plaid/wire';
 import { prismaLanding } from '@/lib/arrivals/prismaLanding';
-import { recordFailedAnswer, runTransactionsPage, type DomainDb } from '@/lib/arrivals/plaidTransactionsPage';
+import { recordFailedAnswer, runTransactionsPage } from '@/lib/arrivals/plaidTransactionsPage';
+// PERF-01: the domain writes of a page land in one statement per kind, not one per row.
+import { prismaDomain } from '@/lib/arrivals/prismaDomain';
 import type { Prisma } from '@prisma/client';
 
 export const maxDuration = 300; // 5 minutes for Pro plan
@@ -133,9 +135,16 @@ export async function POST() {
           // (provider, their_id)) → the existing parser, reading the ARRIVAL payloads →
           // transactions.arrival_id → read / status = done. A parser throw rolls this
           // page back; earlier pages stay landed; this item's stage declares the failure.
+          // PERF-01: the batching domain binding — the parser's per-row intents replay as one
+          // statement per kind inside the page's transaction (finish); one log line per page.
+          let batch: ReturnType<typeof prismaDomain> | null = null;
+          const pageStarted = Date.now();
           const result = await runTransactionsPage(
             prisma,
-            (tx) => ({ landing: prismaLanding(tx as Prisma.TransactionClient), domain: tx as unknown as DomainDb }),
+            (tx) => {
+              batch = prismaDomain(tx as Prisma.TransactionClient);
+              return { landing: prismaLanding(tx as Prisma.TransactionClient), domain: batch, finish: () => batch!.finish() };
+            },
             {
               page,
               userId: user.id,
@@ -147,11 +156,14 @@ export async function POST() {
               transactions: response.data.transactions,
             },
           );
+          const pageMs = Date.now() - pageStarted;
+          const pageStats = batch ? (batch as ReturnType<typeof prismaDomain>).stats() : { intents: 0, statements: 0 };
           if (!result.ok) {
             pageFailure = result.failure;
-            console.error(`Transactions stage failed for ${bankName(item.institutionName)} on page ${page}:`, result.failure.error);
+            console.error(`Transactions stage failed for ${bankName(item.institutionName)} on page ${page} after ${pageMs}ms:`, result.failure.error);
             break;
           }
+          console.log(`[sync] ${bankName(item.institutionName)} transactions page ${page}: ${response.data.transactions.length} objects, ${JSON.stringify(result.counts)}, ${pageStats.intents} domain intents → ${pageStats.statements} statements, ${pageMs}ms`);
           synced += result.counts.synced;
           skipped += result.counts.skipped;
           landed += result.counts.landed;

--- a/src/lib/__tests__/prismaDomainPlan.test.ts
+++ b/src/lib/__tests__/prismaDomainPlan.test.ts
@@ -1,0 +1,184 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  DATA_KEYS,
+  UnsupportedDomainWriteError,
+  deleteByIdSql,
+  deleteSql,
+  groupByColumns,
+  linkSql,
+  planDomainWrites,
+  prismaDomain,
+  upsertSql,
+  type Intent,
+} from '../arrivals/prismaDomain';
+import { runTransactionsPage, type PagePorts } from '../arrivals/plaidTransactionsPage';
+import type { ArrivalRow, LandedArrival, LandingDb } from '../arrivals/land';
+
+// PERF-01 — the batching binding replays the parser's per-row intents as one statement per
+// kind with the sequential order's exact result. The parser and its per-row port are untouched
+// (arrivalsLand.test.ts proves them); these tests prove the replay plan and the SQL shapes.
+
+const NOW = new Date('2026-09-05T12:00:00.000Z');
+const d = (day: string) => new Date(`2026-06-${day}T00:00:00.000Z`);
+
+function data(over: Record<string, unknown> = {}) {
+  return {
+    amount: 10, date: d('10'), name: 'Coffee', merchantName: 'Cafe', category: 'Food and Drink, Coffee', pending: false,
+    authorized_date: null, authorized_datetime: null, counterparties: [{ name: 'X' }], location: { city: 'Austin' },
+    payment_channel: 'in store', payment_meta: { reference_number: null }, personal_finance_category: { primary: 'FOOD_AND_DRINK' },
+    personal_finance_category_icon_url: null, transaction_code: null, transaction_type: 'place', logo_url: null, website: null,
+    arrival_id: 'arr_1', updatedAt: NOW, ...over,
+  };
+}
+type UpsertI = Extract<Intent, { kind: 'upsert' }>;
+type LinkI = Extract<Intent, { kind: 'link' }>;
+type DeleteI = Extract<Intent, { kind: 'delete' }>;
+function upsert(transactionId: string, accountId: string, over: Record<string, unknown> = {}, id = `txn_${transactionId}`): UpsertI {
+  const dd = data(over);
+  return { kind: 'upsert', args: { where: { transactionId }, create: { id, transactionId, accountId, ...dd }, update: dd } };
+}
+function link(transactionId: string, arrivalId: string): LinkI {
+  return { kind: 'link', args: { where: { transactionId, arrival_id: null }, data: { arrival_id: arrivalId } } };
+}
+function del(accountId: string, amount: number, day: string, notTransactionId: string): DeleteI {
+  const gte = d(day); gte.setDate(gte.getDate() - 2);
+  const lte = d(day); lte.setDate(lte.getDate() + 2);
+  return { kind: 'delete', args: { where: { accountId, amount, pending: true, date: { gte, lte }, transactionId: { not: notTransactionId } } } };
+}
+
+test('the plan: one upsert per id (first create, last data), links only for ids the page does not upsert, every delete rule kept', () => {
+  const plan = planDomainWrites([
+    upsert('t1', 'acc_1', { amount: 1 }, 'txn_first'),
+    del('acc_1', 1, '10', 't1'),
+    link('t2', 'arr_2'),
+    link('t2', 'arr_2b'),
+    link('t1', 'arr_9'),
+    upsert('t1', 'acc_1', { amount: 2, name: 'Coffee (corrected)', arrival_id: 'arr_1b' }, 'txn_second'),
+    del('acc_1', 2, '10', 't1'),
+    upsert('t3', 'acc_2', { pending: true }),
+  ]);
+  assert.deepEqual(plan.pageIds, ['t1', 't3']);
+  assert.equal(plan.upserts.length, 2);
+  const t1 = plan.upserts[0];
+  assert.equal(t1.id, 'txn_first', 'the FIRST upsert creates the row — its id stays');
+  assert.equal(t1.data.amount, 2);
+  assert.equal(t1.data.name, 'Coffee (corrected)');
+  assert.equal(t1.data.arrival_id, 'arr_1b', 'the LAST upsert\'s data wins (latest-arrived)');
+  assert.deepEqual(plan.links, [{ transactionId: 't2', arrivalId: 'arr_2' }], 'the first link per id (arrival_id IS NULL makes later ones no-ops); t1\'s link is a no-op because its upsert sets arrival_id');
+  assert.equal(plan.deletes.length, 2, 'every posted row\'s rule, in order, for rows outside the page');
+  assert.deepEqual(plan.deleteInPageIds, []);
+});
+
+test('the plan: an in-page pending row is deleted only by a LATER posted row\'s rule; a later re-upsert revives it', () => {
+  // B (pending) before A (posted, same account/amount/day) → sequentially deleted by A.
+  // C (pending) after A2 (posted) → survives. D (pending) before A3, re-upserted after → survives.
+  const plan = planDomainWrites([
+    upsert('B', 'acc_1', { amount: 77.25, date: d('10'), pending: true }),
+    upsert('A', 'acc_1', { amount: 77.25, date: d('10'), pending: false }),
+    del('acc_1', 77.25, '10', 'A'),
+    upsert('A2', 'acc_2', { amount: 55.5, date: d('20'), pending: false }),
+    del('acc_2', 55.5, '20', 'A2'),
+    upsert('C', 'acc_2', { amount: 55.5, date: d('20'), pending: true }),
+    upsert('D', 'acc_1', { amount: 9, date: d('05'), pending: true }),
+    upsert('A3', 'acc_1', { amount: 9, date: d('06'), pending: false }),
+    del('acc_1', 9, '06', 'A3'),
+    upsert('D', 'acc_1', { amount: 9, date: d('05'), pending: true }),
+    // a different account or amount, or outside ±2 days, is not a duplicate
+    upsert('E', 'acc_2', { amount: 77.25, date: d('10'), pending: true }),
+    upsert('F', 'acc_1', { amount: 77.26, date: d('10'), pending: true }),
+    upsert('G', 'acc_1', { amount: 77.25, date: d('20'), pending: true }),
+    upsert('A4', 'acc_1', { amount: 77.25, date: d('10'), pending: false }),
+    del('acc_1', 77.25, '10', 'A4'),
+  ]);
+  assert.deepEqual(plan.deleteInPageIds.sort(), ['B'], 'only B: C came after its posted twin, D was re-upserted, E/F/G do not match');
+  assert.equal(plan.deletes.length, 4);
+  assert.ok(plan.pageIds.includes('B') && plan.pageIds.includes('C'));
+});
+
+test('the plan: an intent shape the parser never issues is a throw, not a per-row fallback', async () => {
+  const fake = { $executeRaw: async () => 0 } as unknown as Parameters<typeof prismaDomain>[0];
+  const domain = prismaDomain(fake);
+  await assert.rejects(domain.transactions.updateMany({ where: { transactionId: 't1' }, data: { name: 'x' } }), UnsupportedDomainWriteError);
+  await assert.rejects(domain.transactions.deleteMany({ where: { transactionId: 't1' } }), UnsupportedDomainWriteError);
+  await assert.rejects(domain.transactions.upsert({ where: { transactionId: 't1' }, create: { id: 'x', transactionId: 't1', accountId: 'a', bogus: 1 }, update: {} }), UnsupportedDomainWriteError);
+  await assert.rejects(domain.transactions.upsert({ where: { transactionId: 't1' }, create: { id: 'x', transactionId: 't1', accountId: 'a' }, update: { bogus: 1 } }), UnsupportedDomainWriteError);
+  // the parser's real shapes are accepted and buffered — nothing runs until finish()
+  let ran = 0;
+  const counting = prismaDomain({ $executeRaw: async () => { ran += 1; return 1; } } as unknown as Parameters<typeof prismaDomain>[0]);
+  await counting.transactions.upsert(upsert('t1', 'acc_1').args);
+  await counting.transactions.updateMany(link('t2', 'arr_2').args);
+  await counting.transactions.deleteMany(del('acc_1', 10, '10', 't1').args);
+  assert.equal(ran, 0, 'buffered');
+  assert.deepEqual(counting.stats(), { intents: 3, statements: 0 });
+  await counting.finish();
+  assert.equal(ran, 3, 'one upsert statement, one link statement, one delete statement');
+  assert.deepEqual(counting.stats(), { intents: 3, statements: 3 });
+  await assert.rejects(counting.transactions.upsert(upsert('t9', 'acc_1').args), UnsupportedDomainWriteError, 'a write after finish is refused');
+});
+
+test('the SQL: one INSERT … ON CONFLICT DO UPDATE per column group, one UPDATE … FROM VALUES, one DELETE … USING VALUES', () => {
+  const plan = planDomainWrites([
+    upsert('t1', 'acc_1'),
+    upsert('t2', 'acc_1', { merchantName: undefined, logo_url: undefined }),
+    upsert('t3', 'acc_2', { pending: true }),
+    del('acc_1', 10, '10', 't1'),
+    link('t8', 'arr_8'),
+  ]);
+  const groups = groupByColumns(plan.upserts);
+  assert.equal(groups.length, 2, 'rows with an omitted (undefined) column form their own statement — Prisma\'s create defaults it, its update skips it');
+  assert.equal(groups[0].rows.length, 2);
+  assert.deepEqual(groups[0].columns, [...DATA_KEYS]);
+  assert.deepEqual(groups[1].columns, DATA_KEYS.filter((k) => k !== 'merchantName' && k !== 'logo_url'));
+
+  const up = upsertSql(groups[0].columns, groups[0].rows);
+  // Prisma.Sql renders parameters as `?` and joins with `,`; the values ride beside it.
+  assert.match(up.sql, /^INSERT INTO transactions \("id","accountId","transactionId","amount","date","name","merchantName","category","pending"/);
+  assert.match(up.sql, /ON CONFLICT \("transactionId"\) DO UPDATE SET "amount" = EXCLUDED\."amount","date" = EXCLUDED\."date"/);
+  assert.match(up.sql, /"updatedAt" = EXCLUDED\."updatedAt"$/);
+  assert.ok(!/"id" = EXCLUDED|"accountId" = EXCLUDED|"transactionId" = EXCLUDED/.test(up.sql), 'create-only columns are never updated');
+  assert.equal(up.values.length, 2 * (3 + DATA_KEYS.length), 'every value is a bound parameter');
+  assert.match(up.sql, /VALUES \(\?,\?,\?,\?::float8,\?::timestamp,/, 'amount cast to float8, timestamps to timestamp (UTC wall clock, as Prisma stores DateTime)');
+  assert.match(up.sql, /::jsonb/);
+  assert.equal(up.values[4], '2026-06-10T00:00:00.000Z', 'a Date rides as its ISO text');
+  assert.equal(up.values[11], '[{"name":"X"}]', 'JSON rides as text into ::jsonb');
+
+  const ln = linkSql(plan.links);
+  assert.equal(ln.sql, 'UPDATE transactions AS t SET arrival_id = v.arrival_id FROM (VALUES (?, ?)) AS v(transaction_id, arrival_id) WHERE t."transactionId" = v.transaction_id AND t.arrival_id IS NULL');
+  assert.deepEqual(ln.values, ['t8', 'arr_8']);
+
+  const dl = deleteSql(plan.deletes, plan.pageIds);
+  assert.equal(dl.sql, 'DELETE FROM transactions AS t USING (VALUES (?, ?::float8, ?::timestamp, ?::timestamp, ?)) AS v(account_id, amount, lo, hi, transaction_id) WHERE t."accountId" = v.account_id AND t.amount = v.amount AND t.pending = true AND t.date >= v.lo AND t.date <= v.hi AND t."transactionId" <> v.transaction_id AND NOT (t."transactionId" = ANY(?::text[]))');
+  assert.deepEqual(dl.values.slice(0, 5), ['acc_1', 10, '2026-06-08T00:00:00.000Z', '2026-06-12T00:00:00.000Z', 't1']);
+  assert.deepEqual(dl.values[5], ['t1', 't2', 't3']);
+
+  assert.equal(deleteByIdSql(['B']).sql, 'DELETE FROM transactions WHERE "transactionId" = ANY(?::text[])');
+});
+
+test('runTransactionsPage finishes a buffering port inside the page transaction, after the parser', async () => {
+  const order: string[] = [];
+  const table: ArrivalRow[] = [];
+  const landing: LandingDb = {
+    async insertResponse() { order.push('response'); },
+    async insertArrivalsIgnoringDuplicates(rows: ArrivalRow[]) { order.push('arrivals'); table.push(...rows); return rows.map((r) => ({ their_id: r.their_id, fingerprint: r.fingerprint })); },
+    async findArrivals(_provider: string, theirIds: string[]): Promise<LandedArrival[]> {
+      return table.filter((r) => theirIds.includes(r.their_id)).map((r) => ({ id: r.id, their_id: r.their_id, fingerprint: r.fingerprint, payload: r.payload, status: 'pending', arrived: r.arrived }));
+    },
+    async markRead() { order.push('markRead'); },
+  };
+  let executed = 0;
+  const client = { $transaction: async <T,>(fn: (tx: unknown) => Promise<T>) => { order.push('BEGIN'); const r = await fn({ $executeRaw: async () => { executed += 1; return 1; } }); order.push('COMMIT'); return r; } };
+  const ports = (tx: unknown): PagePorts => {
+    const domain = prismaDomain(tx as Parameters<typeof prismaDomain>[0]);
+    return { landing, domain, finish: () => domain.finish() };
+  };
+  const result = await runTransactionsPage(client, ports, {
+    page: 1, userId: 'u', connection: 'item', accounts: [{ id: 'acc_db', accountId: 'acc_p1' }], existing: new Map(),
+    wire: { body: Buffer.from('{}'), asked: NOW, arrived: NOW }, httpStatus: 200,
+    transactions: [{ transaction_id: 't1', account_id: 'acc_p1', amount: 5, date: '2026-06-10', name: 'x', pending: false } as never],
+    now: () => NOW,
+  });
+  assert.equal(result.ok, true);
+  assert.deepEqual(order, ['BEGIN', 'response', 'arrivals', 'markRead', 'COMMIT'], 'the flush ran before COMMIT');
+  assert.equal(executed, 2, 'one upsert statement + one delete statement (a posted row)');
+});

--- a/src/lib/arrivals/plaidTransactionsPage.ts
+++ b/src/lib/arrivals/plaidTransactionsPage.ts
@@ -217,16 +217,26 @@ export interface PageClient {
 
 export type PageResult = { ok: true; counts: PageCounts } | { ok: false; failure: StageFailed & { page: number } };
 
+/** The ports a page runs through. PERF-01: a domain port that BUFFERS its writes (prismaDomain) hands back `finish`, replayed inside the same transaction after the parser is done. */
+export interface PagePorts {
+  landing: LandingDb;
+  domain: DomainDb;
+  finish?: () => Promise<void>;
+}
+
 /** One page, one transaction. A throw inside rolls the page back and comes out as the declared failure. */
 export async function runTransactionsPage(
   client: PageClient,
-  ports: (tx: unknown) => { landing: LandingDb; domain: DomainDb },
+  ports: (tx: unknown) => PagePorts,
   input: TransactionsPageInput,
 ): Promise<PageResult> {
   try {
     const counts = await client.$transaction(async (tx) => {
-      const { landing, domain } = ports(tx);
-      return landTransactionsPage(landing, domain, input);
+      const { landing, domain, finish } = ports(tx);
+      const result = await landTransactionsPage(landing, domain, input);
+      // PERF-01: the batching binding's statements run here — still this transaction, still rolled back whole on a throw.
+      if (finish) await finish();
+      return result;
     }, { maxWait: 10_000, timeout: 120_000 });
     return { ok: true, counts };
   } catch (error) {

--- a/src/lib/arrivals/prismaDomain.ts
+++ b/src/lib/arrivals/prismaDomain.ts
@@ -1,0 +1,267 @@
+/**
+ * PERF-01 — the Prisma-backed DomainDb that lands a page's domain writes in
+ * ONE statement per kind instead of one per row.
+ *
+ * sync-complete hit Vercel's 300 s ceiling on the first full pull after PR-2.
+ * The landing side was already batched (prismaLanding: one INSERT … ON
+ * CONFLICT DO NOTHING RETURNING, one SELECT, one UPDATE per page); the domain
+ * loop was not — the parser (plaidTransactionsPage.ts) issued one upsert per
+ * transaction, one DELETE per posted transaction (pending duplicates) and one
+ * UPDATE per repeated object (the arrival_id link): ~900 statements, ~900
+ * Azure round trips, for a 500-object page.
+ *
+ * The parser is unchanged and still speaks the per-row DomainDb port, so the
+ * existing landing tests (a fake DomainDb) prove its semantics unchanged. THIS
+ * binding buffers the parser's intents, in order, and `finish()` — called by
+ * runTransactionsPage inside the same page transaction — replays them as:
+ *
+ *   1. one INSERT … ON CONFLICT ("transactionId") DO UPDATE for every upsert
+ *      (Prisma's own upsert is that statement, one row at a time);
+ *   2. one UPDATE … FROM (VALUES …) for the arrival_id links (arrival_id IS
+ *      NULL, as the parser's updateMany says);
+ *   3. one DELETE … USING (VALUES …) for the pending-duplicate rule against
+ *      rows that were NOT in this page, and one DELETE by id for the in-page
+ *      rows the sequential order would have removed (planDomainWrites).
+ *
+ * The plan (planDomainWrites) is pure and reproduces the sequential order's
+ * result exactly: same id twice → the first row's create fields, the last
+ * row's data; a link for an id the page also upserts is a no-op (the upsert
+ * sets arrival_id); an in-page pending row is deleted only by a LATER posted
+ * row's rule, and a later re-upsert of that id revives it. An intent shape the
+ * parser does not issue is a throw, never a per-row fallback.
+ *
+ * A page whose payloads omit a column (undefined, not null) is grouped by the
+ * set of omitted columns, one statement per group — Prisma's create treats
+ * undefined as the column default and its update skips it; the grouped
+ * statement does the same by leaving the column out. A real Plaid answer has
+ * one group.
+ */
+import { Prisma } from '@prisma/client';
+import type { DomainDb } from './plaidTransactionsPage';
+
+export interface UpsertIntent {
+  where: { transactionId: string };
+  create: Record<string, unknown>;
+  update: Record<string, unknown>;
+}
+export interface LinkIntent {
+  where: { transactionId: string; arrival_id: null };
+  data: { arrival_id: string };
+}
+export interface DeleteIntent {
+  where: { accountId: string; amount: number; pending: true; date: { gte: Date; lte: Date }; transactionId: { not: string } };
+}
+export type Intent = { kind: 'upsert'; args: UpsertIntent } | { kind: 'link'; args: LinkIntent } | { kind: 'delete'; args: DeleteIntent };
+
+export class UnsupportedDomainWriteError extends Error {
+  constructor(what: string) {
+    super(`prismaDomain: ${what} — the batching binding replays only the parser's three intents (upsert by transactionId, the arrival_id link, the pending-duplicate delete); nothing else is issued`);
+    this.name = 'UnsupportedDomainWriteError';
+  }
+}
+
+/** The create column set, in statement order. `id`, `accountId`, `transactionId` come from the first create; the rest is the parser's txnData. */
+export const CREATE_KEYS = ['id', 'accountId', 'transactionId'] as const;
+export const DATA_KEYS = [
+  'amount', 'date', 'name', 'merchantName', 'category', 'pending', 'authorized_date', 'authorized_datetime',
+  'counterparties', 'location', 'payment_channel', 'payment_meta', 'personal_finance_category',
+  'personal_finance_category_icon_url', 'transaction_code', 'transaction_type', 'logo_url', 'website', 'arrival_id', 'updatedAt',
+] as const;
+type DataKey = (typeof DATA_KEYS)[number];
+
+const TIMESTAMP_KEYS = new Set<DataKey>(['date', 'authorized_date', 'authorized_datetime', 'updatedAt']);
+const JSON_KEYS = new Set<DataKey>(['counterparties', 'location', 'payment_meta', 'personal_finance_category']);
+const FLOAT_KEYS = new Set<DataKey>(['amount']);
+
+export interface PlannedUpsert {
+  id: string;
+  accountId: string;
+  transactionId: string;
+  /** The last update's data for this id; a key that is undefined is OMITTED (Prisma: default on create, skipped on update). */
+  data: Record<DataKey, unknown>;
+}
+
+export interface DomainPlan {
+  upserts: PlannedUpsert[];
+  links: Array<{ transactionId: string; arrivalId: string }>;
+  /** The pending-duplicate rule, one per posted row, applied to rows NOT upserted in this page. */
+  deletes: Array<{ accountId: string; amount: number; gte: Date; lte: Date; notTransactionId: string }>;
+  /** In-page rows the sequential order would have removed (a LATER posted row's rule, not revived by a later upsert). */
+  deleteInPageIds: string[];
+  /** Every transactionId upserted in this page. */
+  pageIds: string[];
+}
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+function assertUpsert(args: unknown): UpsertIntent {
+  if (!isPlainObject(args) || !isPlainObject(args.where) || typeof args.where.transactionId !== 'string' || Object.keys(args.where).length !== 1
+    || !isPlainObject(args.create) || !isPlainObject(args.update)) {
+    throw new UnsupportedDomainWriteError('upsert must be { where: { transactionId }, create, update }');
+  }
+  for (const k of CREATE_KEYS) if (typeof args.create[k] !== 'string') throw new UnsupportedDomainWriteError(`upsert.create.${k} must be a string`);
+  for (const k of Object.keys(args.update)) if (!(DATA_KEYS as readonly string[]).includes(k)) throw new UnsupportedDomainWriteError(`upsert.update carries an unknown column "${k}"`);
+  for (const k of Object.keys(args.create)) if (!(CREATE_KEYS as readonly string[]).includes(k) && !(DATA_KEYS as readonly string[]).includes(k)) throw new UnsupportedDomainWriteError(`upsert.create carries an unknown column "${k}"`);
+  return args as unknown as UpsertIntent;
+}
+
+function assertLink(args: unknown): LinkIntent {
+  if (!isPlainObject(args) || !isPlainObject(args.where) || !isPlainObject(args.data)
+    || typeof args.where.transactionId !== 'string' || args.where.arrival_id !== null || Object.keys(args.where).length !== 2
+    || typeof args.data.arrival_id !== 'string' || Object.keys(args.data).length !== 1) {
+    throw new UnsupportedDomainWriteError('updateMany must be { where: { transactionId, arrival_id: null }, data: { arrival_id } }');
+  }
+  return args as unknown as LinkIntent;
+}
+
+function assertDelete(args: unknown): DeleteIntent {
+  const w = isPlainObject(args) ? args.where : undefined;
+  if (!isPlainObject(w) || Object.keys(w).length !== 5 || typeof w.accountId !== 'string' || typeof w.amount !== 'number' || w.pending !== true
+    || !isPlainObject(w.date) || !(w.date.gte instanceof Date) || !(w.date.lte instanceof Date) || Object.keys(w.date).length !== 2
+    || !isPlainObject(w.transactionId) || typeof w.transactionId.not !== 'string' || Object.keys(w.transactionId).length !== 1) {
+    throw new UnsupportedDomainWriteError('deleteMany must be { where: { accountId, amount, pending: true, date: { gte, lte }, transactionId: { not } } }');
+  }
+  return args as unknown as DeleteIntent;
+}
+
+/** Replay the parser's intents, in order, into the batched plan with the sequential order's exact result. */
+export function planDomainWrites(intents: Intent[]): DomainPlan {
+  const upserts = new Map<string, PlannedUpsert>();
+  const links = new Map<string, string>();
+  const deletes: DomainPlan['deletes'] = [];
+  const deletedNow = new Set<string>();
+  // What the page has written so far, as the sequential order would see it.
+  const inPage = new Map<string, { accountId: string; amount: number; pending: boolean; date: Date }>();
+
+  for (const intent of intents) {
+    if (intent.kind === 'upsert') {
+      const { where, create, update } = intent.args;
+      const id = where.transactionId;
+      const data = {} as Record<DataKey, unknown>;
+      for (const k of DATA_KEYS) if (update[k] !== undefined) data[k] = update[k];
+      const prior = upserts.get(id);
+      upserts.set(id, prior
+        ? { ...prior, data: { ...prior.data, ...data } }
+        : { id: create.id as string, accountId: create.accountId as string, transactionId: create.transactionId as string, data });
+      const row = upserts.get(id)!;
+      inPage.set(id, { accountId: row.accountId, amount: Number(row.data.amount), pending: row.data.pending === true, date: row.data.date instanceof Date ? row.data.date : new Date(String(row.data.date)) });
+      deletedNow.delete(id);
+    } else if (intent.kind === 'link') {
+      const id = intent.args.where.transactionId;
+      if (!links.has(id)) links.set(id, intent.args.data.arrival_id);
+    } else {
+      const w = intent.args.where;
+      deletes.push({ accountId: w.accountId, amount: w.amount, gte: w.date.gte, lte: w.date.lte, notTransactionId: w.transactionId.not });
+      for (const [id, row] of inPage) {
+        if (id === w.transactionId.not || deletedNow.has(id)) continue;
+        if (row.pending && row.accountId === w.accountId && row.amount === w.amount && row.date >= w.date.gte && row.date <= w.date.lte) {
+          deletedNow.add(id);
+        }
+      }
+    }
+  }
+
+  const pageIds = [...upserts.keys()];
+  return {
+    upserts: [...upserts.values()],
+    // A link for an id the page upserts is a no-op either way: the upsert sets arrival_id.
+    links: [...links.entries()].filter(([id]) => !upserts.has(id)).map(([transactionId, arrivalId]) => ({ transactionId, arrivalId })),
+    deletes,
+    deleteInPageIds: [...deletedNow],
+    pageIds,
+  };
+}
+
+const CHUNK = 500;
+function chunks<T>(list: T[]): T[][] {
+  const out: T[][] = [];
+  for (let i = 0; i < list.length; i += CHUNK) out.push(list.slice(i, i + CHUNK));
+  return out;
+}
+
+const ident = (name: string) => Prisma.raw(`"${name}"`);
+const iso = (v: unknown): string | null => (v === null ? null : v instanceof Date ? v.toISOString() : String(v));
+const json = (v: unknown): string | null => (v === null ? null : JSON.stringify(v));
+
+function valueSql(key: DataKey, v: unknown): Prisma.Sql {
+  if (TIMESTAMP_KEYS.has(key)) return Prisma.sql`${iso(v)}::timestamp`;
+  if (JSON_KEYS.has(key)) return Prisma.sql`${json(v)}::jsonb`;
+  if (FLOAT_KEYS.has(key)) return Prisma.sql`${v}::float8`;
+  return Prisma.sql`${v}`;
+}
+
+/** Rows grouped by the set of columns their data carries — one statement per distinct set. */
+export function groupByColumns(rows: PlannedUpsert[]): Array<{ columns: DataKey[]; rows: PlannedUpsert[] }> {
+  const groups = new Map<string, { columns: DataKey[]; rows: PlannedUpsert[] }>();
+  for (const r of rows) {
+    const columns = DATA_KEYS.filter((k) => r.data[k] !== undefined);
+    const key = columns.join(',');
+    const g = groups.get(key) ?? { columns, rows: [] };
+    g.rows.push(r);
+    groups.set(key, g);
+  }
+  return [...groups.values()];
+}
+
+/** INSERT … ON CONFLICT ("transactionId") DO UPDATE for one column group of rows — what Prisma's upsert issues, for the whole set at once. */
+export function upsertSql(columns: DataKey[], rows: PlannedUpsert[]): Prisma.Sql {
+  const names = [...CREATE_KEYS, ...columns];
+  const values = rows.map((r) => Prisma.sql`(${Prisma.join([
+    Prisma.sql`${r.id}`, Prisma.sql`${r.accountId}`, Prisma.sql`${r.transactionId}`,
+    ...columns.map((k) => valueSql(k, r.data[k])),
+  ])})`);
+  const set = columns.length
+    ? Prisma.join(columns.map((k) => Prisma.sql`${ident(k)} = EXCLUDED.${ident(k)}`))
+    : Prisma.sql`"transactionId" = EXCLUDED."transactionId"`;
+  return Prisma.sql`INSERT INTO transactions (${Prisma.join(names.map(ident))}) VALUES ${Prisma.join(values)} ON CONFLICT ("transactionId") DO UPDATE SET ${set}`;
+}
+
+export function linkSql(links: DomainPlan['links']): Prisma.Sql {
+  const values = links.map((l) => Prisma.sql`(${l.transactionId}, ${l.arrivalId})`);
+  return Prisma.sql`UPDATE transactions AS t SET arrival_id = v.arrival_id FROM (VALUES ${Prisma.join(values)}) AS v(transaction_id, arrival_id) WHERE t."transactionId" = v.transaction_id AND t.arrival_id IS NULL`;
+}
+
+export function deleteSql(deletes: DomainPlan['deletes'], pageIds: string[]): Prisma.Sql {
+  const values = deletes.map((d) => Prisma.sql`(${d.accountId}, ${d.amount}::float8, ${d.gte.toISOString()}::timestamp, ${d.lte.toISOString()}::timestamp, ${d.notTransactionId})`);
+  const notInPage = pageIds.length ? Prisma.sql` AND NOT (t."transactionId" = ANY(${pageIds}::text[]))` : Prisma.empty;
+  return Prisma.sql`DELETE FROM transactions AS t USING (VALUES ${Prisma.join(values)}) AS v(account_id, amount, lo, hi, transaction_id) WHERE t."accountId" = v.account_id AND t.amount = v.amount AND t.pending = true AND t.date >= v.lo AND t.date <= v.hi AND t."transactionId" <> v.transaction_id${notInPage}`;
+}
+
+export function deleteByIdSql(ids: string[]): Prisma.Sql {
+  return Prisma.sql`DELETE FROM transactions WHERE "transactionId" = ANY(${ids}::text[])`;
+}
+
+export interface BatchingDomainDb extends DomainDb {
+  /** Replay the buffered intents as the batched statements — inside the page's transaction. */
+  finish(): Promise<void>;
+  /** For the log line: how many intents the page issued and how many statements the flush ran. */
+  stats(): { intents: number; statements: number };
+}
+
+export function prismaDomain(tx: Prisma.TransactionClient): BatchingDomainDb {
+  const intents: Intent[] = [];
+  let statements = 0;
+  let finished = false;
+  const guard = () => { if (finished) throw new UnsupportedDomainWriteError('a write after finish()'); };
+  return {
+    transactions: {
+      async upsert(args) { guard(); intents.push({ kind: 'upsert', args: assertUpsert(args) }); return {}; },
+      async updateMany(args) { guard(); intents.push({ kind: 'link', args: assertLink(args) }); return {}; },
+      async deleteMany(args) { guard(); intents.push({ kind: 'delete', args: assertDelete(args) }); return {}; },
+    },
+    async finish() {
+      guard();
+      finished = true;
+      const plan = planDomainWrites(intents);
+      for (const group of groupByColumns(plan.upserts)) {
+        for (const rows of chunks(group.rows)) { await tx.$executeRaw(upsertSql(group.columns, rows)); statements += 1; }
+      }
+      for (const links of chunks(plan.links)) { await tx.$executeRaw(linkSql(links)); statements += 1; }
+      for (const deletes of chunks(plan.deletes)) { await tx.$executeRaw(deleteSql(deletes, plan.pageIds)); statements += 1; }
+      if (plan.deleteInPageIds.length) { await tx.$executeRaw(deleteByIdSql(plan.deleteInPageIds)); statements += 1; }
+    },
+    stats() { return { intents: intents.length, statements }; },
+  };
+}


### PR DESCRIPTION
**Do not merge — Alex merges after Vercel Preview (SOC 2 gate).**

## WHY

sync-complete hit Vercel's 300 s ceiling (HTTP 504) on the first full pull after PR-2. Thousands of statements per sync, one Azure round trip each.

## AUDIT (read-only, before building) — a correction to the premise

**The landing side was already batched.** The WHY names `landObjects` and `markRead` as one statement per row; they are not, and have not been since PR-2:

| Landing statement | Where | Per page |
|---|---|---|
| `INSERT INTO arrivals … VALUES (…),(…) ON CONFLICT (provider, their_id, fingerprint) DO NOTHING RETURNING their_id, fingerprint` | `src/lib/arrivals/prismaLanding.ts:36-44` (`insertArrivalsIgnoringDuplicates`, one VALUES list) | 1 |
| `SELECT … FROM arrivals WHERE provider = $1 AND their_id IN (…)` | `prismaLanding.ts:48-51` (`findArrivals`, one `findMany`) | 1 |
| `UPDATE arrivals SET read = $1, status = 'done' WHERE id IN (…)` | `prismaLanding.ts:56` (`markRead`, one `updateMany`) | 1 |
| `INSERT INTO provider_responses …` | `prismaLanding.ts:19-32` | 1 |
| `BEGIN` / `COMMIT` | `plaidTransactionsPage.ts:227-230` (`$transaction`) | 2 |

`land.ts` builds the whole page's rows in memory and calls each port method once (`land.ts:212-213`, `:245`). Canonicalize + sha256 are per object, CPU only (`land.ts:191`).

**The per-row statements were the domain loop's** (`src/lib/arrivals/plaidTransactionsPage.ts`, the parser moved from sync-complete in PR-2):

| Domain statement | Where | Per 500-object page (first pull, 20 % pending) |
|---|---|---|
| `INSERT INTO transactions … ON CONFLICT ("transactionId") DO UPDATE …` (Prisma's native upsert, one row) | `:114-123` (`domain.transactions.upsert`) | **500** |
| `DELETE FROM transactions WHERE accountId = $1 AND amount = $2 AND pending = true AND date BETWEEN … AND transactionId <> $n` (the pending-duplicate rule, per posted row) | `:127-142` (`domain.transactions.deleteMany`) | **~400** |
| `UPDATE transactions SET arrival_id = $1 WHERE transactionId = $2 AND arrival_id IS NULL` (the link, per repeated object; and per complete-data skip) | `:181` and `:84` (`domain.transactions.updateMany`) | 0 on a first pull; **~500** on a re-pull |

**Counted, not estimated** — on the throwaway Postgres 16 with Prisma's query-event log (`new PrismaClient({ log: [{ level: 'query', emit: 'event' }] })`), the exact statements a page issued on `main`:

| Page | Objects | Statements on `main` | Of which |
|---|---|---|---|
| 1 (first pull) | 514 new | **922** | 514 upserts · 402 deletes · 6 fixed |
| 2 (re-pull) | 524: 489 repeats, 25 corrections, 10 posted twins | **560** | 489 link updates · 35 upserts · 30 deletes · 6 fixed |
| 3 (the route's real page size) | 100 new | **186** | 100 upserts · 80 deletes · 6 fixed |

The route pages at 100 (`sync-complete/route.ts`, `count: 100`); a 3,000-transaction first pull is ~30 pages × ~186 statements ≈ 5,600 round trips — at Azure's cross-region RTT that is the 300 s.

## BUILD

| Piece | Change |
|---|---|
| `src/lib/arrivals/prismaDomain.ts` (new) | A `DomainDb` that **buffers** the parser's per-row intents in order and, in `finish()`, replays them as: **one** `INSERT … ON CONFLICT ("transactionId") DO UPDATE SET …` for every upsert (the statement Prisma's upsert issues, for the whole set; `$executeRaw` with a VALUES list, chunked at 500; one statement per set of omitted columns — Prisma's create defaults an `undefined`, its update skips it, so a group leaves the column out); **one** `UPDATE transactions AS t SET arrival_id = v.arrival_id FROM (VALUES …) … WHERE … AND t.arrival_id IS NULL` for the links; **one** `DELETE … USING (VALUES …)` for the pending-duplicate rule against rows **not** in the page; **one** `DELETE … WHERE "transactionId" = ANY($1)` for the in-page rows the sequential order would have removed. |
| `planDomainWrites` (pure, in the same file) | Reproduces the sequential order's exact result: the same id twice → the first row's create fields (`id`, `accountId`), the last row's data (latest-arrived wins); a link for an id the page also upserts is a no-op (the upsert sets `arrival_id`); an in-page pending row is deleted only by a **later** posted row's rule, and a later re-upsert of that id revives it. An intent shape the parser never issues → `UnsupportedDomainWriteError` — **no per-row fallback**. |
| `src/lib/arrivals/plaidTransactionsPage.ts` | `PagePorts` gains optional `finish`; `runTransactionsPage` awaits it after the parser, **inside the same transaction, before COMMIT** — a throw in the flush still rolls the page back whole. The parser and its per-row `DomainDb` port are **unchanged**. |
| `src/app/api/transactions/sync-complete/route.ts` | Binds `prismaDomain(tx)` with `finish`; **one log line per page**: `[sync] <bank> transactions page N: <objects> objects, {counts}, <intents> domain intents → <statements> statements, <ms>ms`. |
| `src/lib/__tests__/prismaDomainPlan.test.ts` (new) | The plan rules, the refusal of unknown shapes, the SQL text and bound values, and finish-before-COMMIT. |

Value typing in the raw statements: `amount` → `::float8`, every `DateTime` → its ISO text `::timestamp` (Postgres drops the `Z` on a `timestamp without time zone`, i.e. the UTC wall clock Prisma stores), JSON columns → text `::jsonb`, text/boolean bound as-is. The row-equality probe below is what proves those casts land the same bytes Prisma does.

## VERIFY

| Check | Result |
|---|---|
| `npx tsc --noEmit` | exit 0 |
| eslint, 4 touched/new files | 0 new (the route keeps its 1 pre-existing `no-explicit-any`, on main) |
| `npm test` | **101 / 101 pass** (96 before + 5 new); **`arrivalsLand.test.ts` untouched (`git diff origin/main` empty), 7 / 7** |
| asserts + `next build` | showroom ✓ · tool registry ✓ · reachability 61 pages ✓ · answers law ✓ · arrivals law ✓ · **BUILD EXIT 0** |
| README generator | unchanged (no new route files) |

### The Postgres probe — before / after, same inputs

Throwaway Postgres 16 (`prisma db push` + the PR-1 promise-1 trigger), a deterministic synthetic pull (every column the parser reads exercised; pending/posted mix; the in-page ordinal cases; 10 pre-existing pending twins), a fixed clock, statements counted from Prisma's query events, and every row dumped (transactions minus the random `id` and clock-bound `createdAt`; arrivals; provider_responses count):

| Page | Objects | Statements before → after | Wall ms before → after (localhost) |
|---|---|---|---|
| 1 | 514 new | **922 → 10** (2 upsert chunks, 1 delete, 1 in-page delete, 6 fixed) | **2089 → 380** |
| 2 | 524 mixed | **560 → 9** (1 upsert, 1 link, 1 delete, 6 fixed) | **918 → 169** |
| 3 | 100 new | **186 → 8** | **403 → 74** |

- **Rows byte-equal before / after:** 613 transaction rows, 649 arrival rows, 3 provider_responses — `JSON.stringify` equal; every page's counts equal.
- **The ordinal cases match the sequential result:** the pending row placed *before* its posted twin is gone; the one placed *after* survives; the 10 pre-existing pending twins are deleted by page 2's posted versions in both runs.
- Wall time on localhost understates the gain: what fell ~100× is the number of round trips, and each of those is an Azure cross-region RTT in production.

### Tests (node:test, `prismaDomainPlan.test.ts`)

```
ok 1 - the plan: one upsert per id (first create, last data), links only for ids the page does not upsert, every delete rule kept
ok 2 - the plan: an in-page pending row is deleted only by a LATER posted row's rule; a later re-upsert revives it
ok 3 - the plan: an intent shape the parser never issues is a throw, not a per-row fallback
ok 4 - the SQL: one INSERT … ON CONFLICT DO UPDATE per column group, one UPDATE … FROM VALUES, one DELETE … USING VALUES
ok 5 - runTransactionsPage finishes a buffering port inside the page transaction, after the parser
```

## Notes — stated plainly

- **One documented difference in row identity, not content:** a pre-existing pending row that a posted row's rule deletes sequentially and the *same page* later re-upserts came back as a new row (new `id`, new `createdAt`) on main; here it is updated in place (old `id`, old `createdAt`). Content is identical. The probe excludes `id`/`createdAt` for that reason; no other column differs.
- The `finish` hook is optional on the port so the existing landing tests (a fake per-row `DomainDb`) run unchanged; the production binding is the only one that buffers, and `runTransactionsPage` finishes whatever `ports()` returns. Test 5 pins that it runs before COMMIT.
- Not measured here: Azure RTT. The log line this PR adds is the production instrument — the Preview's first sync prints statements and wall time per page.
- The probe script is archived outside the repo (`scripts/` is gitignored); its method and numbers are above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc

---
_Generated by [Claude Code](https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc)_