### PR TITLE
RULEBOOK-01: the rule book as rows the system applies — every arrival gets its kind

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,12 +97,13 @@ The arrival row above as tables — `prisma/migrations/20260903000000_arrivals/m
 | response_id | text | NULL REFERENCES provider_responses(id) |
 | user_id | text | NULL REFERENCES users(id) |
 | guest_ref | text | NULL |
+| kind | arrival_kind | NOT NULL — `prisma/migrations/20260907180000_arrival_kind/migration.sql`: the rule book's kind, applied on landing and to every earlier row |
 |  | CHECK / KEY | CHECK (octet_length(fingerprint) = 32) |
 |  | CHECK / KEY | CHECK (pg_column_size(payload) <= 1048576) |
 |  | CHECK / KEY | CHECK (user_id IS NOT NULL OR guest_ref IS NOT NULL) |
 |  | CHECK / KEY | UNIQUE (provider, their_id, fingerprint) |
 
-Promise 1 is a database law, not a convention: the `arrivals_promise_1` BEFORE UPDATE trigger raises if provider, connection, resource, their_id, their_id_kind, payload, fingerprint, redactions, asked, arrived, response_id, user_id or guest_ref would change — only `read` and `status` may move, each once (read from NULL, status from pending). There is no updated_at column and no DELETE policy: keep forever is the default.
+Promise 1 is a database law, not a convention: the `arrivals_promise_1` BEFORE UPDATE trigger raises if provider, connection, resource, their_id, their_id_kind, payload, fingerprint, redactions, asked, arrived, response_id, user_id, guest_ref or kind would change — only `read` and `status` may move, each once (read from NULL, status from pending). There is no updated_at column and no DELETE policy: keep forever is the default.
 
 The write rule (PR-2 — one Plaid writer, `src/app/api/transactions/sync-complete/route.ts`, through `src/lib/arrivals/land.ts`):
 
@@ -124,6 +125,35 @@ Five kinds arrive from outside; the sixth is never sent — the system writes po
 | derived | math we did | math we did — never a source |
 | snapshot | how things stood at one moment | how things stood at one moment |
 | posting | debits and credits | never arrives — the system writes postings from events |
+
+### The rule book (step 4, applied)
+
+One written rule per feed — its kind — and the system applies it to every arrival of that feed: `src/lib/providers.ts` RULE_BOOK, 22 rows (the deck's 20 verbatim plus the 2 the deck's sample omits and the store lands). Landing consults it (`src/lib/arrivals/land.ts`): every arrival carries its kind (`arrivals.kind`, `prisma/migrations/20260907180000_arrival_kind/migration.sql` — the same rules applied to every row landed before it), and a feed with no rule is a loud failure, never a default. The build asserts the book against the deck, the schema's enum, the migration's UPDATEs and every landing call site.
+
+| Provider | Resource | Kind | Means | Row |
+|---|---|---|---|---|
+| plaid | transaction | event | something that happened | deck |
+| plaid | account | registry | one of your accounts | deck |
+| plaid | holding | snapshot | how things stood at one moment | deck |
+| stripe | payout | event |  | deck |
+| tastytrade | quote | reference | a fact about the world | deck |
+| finnhub | fundamentals | reference |  | deck |
+| fred | series | reference |  | deck |
+| sec | filing | reference |  | deck |
+| liteapi | booking | event |  | deck |
+| viator | activity | reference |  | deck |
+| google places | place | reference |  | deck |
+| travel buddy | visa | reference |  | deck |
+| anthropic | classification | derived | math we did — never a source | deck |
+| openai | insight | derived |  | deck |
+| xai grok | sentiment | derived |  | deck |
+| voyage | embedding | derived |  | deck |
+| ecfr | title | reference |  | deck |
+| us code | title | reference |  | deck |
+| federal register | document | reference |  | deck |
+| irs | bulletin | reference |  | deck |
+| plaid | security | reference |  | added |
+| plaid | investment_transaction | event |  | added |
 
 ### The loop (step 7)
 
@@ -187,7 +217,7 @@ BLUEPRINT is the step's headline; TODAY is the deck's honest-state line, verbati
 | Step | Blueprint | Today | Gap |
 |---|---|---|---|
 | 03 | Store what arrived. Then decide what it means. | the arrivals store holds 9,092 Plaid transactions, 712 investment transactions and 247 securities — every answer word for word, fingerprinted, status done — counted September 7, 2026; rows before September 3, 2026 carry no arrival. | the other providers (Stripe events, LiteAPI, tastytrade, the market and law feeds) land parsed; the three old Plaid writers still exist. |
-| 04 | One rule per feed. Written down. | We classified every one of the 121 feeds — August 24, 2026 — and posting took zero. | kinds assigned in the August 24 census; the step-3 table is built (PR-1) and no rule row applies to it yet — see 14. |
+| 04 | One rule per feed. Written down. | rules are rows the system applies — src/lib/providers.ts RULE_BOOK, 22 rows (the deck's 20 plus plaid · security → reference and plaid · investment_transaction → event); every Plaid arrival carries its kind (transaction · event, investment_transaction · event, security · reference), stamped on landing and applied by the migration to every row landed before it; a feed with no rule cannot land. | the other providers' arrivals wait on their landing — nothing of theirs has arrived to be labeled; the 121 feeds' classification stays the August 24 census until each lands. |
 | 07 | Every tool runs the same four beats. Discover. Decide. Commit. Record. | This loop is the blueprint — the shape we're building every tool toward. Today, hotel bookings commit for real and an accepted task fires its build; the rest run discover → decide → draft, and commit is the beat we're wiring to the same loop, tool by tool. | commit is real for two tools (hotel bookings, accepted tasks); the other twenty-three stop at draft. |
 | 08 | One table holds everything you do. | The master table is the blueprint. Today each tool keeps its own table; one table holding every document is the shape we're building. | no master table; each tool keeps its own. |
 | 09 | The deposit meets the invoice. The fill meets the order. | (A piece of this is already alive today: card charges find their bookings and propose the match — you approve it.) | one of fourteen matches proposes today (card charge ↔ booking); the other thirteen do not. |
@@ -228,7 +258,7 @@ Versions from package.json, read 2026-09-02:
 
 Observed versus authored (step 6): what the world sends is observed; what you do is authored; the blueprint keeps the two apart and matches them on one key. Today the Plaid feeds land word for word, fingerprinted — 9,092 transactions, 712 investment transactions, 247 securities, counted September 7, 2026; the other providers still land parsed — see the gap ledger, step 14.
 
-Scale, as of 2026-09-02: 114 Prisma models, 33 enums, 292 API route files, 37 runtime dependencies, 18 dev dependencies, one test file (`npm test`).
+Scale, as of 2026-09-02: 114 Prisma models, 34 enums, 292 API route files, 37 runtime dependencies, 18 dev dependencies, one test file (`npm test`).
 
 ## Engineering discipline
 

--- a/prisma/migrations/20260907180000_arrival_kind/migration.sql
+++ b/prisma/migrations/20260907180000_arrival_kind/migration.sql
@@ -1,0 +1,80 @@
+-- RULEBOOK-01: EVERY ARRIVAL GETS ITS KIND. The deck's step 4: each feed gets
+-- one written rule — its kind — and the system applies it to every arrival of
+-- that feed, forever after. The rule book is src/lib/providers.ts RULE_BOOK
+-- (the deck's ROUTING_RULES rows verbatim plus the rows the deck's sample
+-- omits); landing consults it (src/lib/arrivals/land.ts) and an arrival with
+-- no rule is a loud failure. This migration gives the store the column and
+-- applies the book to the rows already landed.
+--
+-- THE UPDATE APPLIES THE RULE BOOK; IT INVENTS NOTHING. Three rules cover
+-- every (provider, resource) the store has landed (Alex's census, September 7,
+-- 2026: plaid · transaction, plaid · investment_transaction, plaid · security):
+--   plaid · transaction            → event      (ROUTING_RULES, the deck)
+--   plaid · investment_transaction → event      (ADDED_RULES)
+--   plaid · security               → reference  (ADDED_RULES)
+-- A row the book does not cover STOPS the migration (the DO block below raises
+-- before SET NOT NULL); the fix is a rule in providers.ts, never a default.
+--
+-- Applied by `prisma migrate deploy` at deploy (schema.prisma moves with it);
+-- Prisma runs it in one transaction on Postgres, so a raise leaves nothing
+-- behind. Enum order = src/lib/providers.ts ARRIVAL_KINDS = the deck's
+-- HANDOFF_KINDS (asserted at build). Promise 1 grows by one column: kind is
+-- frozen at insert like every other identity column.
+
+CREATE TYPE arrival_kind AS ENUM ('reference', 'registry', 'event', 'derived', 'snapshot', 'posting');
+
+ALTER TABLE arrivals ADD COLUMN kind arrival_kind NULL;
+
+UPDATE arrivals SET kind = 'event'     WHERE kind IS NULL AND provider = 'plaid' AND resource = 'transaction';
+UPDATE arrivals SET kind = 'event'     WHERE kind IS NULL AND provider = 'plaid' AND resource = 'investment_transaction';
+UPDATE arrivals SET kind = 'reference' WHERE kind IS NULL AND provider = 'plaid' AND resource = 'security';
+
+DO $$
+DECLARE
+    n bigint;
+    pairs text;
+BEGIN
+    SELECT count(*), string_agg(DISTINCT provider::text || ' · ' || resource, ', ')
+      INTO n, pairs
+      FROM arrivals WHERE kind IS NULL;
+    IF n > 0 THEN
+        RAISE EXCEPTION 'arrival_kind: % arrivals carry no rule (%) — add the rule to src/lib/providers.ts RULE_BOOK and this migration before SET NOT NULL; nothing is assumed', n, pairs
+            USING ERRCODE = 'integrity_constraint_violation';
+    END IF;
+END;
+$$;
+
+ALTER TABLE arrivals ALTER COLUMN kind SET NOT NULL;
+
+-- Promise 1 now covers kind: an arrival's kind never changes after it lands.
+CREATE OR REPLACE FUNCTION arrivals_promise_1() RETURNS trigger
+LANGUAGE plpgsql AS $$
+BEGIN
+    IF NEW.provider      IS DISTINCT FROM OLD.provider
+    OR NEW.connection    IS DISTINCT FROM OLD.connection
+    OR NEW.resource      IS DISTINCT FROM OLD.resource
+    OR NEW.their_id      IS DISTINCT FROM OLD.their_id
+    OR NEW.their_id_kind IS DISTINCT FROM OLD.their_id_kind
+    OR NEW.payload       IS DISTINCT FROM OLD.payload
+    OR NEW.fingerprint   IS DISTINCT FROM OLD.fingerprint
+    OR NEW.redactions    IS DISTINCT FROM OLD.redactions
+    OR NEW.asked         IS DISTINCT FROM OLD.asked
+    OR NEW.arrived       IS DISTINCT FROM OLD.arrived
+    OR NEW.response_id   IS DISTINCT FROM OLD.response_id
+    OR NEW.user_id       IS DISTINCT FROM OLD.user_id
+    OR NEW.guest_ref     IS DISTINCT FROM OLD.guest_ref
+    OR NEW.kind          IS DISTINCT FROM OLD.kind THEN
+        RAISE EXCEPTION 'arrivals promise 1: an arrival never changes (id %)', OLD.id
+            USING ERRCODE = 'integrity_constraint_violation';
+    END IF;
+    IF NEW.read IS DISTINCT FROM OLD.read AND OLD.read IS NOT NULL THEN
+        RAISE EXCEPTION 'arrivals promise 1: read is set once, from NULL (id %)', OLD.id
+            USING ERRCODE = 'integrity_constraint_violation';
+    END IF;
+    IF NEW.status IS DISTINCT FROM OLD.status AND OLD.status <> 'pending' THEN
+        RAISE EXCEPTION 'arrivals promise 1: status moves once, from pending (id %)', OLD.id
+            USING ERRCODE = 'integrity_constraint_violation';
+    END IF;
+    RETURN NEW;
+END;
+$$;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -3613,6 +3613,16 @@ enum their_id_kind {
   composed
 }
 
+/// RULEBOOK-01: the six kinds, the deck's HANDOFF_KINDS order (src/lib/providers.ts ARRIVAL_KINDS; asserted at build). Nothing ever arrives as a posting.
+enum arrival_kind {
+  reference
+  registry
+  event
+  derived
+  snapshot
+  posting
+}
+
 /// The wire: the exact bytes of one HTTP answer, sha256'd. One row per answer.
 model provider_responses {
   id          String           @id
@@ -3650,6 +3660,8 @@ model arrivals {
   response_id   String?
   user_id       String?
   guest_ref     String?
+  /// RULEBOOK-01: the kind the rule book assigns this (provider, resource) — set on landing, applied by the migration to the rows before it; promise 1 freezes it.
+  kind          arrival_kind
   response      provider_responses? @relation(fields: [response_id], references: [id], onDelete: NoAction, onUpdate: NoAction)
   user          users?              @relation(fields: [user_id], references: [id], onDelete: NoAction, onUpdate: NoAction)
   transactions  transactions[]

--- a/scripts/assert-tool-registry.ts
+++ b/scripts/assert-tool-registry.ts
@@ -25,6 +25,17 @@
  * navigation (its first entry); each card's home and the net-worth read are
  * doors on /answers.
  *
+ * THE RULE BOOK LAW (RULEBOOK-01): src/lib/providers.ts RULE_BOOK is the rule
+ * book the system applies — its module-scope law re-run (every ROUTING_RULES
+ * row present with the deck's kind; one kind per pair; six kinds, never
+ * posting), plus what only the schema, the migration and the call sites can
+ * answer: enum arrival_kind === ARRIVAL_KINDS === the *_arrival_kind
+ * migration's CREATE TYPE, in order; every UPDATE that migration applies is a
+ * rule the book holds with the same kind; every resource a landing call site
+ * names (files under src that call landObjects — the provider and resource
+ * they pass, as constants or literals) has a rule. A feed the book does not
+ * name cannot be landed: the build fails before the code does.
+ *
  * THE ARRIVALS LAW (REBUILD-01 PR-1): the provider vocabulary's module-scope
  * law re-run (src/lib/providers.ts — every ROUTING_RULES provider + resource
  * pair resolves, no duplicate word or code), plus what only the texts can
@@ -32,7 +43,9 @@
  * text) and the migration's CREATE TYPE (prisma/migrations/*_arrivals) carry
  * the code set EXACTLY, alphabetical; and the two Prisma models agree with the
  * migration's two CREATE TABLEs column for column — name, type, nullability,
- * order — so schema.prisma and the SQL can never drift.
+ * order — so schema.prisma and the SQL can never drift. RULEBOOK-01: the SQL
+ * side is the CREATE TABLE plus every later migration's ALTER TABLE … ADD
+ * COLUMN / ALTER COLUMN … SET NOT NULL on that table, in migration order.
  *
  * The assert:showroom pattern: a plain script wired into the `build` script so
  * it runs in CI / Vercel and fails the BUILD. It imports the registry (which
@@ -51,7 +64,7 @@ import { PROBLEM_SHEET } from '../src/lib/problemSheet';
 import { EXPECTED_STATUS_COUNTS, FAMILIES, FAMILY_PAGES, FAMILY_READS, TOOL_REGISTRY, familyCards, familyMenu, registryLaw, statusCounts } from '../src/lib/toolRegistry';
 import { OWNER_UTILITIES } from '../src/lib/shellMenu';
 import { ANSWERS_HOME, ANSWER_READS, ANSWER_ROWS, NET_WORTH_READ, answersLaw } from '../src/lib/answers';
-import { PROVIDERS, PROVIDER_CODES, ROUTING_RULES, providersLaw } from '../src/lib/providers';
+import { ARRIVAL_KINDS, PROVIDERS, PROVIDER_CODES, ROUTING_RULES, RULE_BOOK, providersLaw, ruleFor } from '../src/lib/providers';
 
 /**
  * Routes whose door is outside the app map: the front door and its marketing
@@ -294,15 +307,30 @@ if (enumValues.join(',') !== PROVIDER_CODES.join(',')) violations.push(`arrivals
 const typeValues = migrationSql.match(/CREATE TYPE arrival_provider AS ENUM \((.*?)\);/)?.[1].split(', ').map((v) => v.replace(/^'|'$/g, '')) ?? [];
 if (typeValues.join(',') !== PROVIDER_CODES.join(',')) violations.push(`arrivals: migration CREATE TYPE arrival_provider [${typeValues.join(' ')}] ≠ providers.ts codes`);
 
-/** SQL column → { name, type, nullable } from a CREATE TABLE body; constraints and indexes are skipped. */
+/** Every migration.sql, in migration order — the ALTER TABLE … ADD COLUMN / SET NOT NULL a table gained after its CREATE TABLE. */
+const ALL_MIGRATIONS = readdirSync(resolve(ROOT, 'prisma/migrations')).sort()
+  .filter((d) => existsSync(resolve(ROOT, 'prisma/migrations', d, 'migration.sql')))
+  .map((d) => ({ dir: d, sql: readFileSync(resolve(ROOT, 'prisma/migrations', d, 'migration.sql'), 'utf8') }));
+
+/** SQL column → { name, type, nullable }: the CREATE TABLE body (constraints and indexes skipped) plus every later ADD COLUMN, with SET NOT NULL applied. */
 function sqlColumns(table: string): Array<{ name: string; type: string; nullable: boolean }> {
   const m = migrationSql.match(new RegExp(`CREATE TABLE ${table} \\(\\n([\\s\\S]*?)\\n\\);`));
   if (!m) return [];
-  return m[1].split('\n').map((l) => l.trim().replace(/,$/, '')).filter((l) => l && !/^CONSTRAINT /.test(l)).map((l) => {
+  const cols = m[1].split('\n').map((l) => l.trim().replace(/,$/, '')).filter((l) => l && !/^CONSTRAINT /.test(l)).map((l) => {
     const [name, type] = l.split(/\s+/);
     const nullable = !/NOT NULL|PRIMARY KEY/.test(l);
     return { name, type, nullable };
   });
+  for (const { sql } of ALL_MIGRATIONS) {
+    for (const add of sql.matchAll(new RegExp(`ALTER TABLE ${table} ADD COLUMN (\\w+) ([\\w\\[\\]]+)( NOT NULL| NULL)?`, 'g'))) {
+      cols.push({ name: add[1], type: add[2], nullable: add[3] !== ' NOT NULL' });
+    }
+    for (const set of sql.matchAll(new RegExp(`ALTER TABLE ${table} ALTER COLUMN (\\w+) SET NOT NULL`, 'g'))) {
+      const c = cols.find((x) => x.name === set[1]);
+      if (c) c.nullable = false;
+    }
+  }
+  return cols;
 }
 /** Prisma scalar field → the SQL shape it must match. Relation fields (a model type) are skipped. */
 const PRISMA_TO_SQL: Record<string, string> = { String: 'text', Int: 'integer', 'Bytes@db.ByteA': 'bytea', 'Json@db.JsonB': 'jsonb', 'DateTime@db.Timestamptz(6)': 'timestamptz', 'String[]': 'text[]' };
@@ -321,7 +349,7 @@ function modelColumns(model: string): Array<{ name: string; type: string; nullab
     const base = typeTok.replace(/\?$/, '');
     const native = rest.find((t) => t.startsWith('@db.')) ?? '';
     const key = base + native;
-    const type = PRISMA_TO_SQL[key] ?? (['arrival_provider', 'arrival_status', 'their_id_kind'].includes(base) ? base : `?${key}`);
+    const type = PRISMA_TO_SQL[key] ?? (['arrival_provider', 'arrival_status', 'their_id_kind', 'arrival_kind'].includes(base) ? base : `?${key}`);
     out.push({ name, type, nullable });
   }
   return out;
@@ -345,6 +373,61 @@ console.log(`${'table'.padEnd(19)} ${'migration.sql'.padEnd(44)} ${'schema.prism
 for (const r of arrivalsRows) console.log(r);
 console.log(`providers: ${PROVIDERS.length} (${PROVIDERS.filter((p) => p.today).length} today) · rule-book pairs ${ROUTING_RULES.length} · enum values ${enumValues.length} · CREATE TYPE values ${typeValues.length}`);
 
+// ── THE RULE BOOK LAW (RULEBOOK-01) ─────────────────────────────────────────
+const kindMigration = ALL_MIGRATIONS.find((m) => m.dir.endsWith('_arrival_kind'));
+if (!kindMigration) violations.push('rule book: no prisma/migrations/*_arrival_kind/migration.sql');
+const kindMigrationSql = kindMigration?.sql ?? '';
+const kindEnumBlock = schemaText.match(/enum arrival_kind \{\n([\s\S]*?)\n\}/);
+const kindEnumValues = kindEnumBlock ? kindEnumBlock[1].split('\n').map((l) => l.trim()).filter(Boolean) : [];
+if (kindEnumValues.join(',') !== ARRIVAL_KINDS.join(',')) violations.push(`rule book: enum arrival_kind [${kindEnumValues.join(' ')}] ≠ providers.ts ARRIVAL_KINDS [${ARRIVAL_KINDS.join(' ')}]`);
+const kindTypeValues = kindMigrationSql.match(/CREATE TYPE arrival_kind AS ENUM \((.*?)\);/)?.[1].split(', ').map((v) => v.replace(/^'|'$/g, '')) ?? [];
+if (kindTypeValues.join(',') !== ARRIVAL_KINDS.join(',')) violations.push(`rule book: migration CREATE TYPE arrival_kind [${kindTypeValues.join(' ')}] ≠ providers.ts ARRIVAL_KINDS`);
+// The migration applies the book, it invents nothing: every UPDATE it runs is a rule the book holds, with the book's kind.
+const applied: Array<{ provider: string; resource: string; kind: string }> = [];
+for (const m of kindMigrationSql.matchAll(/UPDATE arrivals SET kind = '([a-z]+)'\s+WHERE kind IS NULL AND provider = '([a-z_]+)' AND resource = '([a-z_]+)';/g)) {
+  const [, kind, provider, resource] = m;
+  applied.push({ provider, resource, kind });
+  const rule = ruleFor(provider, resource);
+  if (!rule) violations.push(`rule book: the migration applies ${provider} · ${resource} → ${kind} but the book holds no such rule`);
+  else if (rule.kind !== kind) violations.push(`rule book: the migration sets ${provider} · ${resource} to ${kind}; the book says ${rule.kind}`);
+}
+if (kindMigration && applied.length === 0) violations.push('rule book: the arrival_kind migration applies no rule (no UPDATE … SET kind found)');
+if (kindMigration && !/ALTER TABLE arrivals ALTER COLUMN kind SET NOT NULL/.test(kindMigrationSql)) violations.push('rule book: the arrival_kind migration never sets kind NOT NULL');
+if (kindMigration && !/OR NEW\.kind\s+IS DISTINCT FROM OLD\.kind/.test(kindMigrationSql)) violations.push('rule book: the promise-1 trigger does not freeze kind');
+// Every landing call site's (provider, resource) has a rule — the files under src that call landObjects, the words they pass.
+function tsFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const name of readdirSync(dir)) {
+    const abs = `${dir}/${name}`;
+    if (statSync(abs).isDirectory()) { if (name !== '__tests__' && name !== 'node_modules') out.push(...tsFiles(abs)); continue; }
+    if (name.endsWith('.ts') || name.endsWith('.tsx')) out.push(abs);
+  }
+  return out;
+}
+const landingConstants = new Map<string, string>();
+const srcFiles = tsFiles(resolve(ROOT, 'src')).map((abs) => ({ file: abs.replace(`${ROOT}/`, ''), src: readFileSync(abs, 'utf8') }));
+for (const { src } of srcFiles) for (const m of src.matchAll(/export const ([A-Z_]+) = '([a-z_]+)';/g)) landingConstants.set(m[1], m[2]);
+const wordOf = (expr: string): string | undefined => (expr.startsWith("'") ? expr.slice(1, -1) : landingConstants.get(expr));
+const callSites: Array<{ file: string; provider: string; resource: string; kind: string }> = [];
+for (const { file, src } of srcFiles) {
+  if (!src.includes('landObjects(') || file === 'src/lib/arrivals/land.ts') continue;
+  const providers = [...new Set([...src.matchAll(/provider: ([A-Z_]+|'[a-z_]+')/g)].map((m) => wordOf(m[1])))];
+  const resources = [...new Set([...src.matchAll(/resource: ([A-Z_]+|'[a-z_]+')/g)].map((m) => wordOf(m[1])))];
+  if (providers.length !== 1 || providers[0] === undefined) violations.push(`rule book: ${file} calls landObjects and names ${providers.filter(Boolean).length} provider(s) — expected exactly one, as a constant or a literal`);
+  for (const resource of resources) {
+    if (resource === undefined) { violations.push(`rule book: ${file} names a resource the assert cannot resolve to a word`); continue; }
+    const rule = providers[0] ? ruleFor(providers[0], resource) : undefined;
+    callSites.push({ file, provider: providers[0] ?? '?', resource, kind: rule?.kind ?? 'NO RULE' });
+    if (!rule) violations.push(`rule book: ${file} lands ${providers[0]} · ${resource} and the book holds no rule for it`);
+  }
+}
+if (callSites.length === 0) violations.push('rule book: no landing call site found under src — the scan is broken');
+console.log(`THE RULE BOOK — ${RULE_BOOK.length} rows (${RULE_BOOK.filter((r) => r.source === 'deck').length} the deck's, ${RULE_BOOK.filter((r) => r.source === 'added').length} added)`);
+for (const r of RULE_BOOK) console.log(`${r.provider.padEnd(18)} ${r.resource.padEnd(24)} ${r.kind.padEnd(10)} ${r.source.padEnd(6)} ${r.means}`);
+console.log('LANDING CALL SITES — provider · resource → the rule applied');
+for (const c of callSites) console.log(`${c.file.padEnd(48)} ${c.provider} · ${c.resource.padEnd(24)} → ${c.kind}`);
+console.log(`the migration applies: ${applied.map((a) => `${a.provider} · ${a.resource} → ${a.kind}`).join(' · ')}`);
+
 if (violations.length) {
   console.error('\n✖ TOOL REGISTRY LAW FAILED:');
   for (const v of violations) console.error(`  ${v}`);
@@ -354,4 +437,5 @@ console.log('✔ Tool registry law passed — 25/25 cells, homes resolve to page
 console.log(`✔ Reachability law passed — ${pages.length} pages, every one has a door (family menus and family pages count).`);
 console.log(`✔ The family map law passed — ${FAMILIES.length} menus, ${FAMILIES.length} family pages, every tool once in each.`);
 console.log(`✔ The answers law passed — ${ANSWER_ROWS.length}/4 questions on ${ANSWERS_HOME}, every number sourced.`);
-console.log(`✔ The arrivals law passed — ${PROVIDERS.length} providers, enum === codes, ${arrivalsRows.length} columns agree with the migration.`);
+console.log(`✔ The arrivals law passed — ${PROVIDERS.length} providers, enum === codes, ${arrivalsRows.length} columns agree with the migrations.`);
+console.log(`✔ The rule book law passed — ${RULE_BOOK.length} rules, ${callSites.length} landing call sites covered, enum arrival_kind === the six kinds, the migration applies ${applied.length} rules the book holds.`);

--- a/src/lib/__tests__/arrivalsInvestments.test.ts
+++ b/src/lib/__tests__/arrivalsInvestments.test.ts
@@ -121,6 +121,9 @@ test('(1) a page of securities + investment transactions lands (bytes, one arriv
   }
   const opt = secRows.find((a) => a.row.their_id === 'opt1')!;
   assert.equal(Buffer.compare(Buffer.from(opt.row.fingerprint), fingerprintOf(securities[1])), 0);
+  // RULEBOOK-01: every row carries the book's kind — a security is a reference, an investment transaction an event.
+  assert.deepEqual(secRows.map((a) => a.row.kind), ['reference', 'reference']);
+  assert.deepEqual(invRows.map((a) => a.row.kind), ['event', 'event']);
 
   // the parser: securities first (the FK), every column on create, the option contract mapped, arrival_id set
   assert.deepEqual(domain.calls, ['securities.upsert aapl', 'securities.upsert opt1', 'investment_transactions.create i1', 'investment_transactions.create i2']);

--- a/src/lib/__tests__/arrivalsLand.test.ts
+++ b/src/lib/__tests__/arrivalsLand.test.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import type { Transaction } from 'plaid';
 import { canonicalBytes, fingerprintOf, landObjects, landResponse, sha256 } from '../arrivals/land';
 import { FakeLanding } from './fakeLanding';
+import { NoRuleError } from '../providers';
 import { landTransactionsPage, recordFailedAnswer, runTransactionsPage, type DomainDb, type TransactionsPageInput } from '../arrivals/plaidTransactionsPage';
 import { stageFailed, syncEnvelope } from '../plaid/failLoud';
 import { onWireError, type WireStamp } from '../plaid/wire';
@@ -207,4 +208,34 @@ test('(g) a 429 answer produces one provider_responses row, zero arrivals, and t
   // a network failure with no answer lands nothing — there was no answer to keep
   assert.deepEqual(await recordFailedAnswer(landing, { userId: 'user_1', err: new Error('ECONNRESET') }), { landed: false });
   assert.equal(landing.responses.length, 1);
+});
+
+
+// ── RULEBOOK-01 ──
+
+test('a feed with no rule throws before anything is built — no response consulted, zero arrivals, the name of the missing rule', async () => {
+  const landing = new FakeLanding();
+  const asked = new Date('2026-09-07T10:00:00Z');
+  await assert.rejects(
+    landObjects(landing, { provider: 'plaid', resource: 'balance', connection: 'item_abc', userId: 'user_1', guestRef: null, responseId: 'resp_x', asked, arrived: asked, objects: [{ theirId: 'b1', payload: { account_id: 'a', current: 10 } }] }),
+    (e: unknown) => e instanceof NoRuleError && /no rule for plaid · balance/.test((e as Error).message),
+  );
+  assert.equal(landing.arrivals.size, 0, 'nothing landed');
+  // an unknown provider still fails first, as before
+  await assert.rejects(landObjects(landing, { provider: 'yodlee', resource: 'transaction', connection: null, userId: 'user_1', guestRef: null, responseId: 'resp_x', asked, arrived: asked, objects: [] }), /not a provider the deck names/);
+  assert.equal(landing.arrivals.size, 0);
+});
+
+test('kinds land as the book says: a transaction is an event, a security a reference, an investment transaction an event — on every row, read back from the table', async () => {
+  const landing = new FakeLanding();
+  const domain = new FakeDomain();
+  await landTransactionsPage(landing, domain, pageInput({ transactions: [txn('t1'), txn('t2')] }));
+  assert.deepEqual([...landing.arrivals.values()].map((a) => a.row.kind), ['event', 'event']);
+  const asked = new Date('2026-09-07T10:00:00Z');
+  const base = { provider: 'plaid', connection: 'item_abc', userId: 'user_1', guestRef: null, responseId: 'resp_x', asked, arrived: asked };
+  await landObjects(landing, { ...base, resource: 'security', objects: [{ theirId: 'sec_1', payload: { security_id: 'sec_1', name: 'X' } }] });
+  await landObjects(landing, { ...base, resource: 'investment_transaction', objects: [{ theirId: 'inv_1', payload: { investment_transaction_id: 'inv_1', amount: 1 } }] });
+  await landObjects(landing, { ...base, resource: 'holding', objects: [{ theirId: 'h_1', payload: { account_id: 'a', quantity: 2 } }] });
+  const kinds = Object.fromEntries([...landing.arrivals.values()].map((a) => [a.row.their_id, a.row.kind]));
+  assert.deepEqual(kinds, { t1: 'event', t2: 'event', sec_1: 'reference', inv_1: 'event', h_1: 'snapshot' });
 });

--- a/src/lib/__tests__/providers.test.ts
+++ b/src/lib/__tests__/providers.test.ts
@@ -2,7 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync, readdirSync } from 'node:fs';
 import { resolve } from 'node:path';
-import { PROVIDERS, PROVIDER_CODES, PROVIDER_MENU, ROUTING_RULES, providerByCode, providerByDeck, providerCode, providersLaw } from '../providers';
+import { ADDED_RULES, ARRIVAL_KINDS, NoRuleError, PROVIDERS, PROVIDER_CODES, PROVIDER_MENU, ROUTING_RULES, RULE_BOOK, kindOf, providerByCode, providerByDeck, providerCode, providersLaw, ruleFor, type Rule } from '../providers';
 
 // REBUILD-01 PR-1 — the provider vocabulary. Deck words ↔ codes round-trip, no
 // duplicates, every rule-book pair resolves, and the schema's enum carries the
@@ -38,9 +38,75 @@ test('every ROUTING_RULES provider + resource pair resolves, spelled as the deck
     assert.ok(p, `${provider} is a menu provider`);
     assert.ok(p.resources.includes(resource), `${provider} ${resource}`);
   }
-  assert.equal(PROVIDERS.flatMap((p) => p.resources).length, ROUTING_RULES.length);
-  assert.deepEqual(providerByDeck('plaid')?.resources, ['transaction', 'account', 'holding']);
+  // RULEBOOK-01: resources come from the book — the deck's rows plus the two added plaid rows.
+  assert.equal(PROVIDERS.flatMap((p) => p.resources).length, RULE_BOOK.length);
+  assert.deepEqual(providerByDeck('plaid')?.resources, ['transaction', 'account', 'holding', 'security', 'investment_transaction']);
   assert.deepEqual(providerByDeck('teller')?.resources, []);
+});
+
+// ── RULEBOOK-01 ──
+
+test('the rule book: every deck row verbatim with the deck\'s kind, plus the two rows the sample omits; one rule per pair; kindOf answers from the book and throws for a feed it does not name', () => {
+  assert.deepEqual([...ARRIVAL_KINDS], ['reference', 'registry', 'event', 'derived', 'snapshot', 'posting']);
+  assert.equal(RULE_BOOK.length, ROUTING_RULES.length + ADDED_RULES.length);
+  for (const [provider, resource, kind, means] of ROUTING_RULES) {
+    const rule = RULE_BOOK.find((r) => r.provider === provider && r.resource === resource);
+    assert.ok(rule, `${provider} · ${resource}`);
+    assert.equal(rule.kind, kind.toLowerCase());
+    assert.equal(rule.means, means);
+    assert.equal(rule.source, 'deck');
+    assert.equal(rule.code, providerCode(provider));
+  }
+  assert.deepEqual(ADDED_RULES.map(([p, r, k]) => [p, r, k]), [['plaid', 'security', 'REFERENCE'], ['plaid', 'investment_transaction', 'EVENT']]);
+  assert.equal(ruleFor('plaid', 'security')?.source, 'added');
+  assert.equal(new Set(RULE_BOOK.map((r) => `${r.provider} · ${r.resource}`)).size, RULE_BOOK.length, 'one rule per pair');
+  assert.ok(RULE_BOOK.every((r) => r.kind !== 'posting'), 'nothing ever arrives as a posting');
+  // the three resources the store has landed, the deck's holding, the two the book does not name
+  assert.equal(kindOf('plaid', 'transaction'), 'event');
+  assert.equal(kindOf('plaid', 'investment_transaction'), 'event');
+  assert.equal(kindOf('plaid', 'security'), 'reference');
+  assert.equal(kindOf('plaid', 'holding'), 'snapshot');
+  assert.equal(kindOf('plaid', 'account'), 'registry');
+  assert.equal(kindOf('google_places', 'place'), 'reference', 'keyed by the enum code, not the deck word');
+  assert.throws(() => kindOf('plaid', 'balance'), NoRuleError);
+  assert.throws(() => kindOf('teller', 'transaction'), /no rule for teller · transaction/);
+  assert.equal(ruleFor('plaid', 'balance'), undefined);
+});
+
+test('the law rejects a book missing a deck row, a deck row with another kind, two kinds for one pair, a posting rule, an unknown kind, an unknown provider', () => {
+  const book = [...RULE_BOOK];
+  assert.deepEqual(providersLaw({ throwOnFail: false, book }), []);
+  const missing = book.filter((r) => !(r.provider === 'plaid' && r.resource === 'holding'));
+  assert.match(providersLaw({ throwOnFail: false, book: missing }).join('\n'), /deck row plaid · holding is missing/);
+  const changed = book.map((r) => (r.provider === 'plaid' && r.resource === 'transaction' ? { ...r, kind: 'snapshot' as const } : r));
+  assert.match(providersLaw({ throwOnFail: false, book: changed }).join('\n'), /plaid · transaction is snapshot; the deck says event/);
+  const twice = [...book, { ...book[0], kind: 'reference' as const }];
+  assert.match(providersLaw({ throwOnFail: false, book: twice }).join('\n'), /has two rules \(event, reference\)/);
+  const posting = [...book, { provider: 'stripe', code: 'stripe', resource: 'ledger_line', kind: 'posting' as const, means: '', source: 'added' as const }];
+  assert.match(providersLaw({ throwOnFail: false, book: posting }).join('\n'), /is a posting — nothing ever arrives as a posting/);
+  const unknown = [...book, { provider: 'plaid', code: 'plaid', resource: 'balance', kind: 'ledger' as unknown as Rule['kind'], means: '', source: 'added' as const }];
+  assert.match(providersLaw({ throwOnFail: false, book: unknown }).join('\n'), /unknown kind "ledger"/);
+  const foreign = [...book, { provider: 'yodlee', code: 'yodlee', resource: 'transaction', kind: 'event' as const, means: '', source: 'added' as const }];
+  assert.match(providersLaw({ throwOnFail: false, book: foreign }).join('\n'), /"yodlee" is not a provider the menu names/);
+  assert.throws(() => providersLaw({ book: missing }), /PROVIDER VOCABULARY LAW failed/);
+});
+
+test("the Prisma enum arrival_kind and the migration's CREATE TYPE carry the six kinds in the deck's order; the migration's UPDATEs are rules the book holds", () => {
+  const schema = readFileSync(resolve(ROOT, 'prisma/schema.prisma'), 'utf8');
+  const enumBlock = schema.match(/enum arrival_kind \{\n([\s\S]*?)\n\}/);
+  assert.ok(enumBlock, 'enum arrival_kind exists');
+  assert.deepEqual(enumBlock[1].split('\n').map((l) => l.trim()).filter(Boolean), [...ARRIVAL_KINDS]);
+  assert.match(schema, /\n  kind          arrival_kind\n/, 'arrivals.kind is NOT NULL (no ?)');
+  const dir = readdirSync(resolve(ROOT, 'prisma/migrations')).find((d) => d.endsWith('_arrival_kind'));
+  assert.ok(dir, 'the arrival_kind migration exists');
+  const sql = readFileSync(resolve(ROOT, 'prisma/migrations', dir, 'migration.sql'), 'utf8');
+  assert.deepEqual(sql.match(/CREATE TYPE arrival_kind AS ENUM \((.*?)\);/)?.[1].split(', ').map((v) => v.replace(/^'|'$/g, '')), [...ARRIVAL_KINDS]);
+  const applied = [...sql.matchAll(/UPDATE arrivals SET kind = '([a-z]+)'\s+WHERE kind IS NULL AND provider = '([a-z_]+)' AND resource = '([a-z_]+)';/g)].map((m) => [m[2], m[3], m[1]]);
+  assert.deepEqual(applied, [['plaid', 'transaction', 'event'], ['plaid', 'investment_transaction', 'event'], ['plaid', 'security', 'reference']]);
+  for (const [provider, resource, kind] of applied) assert.equal(kindOf(provider, resource), kind);
+  assert.match(sql, /RAISE EXCEPTION 'arrival_kind: % arrivals carry no rule/, 'a row the book does not cover stops the migration');
+  assert.ok(sql.indexOf('RAISE EXCEPTION \'arrival_kind') < sql.indexOf('ALTER TABLE arrivals ALTER COLUMN kind SET NOT NULL'), 'the check runs before SET NOT NULL');
+  assert.match(sql, /OR NEW\.kind\s+IS DISTINCT FROM OLD\.kind THEN/, 'promise 1 freezes kind');
 });
 
 test("the Prisma enum arrival_provider and the migration's CREATE TYPE carry the code set exactly, alphabetical", () => {

--- a/src/lib/arrivals/land.ts
+++ b/src/lib/arrivals/land.ts
@@ -11,7 +11,9 @@
  *                    their_id = the provider's own id (their_id_kind
  *                    'provider'), redactions [] (the PR-2 audit found no secret
  *                    in a /transactions/get body), response_id set, status
- *                    pending. INSERT … ON CONFLICT (provider, their_id,
+ *                    pending, kind = the rule book's kind for (provider,
+ *                    resource) (RULEBOOK-01 — no rule, no row: NoRuleError
+ *                    before anything is built). INSERT … ON CONFLICT (provider, their_id,
  *                    fingerprint) DO NOTHING — THE SAME THING IS THE SAME
  *                    PROVIDER, ID AND CONTENT; a duplicate is promise 2 working,
  *                    not an error, and a provider's CORRECTION (same id, new
@@ -30,7 +32,8 @@
  */
 import { createHash, randomUUID } from 'node:crypto';
 import canonicalize from 'canonicalize';
-import { PROVIDER_CODES } from '@/lib/providers';
+// RULEBOOK-01: landing consults the rule book — every arrival carries its kind; no rule, no row.
+import { PROVIDER_CODES, kindOf, type ArrivalKind } from '@/lib/providers';
 
 export type JsonObject = Record<string, unknown>;
 
@@ -62,6 +65,8 @@ export interface ArrivalRow {
   response_id: string;
   user_id: string | null;
   guest_ref: string | null;
+  /** RULEBOOK-01: the kind the rule book assigns this (provider, resource) — set on landing, immutable after (promise 1). */
+  kind: ArrivalKind;
 }
 
 export interface LandedArrival {
@@ -184,6 +189,8 @@ const pairKey = (theirId: string, fingerprint: Buffer) => `${theirId}\u0000${fin
 export async function landObjects(db: LandingDb, input: LandObjectsInput): Promise<LandedObjects> {
   assertProvider(input.provider);
   if (input.userId === null && input.guestRef === null) throw new Error('landObjects: an arrival belongs to a user or a guest');
+  // RULEBOOK-01: the rule book is consulted BEFORE any row is built — a feed with no written kind throws here (NoRuleError), never lands, never defaults.
+  const kind = kindOf(input.provider, input.resource);
   const seen = new Set<string>();
   let repeatedInAnswer = 0;
   const rows: ArrivalRow[] = [];
@@ -207,6 +214,7 @@ export async function landObjects(db: LandingDb, input: LandObjectsInput): Promi
       response_id: input.responseId,
       user_id: input.userId,
       guest_ref: input.guestRef,
+      kind,
     });
   }
   const inserted = new Set((rows.length ? await db.insertArrivalsIgnoringDuplicates(rows) : []).map((p) => pairKey(p.their_id, p.fingerprint)));

--- a/src/lib/arrivals/prismaLanding.ts
+++ b/src/lib/arrivals/prismaLanding.ts
@@ -34,10 +34,10 @@ export function prismaLanding(tx: Tx): LandingDb {
     async insertArrivalsIgnoringDuplicates(rows: ArrivalRow[]) {
       if (rows.length === 0) return [];
       const values = rows.map(
-        (r) => Prisma.sql`(${r.id}, ${r.provider}::arrival_provider, ${r.connection}, ${r.resource}, ${r.their_id}, ${r.their_id_kind}::their_id_kind, ${JSON.stringify(r.payload)}::jsonb, ${r.fingerprint}, ${textArray(r.redactions)}, ${r.asked}, ${r.arrived}, 'pending'::arrival_status, ${r.response_id}, ${r.user_id}, ${r.guest_ref})`,
+        (r) => Prisma.sql`(${r.id}, ${r.provider}::arrival_provider, ${r.connection}, ${r.resource}, ${r.their_id}, ${r.their_id_kind}::their_id_kind, ${JSON.stringify(r.payload)}::jsonb, ${r.fingerprint}, ${textArray(r.redactions)}, ${r.asked}, ${r.arrived}, 'pending'::arrival_status, ${r.response_id}, ${r.user_id}, ${r.guest_ref}, ${r.kind}::arrival_kind)`,
       );
       const inserted = await tx.$queryRaw<Array<{ their_id: string; fingerprint: Buffer }>>(Prisma.sql`
-        INSERT INTO arrivals (id, provider, connection, resource, their_id, their_id_kind, payload, fingerprint, redactions, asked, arrived, status, response_id, user_id, guest_ref)
+        INSERT INTO arrivals (id, provider, connection, resource, their_id, their_id_kind, payload, fingerprint, redactions, asked, arrived, status, response_id, user_id, guest_ref, kind)
         VALUES ${Prisma.join(values)}
         ON CONFLICT (provider, their_id, fingerprint) DO NOTHING
         RETURNING their_id, fingerprint`);

--- a/src/lib/providers.ts
+++ b/src/lib/providers.ts
@@ -13,11 +13,24 @@
  * Prisma enum `arrival_provider` carries — and `resources` = the provider's
  * ROUTING_RULES rows, spelled as the deck spells them.
  *
+ * RULEBOOK-01: THIS FILE IS THE RULE BOOK the system applies. RULE_BOOK is
+ * every (provider, resource) with its KIND — the deck's ROUTING_RULES rows
+ * verbatim plus ADDED_RULES, the rows the deck's twenty-row sample omits but
+ * the store lands (plaid · security → reference, plaid · investment_transaction
+ * → event; plaid · holding → snapshot is already a deck row). Landing consults
+ * it (src/lib/arrivals/land.ts kindOf): every arrival carries its kind, and an
+ * arrival with no rule is a loud failure — no default, ever. The six kinds are
+ * the deck's HANDOFF_KINDS in the essay's order; nothing ever ARRIVES as a
+ * posting (the deck's closed-set law), so no rule may carry it.
+ *
  * THE LAW (module scope; re-run at build by scripts/assert-tool-registry.ts,
- * which adds the check only the schema text can answer — enum values === the
- * code set): deck words and codes unique; every ROUTING_RULES provider is a
- * menu provider and every (provider, resource) pair resolves; codes are
- * snake_case identifiers.
+ * which adds the checks only the schema, the migration and the call sites can
+ * answer — enum values === the code set, enum arrival_kind === ARRIVAL_KINDS,
+ * every landing call site's resource is in the book): deck words and codes
+ * unique; every ROUTING_RULES provider is a menu provider and every (provider,
+ * resource) pair resolves; codes are snake_case identifiers; every
+ * ROUTING_RULES row is in the book with the same kind; no (provider, resource)
+ * has two kinds; every kind is one of the six and never posting.
  *
  * Zero imports: server- and client-safe.
  */
@@ -61,6 +74,39 @@ export const ROUTING_RULES = [
   ['irs', 'bulletin', 'REFERENCE', ''],
 ] as const;
 
+/**
+ * RULEBOOK-01: the rows the deck's sample omits — the store lands them, so the
+ * book must name them. Same shape as ROUTING_RULES: [provider, resource, KIND,
+ * means]; MEANS is empty because each kind's first appearance is a deck row
+ * (the deck's own convention for repeat rows). plaid · holding is NOT here: it
+ * is already a ROUTING_RULES row (SNAPSHOT), and one pair may hold one rule.
+ */
+export const ADDED_RULES = [
+  ['plaid', 'security', 'REFERENCE', ''],
+  ['plaid', 'investment_transaction', 'EVENT', ''],
+] as const;
+
+/**
+ * The six kinds, the deck's HANDOFF_KINDS order (the essay's Step 5 list; the
+ * Prisma enum `arrival_kind` and the migration's CREATE TYPE list them in this
+ * order — asserted at build). Five arrive; posting is written, never received.
+ */
+export const ARRIVAL_KINDS = ['reference', 'registry', 'event', 'derived', 'snapshot', 'posting'] as const;
+export type ArrivalKind = (typeof ARRIVAL_KINDS)[number];
+
+export interface Rule {
+  /** The deck's provider word. */
+  provider: string;
+  /** The schema's word — the `arrival_provider` enum value (what a landing call passes). */
+  code: string;
+  resource: string;
+  kind: ArrivalKind;
+  /** The deck's MEANS cell — spoken on a kind's first appearance, empty on repeats. */
+  means: string;
+  /** 'deck' — a ROUTING_RULES row verbatim; 'added' — an ADDED_RULES row. */
+  source: 'deck' | 'added';
+}
+
 export interface Provider {
   /** The deck's word — PROVIDER_MENU / ROUTING_RULES spelling. */
   deck: string;
@@ -68,13 +114,38 @@ export interface Provider {
   code: string;
   /** Named in the menu's TODAY column (true) or its NEXT column (false). */
   today: boolean;
-  /** The resources this provider sends, as ROUTING_RULES spells them (empty until the rule book names one). */
+  /** The resources this provider sends, as the rule book spells them (empty until the book names one). */
   resources: readonly string[];
 }
 
 /** deck word → enum code: spaces become underscores; nothing else changes. */
 export function providerCode(deck: string): string {
   return deck.replace(/ /g, '_');
+}
+
+/** THE RULE BOOK: the deck's rows verbatim (kind lowercased — the enum's spelling), then the added rows. */
+export const RULE_BOOK: readonly Rule[] = [
+  ...ROUTING_RULES.map(([provider, resource, kind, means]): Rule => ({ provider, code: providerCode(provider), resource, kind: kind.toLowerCase() as ArrivalKind, means, source: 'deck' })),
+  ...ADDED_RULES.map(([provider, resource, kind, means]): Rule => ({ provider, code: providerCode(provider), resource, kind: kind.toLowerCase() as ArrivalKind, means, source: 'added' })),
+];
+
+/** The rule for a (provider code, resource), or undefined when the book has none. */
+export function ruleFor(providerCode: string, resource: string): Rule | undefined {
+  return RULE_BOOK.find((r) => r.code === providerCode && r.resource === resource);
+}
+
+export class NoRuleError extends Error {
+  constructor(providerCode: string, resource: string) {
+    super(`rule book: no rule for ${providerCode} · ${resource} — every feed gets one written kind before it lands (src/lib/providers.ts RULE_BOOK); nothing is assumed`);
+    this.name = 'NoRuleError';
+  }
+}
+
+/** The kind the book assigns — the one legal way an arrival gets its kind. Throws when the book has no rule; never defaults. */
+export function kindOf(providerCode: string, resource: string): ArrivalKind {
+  const rule = ruleFor(providerCode, resource);
+  if (!rule) throw new NoRuleError(providerCode, resource);
+  return rule.kind;
 }
 
 const menuWords = (cell: string): string[] => (cell === '—' ? [] : cell.split(' · '));
@@ -90,7 +161,7 @@ export const PROVIDERS: readonly Provider[] = (() => {
           deck,
           code: providerCode(deck),
           today: isToday,
-          resources: ROUTING_RULES.filter(([p]) => p === deck).map(([, r]) => r),
+          resources: RULE_BOOK.filter((r) => r.provider === deck).map((r) => r.resource),
         });
       }
     }
@@ -109,9 +180,10 @@ export function providerByCode(code: string): Provider | undefined {
   return PROVIDERS.find((p) => p.code === code);
 }
 
-/** THE LAW. Throws on the first violation; returns the violations list when asked not to throw. */
-export function providersLaw(opts: { throwOnFail?: boolean } = {}): string[] {
+/** THE LAW. Throws on the first violation; returns the violations list when asked not to throw. `book` is injectable for tests. */
+export function providersLaw(opts: { throwOnFail?: boolean; book?: readonly Rule[] } = {}): string[] {
   const violations: string[] = [];
+  const book = opts.book ?? RULE_BOOK;
   const decks = PROVIDERS.map((p) => p.deck);
   const codes = PROVIDERS.map((p) => p.code);
   if (new Set(decks).size !== decks.length) violations.push('PROVIDERS: a deck word repeats');
@@ -124,6 +196,23 @@ export function providersLaw(opts: { throwOnFail?: boolean } = {}): string[] {
     const p = providerByDeck(provider);
     if (!p) violations.push(`ROUTING_RULES: "${provider}" is not a provider the menu names`);
     else if (!p.resources.includes(resource)) violations.push(`ROUTING_RULES: ${provider} ${resource} does not resolve`);
+  }
+  // RULEBOOK-01: the book carries every deck row with the deck's kind; one rule per pair; six kinds, never posting.
+  for (const [provider, resource, kind] of ROUTING_RULES) {
+    const rule = book.find((r) => r.provider === provider && r.resource === resource);
+    if (!rule) violations.push(`RULE_BOOK: the deck row ${provider} · ${resource} is missing`);
+    else if (rule.kind !== kind.toLowerCase()) violations.push(`RULE_BOOK: ${provider} · ${resource} is ${rule.kind}; the deck says ${kind.toLowerCase()}`);
+  }
+  const pairs = new Map<string, ArrivalKind>();
+  for (const r of book) {
+    const key = `${r.provider} · ${r.resource}`;
+    if (!(ARRIVAL_KINDS as readonly string[]).includes(r.kind)) violations.push(`RULE_BOOK: ${key} carries an unknown kind "${r.kind}"`);
+    if (r.kind === 'posting') violations.push(`RULE_BOOK: ${key} is a posting — nothing ever arrives as a posting; the system writes postings from events`);
+    if (!providerByDeck(r.provider)) violations.push(`RULE_BOOK: "${r.provider}" is not a provider the menu names`);
+    if (r.code !== providerCode(r.provider)) violations.push(`RULE_BOOK: ${key} code "${r.code}" is not the deck word's code`);
+    const prior = pairs.get(key);
+    if (prior !== undefined) violations.push(`RULE_BOOK: ${key} has two rules (${prior}, ${r.kind}) — one pair, one kind`);
+    pairs.set(key, r.kind);
   }
   if (violations.length && opts.throwOnFail !== false) throw new Error(`PROVIDER VOCABULARY LAW failed:\n  ${violations.join('\n  ')}`);
   return violations;


### PR DESCRIPTION
**Do not merge — Alex merges after Vercel Preview (SOC 2 gate).**

**HARD GATE — migration-bearing, with a backfill by rule.** `CREATE TYPE arrival_kind`, `ALTER TABLE arrivals ADD COLUMN kind`, three `UPDATE`s that apply the rule book to the rows already landed, a raise if any row is left uncovered, `SET NOT NULL`, and the promise-1 trigger replaced with `kind` in its frozen set. Applied by `prisma migrate deploy` at deploy, in one transaction. The UPDATE applies the book; it invents nothing. Extra scrutiny asked.

## WHY

The deck's step 4: each feed gets one written rule — its kind — and "the system applies it to every arrival of that feed, forever after." The rule book was a deck const; the store landed resources the vocabulary never named (`security`, `investment_transaction`); no arrival carried a kind. Ruled: `providers.ts` is the rule book; landing consults it; an arrival with no rule is a loud failure.

## AUDIT (file:line on `main` before this PR)

| Fact | Where |
|---|---|
| **providers.ts today**: `PROVIDER_MENU` (13 rows) and `ROUTING_RULES` (20 rows: `[provider, resource, KIND, means]`) moved out of the deck byte-identical; `PROVIDERS` derives one entry per menu word with `resources` = that provider's ROUTING_RULES resources (names only — **no kind on any object the code exposes**); `PROVIDER_CODES` = the enum's values; `providersLaw` checks words/codes unique and every ROUTING_RULES pair resolves. | `src/lib/providers.ts:25-39, :41-62, :83-102, :113-130` |
| **The deck's kinds.** ROUTING_RULES carries five, upper-case: EVENT ×3 (plaid transaction, stripe payout, liteapi booking), REGISTRY ×1 (plaid account), SNAPSHOT ×1 (plaid holding), REFERENCE ×11, DERIVED ×4. The deck's closed-set comment: "nothing ever arrives as a posting — the system writes postings from events. Do not add a POSTING row here." | `providers.ts:42-61`; `Landing.tsx:533-537` |
| **The six kinds, in the essay's order** — `HANDOFF_KINDS`: reference · registry · event · derived · snapshot · posting ("ORDER IS THE ARGUMENT, not the alphabet"). The README's "six kinds" table renders them from it. | `Landing.tsx:583-607`; `README.md:115-127` |
| **Each Plaid resource's kind in the deck**: transaction → EVENT, account → REGISTRY, holding → SNAPSHOT. `security` and `investment_transaction` are not deck rows. | `providers.ts:42-44` |
| **Every resource the store has landed** (Alex's census, `SELECT DISTINCT provider, resource`): plaid · transaction, plaid · investment_transaction, plaid · security. | the ruling |
| **Every resource the code can land** — the `landObjects` / `landResponse` callers: `plaidTransactionsPage.ts` (`TRANSACTION`), `plaidInvestmentsPage.ts` (`SECURITY`, `INVESTMENT_TRANSACTION`; the response row is `INVESTMENT_TRANSACTION`); the constants at `plaidTransactionsPage.ts:31-32`, `plaidInvestmentsPage.ts:43-44`. `landObjects` asserted the **provider** only (`assertProvider`); `resource` was free text on both tables. | `src/lib/arrivals/plaidTransactionsPage.ts:150-171`, `plaidInvestmentsPage.ts:157-170`; `land.ts:116-118, :137, :185` |
| **The schema**: `arrivals` has `provider arrival_provider`, `resource String`, no kind; enums `arrival_provider`, `arrival_status`, `their_id_kind`. The build's column proof compares the `*_arrivals` migration's CREATE TABLE with the model column for column — it knew nothing of columns added by later migrations. | `prisma/schema.prisma:3574-3660`; `scripts/assert-tool-registry.ts:298-345` |
| **Consumers of the vocabulary** that must not move: the deck (`ROUTING_RULES` in S4 / S5 / S6 / S11 laws and the rendered rule book), `answers.ts` (feeds resolve against ROUTING_RULES pairs), the README generator (parses `ROUTING_RULES` text for the kinds table). All read `ROUTING_RULES`, which this PR leaves byte-identical. | `Landing.tsx:185, :623, :631, :724, :1120, :3106`; `src/lib/answers.ts:34-38` |
| **The promise-1 trigger** freezes thirteen columns; a new identity column must join the set. | `prisma/migrations/20260903000000_arrivals/migration.sql:107-136` |

## BUILD

| Piece | Change |
|---|---|
| `src/lib/providers.ts` — **the rule book** | `ARRIVAL_KINDS` (the six, HANDOFF_KINDS order) + `ArrivalKind`; `ADDED_RULES` — the rows the deck's twenty-row sample omits and the store lands: `plaid · security → REFERENCE`, `plaid · investment_transaction → EVENT` (means empty, the deck's own convention for repeat rows; **plaid · holding → SNAPSHOT is already a deck row**, so it is not repeated — one pair, one rule); `RULE_BOOK` = the deck's 20 rows verbatim (kind lowercased to the enum's spelling, `source: 'deck'`) + the 2 added (`source: 'added'`); `ruleFor(code, resource)`, `kindOf(code, resource)` (throws `NoRuleError` — no default, ever). `PROVIDERS[].resources` now derive from the book. **The law adds:** every ROUTING_RULES row present with the deck's kind; one kind per pair; every kind one of the six and never `posting`; every rule's provider a menu provider, its code the deck word's code. `providersLaw({ book })` injectable for tests. `ROUTING_RULES` untouched. |
| `src/lib/arrivals/land.ts`, `prismaLanding.ts` | `ArrivalRow.kind`; `landObjects` calls `kindOf` **before any row is built** — a feed with no rule throws with its name and lands nothing; the INSERT writes `kind::arrival_kind`. |
| `prisma/migrations/20260907180000_arrival_kind/migration.sql` | `CREATE TYPE arrival_kind AS ENUM ('reference','registry','event','derived','snapshot','posting')`; `ADD COLUMN kind arrival_kind NULL`; three UPDATEs, **named in the comment as the three rules used**: `plaid · transaction → event` (the deck), `plaid · investment_transaction → event` (added), `plaid · security → reference` (added); a `DO` block that **raises** with the count and the uncovered pairs if any row is still NULL; `ALTER COLUMN kind SET NOT NULL`; `CREATE OR REPLACE FUNCTION arrivals_promise_1()` with `OR NEW.kind IS DISTINCT FROM OLD.kind`. |
| `prisma/schema.prisma` | `enum arrival_kind` (six, in order); `arrivals.kind arrival_kind` (NOT NULL), placed last so the column proof reads it in migration order. `prisma validate` ✓. |
| `scripts/assert-tool-registry.ts` — **THE RULE BOOK LAW** | enum `arrival_kind` (schema) === `ARRIVAL_KINDS` === the migration's `CREATE TYPE`, in order; every `UPDATE … SET kind` the migration runs is a rule the book holds with the book's kind (the migration applies, never invents); `SET NOT NULL` and the trigger's `kind` line present; **every landing call site** — every file under `src` that calls `landObjects`, the `provider:` / `resource:` words it passes (constants resolved from `export const X = '…'`) — has a rule; the scan itself must find at least one site. The arrivals column proof now folds every later migration's `ALTER TABLE <table> ADD COLUMN` / `ALTER COLUMN … SET NOT NULL` into the SQL side, in migration order (27 columns agree). |
| README (regenerated, byte-stable) | the `arrivals` table gains the `kind` row; promise 1 names kind; a new **"The rule book (step 4, applied)"** subsection lists the 22 rows extracted from `providers.ts` (never retyped); gap row 04 TODAY / GAP re-derived; 34 enums. |
| Tests (+5) | below. |

## VERIFY

| Check | Result |
|---|---|
| `npx tsc --noEmit` | exit 0 |
| eslint — 7 changed files | 0 / 0 |
| `DATABASE_URL=… npx prisma validate` | valid; `prisma generate` ✓ |
| `npm test` | **134 / 134** (129 + 5) |
| asserts + `next build` | showroom ✓ · tool registry ✓ · reachability 67 ✓ · family map ✓ · answers ✓ · arrivals law ✓ (27 columns agree with the migrations) · **rule book law ✓ — 22 rules, 3 landing call sites covered, enum === the six kinds, the migration applies 3 rules the book holds** · **BUILD EXIT 0** |
| README generator | exit 0; byte-stable on a second run; the diff is this PR's cells only (the generator's Books row is tree-aware, so #1655's row does not leak in) |

### Tests (node:test)

```
ok 24 - a feed with no rule throws before anything is built — no response consulted, zero arrivals, the name of the missing rule
ok 25 - kinds land as the book says: a transaction is an event, a security a reference, an investment transaction an event — on every row, read back from the table
ok 83 - the rule book: every deck row verbatim with the deck's kind, plus the two rows the sample omits; one rule per pair; kindOf answers from the book and throws for a feed it does not name
ok 84 - the law rejects a book missing a deck row, a deck row with another kind, two kinds for one pair, a posting rule, an unknown kind, an unknown provider
ok 85 - the Prisma enum arrival_kind and the migration's CREATE TYPE carry the six kinds in the deck's order; the migration's UPDATEs are rules the book holds
```

The investments landing test (PR-2c's first test) now also asserts every security row is `reference` and every investment-transaction row `event`.

### The rehearsal — throwaway Postgres 16

Main's schema pushed (`db push` of `origin/main:prisma/schema.prisma`) + the promise-1 trigger from the arrivals migration; seeded 5 `plaid · transaction`, 3 `plaid · investment_transaction`, 2 `plaid · security` arrivals (a user, one response row).

| Step | Result |
|---|---|
| the migration, `psql -1` (one transaction, as `migrate deploy` runs it) | exit 0 |
| kinds after | `investment_transaction → event 3` · `security → reference 2` · `transaction → event 5`; **zero NULL**; `attnotnull = t`; `enum_range = {reference,registry,event,derived,snapshot,posting}` |
| `UPDATE arrivals SET kind = 'snapshot'` | **raised** — `arrivals promise 1: an arrival never changes` |
| `prisma migrate diff --from-url <db> --to-schema-datamodel prisma/schema.prisma` | `-- This is an empty migration.` — the database after the migration IS the schema |
| **NEGATIVE** — a second database with one extra `plaid · balance` arrival | the DO block raised: `arrival_kind: 1 arrivals carry no rule (plaid · balance) — add the rule to src/lib/providers.ts RULE_BOOK and this migration before SET NOT NULL; nothing is assumed`; exit 3; afterwards **no `kind` column and no `arrival_kind` type** — the whole migration rolled back |
| the real landing port on the migrated database | `landObjects` landed 2 transactions, 1 security, 1 holding → kinds read back `event, event, reference, snapshot`; a `plaid · balance` landing threw `NoRuleError` and the arrivals count was unchanged (14 → 14) |

## Notes — stated plainly

- Not verified: production (Azure) — the census's three pairs are the ruling's; the DO block is what stops the deploy if the store holds a fourth. The Vercel deploy that applies the migration.
- `posting` is in the enum (the six, as ruled) and no rule may carry it — the deck's closed-set law, now a law of the book too.
- The README generator's Books row is now tree-aware (cites `plaid/sync` while that route exists, the one writer once #1655 lands), so this branch's README carries only this PR's cells.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc

---
_Generated by [Claude Code](https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc)_