### PR TITLE
BANK-03b: explicit --old-item pairing when Plaid replaced the institution record

### DIFF
--- a/scripts/plaid-attach-item.ts
+++ b/scripts/plaid-attach-item.ts
@@ -3,6 +3,9 @@
  *
  *   DATABASE_URL=… npx tsx scripts/plaid-attach-item.ts --user <email> --item <plaid_items.id | Plaid item_id>
  *   DATABASE_URL=… npx tsx scripts/plaid-attach-item.ts --user <email> --item <…> --execute
+ *   … --item <new> --old-item <old>   (BANK-03b: Plaid replaced the institution record, so the
+ *                                      pair is declared; the old item must be the same user's,
+ *                                      live, and older; institution ids may differ)
  *
  * Without --execute it is a DRY RUN: it prints the BEFORE counts (every account
  * of both items with its history) and the plan, and writes nothing. With
@@ -10,7 +13,7 @@
  * and prints the AFTER counts. The same code path as POST /api/plaid/attach-item.
  * Exits 1 when the plan stops or an assertion throws (everything rolled back).
  */
-import { PrismaClient } from '@prisma/client';
+import { Prisma, PrismaClient } from '@prisma/client';
 import { attachItem, describePlan, planAttach, totalOf } from '../src/lib/plaid/attachItem';
 import { prismaAttach } from '../src/lib/plaid/prismaAttach';
 
@@ -23,8 +26,9 @@ async function main() {
   if (!process.env.DATABASE_URL) throw new Error('DATABASE_URL must be set (run locally)');
   const email = arg('user');
   const itemRef = arg('item');
+  const oldRef = arg('old-item');
   const execute = process.argv.includes('--execute');
-  if (!email || !itemRef) throw new Error('usage: --user <email> --item <plaid_items.id | Plaid item_id> [--execute]');
+  if (!email || !itemRef) throw new Error('usage: --user <email> --item <plaid_items.id | Plaid item_id> [--old-item <plaid_items.id | Plaid item_id>] [--execute]');
 
   const prisma = new PrismaClient();
   try {
@@ -32,6 +36,11 @@ async function main() {
     if (!user) throw new Error(`no user ${email}`);
     const item = await prisma.plaid_items.findFirst({ where: { userId: user.id, OR: [{ id: itemRef }, { itemId: itemRef }] }, select: { id: true, itemId: true, institutionId: true, institutionName: true } });
     if (!item) throw new Error(`no plaid_items row ${itemRef} for ${email}`);
+    const oldItem = oldRef
+      ? await prisma.plaid_items.findFirst({ where: { userId: user.id, OR: [{ id: oldRef }, { itemId: oldRef }] }, select: { id: true, itemId: true, institutionId: true, institutionName: true } })
+      : null;
+    if (oldRef && !oldItem) throw new Error(`no plaid_items row ${oldRef} for ${email} (--old-item)`);
+    const itemIds = oldItem ? [item.id, oldItem.id] : null;
 
     const counts = async (label: string) => {
       const rows = await prisma.$queryRaw<Array<{ item: string; institution: string | null; retired_at: Date | null; account: string; mask: string | null; plaid_account_id: string; transactions: bigint; investment_transactions: bigint; bank_reconciliations: bigint }>>`
@@ -40,15 +49,17 @@ async function main() {
                (SELECT count(*) FROM investment_transactions i WHERE i."accountId" = a.id) AS investment_transactions,
                (SELECT count(*) FROM bank_reconciliations r WHERE r.account_id = a.id) AS bank_reconciliations
         FROM plaid_items pi LEFT JOIN accounts a ON a."plaidItemId" = pi.id
-        WHERE pi."userId" = ${user.id} AND pi."institutionId" = ${item.institutionId}
+        WHERE pi."userId" = ${user.id} AND ${itemIds ? Prisma.sql`pi.id = ANY(${itemIds}::text[])` : Prisma.sql`pi."institutionId" = ${item.institutionId}`}
         ORDER BY pi."createdAt", a.mask`;
       console.log(`\n${label}`);
       console.table(rows.map((r) => ({ ...r, transactions: Number(r.transactions), investment_transactions: Number(r.investment_transactions), bank_reconciliations: Number(r.bank_reconciliations), retired_at: r.retired_at?.toISOString() ?? null })));
     };
 
-    await counts(`BEFORE — plaid_items + accounts of institution ${item.institutionId} for ${user.email}`);
+    await counts(oldItem
+      ? `BEFORE — the declared pair for ${user.email}: new ${item.id} (${item.institutionName}, ${item.institutionId}) ← old ${oldItem.id} (${oldItem.institutionName}, ${oldItem.institutionId})`
+      : `BEFORE — plaid_items + accounts of institution ${item.institutionId} for ${user.email}`);
     const db = prismaAttach(prisma);
-    const plan = await planAttach(db, { userId: user.id, newItemRowId: item.id });
+    const plan = await planAttach(db, { userId: user.id, newItemRowId: item.id, oldItemRowId: oldItem?.id });
     console.log(`\nPLAN: ${plan.kind} — ${describePlan(plan)}`);
     if (plan.kind === 'merge') {
       for (const p of plan.pairs) console.log(`  ••••${p.mask}: old ${p.oldRow.id} ${JSON.stringify(p.before.old)} · new ${p.newRow.id} ${JSON.stringify(p.before.new)} → ${p.survivorIs} row survives (${totalOf(p.before.old) + totalOf(p.before.new)} rows)`);
@@ -57,7 +68,7 @@ async function main() {
     if (plan.kind !== 'merge') { process.exitCode = plan.kind === 'stop' ? 1 : 0; return; }
     if (!execute) { console.log('\nDRY RUN — nothing written. Re-run with --execute to apply.'); return; }
 
-    const { report } = await attachItem(db, { userId: user.id, newItemRowId: item.id });
+    const { report } = await attachItem(db, { userId: user.id, newItemRowId: item.id, oldItemRowId: oldItem?.id });
     console.log(`\nEXECUTED: ${JSON.stringify(report, null, 1)}`);
     await counts('AFTER');
   } finally {

--- a/src/app/api/plaid/attach-item/route.ts
+++ b/src/app/api/plaid/attach-item/route.ts
@@ -7,12 +7,14 @@ import { attachItem, describePlan } from '@/lib/plaid/attachItem';
 import { prismaAttach } from '@/lib/plaid/prismaAttach';
 
 /**
- * POST /api/plaid/attach-item { itemId, dryRun? }
+ * POST /api/plaid/attach-item { itemId, oldItemId?, dryRun? }
  * BANK-03, OWNER-ONLY (requireAdmin → OWNER_EMAIL): attach the fresh item
  * `itemId` (plaid_items.id, the caller's own) to the account rows that already
  * carry the history — matched by institutionId + mask, one-to-one — and retire
  * the item it replaces. One transaction; every integrity assertion throws →
  * rollback → 500 envelope. `dryRun: true` answers the plan and writes nothing.
+ * `oldItemId` (BANK-03b) declares the old item when Plaid replaced the institution
+ * record — same user, live, older; institution ids may differ; every other guard stays.
  * A plan that stops (ambiguity, a collision, no match) is a 409 with the reason;
  * nothing to do is a 200 saying so. No Plaid call, no token read.
  */
@@ -26,11 +28,12 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: 'User not found' }, { status: 404 });
     }
 
-    const body = (await request.json().catch(() => ({}))) as { itemId?: unknown; dryRun?: unknown };
+    const body = (await request.json().catch(() => ({}))) as { itemId?: unknown; oldItemId?: unknown; dryRun?: unknown };
     if (typeof body.itemId !== 'string' || body.itemId.trim() === '') throw new ValidationError('itemId is required', { field: 'itemId' });
+    if (body.oldItemId !== undefined && (typeof body.oldItemId !== 'string' || body.oldItemId.trim() === '')) throw new ValidationError('oldItemId must be a non-empty string when given', { field: 'oldItemId' });
     const dryRun = body.dryRun === true;
 
-    const { plan, report } = await attachItem(prismaAttach(prisma), { userId: user.id, newItemRowId: body.itemId, dryRun });
+    const { plan, report } = await attachItem(prismaAttach(prisma), { userId: user.id, newItemRowId: body.itemId, oldItemRowId: body.oldItemId, dryRun });
     const stage = 'attach-item';
     if (plan.kind === 'stop') {
       const status = plan.reason === 'Bank connection not found' ? 404 : 409;
@@ -41,8 +44,8 @@ export async function POST(request: Request) {
     }
     const summary = {
       kind: 'merge',
-      newItem: { id: plan.newItem.id, itemId: plan.newItem.itemId, institutionName: plan.newItem.institutionName },
-      oldItem: { id: plan.oldItem.id, itemId: plan.oldItem.itemId, institutionName: plan.oldItem.institutionName },
+      newItem: { id: plan.newItem.id, itemId: plan.newItem.itemId, institutionId: plan.newItem.institutionId, institutionName: plan.newItem.institutionName },
+      oldItem: { id: plan.oldItem.id, itemId: plan.oldItem.itemId, institutionId: plan.oldItem.institutionId, institutionName: plan.oldItem.institutionName },
       pairs: plan.pairs.map((p) => ({ mask: p.mask, oldAccountId: p.oldRow.id, newAccountId: p.newRow.id, survivor: p.survivorIs, before: p.before })),
       unmatchedNew: plan.unmatchedNew.map((a) => a.id),
       unmatchedOld: plan.unmatchedOld.map((a) => a.id),

--- a/src/lib/__tests__/attachItem.test.ts
+++ b/src/lib/__tests__/attachItem.test.ts
@@ -146,7 +146,7 @@ test('match by institutionId + mask, one-to-one; the name is never consulted', a
   assert.deepEqual(plan.unmatchedOld, []);
   assert.equal(plan.retireReason, 'replaced by NEWITEMxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx');
   assert.deepEqual(plan.totalBefore, { transactions: 120, investment_transactions: 1076, bank_reconciliations: 1 });
-  assert.match(describePlan(plan), /^tastytrade ← TastyTrade: ••••2518 \(new row survives\), ••••3062 \(new row survives\), ••••9689 \(new row survives\); 1197 history rows$/);
+  assert.match(describePlan(plan), /^tastytrade \[NEWITEM\S+, ins_116995\] ← TastyTrade \[4Ad9Ba\S+, ins_116995\]: ••••2518 \(new row survives\), ••••3062 \(new row survives\), ••••9689 \(new row survives\); 1197 history rows$/);
 
   // pointed at the OLD item, the merge stops — it would retire the fresh one
   const backwards = await planAttach(db, { userId: USER, newItemRowId: 'pi_old' });
@@ -269,4 +269,76 @@ test('an unmatched new account is left alone; an unclaimed old account stays on 
   assert.ok(db.accounts.find((a) => a.id === 'acc_old_gone')?.plaidItemId === 'pi_old', 'still attached to the retired item');
   assert.equal(db.transactions.filter((r) => r.accountId === 'acc_old_gone').length, 1, 'its history untouched');
   assert.match(describePlan(plan), /1 new account\(s\) without a twin; 1 old account\(s\) unclaimed, staying on the retired item/);
+});
+
+// BANK-03b — Plaid replaced the institution record: the fresh item carries ins_138270, the old
+// item ins_116995. Found by institutionId there is nothing to pair; the owner declares the pair.
+function theReplacedInstitutionCase(): MemoryDb {
+  const db = theCase();
+  db.items[1].institutionId = 'ins_138270';
+  return db;
+}
+
+test('BANK-03b: without --old-item, a replaced institution record finds nothing (unchanged behavior)', async () => {
+  const db = theReplacedInstitutionCase();
+  assert.deepEqual(await planAttach(db, { userId: USER, newItemRowId: 'pi_new' }), { kind: 'nothing', reason: 'no live item of institution ins_138270 to retire — nothing to attach' });
+});
+
+test('BANK-03b: the explicit pair across institution ids plans and executes; the reason names the replacement', async () => {
+  const db = theReplacedInstitutionCase();
+  const before = await totals(db);
+  const plan = await planAttach(db, { userId: USER, newItemRowId: 'pi_new', oldItemRowId: 'pi_old' });
+  assert.equal(plan.kind, 'merge');
+  if (plan.kind !== 'merge') return;
+  assert.equal(plan.oldItem.id, 'pi_old');
+  assert.equal(plan.newItem.institutionId, 'ins_138270');
+  assert.equal(plan.oldItem.institutionId, 'ins_116995');
+  assert.equal(plan.retireReason, 'replaced by NEWITEMxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx; institution ins_116995 → ins_138270');
+  assert.match(describePlan(plan), /^tastytrade \[NEWITEM\S+, ins_138270\] ← TastyTrade \[4Ad9Ba\S+, ins_116995\]: ••••2518/, 'both ids and both institution ids are printed');
+  assert.deepEqual(plan.pairs.map((p) => [p.mask, p.survivorIs]), [['2518', 'new'], ['3062', 'new'], ['9689', 'new']], 'still mask by mask, still the survivor rule');
+
+  const { report } = await attachItem(db, { userId: USER, newItemRowId: 'pi_new', oldItemRowId: 'pi_old', now: NOW });
+  assert.ok(report);
+  assert.deepEqual(await totals(db), before, 'counted moves, nothing lost');
+  assert.deepEqual(report.totalAfter, report.totalBefore);
+  assert.deepEqual(db.deleted.sort(), ['acc_old_2518', 'acc_old_3062', 'acc_old_9689'], 'empty-donor delete');
+  assert.deepEqual(db.retirements, [{ itemRowId: 'pi_old', at: NOW, reason: 'replaced by NEWITEMxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx; institution ins_116995 → ins_138270' }]);
+
+  // Re-run with the same declaration: the old item is retired → nothing, no writes.
+  const again = await attachItem(db, { userId: USER, newItemRowId: 'pi_new', oldItemRowId: 'pi_old', now: NOW });
+  assert.equal(again.plan.kind, 'nothing');
+  assert.match((again.plan as { reason: string }).reason, /the old item 4Ad9Ba\S+ is already retired \(2026-09-05T12:00:00.000Z\) — nothing to attach/);
+  assert.equal(again.report, null);
+  assert.equal(db.deleted.length, 3);
+  assert.equal(db.retirements.length, 1);
+});
+
+test('BANK-03b: a foreign, newer, or self --old-item stops; every other guard stays', async () => {
+  // foreign (another user's item — or an unknown id): the same defensive text, nothing written
+  const foreign = theReplacedInstitutionCase();
+  foreign.items.push({ id: 'pi_theirs', userId: 'user-b', itemId: 'THEIRS', institutionId: 'ins_116995', institutionName: 'TastyTrade', retired_at: null, createdAt: new Date('2026-01-01T00:00:00Z') });
+  assert.deepEqual(await planAttach(foreign, { userId: USER, newItemRowId: 'pi_new', oldItemRowId: 'pi_theirs' }), { kind: 'stop', reason: 'Bank connection not found' });
+  assert.deepEqual(await planAttach(foreign, { userId: USER, newItemRowId: 'pi_new', oldItemRowId: 'pi_nope' }), { kind: 'stop', reason: 'Bank connection not found' });
+
+  // newer: the declared old item was created after the new one
+  const newer = theReplacedInstitutionCase();
+  newer.items[0].createdAt = new Date('2026-09-06T00:00:00Z');
+  const n = await planAttach(newer, { userId: USER, newItemRowId: 'pi_new', oldItemRowId: 'pi_old' });
+  assert.equal(n.kind, 'stop');
+  assert.match((n as { reason: string }).reason, /the declared old item 4Ad9Ba\S+ \(created 2026-09-06T00:00:00.000Z\) is not older than NEWITEM\S+ \(created 2026-09-04T00:00:00.000Z\) — the pair is the other way round/);
+
+  // the same row for both
+  const same = await planAttach(theReplacedInstitutionCase(), { userId: USER, newItemRowId: 'pi_new', oldItemRowId: 'pi_new' });
+  assert.match((same as { reason: string }).reason, /the old item and the new item are the same row/);
+
+  // the mask guards are unchanged under an explicit pair: two old rows with one mask still stop
+  const ambiguous = theReplacedInstitutionCase();
+  ambiguous.accounts.push(account({ id: 'acc_old_dup', plaidItemId: 'pi_old', accountId: 'plaid_old_dup', mask: '2518' }));
+  const a = await planAttach(ambiguous, { userId: USER, newItemRowId: 'pi_new', oldItemRowId: 'pi_old' });
+  assert.match((a as { reason: string }).reason, /mask 2518: 2 old accounts carry it .* — ambiguous, nothing merged/);
+  // and a reconciliation collision still stops
+  const collide = theReplacedInstitutionCase();
+  collide.bank_reconciliations.push({ id: 'r2', account_id: 'acc_new_2518', entity_id: 'ent-1', year: 2026, month: 7 });
+  const c = await planAttach(collide, { userId: USER, newItemRowId: 'pi_new', oldItemRowId: 'pi_old' });
+  assert.match((c as { reason: string }).reason, /reconciliation\(s\) for the same entity\/year\/month on both rows/);
 });

--- a/src/lib/plaid/attachItem.ts
+++ b/src/lib/plaid/attachItem.ts
@@ -143,23 +143,53 @@ export class AttachIntegrityError extends Error {
   }
 }
 
-export const retireReasonFor = (newItem: AttachItem): string => `replaced by ${newItem.itemId}`;
+/** 'replaced by <new item id>' — and, when Plaid retired the institution record too, '; institution <old> → <new>'. */
+export const retireReasonFor = (newItem: AttachItem, oldItem?: AttachItem): string =>
+  oldItem && oldItem.institutionId !== newItem.institutionId
+    ? `replaced by ${newItem.itemId}; institution ${oldItem.institutionId ?? 'none'} → ${newItem.institutionId ?? 'none'}`
+    : `replaced by ${newItem.itemId}`;
+
+export interface PlanAttachInput {
+  userId: string;
+  newItemRowId: string;
+  /**
+   * BANK-03b: the owner DECLARES the old item when Plaid replaced the institution record
+   * (ins_116995 → ins_138270) so no live item of the new institutionId exists. It must be
+   * the same user's, live, and OLDER than the new item; institutionId equality is not
+   * required. Every other guard is unchanged. Without it, the pairing is found by
+   * institutionId as before.
+   */
+  oldItemRowId?: string;
+}
 
 /** Read-only: decide the merge, or why not. Nothing is written here. */
-export async function planAttach(db: AttachDb, input: { userId: string; newItemRowId: string }): Promise<AttachPlan> {
+export async function planAttach(db: AttachDb, input: PlanAttachInput): Promise<AttachPlan> {
   const newItem = await db.item(input.userId, input.newItemRowId);
   if (!newItem) return { kind: 'stop', reason: 'Bank connection not found' };
   if (newItem.retired_at) return { kind: 'stop', reason: `the item ${newItem.itemId} is itself retired (${newItem.retired_at.toISOString()})` };
   if (!newItem.institutionId || newItem.institutionId === 'unknown') return { kind: 'stop', reason: `the item ${newItem.itemId} has no institutionId — matching is by institutionId + mask, never by name` };
 
-  const olderLive = await db.liveItemsOfInstitution(input.userId, newItem.institutionId, newItem.id);
-  if (olderLive.length === 0) return { kind: 'nothing', reason: `no live item of institution ${newItem.institutionId} to retire — nothing to attach` };
-  if (olderLive.length > 1) return { kind: 'stop', reason: `${olderLive.length} live items of institution ${newItem.institutionId} besides ${newItem.itemId} (${olderLive.map((i) => i.itemId).join(', ')}) — one replacement at a time` };
-  const oldItem = olderLive[0];
-  // Direction: the item given must be the NEWER one — the fresh link. Pointed at the old
-  // item, the merge would retire the fresh one; that is a stop, not a guess.
-  if (oldItem.createdAt.getTime() >= newItem.createdAt.getTime()) {
-    return { kind: 'stop', reason: `the item ${newItem.itemId} (created ${newItem.createdAt.toISOString()}) is not the newest of institution ${newItem.institutionId}: ${oldItem.itemId} was created ${oldItem.createdAt.toISOString()} — run the merge on the newest item` };
+  let oldItem: AttachItem;
+  if (input.oldItemRowId !== undefined) {
+    // BANK-03b: the declared pair. A foreign or unknown id is the same defensive 404 text.
+    const declared = await db.item(input.userId, input.oldItemRowId);
+    if (!declared) return { kind: 'stop', reason: 'Bank connection not found' };
+    if (declared.id === newItem.id) return { kind: 'stop', reason: `the old item and the new item are the same row (${newItem.itemId})` };
+    if (declared.retired_at) return { kind: 'nothing', reason: `the old item ${declared.itemId} is already retired (${declared.retired_at.toISOString()}) — nothing to attach` };
+    if (declared.createdAt.getTime() >= newItem.createdAt.getTime()) {
+      return { kind: 'stop', reason: `the declared old item ${declared.itemId} (created ${declared.createdAt.toISOString()}) is not older than ${newItem.itemId} (created ${newItem.createdAt.toISOString()}) — the pair is the other way round` };
+    }
+    oldItem = declared;
+  } else {
+    const olderLive = await db.liveItemsOfInstitution(input.userId, newItem.institutionId, newItem.id);
+    if (olderLive.length === 0) return { kind: 'nothing', reason: `no live item of institution ${newItem.institutionId} to retire — nothing to attach` };
+    if (olderLive.length > 1) return { kind: 'stop', reason: `${olderLive.length} live items of institution ${newItem.institutionId} besides ${newItem.itemId} (${olderLive.map((i) => i.itemId).join(', ')}) — one replacement at a time` };
+    oldItem = olderLive[0];
+    // Direction: the item given must be the NEWER one — the fresh link. Pointed at the old
+    // item, the merge would retire the fresh one; that is a stop, not a guess.
+    if (oldItem.createdAt.getTime() >= newItem.createdAt.getTime()) {
+      return { kind: 'stop', reason: `the item ${newItem.itemId} (created ${newItem.createdAt.toISOString()}) is not the newest of institution ${newItem.institutionId}: ${oldItem.itemId} was created ${oldItem.createdAt.toISOString()} — run the merge on the newest item` };
+    }
   }
 
   const newAccounts = await db.accountsOfItem(newItem.id);
@@ -191,7 +221,7 @@ export async function planAttach(db: AttachDb, input: { userId: string; newItemR
 
   const unmatchedOld = oldAccounts.filter((o) => !claimedOld.has(o.id));
   const totalBefore = pairs.reduce((sum, p) => addCounts(sum, addCounts(p.before.old, p.before.new)), ZERO);
-  return { kind: 'merge', newItem, oldItem, pairs, unmatchedNew, unmatchedOld, retireReason: retireReasonFor(newItem), totalBefore };
+  return { kind: 'merge', newItem, oldItem, pairs, unmatchedNew, unmatchedOld, retireReason: retireReasonFor(newItem, oldItem), totalBefore };
 }
 
 export interface AttachReport {
@@ -258,7 +288,7 @@ export async function executeAttach(db: AttachDb, plan: Extract<AttachPlan, { ki
 }
 
 /** Plan, then execute unless dryRun. */
-export async function attachItem(db: AttachDb, input: { userId: string; newItemRowId: string; now?: Date; dryRun?: boolean }): Promise<{ plan: AttachPlan; report: AttachReport | null }> {
+export async function attachItem(db: AttachDb, input: PlanAttachInput & { now?: Date; dryRun?: boolean }): Promise<{ plan: AttachPlan; report: AttachReport | null }> {
   const plan = await planAttach(db, input);
   if (plan.kind !== 'merge' || input.dryRun) return { plan, report: null };
   return { plan, report: await executeAttach(db, plan, input.now ?? new Date()) };
@@ -272,5 +302,7 @@ export function describePlan(plan: AttachPlan): string {
     plan.unmatchedNew.length ? `${plan.unmatchedNew.length} new account(s) without a twin` : '',
     plan.unmatchedOld.length ? `${plan.unmatchedOld.length} old account(s) unclaimed, staying on the retired item` : '',
   ].filter(Boolean).join('; ');
-  return `${plan.newItem.institutionName ?? 'the new item'} ← ${plan.oldItem.institutionName ?? 'the old item'}: ${masks}; ${totalOf(plan.totalBefore)} history rows${extra ? `; ${extra}` : ''}`;
+  // Both items, by name AND id — with the institution ids when Plaid replaced the record, so the operator sees the pair.
+  const who = `${plan.newItem.institutionName ?? 'the new item'} [${plan.newItem.itemId}, ${plan.newItem.institutionId ?? 'no institution'}] ← ${plan.oldItem.institutionName ?? 'the old item'} [${plan.oldItem.itemId}, ${plan.oldItem.institutionId ?? 'no institution'}]`;
+  return `${who}: ${masks}; ${totalOf(plan.totalBefore)} history rows${extra ? `; ${extra}` : ''}`;
 }


### PR DESCRIPTION
**Do not merge — Alex merges after Vercel Preview (SOC 2 gate).**

**User-financial-data move, as BANK-03 (#1647):** nothing runs against production by itself; the merge executes only when Alex runs the script or the owner-only route, after a dry run, inside one transaction behind the same integrity assertions. No migration in this PR.

## WHY

The fresh OAuth tastytrade item carries `institutionId ins_138270`; the old item carries `ins_116995` — Plaid retired the old institution record and issued a new one. `planAttach` pairs by (institutionId, mask), finds no live item of the new institution, and answers `'nothing'`. The owner now declares the pair; every other guard stays.

## AUDIT — what stopped it (file:line, on `main`)

| Fact | Where |
|---|---|
| The old item is found only among live items of the **new item's** institutionId; none → `'nothing'`. | `src/lib/plaid/attachItem.ts:155-156` (`liveItemsOfInstitution(userId, newItem.institutionId, …)`) |
| The direction guard compares `createdAt` (the item given must be the newer one). | `attachItem.ts:159-163` |
| The retire reason was `'replaced by <new item id>'` only. | `attachItem.ts:146` |
| The script resolves `--item` by `plaid_items.id` or Plaid `itemId`, user-scoped; its BEFORE/AFTER table was filtered by the new item's institutionId — which would have hidden the old item under a replaced record. | `scripts/plaid-attach-item.ts:37`, `:52` |
| The route took `{ itemId, dryRun }`. | `src/app/api/plaid/attach-item/route.ts:30-33` |

## BUILD

| Piece | Change |
|---|---|
| `src/lib/plaid/attachItem.ts` | `PlanAttachInput.oldItemRowId?` — when given: the old item must be the caller's (`db.item(userId, id)`; a foreign or unknown id is the same defensive `'Bank connection not found'`), must not be the new item itself, must be **older** than the new item (`createdAt`; the other way round stops: "the pair is the other way round"), and **institutionId equality is not required**. A declared old item that is already retired answers `'nothing'` — the no-op re-run. Then the unchanged path: mask by mask, exactly one match each, ambiguity stops, the reconciliation collision stops, the survivor rule, counted moves, the empty-donor delete, the total assert. `retireReasonFor(newItem, oldItem)` → `'replaced by <new item id>; institution ins_116995 → ins_138270'` when the institution ids differ, unchanged when they match. `describePlan` prints **both items by name and id with their institution ids**: `tastytrade [NEWITEM…, ins_138270] ← TastyTrade [4Ad9Ba…, ins_116995]: …`. Without `oldItemRowId` the function is byte-for-byte the old path. |
| `scripts/plaid-attach-item.ts` | `--old-item <plaid_items.id \| Plaid item_id>` (user-scoped, a missing row fails loud); the BEFORE/AFTER table covers the declared pair by item id instead of by institution. |
| `src/app/api/plaid/attach-item/route.ts` | Optional body field `oldItemId` (validated: a non-empty string when given); the plan summary carries both `institutionId`s. |
| `src/lib/__tests__/attachItem.test.ts` | Three new tests; the six BANK-03 tests unchanged in substance (one `describePlan` expectation gains the ids). |

## VERIFY

| Check | Result |
|---|---|
| `npx tsc --noEmit` | exit 0 |
| eslint, 4 touched files | 0 |
| `npm test` | **111 / 111 pass** (108 before + 3 new) |
| asserts + `next build` | showroom ✓ · tool registry ✓ · reachability 61 pages ✓ · answers law ✓ · arrivals law ✓ · **BUILD EXIT 0** |
| README generator | unchanged (no new route file) |

### Tests (node:test)

```
ok 7 - BANK-03b: without --old-item, a replaced institution record finds nothing (unchanged behavior)
ok 8 - BANK-03b: the explicit pair across institution ids plans and executes; the reason names the replacement
ok 9 - BANK-03b: a foreign, newer, or self --old-item stops; every other guard stays
```

- **7:** the fresh item on `ins_138270`, the old on `ins_116995`, no flag → `{ kind: 'nothing', reason: 'no live item of institution ins_138270 to retire — nothing to attach' }`.
- **8:** with `oldItemRowId: 'pi_old'` → `merge`; `retireReason === 'replaced by NEWITEM…; institution ins_116995 → ins_138270'`; `describePlan` prints both ids and both institution ids; still mask by mask with the survivor rule; executed: history totals equal before/after, the three donors deleted only after their rows moved, the old item retired with that reason; **re-run** with the same declaration → `'nothing'` ("the old item … is already retired … — nothing to attach"), no writes.
- **9:** another user's item and an unknown id → `'Bank connection not found'`; an old item created after the new one → stop ("is not older than … — the pair is the other way round"); the same row for both → stop; under an explicit pair, two old rows with one mask still stop, and a reconciliation for the same entity/year/month on both rows still stops.

### The rehearsal — throwaway Postgres 16, the two institution ids

Seeded as in #1647 with the new item on `ins_138270` and the old on `ins_116995`:

| Step | Result |
|---|---|
| (a) `--item pi_new` (no flag) | `PLAN: nothing — no live item of institution ins_138270 to retire — nothing to attach` · exit 0 |
| (b) `--item pi_old --old-item pi_new` (the wrong way round) | `PLAN: stop — the declared old item NEWITEM… (created 2026-09-05…) is not older than 4Ad9Ba… (created 2026-01-01…) — the pair is the other way round` · exit 1 |
| (c) `--item pi_new --old-item 4Ad9Ba…` (dry run) | BEFORE table over the declared pair; `PLAN: merge — tastytrade [NEWITEM…, ins_138270] ← TastyTrade [4Ad9Ba…, ins_116995]: ••••2518 (new row survives), ••••3062 …, ••••9689 …; 1197 history rows`; `retire pi_old — replaced by NEWITEM…; institution ins_116995 → ins_138270`; nothing written |
| (d) `… --execute` | 3 pairs: 40 transactions + 120 investment rows (+ 1 reconciliation on 2518) moved onto each surviving row → 40 / 359 / 1, 40 / 359 / 0, 40 / 358 / 0; old item retired with the replacement reason · exit 0 |
| (e) re-run `… --execute` | `PLAN: nothing — the old item 4Ad9Ba… is already retired (…) — nothing to attach` · exit 0 |
| psql | `accounts 3 · plaid_items 2 · retired 1 · transactions 120 · investment_transactions 1076 · bank_reconciliations 1 · orphans 0 / 0`; `pi_old ins_116995 TastyTrade retired "replaced by NEWITEM…; institution ins_116995 → ins_138270"`; `pi_new ins_138270 tastytrade live` |

## For production

```
DATABASE_URL=… npx tsx scripts/plaid-attach-item.ts --user <owner email> --item <new plaid_items.id> --old-item 4Ad9BaBDXDI8B7gNgpjMsXV8pyOVqpHknKKQp
DATABASE_URL=… npx tsx scripts/plaid-attach-item.ts --user <owner email> --item <new plaid_items.id> --old-item 4Ad9BaBDXDI8B7gNgpjMsXV8pyOVqpHknKKQp --execute
```

The BEFORE table now lists both items regardless of their institution ids; the before/after and orphan queries from #1647 apply unchanged (filter `plaid_items` by the two ids rather than by one institution).

## Notes — stated plainly

- Not verified against production: the ids and counts come from the ruling; the dry run prints them before anything moves.
- The content-overlap caveat from #1647 (the fresh item's investment rows vs. rows already on the old account rows) is unchanged and unaddressed here, as ruled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc

---
_Generated by [Claude Code](https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc)_