### PR TITLE
TABLES-01: six tables, one per kind — views over the typed feed tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,53 @@ One written rule per feed — its kind — and the system applies it to every ar
 | plaid | security | reference |  | added |
 | plaid | investment_transaction | event |  | added |
 
+### The six tables (step 5, views)
+
+Six tables, six names, the kind picks the table — as VIEWS over the typed feed tables (`prisma/migrations/20260907200000_kind_views/migration.sql`, generated from the census in `src/lib/kindViews.ts`; the six are `view` models in `prisma/schema.prisma` under Prisma's `views` preview). The feed tables keep their real columns, constraints and `arrival_id`; each view unions exactly the feed tables of its kind, the kind per table from the rule book, in one common shape. Posting is empty by the deck's own law; snapshot is empty until holdings land. A table whose feed the rule book cannot name is reported, never viewed. Today the six are views over the feed tables — event: transactions, investment transactions, bookings; reference: securities, places, the law corpus; registry: accounts; snapshot: none yet; derived: none yet; posting: empty by law.
+
+| Column | Type |
+|---|---|
+| kind | arrival_kind |
+| feed | text |
+| table_name | text |
+| row_id | text |
+| their_id | text |
+| arrival_id | text |
+| user_id | text |
+| arrived | timestamptz |
+
+| View | Unions | Feeds |
+|---|---|---|
+| reference | securities, places_cache, regulatory_documents | plaid · security · google_places · place · by s.domain: ecfr · title / us_code · title / federal_register · document / irs · bulletin |
+| registry | accounts | plaid · account |
+| event | transactions, investment_transactions, reservations | plaid · transaction · plaid · investment_transaction · liteapi · booking |
+| derived | (nothing) |  |
+| snapshot | (nothing) |  |
+| posting | (nothing) |  |
+
+| Feed table | Kind | Feed | arrival_id | user | arrived | Outside Prisma |
+|---|---|---|---|---|---|---|
+| securities | reference | plaid · security | yes | no | s."createdAt" |  |
+| places_cache | reference | google_places · place | no | no | p."cachedAt" |  |
+| regulatory_documents | reference | by s.domain: ecfr · title / us_code · title / federal_register · document / irs · bulletin | no | no | d.retrieved_at | prisma/migrations/20260503000000_pr_f_corpus_foundation/migration.sql (CREATE TABLE regulatory_documents; not a Prisma model) |
+| accounts | registry | plaid · account | no | yes | a."createdAt" |  |
+| transactions | event | plaid · transaction | yes | yes | t."createdAt" |  |
+| investment_transactions | event | plaid · investment_transaction | yes | yes | i."createdAt" |  |
+| reservations | event | liteapi · booking | no | yes | r."createdAt" |  |
+
+Reported, not viewed — rows from a provider answer whose feed the rule book does not name:
+
+| Table | Why |
+|---|---|
+| reservations (provider duffel) | 2 writes carry provider 'duffel' (src/app/api/flights/book/route.ts) — duffel is not a provider the deck names; those rows are outside the event view |
+| trip_scanner_results | src/app/api/trips/[id]/ai-assistant/route.ts writes AI recommendations per trip/category; the book names no such feed (anthropic · classification is the only anthropic row) |
+| scan_snapshots | src/lib/convergence/snapshot-logger.ts writes our own scores over quotes — math we did, not a provider answer; no rule-book feed |
+| operations_ai_usage | src/lib/ai/recordUsage.ts:158 stores our AI calls (purpose, tokens, full_response) — the book's anthropic row is classification, not a usage log |
+| discovery_proposals | AI-authored proposals (src/lib/discovery); not the book's anthropic · classification by name |
+| plaid_items | Plaid's item — a handshake (the access token lives here); the deck: handshakes never enter the tables; the book has no plaid · item row |
+| tastytrade_connections | a handshake (tokens); never data |
+| observatoryHealthLog | our probes of the providers (src/app/api/data-observatory) — not a provider feed |
+
 ### The loop (step 7)
 
 Every tool runs the same four beats: **DISCOVER → DECIDE → COMMIT → RECORD**.
@@ -218,6 +265,7 @@ BLUEPRINT is the step's headline; TODAY is the deck's honest-state line, verbati
 |---|---|---|---|
 | 03 | Store what arrived. Then decide what it means. | the arrivals store holds 9,092 Plaid transactions, 712 investment transactions and 247 securities — every answer word for word, fingerprinted, status done — counted September 7, 2026; rows before September 3, 2026 carry no arrival. | the other providers (Stripe events, LiteAPI, tastytrade, the market and law feeds) land parsed; the three old Plaid writers still exist. |
 | 04 | One rule per feed. Written down. | rules are rows the system applies — src/lib/providers.ts RULE_BOOK, 22 rows (the deck's 20 plus plaid · security → reference and plaid · investment_transaction → event); every Plaid arrival carries its kind (transaction · event, investment_transaction · event, security · reference), stamped on landing and applied by the migration to every row landed before it; a feed with no rule cannot land. | the other providers' arrivals wait on their landing — nothing of theirs has arrived to be labeled; the 121 feeds' classification stays the August 24 census until each lands. |
+| 05 | The kind picks the table. | Today the six are views over the feed tables — event: transactions, investment transactions, bookings; reference: securities, places, the law corpus; registry: accounts; snapshot: none yet; derived: none yet; posting: empty by law. | snapshot waits on holdings (PR-2d); derived has no feed table the rule book names — the AI tables carry no rule-book row; posting is empty by law; 8 tables are reported, not viewed. |
 | 07 | Every tool runs the same four beats. Discover. Decide. Commit. Record. | This loop is the blueprint — the shape we're building every tool toward. Today, hotel bookings commit for real and an accepted task fires its build; the rest run discover → decide → draft, and commit is the beat we're wiring to the same loop, tool by tool. | commit is real for two tools (hotel bookings, accepted tasks); the other twenty-three stop at draft. |
 | 08 | One table holds everything you do. | The master table is the blueprint. Today each tool keeps its own table; one table holding every document is the shape we're building. | no master table; each tool keeps its own. |
 | 09 | The deposit meets the invoice. The fill meets the order. | (A piece of this is already alive today: card charges find their bookings and propose the match — you approve it.) | one of fourteen matches proposes today (card charge ↔ booking); the other thirteen do not. |
@@ -231,15 +279,15 @@ BLUEPRINT is the step's headline; TODAY is the deck's honest-state line, verbati
 
 | Module | What exists in code |
 |---|---|
-| Travel | stays and flights through LiteAPI, activities through Viator, visa checks through RapidAPI — public routes under src/app/api/travel (15 route files) and src/app/api/flights (3); models `trips` (schema:594) and `reservations` (schema:1350). |
-| Runway | the reservation matcher — src/app/api/runway/match/propose, queue, review (the step-9 piece alive today) — plus src/app/api/runway/route.ts; models `budgets` (schema:564) and `home_expenses` (schema:1600). |
-| Books | Plaid-synced transactions, a chart of accounts, journal and ledger entries — src/app/api/plaid/sync/route.ts:103 writes `transactions` (schema:425); `journal_entries` (schema:180), `ledger_entries` (schema:219). |
-| Trade | tastytrade connection, quotes and backtests — src/app/api/tastytrade (13 route files); models `trade_cards` (schema:1731) and `scan_snapshots` (schema:1917). |
-| Tax | scenarios, documents and the 2025 export script (`npm run tax:export:2025`) — src/app/api/tax (7 route files); models `tax_scenarios` (schema:1520) and `tax_documents` (schema:1839). |
-| Compliance | the regulatory corpus (eCFR, US Code, Federal Register, IRS bulletins) ingested by Inngest functions with sha256 on write, citations re-verified, and the hash-chained audit log — models `regulatory_sources` (schema:2230), `citations` (schema:2294), `audit_log` (schema:2460). |
-| Routines | scheduled routines evaluated by the `routine-evaluator` Inngest function — models `operations_routines` (schema:3114) and `hub_scheduled_items` (schema:3220); the deck calls the calendar window live in the cockpit (step 12 honest line). |
-| Projects | projects and tasks; accepting a pending task fires the Execute-Task Routine (src/app/api/operations/projects/[id]/tasks/[taskId]/route.ts:395-405) — models `operations_projects` (schema:2938) and `operations_project_tasks` (schema:2983). |
-| Content | scene groups, scenes, pieces and takes — model `operations_content_pieces` (schema:3347); src/app/api/operations carries 50 route files across Routines, Projects and Content. |
+| Travel | stays and flights through LiteAPI, activities through Viator, visa checks through RapidAPI — public routes under src/app/api/travel (15 route files) and src/app/api/flights (3); models `trips` (schema:599) and `reservations` (schema:1355). |
+| Runway | the reservation matcher — src/app/api/runway/match/propose, queue, review (the step-9 piece alive today) — plus src/app/api/runway/route.ts; models `budgets` (schema:569) and `home_expenses` (schema:1605). |
+| Books | Plaid-synced transactions, a chart of accounts, journal and ledger entries — src/app/api/plaid/sync/route.ts:103 writes `transactions` (schema:430); `journal_entries` (schema:185), `ledger_entries` (schema:224). |
+| Trade | tastytrade connection, quotes and backtests — src/app/api/tastytrade (13 route files); models `trade_cards` (schema:1736) and `scan_snapshots` (schema:1922). |
+| Tax | scenarios, documents and the 2025 export script (`npm run tax:export:2025`) — src/app/api/tax (7 route files); models `tax_scenarios` (schema:1525) and `tax_documents` (schema:1844). |
+| Compliance | the regulatory corpus (eCFR, US Code, Federal Register, IRS bulletins) ingested by Inngest functions with sha256 on write, citations re-verified, and the hash-chained audit log — models `regulatory_sources` (schema:2235), `citations` (schema:2299), `audit_log` (schema:2465). |
+| Routines | scheduled routines evaluated by the `routine-evaluator` Inngest function — models `operations_routines` (schema:3119) and `hub_scheduled_items` (schema:3225); the deck calls the calendar window live in the cockpit (step 12 honest line). |
+| Projects | projects and tasks; accepting a pending task fires the Execute-Task Routine (src/app/api/operations/projects/[id]/tasks/[taskId]/route.ts:395-405) — models `operations_projects` (schema:2943) and `operations_project_tasks` (schema:2988). |
+| Content | scene groups, scenes, pieces and takes — model `operations_content_pieces` (schema:3352); src/app/api/operations carries 50 route files across Routines, Projects and Content. |
 
 ## Architecture
 
@@ -279,7 +327,7 @@ These are the written laws in `CLAUDE.md`, stated as practice:
 - Middleware: every path not in `PUBLIC_PATHS` requires the verified cookie — `src/middleware.ts:50-160, 162, 165-170`; the two Routine callbacks (`…/audit-ingest`, `…/exec-ingest`) bypass the cookie and validate a shared-secret bearer (`AUDIT_INGEST_SECRET`, `EXEC_INGEST_SECRET`) instead — `src/middleware.ts:173-187`.
 - Route gates: `getCurrentUser` (`src/lib/auth-helpers.ts:11`), `requireTier` (`:42`), `requireAdmin` (`src/lib/require-admin.ts:8`); the working law is that a paid external call is never made before the gate (CLAUDE.md, Security-first).
 - User scoping: every query is scoped to the authed user — e.g. `where: { userId: user.id }` at `src/app/api/tastytrade/connect/route.ts:54`.
-- Rate limits: a durable fixed-window limiter backed by the `rate_limit_hits` table (`src/lib/rateLimit.ts:3-15`; schema:1335), plus `src/lib/scan-rate-limit.ts` and `src/lib/ai-rate-limit.ts`; tuned by `SEARCH_/BOOK_/SCAN_/AI_RATE_LIMIT` and `_WINDOW`, with daily caps `AI_PIPE_DAILY_CAP`, `AI_EXEC_DAILY_CAP`, `AI_ROUTINE_DAILY_CAP`, `AI_DISCOVERY_DAILY_CAP` (USD, from recorded spend — `src/lib/discovery/discoveryGate.ts`), `TRAVEL_SEARCH_DAILY_CAP`, and `GOOGLE_PLACES_MONTHLY_CAP`.
+- Rate limits: a durable fixed-window limiter backed by the `rate_limit_hits` table (`src/lib/rateLimit.ts:3-15`; schema:1340), plus `src/lib/scan-rate-limit.ts` and `src/lib/ai-rate-limit.ts`; tuned by `SEARCH_/BOOK_/SCAN_/AI_RATE_LIMIT` and `_WINDOW`, with daily caps `AI_PIPE_DAILY_CAP`, `AI_EXEC_DAILY_CAP`, `AI_ROUTINE_DAILY_CAP`, `AI_DISCOVERY_DAILY_CAP` (USD, from recorded spend — `src/lib/discovery/discoveryGate.ts`), `TRAVEL_SEARCH_DAILY_CAP`, and `GOOGLE_PLACES_MONTHLY_CAP`.
 - Audit log: a hash chain — each entry stores `prev_hash` and its own sha256 `content_hash` with a `sequence_number` (`prisma/schema.prisma:2441-2443`; written at `src/lib/audit/writeAuditLog.ts:99`); `src/lib/audit/verifyAuditChain.ts:47, 80` recomputes the chain.
 - Citations: `src/lib/citations/verifyCitation.ts:97` re-fetches the source and re-hashes it against `citations.retrieved_content_hash` (`prisma/schema.prisma:2287`); the column's only writer stores an empty string today (`src/lib/discovery/materializeProposal.ts:165`), so the check is structurally dead until the arrivals rebuild lands the real hash.
 - Corpus: the four ingest persisters hash content with sha256 on write — `src/lib/corpus/ingest/ecfr-persist.ts:28`, `uscode-persist.ts:32`, `fedreg-persist.ts:31`, `irb-persist.ts:32`.

--- a/prisma/migrations/20260907200000_kind_views/migration.sql
+++ b/prisma/migrations/20260907200000_kind_views/migration.sql
@@ -1,0 +1,137 @@
+-- TABLES-01: SIX TABLES, ONE PER KIND — AS VIEWS OVER THE TYPED FEED TABLES.
+-- The deck's step 5: "create one table per kind: six tables, six names; the
+-- kind picks the table." The typed feed tables stay (real columns,
+-- constraints, arrival_id); these six views — reference · registry · event ·
+-- derived · snapshot · posting — carry ONE common shape and each unions
+-- exactly the feed tables of its kind. The kind per table is the rule book's
+-- (src/lib/providers.ts RULE_BOOK), never typed twice: THIS FILE IS
+-- src/lib/kindViews.ts kindViewsSql() VERBATIM, generated from the census
+-- (KIND_VIEW_CENSUS), and the build asserts the two agree — (a) every census
+-- table in exactly one view, (b) in the rule book's kind for its feed,
+-- (c) posting unions nothing, (d) all six share the common columns in order.
+--
+-- Common shape: kind · feed (the rule-book pair) · table_name · row_id ·
+-- their_id · arrival_id · user_id · arrived. A row an authored or unruled
+-- feed wrote never rides a kind view (accounts.source = 'plaid',
+-- reservations.provider = 'liteapi', the corpus's four named sources).
+--
+-- VIEWS ONLY: no table changes, no data. Applied by `prisma migrate deploy`
+-- at deploy; schema.prisma carries the six as `view` models (Prisma's `views`
+-- preview), which Migrate does not manage — this file is their one source.
+-- Re-running it fails loudly on the first CREATE VIEW (no IF NOT EXISTS, no
+-- OR REPLACE): a change to a view is a new migration that drops and recreates.
+
+-- reference: securities, places_cache, regulatory_documents
+CREATE VIEW reference AS
+  SELECT 'reference'::arrival_kind AS kind,
+         'plaid · security' AS feed,
+         'securities' AS table_name,
+         s.id::text AS row_id,
+         s."securityId"::text AS their_id,
+         s.arrival_id::text AS arrival_id,
+         NULL::text AS user_id,
+         s."createdAt"::timestamptz AS arrived
+  FROM securities s
+  UNION ALL
+  SELECT 'reference'::arrival_kind AS kind,
+         'google places · place' AS feed,
+         'places_cache' AS table_name,
+         p.id::text AS row_id,
+         p."placeId"::text AS their_id,
+         NULL::text AS arrival_id,
+         NULL::text AS user_id,
+         p."cachedAt"::timestamptz AS arrived
+  FROM places_cache p
+  UNION ALL
+  SELECT 'reference'::arrival_kind AS kind,
+         CASE s.domain WHEN 'ecfr.gov' THEN 'ecfr · title' WHEN 'uscode.house.gov' THEN 'us code · title' WHEN 'federalregister.gov' THEN 'federal register · document' WHEN 'irs.gov' THEN 'irs · bulletin' END AS feed,
+         'regulatory_documents' AS table_name,
+         d.id::text AS row_id,
+         d.citation_key::text AS their_id,
+         NULL::text AS arrival_id,
+         NULL::text AS user_id,
+         d.retrieved_at::timestamptz AS arrived
+  FROM regulatory_documents d JOIN regulatory_sources s ON s.id = d.source_id
+  WHERE s.domain IN ('ecfr.gov', 'uscode.house.gov', 'federalregister.gov', 'irs.gov');
+
+-- registry: accounts
+CREATE VIEW registry AS
+  SELECT 'registry'::arrival_kind AS kind,
+         'plaid · account' AS feed,
+         'accounts' AS table_name,
+         a.id::text AS row_id,
+         a."accountId"::text AS their_id,
+         NULL::text AS arrival_id,
+         a."userId"::text AS user_id,
+         a."createdAt"::timestamptz AS arrived
+  FROM accounts a
+  WHERE a.source = 'plaid';
+
+-- event: transactions, investment_transactions, reservations
+CREATE VIEW event AS
+  SELECT 'event'::arrival_kind AS kind,
+         'plaid · transaction' AS feed,
+         'transactions' AS table_name,
+         t.id::text AS row_id,
+         t."transactionId"::text AS their_id,
+         t.arrival_id::text AS arrival_id,
+         a."userId"::text AS user_id,
+         t."createdAt"::timestamptz AS arrived
+  FROM transactions t JOIN accounts a ON a.id = t."accountId"
+  UNION ALL
+  SELECT 'event'::arrival_kind AS kind,
+         'plaid · investment_transaction' AS feed,
+         'investment_transactions' AS table_name,
+         i.id::text AS row_id,
+         i.investment_transaction_id::text AS their_id,
+         i.arrival_id::text AS arrival_id,
+         a."userId"::text AS user_id,
+         i."createdAt"::timestamptz AS arrived
+  FROM investment_transactions i JOIN accounts a ON a.id = i."accountId"
+  UNION ALL
+  SELECT 'event'::arrival_kind AS kind,
+         'liteapi · booking' AS feed,
+         'reservations' AS table_name,
+         r.id::text AS row_id,
+         r."providerBookingId"::text AS their_id,
+         NULL::text AS arrival_id,
+         r."userId"::text AS user_id,
+         r."createdAt"::timestamptz AS arrived
+  FROM reservations r
+  WHERE r.provider = 'liteapi';
+
+-- derived: no feed table the rule book names holds a derived row — the AI tables (operations_ai_usage, discovery_proposals, trip_scanner_results, scan_snapshots) carry no rule-book feed (STOPPED_TABLES)
+CREATE VIEW derived AS
+  SELECT NULL::arrival_kind AS kind,
+         NULL::text AS feed,
+         NULL::text AS table_name,
+         NULL::text AS row_id,
+         NULL::text AS their_id,
+         NULL::text AS arrival_id,
+         NULL::text AS user_id,
+         NULL::timestamptz AS arrived
+  WHERE false;
+
+-- snapshot: no feed table holds a snapshot yet — plaid · holding lands in REBUILD-01 PR-2d
+CREATE VIEW snapshot AS
+  SELECT NULL::arrival_kind AS kind,
+         NULL::text AS feed,
+         NULL::text AS table_name,
+         NULL::text AS row_id,
+         NULL::text AS their_id,
+         NULL::text AS arrival_id,
+         NULL::text AS user_id,
+         NULL::timestamptz AS arrived
+  WHERE false;
+
+-- posting: empty by the deck's own law — nothing ever arrives as a posting; the system writes postings from events (step 10)
+CREATE VIEW posting AS
+  SELECT NULL::arrival_kind AS kind,
+         NULL::text AS feed,
+         NULL::text AS table_name,
+         NULL::text AS row_id,
+         NULL::text AS their_id,
+         NULL::text AS arrival_id,
+         NULL::text AS user_id,
+         NULL::timestamptz AS arrived
+  WHERE false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,5 +1,10 @@
 generator client {
-  provider = "prisma-client-js"
+  provider        = "prisma-client-js"
+  // TABLES-01: the six kind views (src/lib/kindViews.ts) are `view` models — Prisma's `views` preview
+  // (https://www.prisma.io/docs/orm/prisma-schema/data-model/views; Prisma 5.22). Migrate does not
+  // manage views: the CREATE VIEWs live in prisma/migrations/*_kind_views and the build asserts the
+  // two agree.
+  previewFeatures = ["views"]
 }
 
 datasource db {
@@ -3674,4 +3679,86 @@ model arrivals {
   @@index([provider, their_id, arrived(sort: Desc)])
   @@index([status])
   @@index([response_id])
+}
+
+/// TABLES-01: six tables, one per kind — VIEWS over the typed feed tables (src/lib/kindViews.ts KIND_VIEW
+/// census; prisma/migrations/*_kind_views). One common shape; each unions exactly the feed tables of its
+/// kind, the kind per table from the rule book. posting is empty by the deck's own law; snapshot until holdings land.
+
+view reference {
+  kind       arrival_kind
+  feed       String
+  table_name String
+  row_id     String
+  their_id   String
+  arrival_id String?
+  user_id    String?
+  arrived    DateTime? @db.Timestamptz(6)
+
+  @@unique([table_name, row_id])
+}
+
+view registry {
+  kind       arrival_kind
+  feed       String
+  table_name String
+  row_id     String
+  their_id   String
+  arrival_id String?
+  user_id    String?
+  arrived    DateTime? @db.Timestamptz(6)
+
+  @@unique([table_name, row_id])
+}
+
+view event {
+  kind       arrival_kind
+  feed       String
+  table_name String
+  row_id     String
+  their_id   String
+  arrival_id String?
+  user_id    String?
+  arrived    DateTime? @db.Timestamptz(6)
+
+  @@unique([table_name, row_id])
+}
+
+view derived {
+  kind       arrival_kind
+  feed       String
+  table_name String
+  row_id     String
+  their_id   String
+  arrival_id String?
+  user_id    String?
+  arrived    DateTime? @db.Timestamptz(6)
+
+  @@unique([table_name, row_id])
+}
+
+view snapshot {
+  kind       arrival_kind
+  feed       String
+  table_name String
+  row_id     String
+  their_id   String
+  arrival_id String?
+  user_id    String?
+  arrived    DateTime? @db.Timestamptz(6)
+
+  @@unique([table_name, row_id])
+}
+
+view posting {
+  kind       arrival_kind
+  feed       String
+  table_name String
+  row_id     String
+  their_id   String
+  arrival_id String?
+  user_id    String?
+  arrived    DateTime? @db.Timestamptz(6)
+
+  @@unique([table_name, row_id])
 }

--- a/scripts/assert-tool-registry.ts
+++ b/scripts/assert-tool-registry.ts
@@ -36,6 +36,15 @@
  * they pass, as constants or literals) has a rule. A feed the book does not
  * name cannot be landed: the build fails before the code does.
  *
+ * THE KIND-VIEWS LAW (TABLES-01): src/lib/kindViews.ts KIND_VIEW_CENSUS is the
+ * census of the typed feed tables; the *_kind_views migration must be its
+ * generator's text verbatim — (a) every census table in exactly one view,
+ * (b) that view is the rule book's kind for the table's feed, (c) posting
+ * unions nothing, (d) all six views carry the common columns in the same
+ * order — and schema.prisma carries the six as `view` models with those
+ * columns, under the `views` preview feature. The deck's step-5 honest line
+ * is the census's own sentence (the file imports KIND_VIEWS_HONEST_LINE).
+ *
  * THE ARRIVALS LAW (REBUILD-01 PR-1): the provider vocabulary's module-scope
  * law re-run (src/lib/providers.ts — every ROUTING_RULES provider + resource
  * pair resolves, no duplicate word or code), plus what only the texts can
@@ -65,6 +74,7 @@ import { EXPECTED_STATUS_COUNTS, FAMILIES, FAMILY_PAGES, FAMILY_READS, TOOL_REGI
 import { OWNER_UTILITIES } from '../src/lib/shellMenu';
 import { ANSWERS_HOME, ANSWER_READS, ANSWER_ROWS, NET_WORTH_READ, answersLaw } from '../src/lib/answers';
 import { ARRIVAL_KINDS, PROVIDERS, PROVIDER_CODES, ROUTING_RULES, RULE_BOOK, providersLaw, ruleFor } from '../src/lib/providers';
+import { KIND_VIEWS_HONEST_LINE, KIND_VIEW_CENSUS, STOPPED_TABLES, VIEW_COLUMNS, kindOfTable, kindViewsLaw, parseViews } from '../src/lib/kindViews';
 
 /**
  * Routes whose door is outside the app map: the front door and its marketing
@@ -437,5 +447,29 @@ console.log('✔ Tool registry law passed — 25/25 cells, homes resolve to page
 console.log(`✔ Reachability law passed — ${pages.length} pages, every one has a door (family menus and family pages count).`);
 console.log(`✔ The family map law passed — ${FAMILIES.length} menus, ${FAMILIES.length} family pages, every tool once in each.`);
 console.log(`✔ The answers law passed — ${ANSWER_ROWS.length}/4 questions on ${ANSWERS_HOME}, every number sourced.`);
+// ── THE KIND-VIEWS LAW (TABLES-01) ──────────────────────────────────────────
+const viewsMigration = ALL_MIGRATIONS.find((m) => m.dir.endsWith('_kind_views'));
+if (!viewsMigration) violations.push('kind views: no prisma/migrations/*_kind_views/migration.sql');
+violations.push(...kindViewsLaw({ throwOnFail: false, migrationSql: viewsMigration?.sql ?? '' }));
+// schema.prisma: the six `view` models, the common columns in order, the views preview on
+if (!/previewFeatures\s*=\s*\[[^\]]*"views"/.test(schemaText)) violations.push('kind views: generator client must enable previewFeatures = ["views"]');
+const VIEW_FIELD_TYPES: Record<string, string> = { arrival_kind: 'arrival_kind', text: 'String', timestamptz: 'DateTime' };
+for (const kind of ARRIVAL_KINDS) {
+  const block = schemaText.match(new RegExp(`\\nview ${kind} \\{\\n([\\s\\S]*?)\\n\\}`));
+  if (!block) { violations.push(`kind views: schema.prisma has no view ${kind}`); continue; }
+  const fields = block[1].split('\n').map((l) => l.trim()).filter((l) => l && !l.startsWith('@@') && !l.startsWith('//')).map((l) => { const [name, type] = l.split(/\s+/); return { name, type: type.replace(/\?$/, '') }; });
+  const want = VIEW_COLUMNS.map(([n, t]) => `${n} ${VIEW_FIELD_TYPES[t]}`).join(', ');
+  const have = fields.map((f) => `${f.name} ${f.type}`).join(', ');
+  if (want !== have) violations.push(`kind views: view ${kind} in schema.prisma is [${have}], not the common shape [${want}]`);
+}
+const landingSrc = readFileSync(resolve(ROOT, 'src/components/landing/Landing.tsx'), 'utf8');
+if (!landingSrc.includes('{KIND_VIEWS_HONEST_LINE}')) violations.push("kind views: the deck's step 5 must render KIND_VIEWS_HONEST_LINE (never a retyped line)");
+console.log('THE KIND VIEWS — the census, each table once, the kind from the rule book');
+for (const t of KIND_VIEW_CENSUS) console.log(`${t.table.padEnd(26)} ${kindOfTable(t).padEnd(10)} ${Array.isArray(t.feed) ? `${t.feed[0]} · ${t.feed[1]}` : `by ${t.feed.column}: ${Object.values(t.feed.map).map(([p, r]) => `${p} · ${r}`).join(' | ')}`}`);
+for (const v of parseViews(viewsMigration?.sql ?? '')) console.log(`view ${v.name.padEnd(10)} ← ${v.tables.length ? v.tables.join(', ') : '(nothing)'}`);
+console.log(`stopped (reported, not viewed): ${STOPPED_TABLES.map((s) => s.table).join(' · ')}`);
+console.log(`honest line: ${KIND_VIEWS_HONEST_LINE}`);
+
 console.log(`✔ The arrivals law passed — ${PROVIDERS.length} providers, enum === codes, ${arrivalsRows.length} columns agree with the migrations.`);
 console.log(`✔ The rule book law passed — ${RULE_BOOK.length} rules, ${callSites.length} landing call sites covered, enum arrival_kind === the six kinds, the migration applies ${applied.length} rules the book holds.`);
+console.log(`✔ The kind views law passed — ${ARRIVAL_KINDS.length} views over ${KIND_VIEW_CENSUS.length} feed tables, each once, the kind from the rule book; posting unions nothing; ${STOPPED_TABLES.length} tables reported, not viewed.`);

--- a/src/components/landing/Landing.tsx
+++ b/src/components/landing/Landing.tsx
@@ -183,6 +183,8 @@ import GuestTripStrip from './GuestTripStrip';
 import { PROBLEM_SHEET } from '@/lib/problemSheet';
 import { ANSWER_ROWS, ANSWER_INPUTS } from '@/lib/answers';
 import { PROVIDER_MENU, ROUTING_RULES } from '@/lib/providers';
+// TABLES-01: step 5's honest line — every table name from the kind-views census, none retyped.
+import { KIND_VIEWS_HONEST_LINE } from '@/lib/kindViews';
 // PR-ELEV-1: the coming-soon tiles became badged "Soon" chips INSIDE the
 // booking strip (travelStripModes) — the separate tile row is gone.
 
@@ -3318,6 +3320,11 @@ export default function Landing({ onRequireAuth, onRequireLogin, logoAvailabilit
               </div>
             ))}
           </div>
+
+          {/* TABLES-01: the honest line (the 12/13 idiom) — today the six are
+              views over the typed feed tables; the names come from the census
+              (src/lib/kindViews.ts), the kinds from the rule book. */}
+          <p className={`mt-[14px] ${DECK.statement}`}>{KIND_VIEWS_HONEST_LINE}</p>
 
           {/* PR-S5: the tail is ONE paragraph — the essay's consolidated
               Step 5 passage, verbatim, slide-01 body tier. The old kind

--- a/src/lib/__tests__/kindViews.test.ts
+++ b/src/lib/__tests__/kindViews.test.ts
@@ -1,0 +1,87 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { ARRIVAL_KINDS, kindOf } from '../providers';
+import { KIND_VIEWS_HONEST_LINE, KIND_VIEW_CENSUS, STOPPED_TABLES, VIEW_COLUMNS, kindOfTable, kindViewSql, kindViewsHonestLine, kindViewsLaw, kindViewsSql, parseViews, tablesOfKind, type FeedTable } from '../kindViews';
+
+// TABLES-01 — six views, one per kind, generated from the census; the kind per table from the rule book.
+
+const ROOT = resolve(__dirname, '../../..');
+const migration = () => {
+  const dir = readdirSync(resolve(ROOT, 'prisma/migrations')).find((d) => d.endsWith('_kind_views'));
+  assert.ok(dir, 'the kind_views migration exists');
+  return readFileSync(resolve(ROOT, 'prisma/migrations', dir, 'migration.sql'), 'utf8');
+};
+
+test('the census: every table once, its kind from the rule book (never typed), and the deck\'s honest line names exactly those tables', () => {
+  assert.deepEqual(kindViewsLaw({ throwOnFail: false }), []);
+  assert.deepEqual(KIND_VIEW_CENSUS.map((t) => [t.table, kindOfTable(t)]), [
+    ['transactions', 'event'], ['investment_transactions', 'event'], ['reservations', 'event'],
+    ['securities', 'reference'], ['places_cache', 'reference'], ['regulatory_documents', 'reference'],
+    ['accounts', 'registry'],
+  ]);
+  for (const t of KIND_VIEW_CENSUS) {
+    if (Array.isArray(t.feed)) assert.equal(kindOfTable(t), kindOf(t.feed[0], t.feed[1]));
+  }
+  assert.deepEqual(tablesOfKind('snapshot'), []);
+  assert.deepEqual(tablesOfKind('derived'), []);
+  assert.deepEqual(tablesOfKind('posting'), []);
+  assert.equal(KIND_VIEWS_HONEST_LINE, 'Today the six are views over the feed tables — event: transactions, investment transactions, bookings; reference: securities, places, the law corpus; registry: accounts; snapshot: none yet; derived: none yet; posting: empty by law.');
+  assert.ok(STOPPED_TABLES.length >= 5, 'the unruled tables are reported');
+  assert.ok(STOPPED_TABLES.every((s) => !KIND_VIEW_CENSUS.some((t) => t.table === s.table)), 'a stopped table is never viewed');
+});
+
+test('the SQL: one CREATE VIEW per kind in the deck\'s order, the common columns in order on every branch, UNION ALL over exactly the kind\'s tables, an empty SELECT with a reason for the rest; posting unions nothing', () => {
+  const sql = kindViewsSql();
+  const views = parseViews(sql);
+  assert.deepEqual(views.map((v) => v.name), [...ARRIVAL_KINDS]);
+  for (const v of views) assert.deepEqual(v.columns, VIEW_COLUMNS.map(([n]) => n), `${v.name} columns`);
+  assert.deepEqual(views.find((v) => v.name === 'event')!.tables, ['transactions', 'investment_transactions', 'reservations']);
+  assert.deepEqual(views.find((v) => v.name === 'reference')!.tables, ['securities', 'places_cache', 'regulatory_documents']);
+  assert.deepEqual(views.find((v) => v.name === 'registry')!.tables, ['accounts']);
+  for (const k of ['snapshot', 'derived', 'posting']) {
+    const v = views.find((x) => x.name === k)!;
+    assert.deepEqual(v.tables, []);
+    assert.match(v.body, /WHERE false/);
+  }
+  assert.match(kindViewSql('posting'), /^-- posting: empty by the deck's own law/);
+  assert.match(kindViewSql('snapshot'), /plaid · holding lands in REBUILD-01 PR-2d/);
+  // the branches: the kind is a cast literal, the feed is the rule book's words, the filters keep the feed's rows only
+  const event = kindViewSql('event');
+  assert.match(event, /'event'::arrival_kind AS kind/);
+  assert.match(event, /'plaid · transaction' AS feed/);
+  assert.match(event, /'liteapi · booking' AS feed/);
+  assert.match(event, /WHERE r\.provider = 'liteapi'/);
+  assert.match(event, /JOIN accounts a ON a\.id = t\."accountId"/, 'user_id through accounts');
+  const reference = kindViewSql('reference');
+  assert.match(reference, /CASE s\.domain WHEN 'ecfr\.gov' THEN 'ecfr · title' WHEN 'uscode\.house\.gov' THEN 'us code · title' WHEN 'federalregister\.gov' THEN 'federal register · document' WHEN 'irs\.gov' THEN 'irs · bulletin' END AS feed/);
+  assert.match(reference, /WHERE s\.domain IN \('ecfr\.gov', 'uscode\.house\.gov', 'federalregister\.gov', 'irs\.gov'\)/);
+  assert.match(reference, /NULL::text AS user_id/, 'a shared reference row has no user');
+  assert.match(kindViewSql('registry'), /WHERE a\.source = 'plaid'/);
+});
+
+test('the migration is the generator\'s text verbatim, and the law passes over it', () => {
+  const sql = migration();
+  assert.ok(sql.includes(kindViewsSql()), 'never typed twice');
+  assert.deepEqual(kindViewsLaw({ throwOnFail: false, migrationSql: sql }), []);
+});
+
+test('the law fails when a feed table is missing from every view, in two views, in the wrong kind\'s view, when posting unions a table, or when a view\'s columns drift', () => {
+  const sql = kindViewsSql();
+  const missing = sql.replace(/  UNION ALL\n  SELECT 'reference'::arrival_kind AS kind,\n         'google places · place' AS feed,[\s\S]*?FROM places_cache p/, '');
+  assert.match(kindViewsLaw({ throwOnFail: false, migrationSql: missing }).join('\n'), /places_cache appears in 0 views, expected exactly 1/);
+  const twice = sql.replace(/CREATE VIEW registry AS\n/, 'CREATE VIEW registry AS\n  SELECT \'registry\'::arrival_kind AS kind, \'x\' AS feed, \'transactions\' AS table_name, t.id::text AS row_id, t.id::text AS their_id, NULL::text AS arrival_id, NULL::text AS user_id, now()::timestamptz AS arrived FROM transactions t\n  UNION ALL\n');
+  const v2 = kindViewsLaw({ throwOnFail: false, migrationSql: twice }).join('\n');
+  assert.match(v2, /transactions appears in 2 views/);
+  assert.match(v2, /registry unions \[accounts, transactions\]; the census \(through the rule book\) says \[accounts\]/);
+  const postingFull = sql.replace(/CREATE VIEW posting AS\n[\s\S]*?WHERE false;/, "CREATE VIEW posting AS\n  SELECT 'posting'::arrival_kind AS kind, 'x' AS feed, 'accounts' AS table_name, a.id::text AS row_id, a.id::text AS their_id, NULL::text AS arrival_id, NULL::text AS user_id, now()::timestamptz AS arrived FROM accounts a;");
+  assert.match(kindViewsLaw({ throwOnFail: false, migrationSql: postingFull }).join('\n'), /posting unions \[accounts\] — nothing ever arrives as a posting/);
+  const drifted = sql.replace(/NULL::text AS user_id,\n         NULL::timestamptz AS arrived\n  WHERE false;/, 'NULL::timestamptz AS arrived,\n         NULL::text AS user_id\n  WHERE false;');
+  assert.match(kindViewsLaw({ throwOnFail: false, migrationSql: drifted }).join('\n'), /carries \[kind feed table_name row_id their_id arrival_id arrived user_id\], not the common shape/);
+  // a census table whose branches resolve to two kinds is refused by the census law itself
+  const twoKinds: FeedTable = { table: 'mixed', label: 'mixed', feed: { column: 'x.k', map: { a: ['plaid', 'transaction'], b: ['plaid', 'security'] } }, rowId: 'x.id', theirId: 'x.id', arrivalId: null, userId: null, arrived: 'x.at', from: 'mixed x', why: 'test' };
+  assert.match(kindViewsLaw({ throwOnFail: false, census: [...KIND_VIEW_CENSUS, twoKinds] }).join('\n'), /mixed resolves to 2 kinds \(event, reference\)/);
+  // the honest line follows the census: drop a table and its name leaves the line
+  assert.equal(kindViewsHonestLine(KIND_VIEW_CENSUS.filter((t) => t.table !== 'reservations')), 'Today the six are views over the feed tables — event: transactions, investment transactions; reference: securities, places, the law corpus; registry: accounts; snapshot: none yet; derived: none yet; posting: empty by law.');
+});

--- a/src/lib/kindViews.ts
+++ b/src/lib/kindViews.ts
@@ -1,0 +1,274 @@
+/**
+ * TABLES-01 — SIX TABLES, ONE PER KIND, AS VIEWS OVER THE TYPED FEED TABLES.
+ *
+ * The deck's step 5: "create one table per kind: six tables, six names; the
+ * kind picks the table." Ruled: the typed feed tables stay (real columns,
+ * constraints, arrival_id); six VIEWS — reference · registry · event · derived
+ * · snapshot · posting — each with ONE common shape (VIEW_COLUMNS), union the
+ * feed tables of that kind. The kind per table comes from the rule book
+ * (src/lib/providers.ts kindOf) — never typed twice. Posting is empty by the
+ * deck's own law (nothing ever arrives as a posting); snapshot is empty until
+ * holdings land (PR-2d).
+ *
+ * THE CENSUS (KIND_VIEW_CENSUS) is the one source: every table whose rows come
+ * from a provider answer AND whose feed the rule book names, with its columns
+ * for the common shape. A table whose feed the book cannot name is REPORTED
+ * (STOPPED_TABLES), never guessed into a view. The migration
+ * (prisma/migrations/*_kind_views) is kindViewsSql() verbatim; the deck's
+ * step-5 honest line is KIND_VIEWS_HONEST_LINE; the README extracts both. The
+ * build (scripts/assert-tool-registry.ts) runs kindViewsLaw against the
+ * migration text: (a) every census table in exactly one view, (b) that view is
+ * the rule book's kind for the table's feed, (c) posting unions nothing,
+ * (d) all six views carry the common columns in the same order.
+ *
+ * Imports the rule book only; server- and client-safe (the deck renders the line).
+ */
+import { ARRIVAL_KINDS, kindOf, ruleFor, type ArrivalKind } from './providers';
+
+/** The common shape, in order: name · SQL type. */
+export const VIEW_COLUMNS = [
+  ['kind', 'arrival_kind'],
+  ['feed', 'text'],
+  ['table_name', 'text'],
+  ['row_id', 'text'],
+  ['their_id', 'text'],
+  ['arrival_id', 'text'],
+  ['user_id', 'text'],
+  ['arrived', 'timestamptz'],
+] as const;
+
+/** A fixed feed, or a feed picked per row by a column of the FROM clause (one kind for every branch). */
+export type FeedOf = readonly [providerCode: string, resource: string] | { readonly column: string; readonly map: Readonly<Record<string, readonly [string, string]>> };
+
+export interface FeedTable {
+  /** The SQL table name. */
+  table: string;
+  /** The deck's word for the honest line. */
+  label: string;
+  feed: FeedOf;
+  /** SQL expressions over the FROM clause below; row_id / their_id are cast to text by the generator. */
+  rowId: string;
+  theirId: string;
+  /** null → NULL::text (the table carries no arrival_id today). */
+  arrivalId: string | null;
+  /** null → NULL::text (a shared reference or cache row belongs to no user). */
+  userId: string | null;
+  /** The column that says when the row arrived; cast to timestamptz by the generator. */
+  arrived: string;
+  /** The FROM clause, alias and joins included. */
+  from: string;
+  /** A filter that keeps the feed's rows only (an authored or unruled row never rides a kind view). */
+  where?: string;
+  /** file:line — the writer and the columns, from the census. */
+  why: string;
+  /** Not a Prisma model — where it lives. */
+  outsidePrisma?: string;
+}
+
+/** The typed feed tables, sheet order by kind: event, reference, registry. Snapshot and derived have none the book names today. */
+export const KIND_VIEW_CENSUS: readonly FeedTable[] = [
+  {
+    table: 'transactions', label: 'transactions', feed: ['plaid', 'transaction'],
+    rowId: 't.id', theirId: 't."transactionId"', arrivalId: 't.arrival_id', userId: 'a."userId"', arrived: 't."createdAt"',
+    from: 'transactions t JOIN accounts a ON a.id = t."accountId"',
+    why: 'the one Plaid writer (sync-complete → src/lib/arrivals/plaidTransactionsPage.ts:114); user through accounts.userId (schema: transactions has no user column); arrival_id since PR-2',
+  },
+  {
+    table: 'investment_transactions', label: 'investment transactions', feed: ['plaid', 'investment_transaction'],
+    rowId: 'i.id', theirId: 'i.investment_transaction_id', arrivalId: 'i.arrival_id', userId: 'a."userId"', arrived: 'i."createdAt"',
+    from: 'investment_transactions i JOIN accounts a ON a.id = i."accountId"',
+    why: 'sync-complete → src/lib/arrivals/plaidInvestmentsPage.ts (creates / corrections); user through accounts.userId; arrival_id since PR-2c',
+  },
+  {
+    table: 'reservations', label: 'bookings', feed: ['liteapi', 'booking'],
+    rowId: 'r.id', theirId: 'r."providerBookingId"', arrivalId: null, userId: 'r."userId"', arrived: 'r."createdAt"',
+    from: 'reservations r', where: "r.provider = 'liteapi'",
+    why: "src/app/api/travel/liteapi/book/route.ts and liteapi/flights/book/route.ts write provider 'liteapi' (5 writes); the 2 'duffel' writes (src/app/api/flights/book/route.ts) are a provider the deck does not name — filtered out, reported; no arrival_id",
+  },
+  {
+    table: 'securities', label: 'securities', feed: ['plaid', 'security'],
+    rowId: 's.id', theirId: 's."securityId"', arrivalId: 's.arrival_id', userId: null, arrived: 's."createdAt"',
+    from: 'securities s',
+    why: 'sync-complete → plaidInvestmentsPage.ts (securities upsert); a shared reference row, no user column; arrival_id since PR-2c',
+  },
+  {
+    table: 'places_cache', label: 'places', feed: ['google_places', 'place'],
+    rowId: 'p.id', theirId: 'p."placeId"', arrivalId: null, userId: null, arrived: 'p."cachedAt"',
+    from: 'places_cache p',
+    why: 'src/lib/placesCache.ts (upsert by placeId); a cache of Google Places answers, no user column, no arrival_id',
+  },
+  {
+    table: 'regulatory_documents', label: 'the law corpus',
+    feed: { column: 's.domain', map: { 'ecfr.gov': ['ecfr', 'title'], 'uscode.house.gov': ['us_code', 'title'], 'federalregister.gov': ['federal_register', 'document'], 'irs.gov': ['irs', 'bulletin'] } },
+    rowId: 'd.id', theirId: 'd.citation_key', arrivalId: null, userId: null, arrived: 'd.retrieved_at',
+    from: 'regulatory_documents d JOIN regulatory_sources s ON s.id = d.source_id',
+    why: 'src/lib/corpus/db.ts:91 insertDocument (raw SQL); the source domain names the feed — ecfr-persist.ts:37, uscode-persist.ts:37, fedreg-persist.ts:36, irb-persist.ts:37; content_hash / raw_hash are its own fingerprints, no arrival_id',
+    outsidePrisma: 'prisma/migrations/20260503000000_pr_f_corpus_foundation/migration.sql (CREATE TABLE regulatory_documents; not a Prisma model)',
+  },
+  {
+    table: 'accounts', label: 'accounts', feed: ['plaid', 'account'],
+    rowId: 'a.id', theirId: 'a."accountId"', arrivalId: null, userId: 'a."userId"', arrived: 'a."createdAt"',
+    from: 'accounts a', where: "a.source = 'plaid'",
+    why: "src/app/api/plaid/exchange-token/route.ts:118 (create at link); rows with source 'manual' are authored (src/app/api/transactions/manual/route.ts:49) — filtered out; no arrival_id (accounts are never landed as objects)",
+  },
+];
+
+/** Tables whose rows come from a provider answer but whose feed the rule book does not name — reported, never viewed. */
+export const STOPPED_TABLES: ReadonlyArray<{ table: string; why: string }> = [
+  { table: 'reservations (provider duffel)', why: "2 writes carry provider 'duffel' (src/app/api/flights/book/route.ts) — duffel is not a provider the deck names; those rows are outside the event view" },
+  { table: 'trip_scanner_results', why: 'src/app/api/trips/[id]/ai-assistant/route.ts writes AI recommendations per trip/category; the book names no such feed (anthropic · classification is the only anthropic row)' },
+  { table: 'scan_snapshots', why: 'src/lib/convergence/snapshot-logger.ts writes our own scores over quotes — math we did, not a provider answer; no rule-book feed' },
+  { table: 'operations_ai_usage', why: 'src/lib/ai/recordUsage.ts:158 stores our AI calls (purpose, tokens, full_response) — the book\'s anthropic row is classification, not a usage log' },
+  { table: 'discovery_proposals', why: 'AI-authored proposals (src/lib/discovery); not the book\'s anthropic · classification by name' },
+  { table: 'plaid_items', why: "Plaid's item — a handshake (the access token lives here); the deck: handshakes never enter the tables; the book has no plaid · item row" },
+  { table: 'tastytrade_connections', why: 'a handshake (tokens); never data' },
+  { table: 'observatoryHealthLog', why: 'our probes of the providers (src/app/api/data-observatory) — not a provider feed' },
+];
+
+const feedLabel = (code: string, resource: string): string => {
+  const rule = ruleFor(code, resource);
+  if (!rule) throw new Error(`kind views: no rule for ${code} · ${resource}`);
+  return `${rule.provider} · ${rule.resource}`;
+};
+
+/** The one kind a table's feed resolves to — every branch of a per-row feed must agree, or the table is not one kind's. */
+export function kindOfTable(t: FeedTable): ArrivalKind {
+  if (Array.isArray(t.feed)) return kindOf(t.feed[0], t.feed[1]);
+  const m = t.feed as { column: string; map: Record<string, readonly [string, string]> };
+  const kinds = new Set(Object.values(m.map).map(([code, resource]) => kindOf(code, resource)));
+  if (kinds.size !== 1) throw new Error(`kind views: ${t.table} resolves to ${kinds.size} kinds (${[...kinds].join(', ')}) — a table is one kind's`);
+  return [...kinds][0];
+}
+
+export function tablesOfKind(kind: ArrivalKind, census: readonly FeedTable[] = KIND_VIEW_CENSUS): FeedTable[] {
+  return census.filter((t) => kindOfTable(t) === kind);
+}
+
+const q = (s: string) => `'${s.replace(/'/g, "''")}'`;
+
+function feedSql(t: FeedTable): string {
+  if (Array.isArray(t.feed)) return q(feedLabel(t.feed[0], t.feed[1]));
+  const m = t.feed as { column: string; map: Record<string, readonly [string, string]> };
+  return `CASE ${m.column} ${Object.entries(m.map).map(([v, [code, resource]]) => `WHEN ${q(v)} THEN ${q(feedLabel(code, resource))}`).join(' ')} END`;
+}
+
+function whereSql(t: FeedTable): string {
+  const parts: string[] = [];
+  if (!Array.isArray(t.feed)) {
+    const m = t.feed as { column: string; map: Record<string, readonly [string, string]> };
+    parts.push(`${m.column} IN (${Object.keys(m.map).map(q).join(', ')})`);
+  }
+  if (t.where) parts.push(t.where);
+  return parts.length ? `\n  WHERE ${parts.join(' AND ')}` : '';
+}
+
+/** One branch of a view: the common columns, in VIEW_COLUMNS order, over one feed table. */
+export function branchSql(t: FeedTable): string {
+  const kind = kindOfTable(t);
+  return [
+    `  SELECT ${q(kind)}::arrival_kind AS kind,`,
+    `         ${feedSql(t)} AS feed,`,
+    `         ${q(t.table)} AS table_name,`,
+    `         ${t.rowId}::text AS row_id,`,
+    `         ${t.theirId}::text AS their_id,`,
+    `         ${t.arrivalId ?? 'NULL'}::text AS arrival_id,`,
+    `         ${t.userId ?? 'NULL'}::text AS user_id,`,
+    `         ${t.arrived}::timestamptz AS arrived`,
+    `  FROM ${t.from}${whereSql(t)}`,
+  ].join('\n');
+}
+
+/** Why a kind's view unions nothing today — the comment the migration carries. */
+export const EMPTY_VIEW_WHY: Readonly<Partial<Record<ArrivalKind, string>>> = {
+  snapshot: 'no feed table holds a snapshot yet — plaid · holding lands in REBUILD-01 PR-2d',
+  derived: 'no feed table the rule book names holds a derived row — the AI tables (operations_ai_usage, discovery_proposals, trip_scanner_results, scan_snapshots) carry no rule-book feed (STOPPED_TABLES)',
+  posting: "empty by the deck's own law — nothing ever arrives as a posting; the system writes postings from events (step 10)",
+};
+
+const EMPTY_SELECT = `  SELECT ${VIEW_COLUMNS.map(([name, type]) => `NULL::${type} AS ${name}`).join(',\n         ')}\n  WHERE false`;
+
+/** CREATE VIEW <kind> — UNION ALL over exactly the census tables of that kind; an empty SELECT with the same columns when there are none. */
+export function kindViewSql(kind: ArrivalKind, census: readonly FeedTable[] = KIND_VIEW_CENSUS): string {
+  const tables = tablesOfKind(kind, census);
+  if (tables.length === 0) {
+    const why = EMPTY_VIEW_WHY[kind];
+    if (!why) throw new Error(`kind views: ${kind} has no feed table and no stated reason`);
+    return `-- ${kind}: ${why}\nCREATE VIEW ${kind} AS\n${EMPTY_SELECT};`;
+  }
+  return `-- ${kind}: ${tables.map((t) => t.table).join(', ')}\nCREATE VIEW ${kind} AS\n${tables.map(branchSql).join('\n  UNION ALL\n')};`;
+}
+
+/** The six, in the deck's order — the migration's body, verbatim. */
+export function kindViewsSql(census: readonly FeedTable[] = KIND_VIEW_CENSUS): string {
+  return ARRIVAL_KINDS.map((k) => kindViewSql(k, census)).join('\n\n');
+}
+
+/** The deck's step-5 honest line — every name from the census, none retyped. */
+export function kindViewsHonestLine(census: readonly FeedTable[] = KIND_VIEW_CENSUS): string {
+  const part = (kind: ArrivalKind): string => {
+    if (kind === 'posting') return 'posting: empty by law';
+    const names = tablesOfKind(kind, census).map((t) => t.label);
+    return `${kind}: ${names.length ? names.join(', ') : 'none yet'}`;
+  };
+  const order: ArrivalKind[] = ['event', 'reference', 'registry', 'snapshot', 'derived', 'posting'];
+  return `Today the six are views over the feed tables — ${order.map(part).join('; ')}.`;
+}
+
+export const KIND_VIEWS_HONEST_LINE = kindViewsHonestLine();
+
+/** Parse CREATE VIEW blocks out of migration text: name → { tables (FROM …), columns (the AS aliases of the first SELECT), unions }. */
+export function parseViews(sql: string): Array<{ name: string; tables: string[]; columns: string[]; body: string }> {
+  const out: Array<{ name: string; tables: string[]; columns: string[]; body: string }> = [];
+  for (const m of sql.matchAll(/CREATE VIEW (\w+) AS\n([\s\S]*?);/g)) {
+    const body = m[2];
+    const tables = [...body.matchAll(/FROM (\w+)/g)].map((x) => x[1]);
+    const firstSelect = body.split('UNION ALL')[0];
+    const columns = [...firstSelect.matchAll(/ AS (\w+)/g)].map((x) => x[1]);
+    out.push({ name: m[1], tables, columns, body });
+  }
+  return out;
+}
+
+/** THE KIND-VIEWS LAW. Over the census alone, and over a migration's text when given. */
+export function kindViewsLaw(opts: { throwOnFail?: boolean; census?: readonly FeedTable[]; migrationSql?: string } = {}): string[] {
+  const violations: string[] = [];
+  const census = opts.census ?? KIND_VIEW_CENSUS;
+  const seen = new Set<string>();
+  for (const t of census) {
+    if (seen.has(t.table)) violations.push(`kind views: ${t.table} is in the census twice`);
+    seen.add(t.table);
+    try { kindOfTable(t); } catch (e) { violations.push(`kind views: ${t.table}: ${(e as Error).message}`); }
+  }
+  const expectedColumns = VIEW_COLUMNS.map(([n]) => n);
+  if (opts.migrationSql !== undefined) {
+    const views = parseViews(opts.migrationSql);
+    const byName = new Map(views.map((v) => [v.name, v]));
+    for (const kind of ARRIVAL_KINDS) {
+      const v = byName.get(kind);
+      if (!v) { violations.push(`kind views: the migration has no CREATE VIEW ${kind}`); continue; }
+      // (d) the common columns, same order
+      if (v.columns.join(',') !== expectedColumns.join(',')) violations.push(`kind views: ${kind} carries [${v.columns.join(' ')}], not the common shape [${expectedColumns.join(' ')}]`);
+      // (a)(b) exactly the census tables of this kind, each once
+      const want = tablesOfKind(kind, census).map((t) => t.table).sort();
+      const have = [...v.tables].sort();
+      if (want.join(',') !== have.join(',')) violations.push(`kind views: ${kind} unions [${have.join(', ')}]; the census (through the rule book) says [${want.join(', ')}]`);
+      // the migration is the generator's text, verbatim — never typed twice
+      let expected: string | null = null;
+      try { expected = kindViewSql(kind, census); } catch { expected = null; }
+      if (expected !== null && !opts.migrationSql.includes(expected)) violations.push(`kind views: the migration's CREATE VIEW ${kind} is not kindViewSql('${kind}') verbatim`);
+    }
+    // (c) posting unions nothing
+    const posting = byName.get('posting');
+    if (posting && posting.tables.length !== 0) violations.push(`kind views: posting unions [${posting.tables.join(', ')}] — nothing ever arrives as a posting`);
+    // (a) every census table appears in exactly one view
+    for (const t of census) {
+      const n = views.filter((v) => v.tables.includes(t.table)).length;
+      if (n !== 1) violations.push(`kind views: ${t.table} appears in ${n} views, expected exactly 1`);
+    }
+    if (views.length !== ARRIVAL_KINDS.length) violations.push(`kind views: the migration creates ${views.length} views, expected ${ARRIVAL_KINDS.length}`);
+  }
+  if (violations.length && opts.throwOnFail !== false) throw new Error(`KIND VIEWS LAW failed:\n  ${violations.join('\n  ')}`);
+  return violations;
+}
+
+kindViewsLaw();


### PR DESCRIPTION
**Do not merge — Alex merges after Vercel Preview (SOC 2 gate).**

**HARD GATE — migration-bearing (views only).** Six `CREATE VIEW`s, no table change, no data. Applied by `prisma migrate deploy` at deploy. The generated Prisma client gains six read-only models (`prisma.event.findMany()` and the rest). Extra scrutiny asked.

## WHY

Step 5: "create one table per kind: six tables, six names; the kind picks the table." Ruled: the typed feed tables stay; six views — reference · registry · event · derived · snapshot · posting — each with ONE common shape, union the feed tables of that kind, the kind per table from the rule book, never typed twice. Posting is empty by the deck's own law.

## CENSUS — every table whose rows come from a provider answer (file:line on `main`)

Found by the model list the ruling names plus a grep of every provider client's files for `prisma.<model>.create / createMany / upsert`.

| Table | Feed (per `providers.ts`) | Kind | `arrival_id` today | User column | Arrived column | Writer |
|---|---|---|---|---|---|---|
| `transactions` | plaid · transaction | **event** | yes (PR-2) | none — through `accounts.userId` (join) | `createdAt` | sync-complete → `src/lib/arrivals/plaidTransactionsPage.ts:114` |
| `investment_transactions` | plaid · investment_transaction | **event** | yes (PR-2c) | none — through `accounts.userId` | `createdAt` | sync-complete → `plaidInvestmentsPage.ts` |
| `reservations` | liteapi · booking (**rows with `provider = 'liteapi'`**) | **event** | no | `userId` | `createdAt` | `src/app/api/travel/liteapi/book/route.ts`, `liteapi/flights/book/route.ts` (5 writes) |
| `securities` | plaid · security | **reference** | yes (PR-2c) | none (shared reference) | `createdAt` | sync-complete → `plaidInvestmentsPage.ts` |
| `places_cache` | google places · place | **reference** | no | none (a cache) | `cachedAt` | `src/lib/placesCache.ts` |
| `regulatory_documents` — **outside Prisma**: `prisma/migrations/20260503000000_pr_f_corpus_foundation/migration.sql` (CREATE TABLE), written by raw SQL `src/lib/corpus/db.ts:91` | by the source's domain: ecfr.gov → ecfr · title, uscode.house.gov → us code · title, federalregister.gov → federal register · document, irs.gov → irs · bulletin (`ecfr-persist.ts:37`, `uscode-persist.ts:37`, `fedreg-persist.ts:36`, `irb-persist.ts:37`) | **reference** (all four) | no — `content_hash` / `raw_hash` are its own fingerprints | none | `retrieved_at` | `src/lib/corpus/ingest/*-persist.ts` |
| `accounts` | plaid · account (**rows with `source = 'plaid'`**) | **registry** | no (accounts are never landed as objects) | `userId` | `createdAt` | `src/app/api/plaid/exchange-token/route.ts:118` |

**STOP RULE — reported, not guessed into a view** (rows from a provider answer, feed not nameable from the rule book):

| Table | Why it is not in a view |
|---|---|
| `reservations` rows with `provider = 'duffel'` | 2 writes (`src/app/api/flights/book/route.ts`); duffel is not a provider the deck names |
| `trip_scanner_results` | `src/app/api/trips/[id]/ai-assistant/route.ts` writes AI recommendations per trip/category; the book's only anthropic row is `classification` |
| `scan_snapshots` | `src/lib/convergence/snapshot-logger.ts` — our own scores over quotes; math we did, no rule-book feed |
| `operations_ai_usage` | `src/lib/ai/recordUsage.ts:158` — our AI calls (purpose, tokens, full_response); not `anthropic · classification` |
| `discovery_proposals` | AI-authored proposals; not the book's row by name |
| `plaid_items` | Plaid's item — a handshake (the access token lives here); "handshakes never enter the tables" |
| `tastytrade_connections` | a handshake (tokens) |
| `observatoryHealthLog` | our probes of the providers, not a feed |

Also excluded, as authored or metering rather than a provider answer: `commission_ledger`, `travel_search_usage`, `google_places_usage`, `rate_limit_hits`, `trip_itinerary`, `budget_line_items`, `regulatory_sources` (a seeded registry of sources). No table holds tastytrade quotes, finnhub, fred or sec answers (read-through; only `observatoryHealthLog` writes) — reference has no such table; no table holds holdings — snapshot has none (PR-2d); no ruled derived table exists.

## BUILD

| Piece | Change |
|---|---|
| `src/lib/kindViews.ts` (new) | **THE CENSUS** as a const (`KIND_VIEW_CENSUS`: table, feed or per-row feed map, the SQL expressions for the eight columns, the FROM/WHERE, the census note); `STOPPED_TABLES`; `kindOfTable` (the rule book's `kindOf`; a per-row feed whose branches resolve to two kinds throws); `kindViewSql` / `kindViewsSql` (UNION ALL over exactly the kind's tables; an empty `SELECT … WHERE false` with a stated reason for snapshot / derived / posting); `KIND_VIEWS_HONEST_LINE`; `parseViews`; **`kindViewsLaw`** — (a) every census table in exactly one view, (b) in the rule book's kind for its feed, (c) posting unions nothing, (d) all six carry the common columns in order, and the migration is the generator's text verbatim. |
| `prisma/migrations/20260907200000_kind_views/migration.sql` | `kindViewsSql()` verbatim under a header. No `OR REPLACE`: a second run fails loudly. |
| `prisma/schema.prisma` | `previewFeatures = ["views"]` — Prisma's views preview (https://www.prisma.io/docs/orm/prisma-schema/data-model/views; Prisma 5.22.0 in this repo; the CLI lists `views`). Migrate and `db push` do not manage views — the migration is their one source (verified: `db push` of this schema creates no view; `migrate diff` shows no drift from them). The six as `view` models with the common columns; `@@unique([table_name, row_id])` so the client can address a row. `prisma validate` ✓, `prisma generate` ✓. |
| `scripts/assert-tool-registry.ts` | **THE KIND-VIEWS LAW**: `kindViewsLaw` over the `*_kind_views` migration; the six `view` models with the common columns in order; the `views` preview on; the deck renders `{KIND_VIEWS_HONEST_LINE}`. |
| `src/components/landing/Landing.tsx` | step 5's honest line (the 12/13 idiom), rendered from the census const — one `<p>`, one import; every S-law untouched. |
| README (regenerated, byte-stable) | "The six tables (step 5, views)" — the shape, the unions, the census table, the reported tables, all extracted by running the leaf; gap row **05** added (TODAY = the honest line). |
| `src/lib/__tests__/kindViews.test.ts` | 4 tests. |

### The honest line (deck step 5 · README row 05 TODAY)

> Today the six are views over the feed tables — event: transactions, investment transactions, bookings; reference: securities, places, the law corpus; registry: accounts; snapshot: none yet; derived: none yet; posting: empty by law.

### The six view definitions — the migration body, verbatim

```sql
-- reference: securities, places_cache, regulatory_documents
CREATE VIEW reference AS
  SELECT 'reference'::arrival_kind AS kind,
         'plaid · security' AS feed,
         'securities' AS table_name,
         s.id::text AS row_id,
         s."securityId"::text AS their_id,
         s.arrival_id::text AS arrival_id,
         NULL::text AS user_id,
         s."createdAt"::timestamptz AS arrived
  FROM securities s
  UNION ALL
  SELECT 'reference'::arrival_kind AS kind,
         'google places · place' AS feed,
         'places_cache' AS table_name,
         p.id::text AS row_id,
         p."placeId"::text AS their_id,
         NULL::text AS arrival_id,
         NULL::text AS user_id,
         p."cachedAt"::timestamptz AS arrived
  FROM places_cache p
  UNION ALL
  SELECT 'reference'::arrival_kind AS kind,
         CASE s.domain WHEN 'ecfr.gov' THEN 'ecfr · title' WHEN 'uscode.house.gov' THEN 'us code · title' WHEN 'federalregister.gov' THEN 'federal register · document' WHEN 'irs.gov' THEN 'irs · bulletin' END AS feed,
         'regulatory_documents' AS table_name,
         d.id::text AS row_id,
         d.citation_key::text AS their_id,
         NULL::text AS arrival_id,
         NULL::text AS user_id,
         d.retrieved_at::timestamptz AS arrived
  FROM regulatory_documents d JOIN regulatory_sources s ON s.id = d.source_id
  WHERE s.domain IN ('ecfr.gov', 'uscode.house.gov', 'federalregister.gov', 'irs.gov');

-- registry: accounts
CREATE VIEW registry AS
  SELECT 'registry'::arrival_kind AS kind,
         'plaid · account' AS feed,
         'accounts' AS table_name,
         a.id::text AS row_id,
         a."accountId"::text AS their_id,
         NULL::text AS arrival_id,
         a."userId"::text AS user_id,
         a."createdAt"::timestamptz AS arrived
  FROM accounts a
  WHERE a.source = 'plaid';

-- event: transactions, investment_transactions, reservations
CREATE VIEW event AS
  SELECT 'event'::arrival_kind AS kind,
         'plaid · transaction' AS feed,
         'transactions' AS table_name,
         t.id::text AS row_id,
         t."transactionId"::text AS their_id,
         t.arrival_id::text AS arrival_id,
         a."userId"::text AS user_id,
         t."createdAt"::timestamptz AS arrived
  FROM transactions t JOIN accounts a ON a.id = t."accountId"
  UNION ALL
  SELECT 'event'::arrival_kind AS kind,
         'plaid · investment_transaction' AS feed,
         'investment_transactions' AS table_name,
         i.id::text AS row_id,
         i.investment_transaction_id::text AS their_id,
         i.arrival_id::text AS arrival_id,
         a."userId"::text AS user_id,
         i."createdAt"::timestamptz AS arrived
  FROM investment_transactions i JOIN accounts a ON a.id = i."accountId"
  UNION ALL
  SELECT 'event'::arrival_kind AS kind,
         'liteapi · booking' AS feed,
         'reservations' AS table_name,
         r.id::text AS row_id,
         r."providerBookingId"::text AS their_id,
         NULL::text AS arrival_id,
         r."userId"::text AS user_id,
         r."createdAt"::timestamptz AS arrived
  FROM reservations r
  WHERE r.provider = 'liteapi';

-- derived: no feed table the rule book names holds a derived row — the AI tables (operations_ai_usage, discovery_proposals, trip_scanner_results, scan_snapshots) carry no rule-book feed (STOPPED_TABLES)
CREATE VIEW derived AS
  SELECT NULL::arrival_kind AS kind,
         NULL::text AS feed,
         NULL::text AS table_name,
         NULL::text AS row_id,
         NULL::text AS their_id,
         NULL::text AS arrival_id,
         NULL::text AS user_id,
         NULL::timestamptz AS arrived
  WHERE false;

-- snapshot: no feed table holds a snapshot yet — plaid · holding lands in REBUILD-01 PR-2d
CREATE VIEW snapshot AS
  SELECT NULL::arrival_kind AS kind,
         NULL::text AS feed,
         NULL::text AS table_name,
         NULL::text AS row_id,
         NULL::text AS their_id,
         NULL::text AS arrival_id,
         NULL::text AS user_id,
         NULL::timestamptz AS arrived
  WHERE false;

-- posting: empty by the deck's own law — nothing ever arrives as a posting; the system writes postings from events (step 10)
CREATE VIEW posting AS
  SELECT NULL::arrival_kind AS kind,
         NULL::text AS feed,
         NULL::text AS table_name,
         NULL::text AS row_id,
         NULL::text AS their_id,
         NULL::text AS arrival_id,
         NULL::text AS user_id,
         NULL::timestamptz AS arrived
  WHERE false;
```

## VERIFY

| Check | Result |
|---|---|
| `npx tsc --noEmit` | exit 0 |
| eslint — 4 changed files | 0 / 0 (Landing.tsx baseline 0 / 0) |
| `DATABASE_URL=… npx prisma validate` | valid; `prisma generate` ✓ (the client lists the six view models) |
| `npm test` | **138 / 138** (134 + 4) |
| asserts + `next build` | showroom ✓ · tool registry ✓ · reachability 67 ✓ · family map ✓ · answers ✓ · arrivals law ✓ · rule book law ✓ · **kind views law ✓ — 6 views over 7 feed tables, each once, the kind from the rule book; posting unions nothing; 8 tables reported** · **BUILD EXIT 0** |
| README generator | exit 0; byte-stable on a second run |

### Tests (node:test)

```
ok 59 - the census: every table once, its kind from the rule book (never typed), and the deck's honest line names exactly those tables
ok 60 - the SQL: one CREATE VIEW per kind in the deck's order, the common columns in order on every branch, UNION ALL over exactly the kind's tables, an empty SELECT with a reason for the rest; posting unions nothing
ok 61 - the migration is the generator's text verbatim, and the law passes over it
ok 62 - the law fails when a feed table is missing from every view, in two views, in the wrong kind's view, when posting unions a table, or when a view's columns drift
```

Test 62 is the ruled negative: the `places_cache` branch removed from the SQL → `places_cache appears in 0 views, expected exactly 1`; `transactions` added to registry → `appears in 2 views` and `registry unions [accounts, transactions]; the census (through the rule book) says [accounts]`; posting unioning accounts → `posting unions [accounts] — nothing ever arrives as a posting`; two columns swapped → `not the common shape`; a census table whose branches resolve to two kinds → refused by the census law itself.

### The rehearsal — throwaway Postgres 16

The full schema pushed (`db push` created no view — Prisma's views preview leaves views to the migration), the corpus table created from its own migration's CREATE TABLE alone (that migration also needs pgvector, absent locally), then the six `CREATE VIEW`s in one transaction (exit 0). Seeded: 3 transactions (1 with an arrival), 2 investment transactions, 3 reservations (1 duffel), 2 securities, 1 place, 5 law documents (1 from an unnamed source, example.org), 3 accounts (1 manual).

| View | `count(*)` |
|---|---|
| event | **7** — 3 transactions (tx1 carries `arr_t1`), 2 investment transactions, 2 liteapi bookings; user u1 through the join |
| reference | **7** — 2 securities, 1 place, 4 law documents (`ecfr · title`, `us code · title`, `federal register · document`, `irs · bulletin`) |
| registry | **2** — the two plaid accounts |
| derived | 0 |
| snapshot | 0 |
| posting | **0** |

The duffel booking, the example.org document and the manual account appear in **no** view (0 hits across the three populated views). `information_schema.columns` reports every view as `kind arrival_kind, feed text, table_name text, row_id text, their_id text, arrival_id text, user_id text, arrived timestamptz`, in that order. `prisma.event.findMany()` returned the 7 rows and `prisma.posting.count()` 0 through the generated client. A second run of the migration failed loudly (`relation "reference" already exists`). `prisma migrate diff --from-url <db> --to-schema-datamodel` reported no drift from the views; its only line was `DROP TABLE "regulatory_documents"`, the corpus table that has always lived outside Prisma.

## Notes — stated plainly

- Not verified: production (Azure); the Vercel deploy that applies the migration.
- `arrived` is each feed table's own arrival column (the row's `createdAt` / `cachedAt` / `retrieved_at`), cast to `timestamptz`; `arrival_id` is the store's link where the table carries one. A pre-cutoff row shows `arrival_id` NULL, as its table does.
- `user_id` for transactions and investment transactions comes through `accounts.userId` (the tables carry no user column); a security, a place and a law document belong to no user.
- Rows an authored or unruled feed wrote never ride a kind view: `accounts.source = 'manual'`, `reservations.provider = 'duffel'`, corpus rows from a source domain the rule book does not name. Each exclusion is a filter in the generated SQL and a row in STOPPED_TABLES or the census note.
- Prisma's `views` preview: cited above; the alternative (a raw-SQL read helper) was not needed — the six `view` models validate, generate, and read. Migrate ignores them, so the migration is the views' one source and the build asserts the two agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc

---
_Generated by [Claude Code](https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc)_