### PR TITLE
NAV-02: family tabs become menus; the registry rows become family pages

### DIFF
--- a/scripts/assert-tool-registry.ts
+++ b/scripts/assert-tool-registry.ts
@@ -2,11 +2,19 @@
 /**
  * assert-tool-registry — THE TOOL REGISTRY LAW at build time (NAV-01a), and
  * THE REACHABILITY LAW (NAV-01b): every page file under src/app must have a
- * door — the family navigation (a registry home, link, or family read), the
- * header/profile utilities menu (src/lib/shellMenu.ts), a listed guest /
+ * door — the family navigation (NAV-02: a family MENU's links — "All of
+ * <FAMILY>" opens the family page, each tool item its door — and a family
+ * PAGE's cards — the registry home, the related surfaces, the family reads),
+ * the header/profile utilities menu (src/lib/shellMenu.ts), a listed guest /
  * marketing / flow route (GUEST_ROUTES below, each cited), or a redirect whose
  * target has a door. A child page is reached through its parent (segment-prefix
  * rule: /agenda/[id] through /agenda). A page with no door fails the build.
+ *
+ * THE FAMILY MAP LAW (NAV-02): every tool appears in its family's menu exactly
+ * once and on its family's page exactly once (familyMenu / familyCards, the
+ * registry's one source); each family page route has a page file that names
+ * its family; FamilyNav renders familyMenu() and FamilyPage renders
+ * familyCards() — never a retyped list.
  *
  * THE ANSWERS LAW (NAV-01c): the module-scope law of src/lib/answers.ts re-run
  * here (ANSWER_READS keys === ANSWER_ROWS questions 4/4 in order; a computed
@@ -40,7 +48,7 @@ import { existsSync, readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { readdirSync, statSync } from 'node:fs';
 import { PROBLEM_SHEET } from '../src/lib/problemSheet';
-import { COCKPIT_PATH, EXPECTED_STATUS_COUNTS, FAMILY_READS, TOOL_REGISTRY, registryLaw, statusCounts } from '../src/lib/toolRegistry';
+import { EXPECTED_STATUS_COUNTS, FAMILIES, FAMILY_PAGES, FAMILY_READS, TOOL_REGISTRY, familyCards, familyMenu, registryLaw, statusCounts } from '../src/lib/toolRegistry';
 import { OWNER_UTILITIES } from '../src/lib/shellMenu';
 import { ANSWERS_HOME, ANSWER_READS, ANSWER_ROWS, NET_WORTH_READ, answersLaw } from '../src/lib/answers';
 import { PROVIDERS, PROVIDER_CODES, ROUTING_RULES, providersLaw } from '../src/lib/providers';
@@ -144,15 +152,21 @@ for (const t of TOOL_REGISTRY) {
 // ── THE REACHABILITY LAW (NAV-01b) ──────────────────────────────────────────
 type Door = { route: string; kind: string; via: string };
 const doors: Door[] = [];
-for (const t of TOOL_REGISTRY) {
-  if (t.home) doors.push({ route: t.home, kind: 'family nav', via: `${t.name} · home` });
-  if (t.cockpitKey) doors.push({ route: COCKPIT_PATH[t.cockpitKey], kind: 'family nav', via: `${t.name} · cockpit` });
-  for (const l of t.links ?? []) {
-    if (l.href) doors.push({ route: l.href, kind: 'family nav', via: `${t.name} · link "${l.label}"` });
-    if (l.cockpitKey) doors.push({ route: COCKPIT_PATH[l.cockpitKey], kind: 'family nav', via: `${t.name} · link "${l.label}"` });
+// NAV-02: the family navigation's doors are what it RENDERS — each family's menu
+// (familyMenu: "All of <FAMILY>" → the family page, then each tool's door) and
+// each family's page (familyCards: the registry home, the related surfaces, and
+// the family's reads). Nothing renders inline under the bar any more.
+for (const f of FAMILIES) {
+  doors.push({ route: FAMILY_PAGES[f], kind: 'family menu', via: `${f} · "All of ${f}"` });
+  for (const item of familyMenu(f)) {
+    if (item.kind === 'tool' && item.door.kind !== 'none') doors.push({ route: item.door.href, kind: 'family menu', via: `${f} · ${item.tool.name}` });
   }
+  for (const c of familyCards(f)) {
+    if (c.home) doors.push({ route: c.home, kind: 'family page', via: `${FAMILY_PAGES[f]} · ${c.tool.name} · Open` });
+    for (const l of c.links) if (l.door.kind !== 'none') doors.push({ route: l.door.href, kind: 'family page', via: `${FAMILY_PAGES[f]} · ${c.tool.name} · "${l.label}"` });
+  }
+  for (const r of FAMILY_READS[f] ?? []) doors.push({ route: r.href as string, kind: 'family page', via: `${FAMILY_PAGES[f]} · read "${r.label}"` });
 }
-for (const [family, reads] of Object.entries(FAMILY_READS)) for (const r of reads ?? []) doors.push({ route: r.href as string, kind: 'family read', via: `${family} · "${r.label}"` });
 for (const u of OWNER_UTILITIES) doors.push({ route: u.href, kind: 'utilities menu', via: u.label });
 for (const g of GUEST_ROUTES) doors.push({ route: g.route, kind: 'listed route', via: g.why });
 // NAV-01c: THE ANSWERS is the family navigation's first entry; each card opens its lens's home.
@@ -187,13 +201,59 @@ console.log('REACHABILITY — every page under src/app and its door');
 for (const p of pages) {
   const d = reach.get(p.route);
   console.log(`${p.route.padEnd(48)} ${d ? `${d.kind.padEnd(15)} ${d.via}` : 'NO DOOR'}`);
-  if (!d) violations.push(`${p.route} (${p.file}) has no door — not in the family nav, the utilities menu, GUEST_ROUTES, or a redirect`);
+  if (!d) violations.push(`${p.route} (${p.file}) has no door — not in a family menu, on a family page, in the utilities menu, GUEST_ROUTES, or a redirect`);
 }
 for (const d of doors) {
   if (d.route.startsWith('/?')) continue;
   if (!pages.some((p) => doorCovers(p.route, d.route) || doorCovers(d.route, p.route))) violations.push(`door ${d.route} (${d.kind}: ${d.via}) points at no page`);
 }
 console.log(`pages: ${pages.length} · doors: ${doors.length}`);
+
+// ── THE FAMILY MAP LAW (NAV-02) ─────────────────────────────────────────────
+const inMenus = new Map<string, string[]>();
+const onPages = new Map<string, string[]>();
+console.log('FAMILY MENUS — "All of <FAMILY>" first, then the tools in sheet order');
+for (const f of FAMILIES) {
+  const menu = familyMenu(f);
+  const first = menu[0];
+  if (!first || first.kind !== 'family' || first.label !== `All of ${f}` || first.href !== FAMILY_PAGES[f]) violations.push(`${f}: the menu's first item must be "All of ${f}" → ${FAMILY_PAGES[f]}`);
+  const names: string[] = [];
+  for (const item of menu.slice(1)) {
+    if (item.kind !== 'tool') { violations.push(`${f}: a second family item in the menu`); continue; }
+    names.push(item.tool.name);
+    inMenus.set(item.tool.name, [...(inMenus.get(item.tool.name) ?? []), f]);
+  }
+  const sheet = PROBLEM_SHEET.find((x) => x.header === f)?.tools ?? [];
+  if (names.join('|') !== sheet.join('|')) violations.push(`${f}: menu order [${names.join(', ')}] ≠ sheet order [${sheet.join(', ')}]`);
+  for (const c of familyCards(f)) onPages.set(c.tool.name, [...(onPages.get(c.tool.name) ?? []), f]);
+  console.log(`${f.padEnd(13)} ${menu.map((i) => (i.kind === 'family' ? `[${i.label} → ${i.href}]` : `${i.tool.name}${i.door.kind === 'none' ? ' (no door)' : ` → ${i.door.href}`}`)).join(' · ')}`);
+}
+for (const t of TOOL_REGISTRY) {
+  const m = inMenus.get(t.name) ?? [];
+  const c = onPages.get(t.name) ?? [];
+  if (m.length !== 1 || m[0] !== t.family) violations.push(`${t.name}: in ${m.length} family menu(s) [${m.join(', ')}] — must be exactly once, in ${t.family}`);
+  if (c.length !== 1 || c[0] !== t.family) violations.push(`${t.name}: on ${c.length} family page(s) [${c.join(', ')}] — must be exactly once, on ${FAMILY_PAGES[t.family]}`);
+}
+console.log('FAMILY PAGES — route → page file (names its family) → cards');
+const FAMILY_NAV = 'src/components/home/FamilyNav.tsx';
+const FAMILY_PAGE = 'src/components/home/FamilyPage.tsx';
+for (const f of FAMILIES) {
+  const route = FAMILY_PAGES[f];
+  const file = pageFor(route, tabs);
+  const expected = `src/app${route}/page.tsx`;
+  if (file !== expected) violations.push(`${f}: family page ${route} has no page file (${expected})`);
+  const src = file === expected ? readFileSync(resolve(ROOT, expected), 'utf8') : '';
+  const names = src.split(`family="${f}"`).length - 1;
+  if (file === expected && names !== 1) violations.push(`${expected} must name its family exactly once (family="${f}" ×${names})`);
+  if (file === expected && !src.includes("from '@/components/home/FamilyPage'")) violations.push(`${expected} must render FamilyPage`);
+  console.log(`${f.padEnd(13)} ${route.padEnd(15)} ${(file ?? 'NO PAGE FILE').padEnd(34)} ${familyCards(f).length} cards`);
+}
+const navSrc = existsSync(resolve(ROOT, FAMILY_NAV)) ? readFileSync(resolve(ROOT, FAMILY_NAV), 'utf8') : '';
+const pageSrc = existsSync(resolve(ROOT, FAMILY_PAGE)) ? readFileSync(resolve(ROOT, FAMILY_PAGE), 'utf8') : '';
+if (!navSrc.includes('familyMenu(')) violations.push(`${FAMILY_NAV} must render the menu from familyMenu() — never a retyped list`);
+if (!pageSrc.includes('familyCards(')) violations.push(`${FAMILY_PAGE} must render the cards from familyCards() — never a retyped list`);
+if (!navSrc.includes('role="menu"')) violations.push(`${FAMILY_NAV} must render the family tabs as menus (role="menu")`);
+if (/role="tabpanel"/.test(navSrc)) violations.push(`${FAMILY_NAV} renders a tab panel inline under the bar — the map of a family is its page`);
 
 // ── THE ANSWERS LAW (NAV-01c) ───────────────────────────────────────────────
 violations.push(...answersLaw({ throwOnFail: false }));
@@ -291,6 +351,7 @@ if (violations.length) {
   process.exit(1);
 }
 console.log('✔ Tool registry law passed — 25/25 cells, homes resolve to page files, counts match the census.');
-console.log(`✔ Reachability law passed — ${pages.length} pages, every one has a door.`);
+console.log(`✔ Reachability law passed — ${pages.length} pages, every one has a door (family menus and family pages count).`);
+console.log(`✔ The family map law passed — ${FAMILIES.length} menus, ${FAMILIES.length} family pages, every tool once in each.`);
 console.log(`✔ The answers law passed — ${ANSWER_ROWS.length}/4 questions on ${ANSWERS_HOME}, every number sourced.`);
 console.log(`✔ The arrivals law passed — ${PROVIDERS.length} providers, enum === codes, ${arrivalsRows.length} columns agree with the migration.`);

--- a/src/app/money-in/page.tsx
+++ b/src/app/money-in/page.tsx
@@ -1,0 +1,16 @@
+import { getVerifiedEmail } from '@/lib/cookie-auth';
+import FamilyPage from '@/components/home/FamilyPage';
+
+/**
+ * NAV-02 — /money-in, the MONEY IN family page: the map of the family's tools
+ * (src/lib/toolRegistry.ts FAMILY_PAGES; one card per tool from familyCards()).
+ * Auth: a protected path — middleware (src/middleware.ts) bounces an unverified
+ * visitor to '/' before this renders; the verified cookie names the viewer for
+ * the shell bar only, and nothing here touches the database (the /answers shape).
+ */
+export const dynamic = 'force-dynamic';
+
+export default async function MoneyInPage() {
+  const viewer = await getVerifiedEmail();
+  return <FamilyPage family="MONEY IN" viewer={viewer ?? ''} />;
+}

--- a/src/app/money-out/page.tsx
+++ b/src/app/money-out/page.tsx
@@ -1,0 +1,16 @@
+import { getVerifiedEmail } from '@/lib/cookie-auth';
+import FamilyPage from '@/components/home/FamilyPage';
+
+/**
+ * NAV-02 — /money-out, the MONEY OUT family page: the map of the family's tools
+ * (src/lib/toolRegistry.ts FAMILY_PAGES; one card per tool from familyCards()).
+ * Auth: a protected path — middleware (src/middleware.ts) bounces an unverified
+ * visitor to '/' before this renders; the verified cookie names the viewer for
+ * the shell bar only, and nothing here touches the database (the /answers shape).
+ */
+export const dynamic = 'force-dynamic';
+
+export default async function MoneyOutPage() {
+  const viewer = await getVerifiedEmail();
+  return <FamilyPage family="MONEY OUT" viewer={viewer ?? ''} />;
+}

--- a/src/app/the-proof/page.tsx
+++ b/src/app/the-proof/page.tsx
@@ -1,0 +1,16 @@
+import { getVerifiedEmail } from '@/lib/cookie-auth';
+import FamilyPage from '@/components/home/FamilyPage';
+
+/**
+ * NAV-02 — /the-proof, the THE PROOF family page: the map of the family's tools
+ * (src/lib/toolRegistry.ts FAMILY_PAGES; one card per tool from familyCards()).
+ * Auth: a protected path — middleware (src/middleware.ts) bounces an unverified
+ * visitor to '/' before this renders; the verified cookie names the viewer for
+ * the shell bar only, and nothing here touches the database (the /answers shape).
+ */
+export const dynamic = 'force-dynamic';
+
+export default async function TheProofPage() {
+  const viewer = await getVerifiedEmail();
+  return <FamilyPage family="THE PROOF" viewer={viewer ?? ''} />;
+}

--- a/src/app/what-you-owe/page.tsx
+++ b/src/app/what-you-owe/page.tsx
@@ -1,0 +1,16 @@
+import { getVerifiedEmail } from '@/lib/cookie-auth';
+import FamilyPage from '@/components/home/FamilyPage';
+
+/**
+ * NAV-02 — /what-you-owe, the WHAT YOU OWE family page: the map of the family's tools
+ * (src/lib/toolRegistry.ts FAMILY_PAGES; one card per tool from familyCards()).
+ * Auth: a protected path — middleware (src/middleware.ts) bounces an unverified
+ * visitor to '/' before this renders; the verified cookie names the viewer for
+ * the shell bar only, and nothing here touches the database (the /answers shape).
+ */
+export const dynamic = 'force-dynamic';
+
+export default async function WhatYouOwePage() {
+  const viewer = await getVerifiedEmail();
+  return <FamilyPage family="WHAT YOU OWE" viewer={viewer ?? ''} />;
+}

--- a/src/app/what-you-own/page.tsx
+++ b/src/app/what-you-own/page.tsx
@@ -1,0 +1,16 @@
+import { getVerifiedEmail } from '@/lib/cookie-auth';
+import FamilyPage from '@/components/home/FamilyPage';
+
+/**
+ * NAV-02 — /what-you-own, the WHAT YOU OWN family page: the map of the family's tools
+ * (src/lib/toolRegistry.ts FAMILY_PAGES; one card per tool from familyCards()).
+ * Auth: a protected path — middleware (src/middleware.ts) bounces an unverified
+ * visitor to '/' before this renders; the verified cookie names the viewer for
+ * the shell bar only, and nothing here touches the database (the /answers shape).
+ */
+export const dynamic = 'force-dynamic';
+
+export default async function WhatYouOwnPage() {
+  const viewer = await getVerifiedEmail();
+  return <FamilyPage family="WHAT YOU OWN" viewer={viewer ?? ''} />;
+}

--- a/src/app/work/page.tsx
+++ b/src/app/work/page.tsx
@@ -1,0 +1,16 @@
+import { getVerifiedEmail } from '@/lib/cookie-auth';
+import FamilyPage from '@/components/home/FamilyPage';
+
+/**
+ * NAV-02 — /work, the THE WORK family page: the map of the family's tools
+ * (src/lib/toolRegistry.ts FAMILY_PAGES; one card per tool from familyCards()).
+ * Auth: a protected path — middleware (src/middleware.ts) bounces an unverified
+ * visitor to '/' before this renders; the verified cookie names the viewer for
+ * the shell bar only, and nothing here touches the database (the /answers shape).
+ */
+export const dynamic = 'force-dynamic';
+
+export default async function WorkPage() {
+  const viewer = await getVerifiedEmail();
+  return <FamilyPage family="THE WORK" viewer={viewer ?? ''} />;
+}

--- a/src/components/home/FamilyNav.tsx
+++ b/src/components/home/FamilyNav.tsx
@@ -1,31 +1,44 @@
 'use client';
 
 /**
- * NAV-01a — THE FAMILY NAVIGATION. Replaces the nine product-history tabs in
- * the cockpit with the deck's six families (PROBLEM_SHEET order); selecting a
- * family lists its tools in sheet order. Every row states the tool's TRUE
- * state from the registry (src/lib/toolRegistry.ts): name · status chip · the
- * beats it has · a way in when a home exists. A cockpit-hosted tool opens its
- * existing section in place (the same selectTab funnel the old tabs used, so
- * the URL keeps being written as today); an off-cockpit tool is a plain link.
- * A NOT_BUILT row is exactly that — no screen, no mock, no "coming soon" copy.
+ * NAV-01a → NAV-02 — THE FAMILY NAVIGATION. THE ANSWERS first (a link to
+ * /answers, current when you are on it — NAV-01c), then the deck's six
+ * families in PROBLEM_SHEET order.
  *
- * NAV-01c — THE ANSWERS is the first entry of the row: a link to /answers, the
- * app's front page (src/lib/answers.ts ANSWERS_HOME), current when you are on
- * it. Off the cockpit (no selectTab funnel — /answers), the nav runs in LINK
- * MODE: a cockpit-hosted tool is a plain link to the URL the cockpit writes
- * for its section (COCKPIT_PATH, one source with the reachability law), and
- * the tool list opens only when a family is picked.
+ * NAV-02: a family tab is a MENU, not a tab panel. It opens on click — never on
+ * hover — and lists "All of <FAMILY>" (the family page) and then the family's
+ * tools in sheet order: name · status chip · the tool's door. Selecting closes
+ * it; so do Escape, a click outside, and focus leaving the bar. Nothing renders
+ * inline below the bar: the map of a family is its page (/work, /money-in, …
+ * — src/lib/toolRegistry.ts FAMILY_PAGES). The items come from familyMenu()
+ * in the registry — ONE source with the build-time law that counts every tool
+ * in exactly one menu, exactly once (scripts/assert-tool-registry.ts).
  *
- * Mobile: the family row scrolls horizontally; tool rows stack; nothing under
- * 10px type.
+ * Doors: on the cockpit a cockpit-hosted tool opens its section in place
+ * through the SAME selectTab funnel the old tabs used (onSelectModule — the
+ * URL keeps being written as today); off the cockpit (link mode — /answers,
+ * the family pages) it is a plain link to COCKPIT_PATH. An off-cockpit tool
+ * is a link to its home. A NOT_BUILT tool is a disabled item that says so —
+ * no screen, no mock, no "coming soon" copy.
+ *
+ * Keyboard (the ARIA menu-button pattern, no mouse needed): on a family tab,
+ * Enter / Space open and focus the first item, ArrowDown the first, ArrowUp
+ * the last; Left / Right move between the family tabs (an open menu follows).
+ * In a menu, Up / Down move (wrapping), Home / End jump, Left / Right open the
+ * neighbouring family's menu, Escape closes and returns focus to the tab, Tab
+ * closes and moves on.
+ *
+ * Mobile (< sm, 640px): a family tab is a plain LINK to its family page — a
+ * menu on a 375px screen is the page. The row scrolls horizontally; nothing
+ * under 10px type.
  */
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { COCKPIT_PATH, FAMILIES, FAMILY_READS, COCKPIT_PRIMARY_TOOL, TOOL_REGISTRY, toolsOf, type Beats, type ToolEntry, type ToolStatus } from '@/lib/toolRegistry';
+import { COCKPIT_PRIMARY_TOOL, FAMILIES, FAMILY_PAGES, TOOL_REGISTRY, familyMenu, familyOfPath, type MenuItem } from '@/lib/toolRegistry';
 import { ANSWERS_HOME } from '@/lib/answers';
 import type { FamilyName } from '@/lib/problemSheet';
+import { StatusChip } from './ToolChrome';
 
 interface Props {
   /** The cockpit's active section key (ModuleLauncher activeModule). Absent off the cockpit. */
@@ -34,16 +47,10 @@ interface Props {
   onSelectModule?: (key: string) => void;
 }
 
-const STATUS_LABEL: Record<ToolStatus, string> = { LIVE: 'LIVE', PARTIAL: 'PARTIAL', NOT_BUILT: 'NOT BUILT' };
-const STATUS_CLASS: Record<ToolStatus, string> = {
-  LIVE: 'border-brand-gold text-brand-gold',
-  PARTIAL: 'border-brand-amber text-brand-amber',
-  NOT_BUILT: 'border-border text-text-faint',
-};
-const BEATS: ReadonlyArray<[keyof Beats, string]> = [['discover', 'discover'], ['decide', 'decide'], ['commit', 'commit'], ['record', 'record']];
-const CHIP = 'shrink-0 border-b-2 px-3 sm:px-4 py-3 font-mono text-[10px] sm:text-xs uppercase tracking-wider transition-colors';
+const CHIP = 'shrink-0 whitespace-nowrap border-b-2 px-3 sm:px-4 py-3 font-mono text-[10px] sm:text-xs uppercase tracking-wider transition-colors';
 const CHIP_ON = 'border-brand-purple text-brand-purple';
 const CHIP_OFF = 'border-transparent text-text-muted hover:text-text-primary';
+const ITEM = 'flex w-full items-center gap-2 rounded px-2.5 py-2 text-left text-xs outline-none hover:bg-bg-row focus-visible:bg-bg-row focus-visible:ring-1 focus-visible:ring-brand-purple';
 
 function familyOfModule(key: string | undefined): FamilyName | null {
   if (!key) return null;
@@ -52,26 +59,88 @@ function familyOfModule(key: string | undefined): FamilyName | null {
   return TOOL_REGISTRY.find((t) => t.name === name)?.family ?? null;
 }
 
+const menuId = (f: FamilyName) => `family-menu-${f.toLowerCase().replace(/\s+/g, '-')}`;
+const adjacent = (f: FamilyName, delta: 1 | -1): FamilyName => FAMILIES[(FAMILIES.indexOf(f) + delta + FAMILIES.length) % FAMILIES.length];
+
 export default function FamilyNav({ activeModule, onSelectModule }: Props) {
   const pathname = usePathname();
   const onAnswers = pathname === ANSWERS_HOME;
-  // Cockpit mode opens a family at once (the section's own); link mode opens none until picked.
-  const [family, setFamily] = useState<FamilyName | null>(() => familyOfModule(activeModule) ?? (onSelectModule ? FAMILIES[0] : null));
+  // The current family: the cockpit section's own, or the family page you are on.
+  const current = familyOfModule(activeModule) ?? familyOfPath(pathname);
+  const [open, setOpen] = useState<FamilyName | null>(null);
+  const [pendingFocus, setPendingFocus] = useState<'first' | 'last' | null>(null);
+  const rootRef = useRef<HTMLElement>(null);
+  const buttons = useRef(new Map<FamilyName, HTMLButtonElement>());
 
-  // A deep link or the path restore lands on a cockpit section → open its family.
+  const menuItems = () => Array.from(rootRef.current?.querySelectorAll<HTMLElement>('[role="menu"] [role="menuitem"]') ?? []);
+
+  // A click (or touch) outside the bar closes the open menu.
   useEffect(() => {
-    const f = familyOfModule(activeModule);
-    if (f) setFamily(f);
-  }, [activeModule]);
+    if (open === null) return;
+    const onPointerDown = (e: PointerEvent) => {
+      if (!rootRef.current?.contains(e.target as Node)) setOpen(null);
+    };
+    document.addEventListener('pointerdown', onPointerDown);
+    return () => document.removeEventListener('pointerdown', onPointerDown);
+  }, [open]);
 
-  const tools = family ? toolsOf(family) : [];
-  const reads = family ? (FAMILY_READS[family] ?? []) : [];
+  // A keyboard open lands focus on the first (or last) item once the menu is in the DOM.
+  useEffect(() => {
+    if (open === null || pendingFocus === null) return;
+    const items = menuItems();
+    (pendingFocus === 'first' ? items[0] : items[items.length - 1])?.focus();
+    setPendingFocus(null);
+  }, [open, pendingFocus]);
+
+  const openWithFocus = (f: FamilyName, where: 'first' | 'last') => { setOpen(f); setPendingFocus(where); };
+  const closeToButton = (f: FamilyName) => { setOpen(null); buttons.current.get(f)?.focus(); };
+
+  // Focus leaving the bar closes the menu. Deferred one tick: a keyboard move
+  // between menus unmounts the focused item before the next one takes focus.
+  const onRootBlur = (e: React.FocusEvent<HTMLElement>) => {
+    const root = e.currentTarget;
+    if (root.contains(e.relatedTarget as Node | null)) return;
+    window.setTimeout(() => { if (!root.contains(document.activeElement)) setOpen(null); }, 0);
+  };
+
+  const onButtonKey = (f: FamilyName, e: React.KeyboardEvent<HTMLButtonElement>) => {
+    if (e.key === 'ArrowDown') { e.preventDefault(); openWithFocus(f, 'first'); }
+    else if (e.key === 'ArrowUp') { e.preventDefault(); openWithFocus(f, 'last'); }
+    else if (e.key === 'ArrowRight' || e.key === 'ArrowLeft') {
+      e.preventDefault();
+      const next = adjacent(f, e.key === 'ArrowRight' ? 1 : -1);
+      const wasOpen = open === f;
+      buttons.current.get(next)?.focus();
+      if (wasOpen) setOpen(next);
+    }
+    else if (e.key === 'Escape' && open === f) { e.preventDefault(); setOpen(null); }
+  };
+
+  const onMenuKey = (f: FamilyName, e: React.KeyboardEvent<HTMLUListElement>) => {
+    const items = menuItems();
+    const i = items.indexOf(document.activeElement as HTMLElement);
+    switch (e.key) {
+      case 'ArrowDown': e.preventDefault(); items[(i + 1) % items.length]?.focus(); break;
+      case 'ArrowUp': e.preventDefault(); items[(i - 1 + items.length) % items.length]?.focus(); break;
+      case 'Home': e.preventDefault(); items[0]?.focus(); break;
+      case 'End': e.preventDefault(); items[items.length - 1]?.focus(); break;
+      case 'ArrowRight': e.preventDefault(); openWithFocus(adjacent(f, 1), 'first'); break;
+      case 'ArrowLeft': e.preventDefault(); openWithFocus(adjacent(f, -1), 'first'); break;
+      case 'Escape': e.preventDefault(); closeToButton(f); break;
+      case 'Tab':
+        // Close and hand focus back to the tab; a forward Tab then moves on from there.
+        if (e.shiftKey) e.preventDefault();
+        closeToButton(f);
+        break;
+      default: break;
+    }
+  };
 
   return (
-    <nav aria-label="Tool families" className="border-b border-border bg-white">
+    <nav ref={rootRef} aria-label="Tool families" onBlur={onRootBlur} className="border-b border-border bg-white">
       <div className="max-w-7xl mx-auto px-4 lg:px-8">
-        {/* THE ANSWERS first, then the six families — one row, horizontal scroll on a phone. */}
-        <div className="flex overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+        {/* THE ANSWERS first, then the six families — one row; horizontal scroll on a phone, room for the menus from sm. */}
+        <div className="flex overflow-x-auto sm:overflow-visible [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
           <Link
             href={ANSWERS_HOME}
             aria-current={onAnswers ? 'page' : undefined}
@@ -80,107 +149,102 @@ export default function FamilyNav({ activeModule, onSelectModule }: Props) {
           >
             THE ANSWERS
           </Link>
-          <div role="tablist" className="flex">
-            {FAMILIES.map((f) => (
-              <button
-                key={f}
-                type="button"
-                role="tab"
-                aria-selected={family === f}
-                onClick={() => setFamily(f)}
-                className={`${CHIP} ${family === f ? CHIP_ON : CHIP_OFF}`}
-              >
-                {f}
-              </button>
-            ))}
-          </div>
-        </div>
-
-        {/* The family's tools, sheet order. */}
-        {family !== null && (
-          <ul role="tabpanel" className="divide-y divide-border">
-            {tools.map((t) => (
-              <ToolRow key={t.slug} tool={t} activeModule={activeModule} onSelectModule={onSelectModule} />
-            ))}
+          <ul className="flex" data-families>
+            {FAMILIES.map((f, index) => {
+              const isCurrent = current === f;
+              const isOpen = open === f;
+              return (
+                <li key={f} className="relative">
+                  {/* < sm: the family tab IS the family page. */}
+                  <Link
+                    href={FAMILY_PAGES[f]}
+                    aria-current={isCurrent ? 'page' : undefined}
+                    data-family-link={f}
+                    className={`block sm:hidden ${CHIP} ${isCurrent ? CHIP_ON : CHIP_OFF}`}
+                  >
+                    {f}
+                  </Link>
+                  {/* ≥ sm: the family tab opens its menu. */}
+                  <button
+                    type="button"
+                    ref={(el) => { if (el) buttons.current.set(f, el); else buttons.current.delete(f); }}
+                    aria-haspopup="menu"
+                    aria-expanded={isOpen}
+                    aria-controls={isOpen ? menuId(f) : undefined}
+                    aria-current={isCurrent ? 'true' : undefined}
+                    data-family={f}
+                    onClick={(e) => {
+                      const next = isOpen ? null : f;
+                      setOpen(next);
+                      // A keyboard "click" (Enter / Space — detail 0) lands on the first item; a pointer click leaves focus on the tab.
+                      if (next && e.detail === 0) setPendingFocus('first');
+                    }}
+                    onKeyDown={(e) => onButtonKey(f, e)}
+                    onFocus={() => { if (open !== null && open !== f) setOpen(null); }}
+                    className={`hidden sm:block ${CHIP} ${isCurrent || isOpen ? CHIP_ON : CHIP_OFF}`}
+                  >
+                    {f}
+                    <span aria-hidden="true" className="ml-1 text-text-faint">▾</span>
+                  </button>
+                  {isOpen && (
+                    <ul
+                      role="menu"
+                      id={menuId(f)}
+                      aria-label={f}
+                      onKeyDown={(e) => onMenuKey(f, e)}
+                      className={`absolute top-full z-40 mt-px hidden w-[22rem] max-w-[calc(100vw-2rem)] rounded-b-lg border border-border bg-white p-1 shadow-lg sm:block ${index >= FAMILIES.length / 2 ? 'right-0' : 'left-0'}`}
+                    >
+                      {familyMenu(f).map((item) => (
+                        <li key={item.kind === 'family' ? item.href : item.tool.slug} role="none">
+                          <MenuRow item={item} activeModule={activeModule} onSelectModule={onSelectModule} close={() => setOpen(null)} />
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </li>
+              );
+            })}
           </ul>
-        )}
-        {/* NAV-01b: family-level reads — pages that read across the family's tools. */}
-        {reads.length > 0 && (
-          <div className="flex flex-wrap items-center gap-x-3 gap-y-1 border-t border-border py-2 font-mono text-[10px] uppercase tracking-wider">
-            <span className="text-text-faint">Reads</span>
-            {reads.map((r) => (
-              <Link key={r.label} href={r.href as string} className="text-text-muted underline-offset-2 hover:text-text-primary hover:underline normal-case tracking-normal">
-                {r.label}
-              </Link>
-            ))}
-          </div>
-        )}
+        </div>
       </div>
     </nav>
   );
 }
 
-function ToolRow({ tool, activeModule, onSelectModule }: { tool: ToolEntry; activeModule?: string; onSelectModule?: (key: string) => void }) {
-  const isOpen = onSelectModule !== undefined && tool.cockpitKey !== undefined && tool.cockpitKey === activeModule;
-  const openClass = 'rounded border px-2.5 py-1 font-mono text-[10px] uppercase tracking-wider transition-colors';
-  const linkClass = 'font-mono text-[10px] text-text-muted underline-offset-2 hover:text-text-primary hover:underline';
+function MenuRow({ item, activeModule, onSelectModule, close }: { item: MenuItem; activeModule?: string; onSelectModule?: (key: string) => void; close: () => void }) {
+  if (item.kind === 'family') {
+    return (
+      <Link role="menuitem" tabIndex={-1} href={item.href} onClick={close} data-menu-family className={`${ITEM} font-mono text-[10px] uppercase tracking-wider text-brand-purple`}>
+        {item.label}
+        <span className="ml-auto normal-case tracking-normal text-text-faint">the family page</span>
+      </Link>
+    );
+  }
+  const { tool, door } = item;
+  const isOpenBelow = door.kind === 'cockpit' && onSelectModule !== undefined && door.key === activeModule;
+  const doorText = door.kind === 'none' ? 'no door' : isOpenBelow ? 'Open below' : `Open · ${door.href}`;
+  const inner = (
+    <>
+      <span className="w-5 shrink-0 text-right font-mono text-[10px] text-text-faint">{String(tool.order).padStart(2, '0')}</span>
+      <span className={`font-semibold ${tool.status === 'NOT_BUILT' ? 'text-text-muted' : 'text-text-primary'}`}>{tool.name}</span>
+      <StatusChip status={tool.status} />
+      <span className="ml-auto shrink-0 pl-3 font-mono text-[10px] text-text-muted">{doorText}</span>
+    </>
+  );
+  const data = { 'data-tool': tool.slug, 'data-status': tool.status };
+  if (door.kind === 'none') {
+    return <span role="menuitem" aria-disabled="true" tabIndex={-1} {...data} className={`${ITEM} cursor-default`}>{inner}</span>;
+  }
+  if (door.kind === 'cockpit' && onSelectModule) {
+    return (
+      <button type="button" role="menuitem" tabIndex={-1} aria-current={isOpenBelow ? 'page' : undefined} {...data} onClick={() => { onSelectModule(door.key); close(); }} className={ITEM}>
+        {inner}
+      </button>
+    );
+  }
   return (
-    <li className="flex flex-col gap-2 py-2.5 sm:flex-row sm:items-center sm:gap-4" data-tool={tool.slug} data-status={tool.status}>
-      <div className="flex items-center gap-3 sm:w-64">
-        <span className="font-mono text-[10px] text-text-faint w-5 text-right">{String(tool.order).padStart(2, '0')}</span>
-        <span className={`text-sm font-semibold ${tool.status === 'NOT_BUILT' ? 'text-text-muted' : 'text-text-primary'}`}>{tool.name}</span>
-        <span className={`rounded border px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wider ${STATUS_CLASS[tool.status]}`}>
-          {STATUS_LABEL[tool.status]}
-        </span>
-      </div>
-
-      {/* The beats it has — a filled dot is a cited beat, a hollow one is "—". */}
-      <ul className="flex items-center gap-3 font-mono text-[10px] uppercase tracking-wider" aria-label={`${tool.name} beats`}>
-        {BEATS.map(([key, label]) => (
-          <li key={key} className={`flex items-center gap-1 ${tool.beats[key] ? 'text-text-primary' : 'text-text-faint'}`}>
-            <span aria-hidden="true" className={`inline-block h-2 w-2 rounded-full border ${tool.beats[key] ? 'border-brand-purple bg-brand-purple' : 'border-border bg-transparent'}`} />
-            {label}
-          </li>
-        ))}
-      </ul>
-
-      {/* A way in — only when a home exists. NOT_BUILT renders nothing here. */}
-      {tool.home !== null && (
-        <div className="flex flex-wrap items-center gap-x-3 gap-y-1 sm:ml-auto">
-          {tool.cockpitKey && onSelectModule ? (
-            <button
-              type="button"
-              onClick={() => onSelectModule(tool.cockpitKey as string)}
-              aria-current={isOpen ? 'page' : undefined}
-              className={`${openClass} ${isOpen ? 'border-brand-purple bg-brand-purple text-white' : 'border-brand-purple text-brand-purple hover:bg-brand-purple-wash'}`}
-            >
-              {isOpen ? 'Open below' : `Open · ${tool.home}`}
-            </button>
-          ) : (
-            <Link
-              href={tool.cockpitKey ? COCKPIT_PATH[tool.cockpitKey] : tool.home}
-              className={`${openClass} border-brand-purple text-brand-purple hover:bg-brand-purple-wash`}
-            >
-              Open · {tool.cockpitKey ? COCKPIT_PATH[tool.cockpitKey] : tool.home}
-            </Link>
-          )}
-          {(tool.links ?? []).map((l) =>
-            l.href ? (
-              <Link key={l.label} href={l.href} className={linkClass}>
-                {l.label}
-              </Link>
-            ) : onSelectModule ? (
-              <button key={l.label} type="button" onClick={() => onSelectModule(l.cockpitKey as string)} className={linkClass}>
-                {l.label}
-              </button>
-            ) : (
-              <Link key={l.label} href={COCKPIT_PATH[l.cockpitKey as string]} className={linkClass}>
-                {l.label}
-              </Link>
-            ),
-          )}
-        </div>
-      )}
-    </li>
+    <Link role="menuitem" tabIndex={-1} href={door.href} {...data} onClick={close} className={ITEM}>
+      {inner}
+    </Link>
   );
 }

--- a/src/components/home/FamilyPage.tsx
+++ b/src/components/home/FamilyPage.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+/**
+ * NAV-02 — a FAMILY PAGE: the map of one family's tools (/work, /money-in,
+ * /money-out, /what-you-own, /what-you-owe, /the-proof — src/lib/toolRegistry.ts
+ * FAMILY_PAGES). A grid, one card per tool from familyCards() in sheet order —
+ * ONE source with the build-time law that counts every tool on exactly one
+ * page, exactly once. Each card: name · status chip · the four beats as dots ·
+ * the doors (the registry home, then the related surfaces — plain links; there
+ * is no cockpit funnel here) · the census citation as a small line. A
+ * NOT_BUILT card says exactly that: no door, no mock, no "coming soon" copy.
+ * Below the grid: the family's reads (FAMILY_READS), pages that read across
+ * its tools and belong to no single one.
+ *
+ * The shell is ShellFrame (ShellBar + the family navigation in link mode; this
+ * family's tab is current). Mobile: cards stack; nothing under 10px type.
+ */
+import Link from 'next/link';
+import ShellFrame from '@/components/ui/ShellFrame';
+import { FAMILY_READS, familyCards, statusCounts, toolsOf, type FamilyCard } from '@/lib/toolRegistry';
+import type { FamilyName } from '@/lib/problemSheet';
+import { BeatDots, StatusChip } from './ToolChrome';
+
+const DOOR = 'rounded border border-brand-purple px-2.5 py-1 font-mono text-[10px] uppercase tracking-wider text-brand-purple transition-colors hover:bg-brand-purple-wash';
+const LINK = 'font-mono text-[10px] text-text-muted underline-offset-2 hover:text-text-primary hover:underline';
+
+export default function FamilyPage({ family, viewer }: { family: FamilyName; viewer: string }) {
+  const cards = familyCards(family);
+  const counts = statusCounts(toolsOf(family));
+  const reads = FAMILY_READS[family] ?? [];
+  return (
+    <ShellFrame viewer={viewer}>
+      <header className="mb-5 sm:mb-6">
+        <p className="font-mono text-[10px] sm:text-xs uppercase tracking-[0.2em] text-text-faint">The family</p>
+        <h1 className="mt-1 text-xl sm:text-2xl font-semibold tracking-tight text-text-primary">{family}</h1>
+        <p className="mt-1 text-xs text-text-muted" data-family-counts>
+          {cards.length} tools in sheet order · {counts.LIVE} live · {counts.PARTIAL} partial · {counts.NOT_BUILT} not built. Every card states the tool&apos;s true state from the registry.
+        </p>
+      </header>
+
+      <ul aria-label={`${family} tools`} className="grid grid-cols-1 gap-3 sm:grid-cols-2 sm:gap-4 lg:grid-cols-3" data-family-page={family}>
+        {cards.map((c) => <ToolCard key={c.tool.slug} card={c} />)}
+      </ul>
+
+      {/* NAV-01b: family-level reads — pages that read across the family's tools. */}
+      {reads.length > 0 && (
+        <div className="mt-5 flex flex-wrap items-center gap-x-3 gap-y-1 border-t border-border pt-3 font-mono text-[10px] uppercase tracking-wider sm:mt-6" data-family-reads>
+          <span className="text-text-faint">Reads across {family}</span>
+          {reads.map((r) => (
+            <Link key={r.label} href={r.href as string} className="normal-case tracking-normal text-text-muted underline-offset-2 hover:text-text-primary hover:underline">
+              {r.label}
+            </Link>
+          ))}
+        </div>
+      )}
+    </ShellFrame>
+  );
+}
+
+function ToolCard({ card }: { card: FamilyCard }) {
+  const { tool, home, links } = card;
+  const notBuilt = tool.status === 'NOT_BUILT';
+  return (
+    <li className="flex flex-col gap-3 rounded-lg border border-border bg-white p-4" data-tool={tool.slug} data-status={tool.status}>
+      <div className="flex items-start gap-3">
+        <span className="w-5 shrink-0 pt-0.5 text-right font-mono text-[10px] text-text-faint">{String(tool.order).padStart(2, '0')}</span>
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <h2 className={`text-sm font-semibold ${notBuilt ? 'text-text-muted' : 'text-text-primary'}`}>{tool.name}</h2>
+            <StatusChip status={tool.status} />
+          </div>
+          {tool.note && <p className="mt-1 text-xs text-text-muted">{tool.note}</p>}
+        </div>
+      </div>
+
+      <BeatDots name={tool.name} beats={tool.beats} />
+
+      {/* The doors — the registry home first, then the related surfaces. A NOT_BUILT card has none and says so. */}
+      {home !== null ? (
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-1.5" data-doors>
+          <Link href={home} className={DOOR}>Open · {home}</Link>
+          {links.map((l) => (
+            l.door.kind === 'none' ? null : (
+              <Link key={l.label} href={l.door.href} className={LINK}>{l.label}</Link>
+            )
+          ))}
+        </div>
+      ) : (
+        <p className="font-mono text-[10px] uppercase tracking-wider text-text-faint" data-not-built>Not built — no door</p>
+      )}
+
+      <p className="break-words font-mono text-[10px] leading-relaxed text-text-faint" data-citation>{tool.citation}</p>
+    </li>
+  );
+}

--- a/src/components/home/ToolChrome.tsx
+++ b/src/components/home/ToolChrome.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+/**
+ * NAV-02: the chrome a tool wears wherever it is listed. The family menu
+ * (FamilyNav) and the family page cards (FamilyPage) share it, so a status
+ * reads the same in both places and the beats render as today's dots.
+ */
+import type { Beats, ToolStatus } from '@/lib/toolRegistry';
+
+export const STATUS_LABEL: Record<ToolStatus, string> = { LIVE: 'LIVE', PARTIAL: 'PARTIAL', NOT_BUILT: 'NOT BUILT' };
+const STATUS_CLASS: Record<ToolStatus, string> = {
+  LIVE: 'border-brand-gold text-brand-gold',
+  PARTIAL: 'border-brand-amber text-brand-amber',
+  NOT_BUILT: 'border-border text-text-faint',
+};
+const BEATS: ReadonlyArray<[keyof Beats, string]> = [['discover', 'discover'], ['decide', 'decide'], ['commit', 'commit'], ['record', 'record']];
+
+export function StatusChip({ status }: { status: ToolStatus }) {
+  return (
+    <span className={`shrink-0 rounded border px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wider ${STATUS_CLASS[status]}`}>
+      {STATUS_LABEL[status]}
+    </span>
+  );
+}
+
+/** The beats it has — a filled dot is a cited beat, a hollow one is "—". */
+export function BeatDots({ name, beats }: { name: string; beats: Beats }) {
+  return (
+    <ul className="flex flex-wrap items-center gap-x-3 gap-y-1 font-mono text-[10px] uppercase tracking-wider" aria-label={`${name} beats`}>
+      {BEATS.map(([key, label]) => (
+        <li key={key} className={`flex items-center gap-1 ${beats[key] ? 'text-text-primary' : 'text-text-faint'}`}>
+          <span aria-hidden="true" className={`inline-block h-2 w-2 rounded-full border ${beats[key] ? 'border-brand-purple bg-brand-purple' : 'border-border bg-transparent'}`} />
+          {label}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/components/ui/ShellFrame.tsx
+++ b/src/components/ui/ShellFrame.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+/**
+ * NAV-02: the ONE shell for an off-cockpit app page — ShellBar + the family
+ * navigation in link mode + the page's main column. The /answers shape
+ * (AnswersClient.tsx, which keeps its own copy by ruling — THE ANSWERS stays
+ * as is): the utilities menu is admin-only, read from /api/auth/me; a failed
+ * profile read is declared under the bar (no menu, the failure printed), never
+ * swallowed, never retried. Sign-out is the app's one recipe.
+ */
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useSession, signOut } from 'next-auth/react';
+import ShellBar from './ShellBar';
+import FamilyNav from '@/components/home/FamilyNav';
+
+export default function ShellFrame({ viewer, children }: { viewer: string; children: React.ReactNode }) {
+  const router = useRouter();
+  const { data: session } = useSession();
+  const [isAdmin, setIsAdmin] = useState(false);
+  const [profileError, setProfileError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let live = true;
+    (async () => {
+      try {
+        const res = await fetch('/api/auth/me', { cache: 'no-store' });
+        if (!res.ok) {
+          let detail = '';
+          try {
+            const body = (await res.json()) as { error?: unknown };
+            if (typeof body.error === 'string') detail = body.error;
+          } catch {
+            detail = 'no error body';
+          }
+          if (live) setProfileError(`HTTP ${res.status}${detail ? ` · ${detail}` : ''}`);
+          return;
+        }
+        const body = (await res.json()) as { user?: { isAdmin?: boolean } };
+        if (live) setIsAdmin(Boolean(body.user?.isAdmin));
+      } catch (e) {
+        if (live) setProfileError(`network — ${e instanceof Error ? e.message : String(e)}`);
+      }
+    })();
+    return () => { live = false; };
+  }, []);
+
+  const handleSignOut = async () => {
+    document.cookie = 'userEmail=; path=/; max-age=0';
+    if (session) {
+      await signOut({ callbackUrl: '/' });
+    } else {
+      await fetch('/api/auth/logout', { method: 'POST' });
+      router.push('/');
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-bg-terminal flex flex-col">
+      <ShellBar userLabel={viewer.split('@')[0]} isAdmin={isAdmin} onSignOut={handleSignOut} />
+      <FamilyNav />
+      <main className="max-w-7xl mx-auto w-full px-4 lg:px-8 py-6 sm:py-8">
+        {profileError && (
+          <p role="alert" className="mb-4 font-mono text-[10px] text-rose-700">Profile read failed — {profileError}. Utilities hidden.</p>
+        )}
+        {children}
+      </main>
+    </div>
+  );
+}

--- a/src/lib/__tests__/familyNav.test.ts
+++ b/src/lib/__tests__/familyNav.test.ts
@@ -1,0 +1,90 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { PROBLEM_SHEET, type FamilyName } from '../problemSheet';
+import { COCKPIT_PATH, FAMILIES, FAMILY_PAGES, TOOL_REGISTRY, familyCards, familyMenu, familyOfPath, registryLaw, toolsOf } from '../toolRegistry';
+
+// NAV-02 — the family MENUS and the family PAGES come from one source (the registry). Hermetic:
+// the real constants must pass the law (the module ran it at import); failing shapes are injected.
+
+test('FAMILY_PAGES: six single-segment routes, one per family, unique; familyOfPath round-trips', () => {
+  assert.deepEqual(Object.keys(FAMILY_PAGES), [...FAMILIES]);
+  assert.deepEqual(FAMILIES.map((f) => FAMILY_PAGES[f]), ['/work', '/money-in', '/money-out', '/what-you-own', '/what-you-owe', '/the-proof']);
+  for (const f of FAMILIES) assert.equal(familyOfPath(FAMILY_PAGES[f]), f);
+  assert.equal(familyOfPath('/answers'), null);
+  assert.equal(familyOfPath('/books'), null);
+  assert.equal(familyOfPath(null), null);
+  assert.deepEqual(registryLaw({ throwOnFail: false }), []);
+});
+
+test('the law: a family page route must be kebab-case, unique, and never a cockpit path or a tool home', () => {
+  const good = { ...FAMILY_PAGES };
+  assert.deepEqual(registryLaw({ throwOnFail: false, familyPages: good }), []);
+  const dup = { ...FAMILY_PAGES, 'THE PROOF': '/work' } as Record<FamilyName, string>;
+  assert.match(registryLaw({ throwOnFail: false, familyPages: dup }).join('\n'), /not unique/);
+  const cockpit = { ...FAMILY_PAGES, 'THE PROOF': '/books' } as Record<FamilyName, string>;
+  assert.match(registryLaw({ throwOnFail: false, familyPages: cockpit }).join('\n'), /collides with a cockpit path or a tool's home/);
+  const home = { ...FAMILY_PAGES, 'THE WORK': '/agenda' } as Record<FamilyName, string>;
+  assert.match(registryLaw({ throwOnFail: false, familyPages: home }).join('\n'), /collides/);
+  const nested = { ...FAMILY_PAGES, 'MONEY IN': '/money/in' } as Record<FamilyName, string>;
+  assert.match(registryLaw({ throwOnFail: false, familyPages: nested }).join('\n'), /not a single-segment kebab-case route/);
+  const missing = Object.fromEntries(Object.entries(FAMILY_PAGES).slice(0, 5)) as Record<FamilyName, string>;
+  assert.match(registryLaw({ throwOnFail: false, familyPages: missing }).join('\n'), /must name the 6 families exactly/);
+});
+
+test('familyMenu: "All of <FAMILY>" first (→ the family page), then the tools in sheet order with their doors', () => {
+  for (const { header, tools } of PROBLEM_SHEET) {
+    const menu = familyMenu(header);
+    assert.equal(menu.length, tools.length + 1);
+    const [first, ...rest] = menu;
+    assert.deepEqual(first, { kind: 'family', label: `All of ${header}`, href: FAMILY_PAGES[header] });
+    assert.deepEqual(rest.map((i) => (i.kind === 'tool' ? i.tool.name : '?')), [...tools]);
+    for (const item of rest) {
+      assert.equal(item.kind, 'tool');
+      if (item.kind !== 'tool') continue;
+      const t = item.tool;
+      if (t.status === 'NOT_BUILT') assert.deepEqual(item.door, { kind: 'none' });
+      else if (t.cockpitKey) assert.deepEqual(item.door, { kind: 'cockpit', key: t.cockpitKey, href: COCKPIT_PATH[t.cockpitKey] });
+      else assert.deepEqual(item.door, { kind: 'route', href: t.home });
+    }
+  }
+  // Compliance: the menu opens the cockpit section (the carve-out's /?tab= URL), the card opens the registry home.
+  const proof = familyMenu('THE PROOF').find((i) => i.kind === 'tool' && i.tool.name === 'Compliance');
+  assert.ok(proof && proof.kind === 'tool');
+  assert.deepEqual(proof.door, { kind: 'cockpit', key: 'compliance', href: '/?tab=compliance' });
+  const card = familyCards('THE PROOF').find((c) => c.tool.name === 'Compliance');
+  assert.equal(card?.home, '/compliance');
+});
+
+test('familyCards: one card per tool in sheet order — the registry home, the related surfaces resolved to doors; NOT_BUILT has neither', () => {
+  for (const { header, tools } of PROBLEM_SHEET) {
+    const cards = familyCards(header);
+    assert.deepEqual(cards.map((c) => c.tool.name), [...tools]);
+    for (const c of cards) {
+      assert.equal(c.home, c.tool.home);
+      if (c.tool.status === 'NOT_BUILT') { assert.equal(c.home, null); assert.equal(c.links.length, 0); }
+      for (const l of c.links) assert.notEqual(l.door.kind, 'none');
+    }
+  }
+  const budget = familyCards('MONEY OUT').find((c) => c.tool.name === 'Budget');
+  assert.ok(budget);
+  assert.equal(budget.home, '/business');
+  assert.deepEqual(budget.links.find((l) => l.label.startsWith('Runway'))?.door, { kind: 'cockpit', key: 'calendar', href: '/runway' });
+  assert.deepEqual(budget.links.find((l) => l.label === 'Personal')?.door, { kind: 'route', href: '/personal' });
+});
+
+test('every tool is in exactly one family menu and on exactly one family page, once each, and it is its own family', () => {
+  const inMenus = new Map<string, FamilyName[]>();
+  const onPages = new Map<string, FamilyName[]>();
+  for (const f of FAMILIES) {
+    for (const item of familyMenu(f)) if (item.kind === 'tool') inMenus.set(item.tool.name, [...(inMenus.get(item.tool.name) ?? []), f]);
+    for (const c of familyCards(f)) onPages.set(c.tool.name, [...(onPages.get(c.tool.name) ?? []), f]);
+  }
+  assert.equal(TOOL_REGISTRY.length, 25);
+  for (const t of TOOL_REGISTRY) {
+    assert.deepEqual(inMenus.get(t.name), [t.family], `${t.name} in menus`);
+    assert.deepEqual(onPages.get(t.name), [t.family], `${t.name} on pages`);
+  }
+  assert.equal([...inMenus.values()].flat().length, 25);
+  assert.equal([...onPages.values()].flat().length, 25);
+  for (const f of FAMILIES) assert.equal(familyCards(f).length, toolsOf(f).length);
+});

--- a/src/lib/toolRegistry.ts
+++ b/src/lib/toolRegistry.ts
@@ -13,13 +13,20 @@
  * that IS its home, selected in place); an off-cockpit tool is a plain link.
  * A NOT_BUILT tool has no home, no screen, no copy.
  *
+ * NAV-02: the family navigation's tabs are MENUS and each family has a PAGE
+ * (FAMILY_PAGES). familyMenu() and familyCards() below are the ONE source the
+ * nav and the pages render from and the build assert counts: every tool in
+ * exactly one menu and on exactly one page, once each, in sheet order.
+ *
  * THE LAW (module scope — the deck's LAYOUT LAW idiom; also re-run at build by
  * scripts/assert-tool-registry.ts, which adds the filesystem check that every
  * home resolves to a page file):
  *   1. registry keys == PROBLEM_SHEET cells, 25/25, both directions;
  *   2. a LIVE or PARTIAL tool has a home; a NOT_BUILT tool has none;
  *   3. beats agree with status (LIVE ⇔ four; NOT_BUILT ⇔ none; PARTIAL ⇔ some);
- *   4. status counts == 6 / 7 / 12.
+ *   4. status counts == 6 / 7 / 12;
+ *   5. (NAV-02) every family has one page route — single-segment kebab-case,
+ *      unique, never a cockpit path or a tool's home.
  */
 import { PROBLEM_SHEET, type FamilyName, type ToolName } from './problemSheet';
 
@@ -203,6 +210,91 @@ export function toolsOf(family: FamilyName): readonly ToolEntry[] {
   return TOOL_REGISTRY.filter((t) => t.family === family);
 }
 
+/**
+ * NAV-02: the family PAGES — one route per family: the map of its tools (a
+ * grid, one card per tool) and the door the family menu's first item opens.
+ * On a phone the family tab IS this link (a menu on a 375px screen is the
+ * page). The law holds the six unique and kebab-case; the build assert checks
+ * each has a page file that names its family.
+ */
+export const FAMILY_PAGES: Readonly<Record<FamilyName, string>> = {
+  'THE WORK': '/work',
+  'MONEY IN': '/money-in',
+  'MONEY OUT': '/money-out',
+  'WHAT YOU OWN': '/what-you-own',
+  'WHAT YOU OWE': '/what-you-owe',
+  'THE PROOF': '/the-proof',
+};
+
+/** The family whose page this path is, or null. */
+export function familyOfPath(pathname: string | null | undefined): FamilyName | null {
+  if (!pathname) return null;
+  return FAMILIES.find((f) => FAMILY_PAGES[f] === pathname) ?? null;
+}
+
+/**
+ * NAV-02: a DOOR — where a menu item or a card link opens. A cockpit door is
+ * a ModuleLauncher section: on the cockpit it is selected in place through the
+ * selectTab funnel (the URL is written as today); anywhere else it is a plain
+ * link to COCKPIT_PATH. A route door is a page. `none` is a NOT_BUILT tool.
+ */
+export type ToolDoor =
+  | { kind: 'cockpit'; key: string; href: string }
+  | { kind: 'route'; href: string }
+  | { kind: 'none' };
+
+/** The tool's own door for its MENU item: its cockpit section when it has one, else its home; none for NOT_BUILT. */
+export function doorOf(tool: ToolEntry): ToolDoor {
+  if (tool.home === null) return { kind: 'none' };
+  if (tool.cockpitKey) return { kind: 'cockpit', key: tool.cockpitKey, href: COCKPIT_PATH[tool.cockpitKey] };
+  return { kind: 'route', href: tool.home };
+}
+
+/** A related surface's door. The law holds every link to exactly one of href / cockpitKey; anything else is a registry bug, thrown. */
+export function doorOfLink(tool: ToolEntry, link: ToolLink): ToolDoor {
+  if (link.href) return { kind: 'route', href: link.href };
+  if (link.cockpitKey) return { kind: 'cockpit', key: link.cockpitKey, href: COCKPIT_PATH[link.cockpitKey] };
+  throw new Error(`${tool.name}: link "${link.label}" has neither href nor cockpitKey`);
+}
+
+/**
+ * NAV-02: a family's MENU — what its tab opens. The first item is the family
+ * page ("All of <FAMILY>"); then the family's tools in sheet order, each with
+ * its status and its door. FamilyNav renders exactly this; the build assert
+ * counts it (every tool in exactly one menu, exactly once).
+ */
+export type MenuItem =
+  | { kind: 'family'; label: string; href: string }
+  | { kind: 'tool'; tool: ToolEntry; door: ToolDoor };
+
+export function familyMenu(family: FamilyName): readonly MenuItem[] {
+  return [
+    { kind: 'family', label: `All of ${family}`, href: FAMILY_PAGES[family] },
+    ...toolsOf(family).map((tool): MenuItem => ({ kind: 'tool', tool, door: doorOf(tool) })),
+  ];
+}
+
+/**
+ * NAV-02: a family PAGE's cards — one per tool in sheet order: the tool, its
+ * home (the registry's own route — a page, never a cockpit param) and its
+ * related surfaces' doors. The family page renders exactly this; the build
+ * assert counts it (every tool on exactly one page, exactly once).
+ */
+export interface FamilyCard {
+  tool: ToolEntry;
+  /** The registry home, or null for NOT_BUILT. */
+  home: string | null;
+  links: ReadonlyArray<{ label: string; door: ToolDoor }>;
+}
+
+export function familyCards(family: FamilyName): readonly FamilyCard[] {
+  return toolsOf(family).map((tool) => ({
+    tool,
+    home: tool.home,
+    links: (tool.links ?? []).map((l) => ({ label: l.label, door: doorOfLink(tool, l) })),
+  }));
+}
+
 export function statusCounts(registry: readonly ToolEntry[] = TOOL_REGISTRY): Record<ToolStatus, number> {
   const counts: Record<ToolStatus, number> = { LIVE: 0, PARTIAL: 0, NOT_BUILT: 0 };
   for (const t of registry) counts[t.status] += 1;
@@ -214,7 +306,7 @@ function beatCount(b: Beats): number {
 }
 
 /** THE LAW. Throws on the first violation; returns the violations list when asked not to throw. */
-export function registryLaw(opts: { throwOnFail?: boolean } = {}): string[] {
+export function registryLaw(opts: { throwOnFail?: boolean; familyPages?: Readonly<Record<FamilyName, string>> } = {}): string[] {
   const violations: string[] = [];
   const cells = PROBLEM_SHEET.flatMap((f) => f.tools as readonly string[]);
   const keys = Object.keys(FACTS);
@@ -253,6 +345,18 @@ export function registryLaw(opts: { throwOnFail?: boolean } = {}): string[] {
     if (!FAMILIES.includes(family as FamilyName)) violations.push(`FAMILY_READS names unknown family "${family}"`);
     for (const r of reads ?? []) if (!r.href || !r.href.startsWith('/')) violations.push(`FAMILY_READS[${family}]: "${r.label}" must be an href route`);
   }
+  // NAV-02 (rule 5): one page route per family — single-segment kebab-case, unique, never a cockpit path or a tool's home.
+  const pages = opts.familyPages ?? FAMILY_PAGES;
+  const pageKeys = Object.keys(pages);
+  if (pageKeys.length !== FAMILIES.length || FAMILIES.some((f) => !(f in pages))) violations.push(`FAMILY_PAGES must name the ${FAMILIES.length} families exactly (has ${pageKeys.join(', ')})`);
+  for (const k of pageKeys) if (!FAMILIES.includes(k as FamilyName)) violations.push(`FAMILY_PAGES names unknown family "${k}"`);
+  const routes = FAMILIES.map((f) => pages[f]).filter((r): r is string => typeof r === 'string');
+  for (const f of FAMILIES) {
+    const r = pages[f];
+    if (typeof r !== 'string' || !/^\/[a-z][a-z0-9-]*$/.test(r)) violations.push(`FAMILY_PAGES[${f}] "${r}" is not a single-segment kebab-case route`);
+    else if (Object.values(COCKPIT_PATH).includes(r) || TOOL_REGISTRY.some((t) => t.home === r)) violations.push(`FAMILY_PAGES[${f}] "${r}" collides with a cockpit path or a tool's home`);
+  }
+  if (new Set(routes).size !== routes.length) violations.push(`FAMILY_PAGES routes are not unique (${routes.join(', ')})`);
   if (violations.length && opts.throwOnFail !== false) {
     throw new Error(`TOOL REGISTRY LAW failed:\n  ${violations.join('\n  ')}`);
   }


### PR DESCRIPTION
**Do not merge — Alex merges after Vercel Preview (SOC 2 gate).**

No migration, no paid call, no auth change, no user data. Six new protected pages (the middleware gate, the /answers shape: cookie for the viewer label only, no database).

## WHY

FamilyNav rendered a family's tool rows inline under the tab bar whenever a family was selected — always visible, tall, clutter. Navigation and map are two jobs: the tab is now a **menu**, the map is a **page**.

## AUDIT — what was there (file:line, on `main` before this PR)

| Fact | Where |
|---|---|
| The family row is a `role="tablist"` of `role="tab"` buttons with `aria-selected`; a click sets `family` state. | `src/components/home/FamilyNav.tsx:83-95` |
| The selected family's tools render **inline** as a `role="tabpanel"` list under the bar (name · status chip · four beat dots · the door), then a "Reads" row. Always open on the cockpit (`FAMILIES[0]` by default). | `FamilyNav.tsx:59, :100-117, :123-186` |
| A deep link opens the section's family through an effect. | `FamilyNav.tsx:62-65` |
| **The selectTab funnel:** `selectTab = (key) => { setActiveModule(key); onTabChange?.(key); writeTabParam(key); }` — the one path that sets the section AND writes the URL; FamilyNav receives it as `onSelectModule`. | `src/components/home/ModuleLauncher.tsx:279, :657` |
| Off the cockpit, FamilyNav runs in link mode (no funnel): a cockpit tool is a link to `COCKPIT_PATH`. | `FamilyNav.tsx:160-165`; `AnswersClient.tsx:270` |
| **Reachability law's doors:** a registry home, a cockpit path, a link, a family read, the utilities menu, GUEST_ROUTES, a redirect. The door list was derived from the registry directly, not from what the nav rendered — `Compliance · home → /compliance` was a door the nav never linked (a cockpit tool linked `COCKPIT_PATH` only). | `scripts/assert-tool-registry.ts:145-161` |
| **Mobile:** the family row scrolls horizontally; the tool rows stack (`flex-col … sm:flex-row`). No collapse — the rows were always rendered. | `FamilyNav.tsx:74, :128` |
| **Keyboard / ARIA:** native button focus only. No `aria-expanded`, no `role="menu"`, no arrow keys, no Escape, no click-outside — there was nothing to close. | `FamilyNav.tsx:83-95` |
| The existing menu in the shell (`UtilitiesMenu`) is a plain `<details>` — no keyboard model to reuse for a menu with roving items. | `src/components/ui/UtilitiesMenu.tsx:13` |
| The six family routes did not exist; a second root-level dynamic segment beside `[tab]` is not possible, so they are six thin pages. | `src/app/[tab]/page.tsx:43-45` |

## BUILD

| Piece | Change |
|---|---|
| `src/lib/toolRegistry.ts` | **`FAMILY_PAGES`** (`/work /money-in /money-out /what-you-own /what-you-owe /the-proof`), `familyOfPath`, **`ToolDoor`** + `doorOf` (a cockpit section, a route, or none for NOT_BUILT) + `doorOfLink`, **`familyMenu(family)`** — `"All of <FAMILY>"` → the family page, then the tools in sheet order with their doors — and **`familyCards(family)`** — one card per tool: the registry home and the related surfaces' doors. **Law rule 5:** one single-segment kebab-case route per family, unique, never a cockpit path or a tool's home (`registryLaw({ familyPages })` injectable for tests). |
| `src/components/home/FamilyNav.tsx` | Each family tab is a **menu button** (`aria-haspopup="menu"`, `aria-expanded`, `aria-controls`, `aria-current` on the current family) opening a `role="menu"` of `role="menuitem"`s on click — never hover. Items from `familyMenu()`: the family page first, then name · status chip · door. On the cockpit a cockpit tool opens its section **through the same selectTab funnel** (`onSelectModule`; "Open below" when it is the active one); off the cockpit a plain link to `COCKPIT_PATH`; an off-cockpit tool a link to its home; a NOT_BUILT tool a disabled item — "no door". Selecting closes; Escape, a click outside, and focus leaving the bar close. **Nothing renders inline below the bar** (the reads row moved to the family page). **Keyboard:** Enter / Space / ArrowDown open on the first item, ArrowUp on the last; Up / Down wrap, Home / End; Left / Right move between families (an open menu follows); Escape closes and returns focus to the tab; Tab closes and moves on. **Mobile (< sm):** the family tab is a plain **link** to the family page — a menu on a 375px screen is the page. |
| `src/app/{work,money-in,money-out,what-you-own,what-you-owe,the-proof}/page.tsx` | Six thin server pages (`force-dynamic`; `getVerifiedEmail()` for the shell label; no database) each rendering `<FamilyPage family="…">`. Protected by the middleware like /answers. |
| `src/components/home/FamilyPage.tsx` | The map: a grid (1 / 2 / 3 columns), one card per tool from `familyCards()` — name, status chip, the census note when there is one, the four beats as today's dots, the doors (`Open · <home>` + the related surfaces), the census citation as a 10px line. A NOT_BUILT card says **"Not built — no door"**. Below the grid: the family's reads (`FAMILY_READS`). |
| `src/components/ui/ShellFrame.tsx` (new) | ShellBar + FamilyNav in link mode + main, with the admin-only utilities read from `/api/auth/me` declared on failure (the AnswersClient wiring; **AnswersClient itself is untouched — THE ANSWERS stays as is**). |
| `src/components/home/ToolChrome.tsx` (new) | `StatusChip` and `BeatDots`, shared by the menu and the cards. |
| `scripts/assert-tool-registry.ts` | **Reachability:** the family doors are now what the nav renders — each menu's links (`family menu`: "All of …" → the family page, each tool's door) and each family page's cards and reads (`family page`). **THE FAMILY MAP LAW:** every tool in its family's menu exactly once and on its family's page exactly once, in sheet order; each family route has a page file that names its family exactly once and renders FamilyPage; FamilyNav renders `familyMenu(` and FamilyPage renders `familyCards(` (never a retyped list); FamilyNav renders `role="menu"` and no `role="tabpanel"`. |
| `src/lib/__tests__/familyNav.test.ts` | 5 tests (below). |

Unchanged: ModuleLauncher (same props, same funnel), AnswersClient, the registry facts, the census counts, middleware.

## VERIFY

| Check | Result |
|---|---|
| `npx tsc --noEmit` | exit 0 |
| eslint — 3 changed files vs `main` baseline, 11 new files | 0 errors, 0 new warnings |
| `npm test` | **118 / 118** (113 before + 5 new) |
| asserts + `next build` | showroom ✓ · tool registry ✓ · **reachability 67 pages** (61 + the six family pages), every one has a door ✓ · **family map law 6 menus / 6 pages, every tool once in each** ✓ · answers law ✓ · arrivals law ✓ · **BUILD EXIT 0** |
| README generator | byte-identical (no API route change) |

### Tests (node:test)

```
ok 41 - FAMILY_PAGES: six single-segment routes, one per family, unique; familyOfPath round-trips
ok 42 - the law: a family page route must be kebab-case, unique, and never a cockpit path or a tool home
ok 43 - familyMenu: "All of <FAMILY>" first (→ the family page), then the tools in sheet order with their doors
ok 44 - familyCards: one card per tool in sheet order — the registry home, the related surfaces resolved to doors; NOT_BUILT has neither
ok 45 - every tool is in exactly one family menu and on exactly one family page, once each, and it is its own family
```

### The doors, as the assert now prints them

```
THE WORK      [All of THE WORK → /work] · Calendar → /agenda · Tasks → /projects · Time → /content
MONEY IN      [All of MONEY IN → /money-in] · CRM → /owner · Contracts (no door) · Invoicing (no door) · Payments (no door)
MONEY OUT     [All of MONEY OUT → /money-out] · Bill Pay (no door) · Payroll (no door) · Expenses → /budgets/trips · Travel → /travel · Mileage (no door) · Budget → /business
WHAT YOU OWN  [All of WHAT YOU OWN → /what-you-own] · Banking → /books · Fixed Assets (no door) · Retirement (no door) · Brokerage → /trade · Trade Log → /books
WHAT YOU OWE  [All of WHAT YOU OWE → /what-you-owe] · Debt (no door) · Sales Tax (no door) · Ent Filings (no door)
THE PROOF     [All of THE PROOF → /the-proof] · Bookkeeping → /books · Tax → /tax · Compliance → /?tab=compliance · FP&A (no door)
```

Compliance keeps both doors it always had in the law: the menu opens the cockpit section (`/?tab=compliance`, the carve-out), the family-page card opens the registry home `/compliance` (which the old nav never actually linked).

### In the browser (dev server on this branch, every API answer mocked at the network layer — no database, no Plaid)

**Desktop, /books (cockpit mode), WHAT YOU OWN opened by click** — the bar is 43px tall closed, `role="tabpanel"` count 0, no inline rows; the menu lists `All of WHAT YOU OWN → /what-you-own`, then `14 Banking PARTIAL · Open below` (aria-current, the active section), `15 Fixed Assets NOT BUILT · no door` (aria-disabled), `16 Retirement NOT BUILT · no door`, `17 Brokerage PARTIAL · Open · /trade`, `18 Trade Log PARTIAL · Open below`. Clicking Brokerage closed the menu and the URL became `/trade` (the selectTab funnel). A click outside closed THE PROOF's menu. "All of THE PROOF" navigated to `/the-proof` with THE PROOF current.

**Keyboard only, /answers (link mode):**

| Key | Result |
|---|---|
| Tab | focus on THE WORK ▾ |
| Enter | menu open, focus on "All of THE WORK" |
| ArrowDown | 01 Calendar |
| End | 03 Time |
| ArrowDown | wraps to "All of THE WORK" |
| ArrowRight | MONEY IN open, focus on "All of MONEY IN" |
| Escape | closed, focus on MONEY IN ▾ |
| ArrowRight | MONEY OUT ▾ (still closed) |
| ArrowDown | MONEY OUT open, first item |
| Tab | closed, focus on WHAT YOU OWN ▾ |
| Shift+Tab, Space | MONEY OUT open, first item |
| Enter | navigated to `/money-out` |

**Family page, /money-out desktop:** "MONEY OUT · 6 tools in sheet order · 2 live · 1 partial · 3 not built"; cards 08 Bill Pay NOT BUILT (four hollow dots, "Not built — no door", census row 8), 09 Payroll, 10 Expenses PARTIAL (decide filled, `Open · /budgets/trips`), 11 Travel LIVE (four filled, `Open · /travel`, Trips · the legacy pages), 12 Mileage, 13 Budget LIVE (`Open · /business` + Personal Home Auto Growth Health Shopping Itinerary Runway → `/runway`); every card carries its citation. **Mobile 375px:** the six family tabs are links (`/work` … `/the-proof`), the menu buttons are `display: none`; tapping MONEY OUT opens `/money-out` with the tab current and 6 stacked cards.

**≥10px:** the smallest type in the nav is 12px, in the open menu 10px (the order numbers), on the family page 10px (the "← the map" chip and the citations). The 9px hits on /books are the cockpit's own Books pipeline labels (`text-[9px]`), outside this PR.

Screenshots (desktop menu open, desktop family page, keyboard-opened menu, mobile bar, mobile family page) are attached to the session report.

## Notes — stated plainly

- Not verified: the Vercel Preview itself, and a screen reader; the ARIA is the menu-button pattern (`aria-haspopup="menu"`, `aria-expanded`, `role="menu"` / `role="menuitem"`, disabled items `aria-disabled`).
- The family menus and family pages count as doors because they are what the nav renders. The old "family nav" door kind claimed a `/compliance` link the UI never drew; it is drawn now (the family-page card).
- ShellFrame duplicates ~30 lines of AnswersClient's shell wiring by ruling (THE ANSWERS stays as is); a follow-up could adopt ShellFrame there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc

---
_Generated by [Claude Code](https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc)_