### PR TITLE
BANK-03c: retire-only when the declared old item holds no account rows

### DIFF
--- a/scripts/plaid-attach-item.ts
+++ b/scripts/plaid-attach-item.ts
@@ -6,6 +6,8 @@
  *   … --item <new> --old-item <old>   (BANK-03b: Plaid replaced the institution record, so the
  *                                      pair is declared; the old item must be the same user's,
  *                                      live, and older; institution ids may differ)
+ *   A declared old item with NO account rows (BANK-03c) is a 'retire-only' plan: one UPDATE
+ *   sets retired_at / retired_reason; nothing moves. With --execute the AFTER row is printed.
  *
  * Without --execute it is a DRY RUN: it prints the BEFORE counts (every account
  * of both items with its history) and the plan, and writes nothing. With
@@ -65,7 +67,8 @@ async function main() {
       for (const p of plan.pairs) console.log(`  ••••${p.mask}: old ${p.oldRow.id} ${JSON.stringify(p.before.old)} · new ${p.newRow.id} ${JSON.stringify(p.before.new)} → ${p.survivorIs} row survives (${totalOf(p.before.old) + totalOf(p.before.new)} rows)`);
       console.log(`  retire ${plan.oldItem.id} (${plan.oldItem.itemId}) — ${plan.retireReason}`);
     }
-    if (plan.kind !== 'merge') { process.exitCode = plan.kind === 'stop' ? 1 : 0; return; }
+    if (plan.kind === 'retire-only') console.log(`  retire ${plan.oldItem.id} (${plan.oldItem.itemId}) — ${plan.retireReason} — one UPDATE, nothing moves`);
+    if (plan.kind !== 'merge' && plan.kind !== 'retire-only') { process.exitCode = plan.kind === 'stop' ? 1 : 0; return; }
     if (!execute) { console.log('\nDRY RUN — nothing written. Re-run with --execute to apply.'); return; }
 
     const { report } = await attachItem(db, { userId: user.id, newItemRowId: item.id, oldItemRowId: oldItem?.id });

--- a/src/app/api/plaid/attach-item/route.ts
+++ b/src/app/api/plaid/attach-item/route.ts
@@ -15,6 +15,7 @@ import { prismaAttach } from '@/lib/plaid/prismaAttach';
  * rollback → 500 envelope. `dryRun: true` answers the plan and writes nothing.
  * `oldItemId` (BANK-03b) declares the old item when Plaid replaced the institution
  * record — same user, live, older; institution ids may differ; every other guard stays.
+ * A declared old item with no account rows (BANK-03c) is retire-only: one UPDATE.
  * A plan that stops (ambiguity, a collision, no match) is a 409 with the reason;
  * nothing to do is a 200 saying so. No Plaid call, no token read.
  */
@@ -41,6 +42,17 @@ export async function POST(request: Request) {
     }
     if (plan.kind === 'nothing') {
       return NextResponse.json({ ok: true, stage, message: plan.reason, plan: { kind: 'nothing' } });
+    }
+    if (plan.kind === 'retire-only') {
+      // BANK-03c: the declared old item holds no account rows — one UPDATE, nothing moves.
+      const summary = {
+        kind: 'retire-only',
+        newItem: { id: plan.newItem.id, itemId: plan.newItem.itemId, institutionId: plan.newItem.institutionId, institutionName: plan.newItem.institutionName },
+        oldItem: { id: plan.oldItem.id, itemId: plan.oldItem.itemId, institutionId: plan.oldItem.institutionId, institutionName: plan.oldItem.institutionName },
+        retireReason: plan.retireReason,
+      };
+      if (dryRun) return NextResponse.json({ ok: true, stage, dryRun: true, message: `DRY RUN — ${describePlan(plan)}`, plan: summary });
+      return NextResponse.json({ ok: true, stage, message: `${plan.oldItem.institutionName ?? 'The old item'} retired (no accounts to attach)`, plan: summary, report });
     }
     const summary = {
       kind: 'merge',

--- a/src/lib/__tests__/attachItem.test.ts
+++ b/src/lib/__tests__/attachItem.test.ts
@@ -49,6 +49,17 @@ class MemoryDb implements AttachDb {
       bank_reconciliations: this.bank_reconciliations.filter((r) => r.account_id === id).length,
     };
   }
+  /** A fault injected for BANK-03c: history that claims to reach the item despite zero account rows. */
+  phantomHistory: HistoryCounts | null = null;
+  async historyCountsOfItem(itemRowId: string): Promise<HistoryCounts> {
+    if (this.phantomHistory) return this.phantomHistory;
+    const ids = new Set(this.accounts.filter((a) => a.plaidItemId === itemRowId).map((a) => a.id));
+    return {
+      transactions: this.transactions.filter((r) => ids.has(r.accountId)).length,
+      investment_transactions: this.investment_transactions.filter((r) => ids.has(r.accountId)).length,
+      bank_reconciliations: this.bank_reconciliations.filter((r) => ids.has(r.account_id)).length,
+    };
+  }
   async reconciliationCollisions(a: string, b: string) {
     const key = (r: Rec) => `${r.entity_id} ${r.year} ${r.month}`;
     const ka = new Set(this.bank_reconciliations.filter((r) => r.account_id === a).map(key));
@@ -341,4 +352,82 @@ test('BANK-03b: a foreign, newer, or self --old-item stops; every other guard st
   collide.bank_reconciliations.push({ id: 'r2', account_id: 'acc_new_2518', entity_id: 'ent-1', year: 2026, month: 7 });
   const c = await planAttach(collide, { userId: USER, newItemRowId: 'pi_new', oldItemRowId: 'pi_old' });
   assert.match((c as { reason: string }).reason, /reconciliation\(s\) for the same entity\/year\/month on both rows/);
+});
+
+// BANK-03c — the fresh link's dedup already re-pointed the account rows to the new item; the declared
+// old item holds zero account rows. Retire it; move nothing.
+function theEmptyOldItemCase(): MemoryDb {
+  const db = theReplacedInstitutionCase();
+  // every account row already on the new item, with the history on them
+  for (const a of db.accounts) if (a.plaidItemId === 'pi_old') { db.accounts = db.accounts.filter((x) => x.id !== a.id); }
+  for (const r of db.transactions) r.accountId = r.accountId.replace('acc_old_', 'acc_new_');
+  for (const r of db.investment_transactions) r.accountId = r.accountId.replace('acc_old_', 'acc_new_');
+  for (const r of db.bank_reconciliations) r.account_id = r.account_id.replace('acc_old_', 'acc_new_');
+  return db;
+}
+
+test('BANK-03c: a declared old item with zero account rows → retire-only plan, one UPDATE, nothing else written', async () => {
+  const db = theEmptyOldItemCase();
+  assert.equal(db.accounts.filter((a) => a.plaidItemId === 'pi_old').length, 0);
+  const before = { totals: await totals(db), accounts: structuredClone(db.accounts) };
+  const plan = await planAttach(db, { userId: USER, newItemRowId: 'pi_new', oldItemRowId: 'pi_old' });
+  assert.equal(plan.kind, 'retire-only');
+  if (plan.kind !== 'retire-only') return;
+  assert.equal(plan.oldItem.id, 'pi_old');
+  assert.equal(plan.retireReason, 'replaced by NEWITEMxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx; institution ins_116995 → ins_138270; no accounts to attach');
+  assert.match(describePlan(plan), /^tastytrade \[NEWITEM\S+, ins_138270\] ← TastyTrade \[4Ad9Ba\S+, ins_116995\]: the old item holds no account rows and no history — retire only \(replaced by .*; no accounts to attach\); no other write$/);
+
+  const { report } = await attachItem(db, { userId: USER, newItemRowId: 'pi_new', oldItemRowId: 'pi_old', now: NOW });
+  assert.ok(report);
+  assert.equal(report.kind, 'retire-only');
+  assert.deepEqual(report.pairs, []);
+  assert.deepEqual(db.retirements, [{ itemRowId: 'pi_old', at: NOW, reason: 'replaced by NEWITEMxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx; institution ins_116995 → ins_138270; no accounts to attach' }], 'exactly one write: the retirement');
+  assert.deepEqual(db.deleted, [], 'no delete');
+  assert.deepEqual(db.updates, [], 'no survivor update');
+  assert.deepEqual(await totals(db), before.totals, 'no history moved');
+  assert.deepEqual(db.accounts, before.accounts, 'no account row touched');
+  assert.equal(db.items.length, 2, 'plaid_items rows are never deleted');
+
+  // dry run writes nothing
+  const dryDb = theEmptyOldItemCase();
+  const d = await attachItem(dryDb, { userId: USER, newItemRowId: 'pi_new', oldItemRowId: 'pi_old', dryRun: true, now: NOW });
+  assert.deepEqual(dryDb.retirements, []);
+  assert.equal(d.plan.kind, 'retire-only');
+  assert.equal(d.report, null);
+
+  // re-run on the retired item → nothing, no writes
+  const again = await attachItem(db, { userId: USER, newItemRowId: 'pi_new', oldItemRowId: 'pi_old', now: NOW });
+  assert.equal(again.plan.kind, 'nothing');
+  assert.match((again.plan as { reason: string }).reason, /is already retired .* — nothing to attach/);
+  assert.equal(db.retirements.length, 1);
+});
+
+test('BANK-03c: an old item with ANY account row keeps the existing path; found by institution, an empty old item keeps the existing stop', async () => {
+  // one account row on the old item, its mask matching → the merge path as before
+  const merge = theEmptyOldItemCase();
+  merge.accounts.push(account({ id: 'acc_old_2518', plaidItemId: 'pi_old', accountId: 'plaid_old_2518', mask: '2518', name: 'TastyTrade 2518', accountCode: '1200-2518' }));
+  const m = await planAttach(merge, { userId: USER, newItemRowId: 'pi_new', oldItemRowId: 'pi_old' });
+  assert.equal(m.kind, 'merge');
+  if (m.kind === 'merge') assert.deepEqual(m.pairs.map((p) => p.mask), ['2518']);
+
+  // one account row on the old item, no mask match → the existing stop, not retire-only
+  const nomatch = theEmptyOldItemCase();
+  nomatch.accounts.push(account({ id: 'acc_old_0000', plaidItemId: 'pi_old', accountId: 'plaid_old_0000', mask: '0000' }));
+  const n = await planAttach(nomatch, { userId: USER, newItemRowId: 'pi_new', oldItemRowId: 'pi_old' });
+  assert.equal(n.kind, 'stop');
+  assert.match((n as { reason: string }).reason, /no new account's mask matches an old account/);
+
+  // WITHOUT --old-item, an empty old item found by institution: unchanged — the existing stop
+  const byInstitution = theEmptyOldItemCase();
+  byInstitution.items[0].institutionId = 'ins_138270';
+  const b = await planAttach(byInstitution, { userId: USER, newItemRowId: 'pi_new' });
+  assert.equal(b.kind, 'stop');
+  assert.match((b as { reason: string }).reason, /no new account's mask matches an old account of 4Ad9Ba\S+ — nothing to attach/);
+
+  // the assertion: history that somehow reaches the item without account rows → stop, not retire
+  const phantom = theEmptyOldItemCase();
+  phantom.phantomHistory = { transactions: 3, investment_transactions: 0, bank_reconciliations: 0 };
+  const ph = await planAttach(phantom, { userId: USER, newItemRowId: 'pi_new', oldItemRowId: 'pi_old' });
+  assert.equal(ph.kind, 'stop');
+  assert.match((ph as { reason: string }).reason, /has no account rows yet .* history rows reach it — not retiring/);
 });

--- a/src/lib/plaid/attachItem.ts
+++ b/src/lib/plaid/attachItem.ts
@@ -100,6 +100,8 @@ export interface AttachDb {
   liveItemsOfInstitution(userId: string, institutionId: string, excludeItemRowId: string): Promise<AttachItem[]>;
   accountsOfItem(itemRowId: string): Promise<AttachAccount[]>;
   historyCounts(accountRowId: string): Promise<HistoryCounts>;
+  /** BANK-03c: history rows reaching the ITEM through any of its account rows — the assertion behind retire-only. */
+  historyCountsOfItem(itemRowId: string): Promise<HistoryCounts>;
   /** (entity_id, year, month) reconciliation keys present on BOTH rows — a move would violate the unique key. */
   reconciliationCollisions(accountRowIdA: string, accountRowIdB: string): Promise<number>;
   /** UPDATE … SET account = to WHERE account = from, on every history table; resolves to the rows moved. */
@@ -123,6 +125,8 @@ export interface AttachPair {
 export type AttachPlan =
   | { kind: 'nothing'; reason: string }
   | { kind: 'stop'; reason: string }
+  /** BANK-03c: the declared old item holds no account rows (and, asserted, no history) — retire it, move nothing. */
+  | { kind: 'retire-only'; newItem: AttachItem; oldItem: AttachItem; retireReason: string }
   | {
       kind: 'merge';
       newItem: AttachItem;
@@ -196,6 +200,18 @@ export async function planAttach(db: AttachDb, input: PlanAttachInput): Promise<
   const oldAccounts = await db.accountsOfItem(oldItem.id);
   if (newAccounts.length === 0) return { kind: 'stop', reason: `the item ${newItem.itemId} has no account rows` };
 
+  // BANK-03c: a DECLARED old item with no account rows has nothing to attach — the fresh
+  // link's dedup already re-pointed its rows. Asserted against the three history tables
+  // through the item (nothing can reference an account row that is not there), then the
+  // plan is retire-only: one UPDATE, no other write. Found by institution, the old path stays.
+  if (input.oldItemRowId !== undefined && oldAccounts.length === 0) {
+    const reaching = await db.historyCountsOfItem(oldItem.id);
+    if (totalOf(reaching) !== 0) {
+      return { kind: 'stop', reason: `the old item ${oldItem.itemId} has no account rows yet ${JSON.stringify(reaching)} history rows reach it — not retiring` };
+    }
+    return { kind: 'retire-only', newItem, oldItem, retireReason: `${retireReasonFor(newItem, oldItem)}; no accounts to attach` };
+  }
+
   const pairs: AttachPair[] = [];
   const unmatchedNew: AttachAccount[] = [];
   const claimedOld = new Map<string, string>();
@@ -225,6 +241,7 @@ export async function planAttach(db: AttachDb, input: PlanAttachInput): Promise<
 }
 
 export interface AttachReport {
+  kind: 'merge' | 'retire-only';
   pairs: Array<{ mask: string; survivorId: string; survivorWas: 'old' | 'new'; deletedAccountId: string; moved: HistoryCounts; after: HistoryCounts }>;
   retired: { itemRowId: string; itemId: string; institutionName: string | null; reason: string };
   unmatchedNew: string[];
@@ -277,6 +294,7 @@ export async function executeAttach(db: AttachDb, plan: Extract<AttachPlan, { ki
     if (!sameCounts(totalAfter, plan.totalBefore)) throw new AttachIntegrityError(`history total changed: before ${JSON.stringify(plan.totalBefore)}, after ${JSON.stringify(totalAfter)}`);
     await tx.retireItem(plan.oldItem.id, now, plan.retireReason);
     return {
+      kind: 'merge',
       pairs,
       retired: { itemRowId: plan.oldItem.id, itemId: plan.oldItem.itemId, institutionName: plan.oldItem.institutionName, reason: plan.retireReason },
       unmatchedNew: plan.unmatchedNew.map((a) => a.id),
@@ -288,14 +306,35 @@ export async function executeAttach(db: AttachDb, plan: Extract<AttachPlan, { ki
 }
 
 /** Plan, then execute unless dryRun. */
+/** BANK-03c: exactly one UPDATE — retired_at, retired_reason — inside the transaction. Nothing else moves. */
+export async function executeRetireOnly(db: AttachDb, plan: Extract<AttachPlan, { kind: 'retire-only' }>, now: Date = new Date()): Promise<AttachReport> {
+  return db.transaction(async (tx) => {
+    await tx.retireItem(plan.oldItem.id, now, plan.retireReason);
+    return {
+      kind: 'retire-only',
+      pairs: [],
+      retired: { itemRowId: plan.oldItem.id, itemId: plan.oldItem.itemId, institutionName: plan.oldItem.institutionName, reason: plan.retireReason },
+      unmatchedNew: [],
+      unmatchedOld: [],
+      totalBefore: ZERO,
+      totalAfter: ZERO,
+    };
+  });
+}
+
 export async function attachItem(db: AttachDb, input: PlanAttachInput & { now?: Date; dryRun?: boolean }): Promise<{ plan: AttachPlan; report: AttachReport | null }> {
   const plan = await planAttach(db, input);
-  if (plan.kind !== 'merge' || input.dryRun) return { plan, report: null };
-  return { plan, report: await executeAttach(db, plan, input.now ?? new Date()) };
+  if (input.dryRun) return { plan, report: null };
+  if (plan.kind === 'merge') return { plan, report: await executeAttach(db, plan, input.now ?? new Date()) };
+  if (plan.kind === 'retire-only') return { plan, report: await executeRetireOnly(db, plan, input.now ?? new Date()) };
+  return { plan, report: null };
 }
 
 /** The one-line summary for a route answer or a script. */
 export function describePlan(plan: AttachPlan): string {
+  if (plan.kind === 'retire-only') {
+    return `${plan.newItem.institutionName ?? 'the new item'} [${plan.newItem.itemId}, ${plan.newItem.institutionId ?? 'no institution'}] ← ${plan.oldItem.institutionName ?? 'the old item'} [${plan.oldItem.itemId}, ${plan.oldItem.institutionId ?? 'no institution'}]: the old item holds no account rows and no history — retire only (${plan.retireReason}); no other write`;
+  }
   if (plan.kind !== 'merge') return plan.reason;
   const masks = plan.pairs.map((p) => `••••${p.mask} (${p.survivorIs} row survives)`).join(', ');
   const extra = [

--- a/src/lib/plaid/prismaAttach.ts
+++ b/src/lib/plaid/prismaAttach.ts
@@ -40,6 +40,14 @@ function bind(client: Client, root: Root | null): AttachDb {
       ]);
       return { transactions, investment_transactions, bank_reconciliations };
     },
+    async historyCountsOfItem(itemRowId): Promise<HistoryCounts> {
+      const [transactions, investment_transactions, bank_reconciliations] = await Promise.all([
+        client.transactions.count({ where: { accounts: { plaidItemId: itemRowId } } }),
+        client.investment_transactions.count({ where: { accounts: { plaidItemId: itemRowId } } }),
+        client.bank_reconciliations.count({ where: { account: { plaidItemId: itemRowId } } }),
+      ]);
+      return { transactions, investment_transactions, bank_reconciliations };
+    },
     async reconciliationCollisions(a, b): Promise<number> {
       const key = (r: { entity_id: string; year: number; month: number }) => `${r.entity_id} ${r.year} ${r.month}`;
       const [ra, rb] = await Promise.all([


### PR DESCRIPTION
**Do not merge — Alex merges after Vercel Preview (SOC 2 gate).**

**Write to a user's data row, as BANK-03 (#1647) / BANK-03b (#1648):** the retire-only plan is exactly one UPDATE on `plaid_items` (`retired_at`, `retired_reason`), executed only when Alex runs the script or the owner-only route after a dry run. No account row, no history row is touched. No migration.

## WHY

The fresh OAuth link's dedup already re-pointed the three TastyTrade account rows to the new item; the declared old item (`plaid_1760348019981_pajqul5sv`) holds zero account rows, so `planAttach` stops with "nothing to attach" and the item keeps being flagged on every sync. An item with no account rows has no history hanging off it — the three history tables reference `accounts.id` and nothing else (`prisma/schema.prisma:419/:452`, `:463/:497`, `:1874/:1892`). Retiring it moves nothing.

## AUDIT — what stopped it (file:line, on `main`)

| Fact | Where |
|---|---|
| With a declared pair, the plan loads both items' account rows and, with no mask match, stops: "no new account's mask matches an old account of … — nothing to attach". An old item with zero rows can never match. | `src/lib/plaid/attachItem.ts:195-197`, `:220` |
| Sync already skips retired items and reports them as retired; `/api/accounts` and `/api/plaid/items` hide them (#1647). So retiring the empty item is the whole fix. | `sync-complete/route.ts` (`retired_at: null` / `retiredItems`), `accounts/route.ts`, `plaid/items/route.ts` |
| The port counted history per account row only (`historyCounts(accountRowId)`); nothing counted history reaching an ITEM. | `attachItem.ts:102` |

## BUILD

| Piece | Change |
|---|---|
| `src/lib/plaid/attachItem.ts` | **`planAttach`:** when `--old-item` is declared **and** the old item has zero account rows, the plan is **`'retire-only'`** — after the assertion that no history row reaches the item through any account (`historyCountsOfItem`; a non-zero count **stops**: "has no account rows yet … history rows reach it — not retiring"). `retired_reason = 'replaced by <new item id>; institution <old> → <new>; no accounts to attach'`. The guards before it are unchanged (same user, live, older, the new item must have account rows). Found by institution (no flag), or with **any** account row on the old item, the existing stop or merge path runs unchanged. **`executeRetireOnly`:** exactly one `retireItem` (one UPDATE) inside the transaction; the report carries `kind: 'retire-only'`, empty pairs, zero totals. `attachItem` dispatches on the plan kind; `describePlan` names both items, both institution ids, and "retire only (…); no other write". |
| `src/lib/plaid/prismaAttach.ts` | `historyCountsOfItem`: the three counts through the `accounts` relation (`where: { accounts: { plaidItemId } }`, `{ account: { plaidItemId } }`). |
| `scripts/plaid-attach-item.ts` | Prints `PLAN: retire-only — …` and the retire line; `--execute` performs the one UPDATE and prints the AFTER row. |
| `src/app/api/plaid/attach-item/route.ts` | A `retire-only` summary for the dry run and for the executed answer ("<old item> retired (no accounts to attach)"). |
| `src/lib/__tests__/attachItem.test.ts` | Two new tests; the fake port gains `historyCountsOfItem` and a phantom-history injection. |

## VERIFY

| Check | Result |
|---|---|
| `npx tsc --noEmit` | exit 0 |
| eslint, 5 touched files | 0 |
| `npm test` | **113 / 113 pass** (111 before + 2 new) |
| asserts + `next build` | showroom ✓ · tool registry ✓ · reachability 61 pages ✓ · answers law ✓ · arrivals law ✓ · **BUILD EXIT 0** |
| README generator | unchanged (no new route file) |

### Tests (node:test)

```
ok 10 - BANK-03c: a declared old item with zero account rows → retire-only plan, one UPDATE, nothing else written
ok 11 - BANK-03c: an old item with ANY account row keeps the existing path; found by institution, an empty old item keeps the existing stop
```

- **10:** the plan is `retire-only` with `retireReason === 'replaced by NEWITEM…; institution ins_116995 → ins_138270; no accounts to attach'`; executed, the fake records **exactly one retirement** and no delete, no survivor update, no history move, no account row change; the two `plaid_items` rows remain; a dry run writes nothing; a re-run answers `'nothing'` ("is already retired …").
- **11:** one old account row whose mask matches → the merge path as before; one old account row with no match → the existing stop; **without** the flag, an empty old item found by institution → the existing stop (unchanged); phantom history reaching the item without account rows → stop, not retire.

### The rehearsal — throwaway Postgres 16

Seeded the case as the ruling states it: old item `plaid_1760348019981_pajqul5sv` (`ins_116995`) with **zero** account rows; the new item (`ins_138270`) holding the three accounts with all the history (120 transactions, 1076 investment rows, 1 reconciliation).

| Step | Result |
|---|---|
| dry run `--item pi_new --old-item plaid_1760348019981_pajqul5sv` | `PLAN: retire-only — tastytrade [NEWITEM…, ins_138270] ← TastyTrade [4Ad9Ba…, ins_116995]: the old item holds no account rows and no history — retire only (replaced by NEWITEM…; institution ins_116995 → ins_138270; no accounts to attach); no other write` · nothing written · exit 0 |
| `--execute` | `"kind": "retire-only"`; the AFTER row: `plaid_1760348019981_pajqul5sv · TastyTrade · retired_at 2026-09-07T10:43:33Z · no accounts`; the three new-item rows unchanged at 40 / 359 / 1, 40 / 359 / 0, 40 / 358 / 0 · exit 0 |
| re-run `--execute` | `PLAN: nothing — the old item 4Ad9Ba… is already retired (…) — nothing to attach` · exit 0 |
| psql | `accounts 3 · plaid_items 2 · retired 1 · transactions 120 · investment_transactions 1076 · bank_reconciliations 1`; `retired_reason = 'replaced by NEWITEM…; institution ins_116995 → ins_138270; no accounts to attach'` |

## For production

```
DATABASE_URL=… npx tsx scripts/plaid-attach-item.ts --user <owner email> --item <new plaid_items.id> --old-item plaid_1760348019981_pajqul5sv
DATABASE_URL=… npx tsx scripts/plaid-attach-item.ts --user <owner email> --item <new plaid_items.id> --old-item plaid_1760348019981_pajqul5sv --execute
```

The dry run must print `PLAN: retire-only` — if it prints `merge` or `stop`, the old item is not empty and this PR changes nothing about that path.

## Notes — stated plainly

- Not verified against production: that the old item holds zero account rows is taken from the ruling; the dry run's BEFORE table shows it before anything is written.
- The assertion "zero across the three history tables" is checked through the `accounts` relation; with no account rows it is zero by the schema's own foreign keys, and the check exists so the plan never trusts that by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc

---
_Generated by [Claude Code](https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc)_