### PR TITLE
DECK-TRUE-04: step 5's honest line after the closer's lead-in, in the 12/13 idiom

### DIFF
--- a/src/components/landing/Landing.tsx
+++ b/src/components/landing/Landing.tsx
@@ -3321,18 +3321,19 @@ export default function Landing({ onRequireAuth, onRequireLogin, logoAvailabilit
             ))}
           </div>
 
-          {/* TABLES-01: the honest line (the 12/13 idiom) — today the six are
-              views over the typed feed tables; the names come from the census
-              (src/lib/kindViews.ts), the kinds from the rule book. */}
-          <p className={`mt-[14px] ${DECK.statement}`}>{KIND_VIEWS_HONEST_LINE}</p>
-
           {/* PR-S5: the tail is ONE paragraph — the essay's consolidated
               Step 5 passage, verbatim, slide-01 body tier. The old kind
               table, the divider, the twenty-five-tools statement, the
               notice block and the census receipt all return inside it —
               they render nowhere else now. */}
           <p className="mt-8 max-w-[680px] text-[15px] leading-[1.6] text-text-secondary">Twenty-five tools, six tables; because we sorted by what a thing is, not by which tool it came from. But notice something strange here: (1) the outside world only ever fills four of the six — reference, registry, event, and snapshot; (2) derived is filled only by math we ordered, our AIs included; (3) and posting? Nothing from the outside world ever lands there. Nobody sends you debits and credits — the bookkeeping step builds those, from your own events. Remember that; it matters soon. We did not guess this. We classified every one of the 121 feeds — August 24, 2026 — and posting took zero. The data agreed!</p>
-          <p className="mt-[22px] lg:mt-9 text-[17px] lg:text-[28px] text-brand-purple">Everything so far arrived from the world. So where do the things you do live?</p>
+          <p className="mt-[22px] lg:mt-9 text-[17px] lg:text-[28px] text-brand-purple">Everything so far arrived from the world.</p>
+          {/* DECK-TRUE-04: the honest line (the 12/13 idiom) — muted, after the
+              closer's lead-in, before its question. Every table and feed name
+              comes from the kind-views census (src/lib/kindViews.ts), the kinds
+              from the rule book; the README's row 05 TODAY is the same const. */}
+          <p className={`mt-[14px] ${DECK.statement}`}>{KIND_VIEWS_HONEST_LINE}</p>
+          <p className="mt-[22px] lg:mt-9 text-[17px] lg:text-[28px] text-brand-purple">So where do the things you do live?</p>
         </div>
       </section>
 


### PR DESCRIPTION
**Do not merge — Alex merges after Vercel Preview (SOC 2 gate).**

Deck copy placement only. One file, one section, seven lines. No code path, no migration, no data, README unchanged.

## Finding first — the premise, corrected

The ruling says step 5's honest line is on the README and missing from the deck. On `main` it already renders on the deck: TABLES-01 (#1657) placed `{KIND_VIEWS_HONEST_LINE}` at `src/components/landing/Landing.tsx:3327`, muted (`DECK.statement`), **before the tail paragraph** ("Twenty-five tools, six tables…") and above the closer. What was missing is the **ruled placement** — after the closer's lead-in, before its question. This PR moves it there. Nothing else.

## Before / after — the deck-05 tail

Before (`main`, `Landing.tsx:3324-3335`):

```tsx
<p className={`mt-[14px] ${DECK.statement}`}>{KIND_VIEWS_HONEST_LINE}</p>

{/* PR-S5: the tail is ONE paragraph … */}
<p className="mt-8 max-w-[680px] …">Twenty-five tools, six tables; because we sorted by what a thing is, …</p>
<p className="mt-[22px] lg:mt-9 text-[17px] lg:text-[28px] text-brand-purple">Everything so far arrived from the world. So where do the things you do live?</p>
```

After:

```tsx
{/* PR-S5: the tail is ONE paragraph … */}
<p className="mt-8 max-w-[680px] …">Twenty-five tools, six tables; because we sorted by what a thing is, …</p>
<p className="mt-[22px] lg:mt-9 text-[17px] lg:text-[28px] text-brand-purple">Everything so far arrived from the world.</p>
{/* DECK-TRUE-04: the honest line (the 12/13 idiom) — muted, after the closer's lead-in, before its question … */}
<p className={`mt-[14px] ${DECK.statement}`}>{KIND_VIEWS_HONEST_LINE}</p>
<p className="mt-[22px] lg:mt-9 text-[17px] lg:text-[28px] text-brand-purple">So where do the things you do live?</p>
```

The closer's one paragraph becomes lead-in · honest line · question, the two closer sentences keeping their exact class string. The line itself is unchanged and still the census const — every table and feed name from `src/lib/kindViews.ts` (`KIND_VIEWS_HONEST_LINE`), never retyped:

> Today the six are views over the feed tables — event: transactions, investment transactions, bookings; reference: securities, places, the law corpus; registry: accounts; snapshot: none yet; derived: none yet; posting: empty by law.

## VERIFY

| Check | Result |
|---|---|
| byte-equal to README row 05's TODAY cell | the cell (`grep '^\| 05 \| ' README.md`, column 4) `cmp` the rendered const → **identical** (the generator reads the same const) |
| README regenerates unchanged | generator exit 0; `cmp` against `main`'s README → **byte-identical**; byte-stable on a second run |
| every S-law untouched | `git diff origin/main` on Landing.tsx: two hunks, both inside the deck-05 tail (`-3324,5` / `-3335`); zero changed lines declare or reference a law const |
| `npx tsc --noEmit` | exit 0 |
| eslint `Landing.tsx` | 0 / 0, same as main |
| asserts + `next build` | showroom ✓ · tool registry ✓ · reachability 67 ✓ · family map ✓ · answers ✓ · arrivals ✓ · rule book ✓ · **kind views ✓ (the deck still renders the const)** · **BUILD EXIT 0** |
| branch base | `e8253039` — main after #1655 merged, as ruled |

## Notes — stated plainly

- Not verified: the Vercel Preview.
- The 12/13 idiom on those slides is statement → hairline → question; deck-05 has no hairline, so the muted line sits between the closer's two sentences exactly as ruled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc

---
_Generated by [Claude Code](https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc)_