### PR TITLE
REBUILD-01 PR-4 + 4b: Stripe webhook events land raw-first; no secret at rest in the wire row either

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Five kinds arrive from outside; the sixth is never sent — the system writes po
 
 ### The rule book (step 4, applied)
 
-One written rule per feed — its kind — and the system applies it to every arrival of that feed: `src/lib/providers.ts` RULE_BOOK, 22 rows (the deck's 20 verbatim plus the 2 the deck's sample omits and the store lands). Landing consults it (`src/lib/arrivals/land.ts`): every arrival carries its kind (`arrivals.kind`, `prisma/migrations/20260907180000_arrival_kind/migration.sql` — the same rules applied to every row landed before it), and a feed with no rule is a loud failure, never a default. The build asserts the book against the deck, the schema's enum, the migration's UPDATEs and every landing call site.
+One written rule per feed — its kind — and the system applies it to every arrival of that feed: `src/lib/providers.ts` RULE_BOOK, 23 rows (the deck's 20 verbatim plus the 3 the deck's sample omits and the store lands). Landing consults it (`src/lib/arrivals/land.ts`): every arrival carries its kind (`arrivals.kind`, `prisma/migrations/20260907180000_arrival_kind/migration.sql` — the same rules applied to every row landed before it), and a feed with no rule is a loud failure, never a default. The build asserts the book against the deck, the schema's enum, the migration's UPDATEs and every landing call site.
 
 | Provider | Resource | Kind | Means | Row |
 |---|---|---|---|---|
@@ -154,6 +154,7 @@ One written rule per feed — its kind — and the system applies it to every ar
 | irs | bulletin | reference |  | deck |
 | plaid | security | reference |  | added |
 | plaid | investment_transaction | event |  | added |
+| stripe | event | event |  | added |
 
 ### The six tables (step 5, views)
 
@@ -264,7 +265,7 @@ BLUEPRINT is the step's headline; TODAY is the deck's honest-state line, verbati
 | Step | Blueprint | Today | Gap |
 |---|---|---|---|
 | 03 | Store what arrived. Then decide what it means. | the arrivals store holds 9,092 Plaid transactions, 712 investment transactions and 247 securities — every answer word for word, fingerprinted, status done — counted September 7, 2026; rows before September 3, 2026 carry no arrival. | the other providers (Stripe events, LiteAPI, tastytrade, the market and law feeds) land parsed; the three old Plaid writers still exist. |
-| 04 | One rule per feed. Written down. | rules are rows the system applies — src/lib/providers.ts RULE_BOOK, 22 rows (the deck's 20 plus plaid · security → reference and plaid · investment_transaction → event); every Plaid arrival carries its kind (transaction · event, investment_transaction · event, security · reference), stamped on landing and applied by the migration to every row landed before it; a feed with no rule cannot land. | the other providers' arrivals wait on their landing — nothing of theirs has arrived to be labeled; the 121 feeds' classification stays the August 24 census until each lands. |
+| 04 | One rule per feed. Written down. | rules are rows the system applies — src/lib/providers.ts RULE_BOOK, 23 rows (the deck's 20 plus plaid · security → reference, plaid · investment_transaction → event, stripe · event → event); every Plaid and Stripe arrival carries its kind (transaction · event, investment_transaction · event, security · reference, stripe event · event), stamped on landing and applied by the migration to every row landed before it; a feed with no rule cannot land. | the other providers' arrivals wait on their landing — nothing of theirs has arrived to be labeled; the 121 feeds' classification stays the August 24 census until each lands. |
 | 05 | The kind picks the table. | Today the six are views over the feed tables — event: transactions, investment transactions, bookings; reference: securities, places, the law corpus; registry: accounts; snapshot: none yet; derived: none yet; posting: empty by law. | snapshot waits on holdings (PR-2d); derived has no feed table the rule book names — the AI tables carry no rule-book row; posting is empty by law; 8 tables are reported, not viewed. |
 | 07 | Every tool runs the same four beats. Discover. Decide. Commit. Record. | This loop is the blueprint — the shape we're building every tool toward. Today, hotel bookings commit for real and an accepted task fires its build; the rest run discover → decide → draft, and commit is the beat we're wiring to the same loop, tool by tool. | commit is real for two tools (hotel bookings, accepted tasks); the other twenty-three stop at draft. |
 | 08 | One table holds everything you do. | The master table is the blueprint. Today each tool keeps its own table; one table holding every document is the shape we're building. | no master table; each tool keeps its own. |

--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -1,10 +1,18 @@
 import { NextRequest, NextResponse } from 'next/server';
 import Stripe from 'stripe';
+import type { Prisma } from '@prisma/client';
 import { prisma } from '@/lib/prisma';
 import { getStripe, getTierFromPriceId, getEntitlementKeyFromPriceId } from '@/lib/stripe';
 import { writeAuditLog } from '@/lib/audit/writeAuditLog';
+// REBUILD-01 PR-4: every delivery lands raw-first — the signed bytes, one arrival per event
+// (client_secret redacted and declared), the handler from the arrival, one transaction.
+import { prismaLanding } from '@/lib/arrivals/prismaLanding';
+import { customerIdOf, runStripeDelivery } from '@/lib/arrivals/stripeWebhook';
 
 const OWNER_EMAIL = process.env.OWNER_EMAIL;
+
+/** The handler's database — the delivery's transaction client (PR-4), so its writes roll back with the landing. writeAuditLog keeps its own hash-chained transaction. */
+type Db = Prisma.TransactionClient;
 
 // PAYWALL: every tier entitlement change lands in the tamper-evident audit log.
 // actor = external_integration (Stripe, authenticated by webhook signature);
@@ -75,7 +83,7 @@ function entitlementPeriodEnd(subscription: Stripe.Subscription): Date | null {
 // ENTITLEMENT-WRITER: the ONE place an entitlement row is written from a paid
 // event. Caller must have (a) verified the webhook signature and (b) derived
 // `key` from the RECOGNIZED price ID — never from metadata alone.
-async function grantEntitlement(opts: {
+async function grantEntitlement(db: Db, opts: {
   eventId: string;
   eventType: string;
   userId: string;
@@ -89,11 +97,11 @@ async function grantEntitlement(opts: {
   // Audit on state TRANSITIONS only — a renewal that refreshes the period end
   // without changing status updates the row silently (the row itself is the
   // record); a grant or revoke always lands in the audit log.
-  const previous = await prisma.userCategoryEntitlement.findUnique({
+  const previous = await db.userCategoryEntitlement.findUnique({
     where: { userId_categoryKey: { userId: opts.userId, categoryKey: opts.key } },
     select: { status: true },
   });
-  const row = await prisma.userCategoryEntitlement.upsert({
+  const row = await db.userCategoryEntitlement.upsert({
     where: { userId_categoryKey: { userId: opts.userId, categoryKey: opts.key } },
     create: {
       userId: opts.userId,
@@ -122,21 +130,60 @@ async function grantEntitlement(opts: {
   }
 }
 
-export async function POST(request: NextRequest) {
-  try {
-    const body = await request.text();
-    const signature = request.headers.get('stripe-signature');
-
-    if (!signature || !process.env.STRIPE_WEBHOOK_SECRET) {
-      return NextResponse.json({ error: 'Missing signature' }, { status: 400 });
+/**
+ * Who an event belongs to: the checkout session's metadata.userId when it names one
+ * of our users, else the user whose stripeCustomerId is the object's customer. Null
+ * → the arrival lands as a guest (guest_ref = the customer id, or event:<id>).
+ */
+async function userForEvent(db: Db, event: Stripe.Event): Promise<string | null> {
+  if (event.type === 'checkout.session.completed') {
+    const metaUserId = event.data.object.metadata?.userId;
+    if (metaUserId) {
+      const u = await db.users.findUnique({ where: { id: metaUserId }, select: { id: true } });
+      if (u) return u.id;
     }
+  }
+  const customerId = customerIdOf(event);
+  if (!customerId) return null;
+  const u = await db.users.findFirst({ where: { stripeCustomerId: customerId }, select: { id: true } });
+  return u?.id ?? null;
+}
 
-    const event = getStripe().webhooks.constructEvent(
-      body,
-      signature,
-      process.env.STRIPE_WEBHOOK_SECRET
-    );
+export async function POST(request: NextRequest) {
+  const rawBody = Buffer.from(await request.arrayBuffer());
+  const signature = request.headers.get('stripe-signature');
 
+  const outcome = await runStripeDelivery<Stripe.Event>(
+    prisma,
+    { rawBody, signature, secret: process.env.STRIPE_WEBHOOK_SECRET, receivedAt: new Date() },
+    (body, sig, secret) => getStripe().webhooks.constructEvent(body, sig, secret),
+    (tx) => {
+      const db = tx as Db;
+      return {
+        landing: prismaLanding(db),
+        userFor: (event) => userForEvent(db, event),
+        handle: (event) => handleStripeEvent(db, event),
+      };
+    },
+  );
+
+  if (!outcome.ok && outcome.failure === 'signature') {
+    // Nothing landed; Stripe's expected 400.
+    console.error('Stripe webhook:', outcome.error.message);
+    return NextResponse.json({ error: 'Invalid signature' }, { status: 400 });
+  }
+  if (!outcome.ok) {
+    // The delivery rolled back whole; a non-2xx makes Stripe redeliver.
+    console.error('Stripe webhook error:', outcome.error);
+    return NextResponse.json({ error: 'Webhook failed' }, { status: 500 });
+  }
+  const r = outcome.result;
+  console.log(`[stripe] ${r.type} ${r.eventId}: ${r.outcome}${r.handled ? '' : ' — handler skipped'}${r.redactions.length ? ` · redacted ${r.redactions.join(', ')}` : ''}${r.guestRef ? ` · guest ${r.guestRef}` : ''}`);
+  return NextResponse.json({ received: true, landed: r.outcome, handled: r.handled });
+}
+
+/** The existing handler, unchanged in what it does — it reads the ARRIVAL payload (PR-4) and writes through the delivery's transaction. */
+async function handleStripeEvent(db: Db, event: Stripe.Event): Promise<void> {
     switch (event.type) {
       case 'checkout.session.completed': {
         const session = event.data.object;
@@ -167,7 +214,7 @@ export async function POST(request: NextRequest) {
           const entitlementKey = getEntitlementKeyFromPriceId(priceId);
           const tier = getTierFromPriceId(priceId); // 'free' when not a tier price
 
-          const checkoutUser = await prisma.users.findUnique({ where: { id: userId } });
+          const checkoutUser = await db.users.findUnique({ where: { id: userId } });
           if (!checkoutUser || checkoutUser.email === OWNER_EMAIL) break;
 
           if (entitlementKey) {
@@ -181,7 +228,7 @@ export async function POST(request: NextRequest) {
               );
               break;
             }
-            await grantEntitlement({
+            await grantEntitlement(db, {
               eventId: event.id,
               eventType: event.type,
               userId,
@@ -192,7 +239,7 @@ export async function POST(request: NextRequest) {
               currentPeriodEnd: entitlementPeriodEnd(subscription),
             });
           } else if (tier !== 'free') {
-            await prisma.users.update({
+            await db.users.update({
               where: { id: userId },
               data: {
                 tier,
@@ -225,7 +272,7 @@ export async function POST(request: NextRequest) {
         const customerId = subscription.customer as string;
 
         // Find user by Stripe customer ID
-        const user = await prisma.users.findFirst({
+        const user = await db.users.findFirst({
           where: { stripeCustomerId: customerId },
         });
         if (!user || user.email === OWNER_EMAIL) break;
@@ -240,7 +287,7 @@ export async function POST(request: NextRequest) {
           // (past_due, canceled, unpaid…) → row inactive. Upsert covers the
           // renewal case and a race where 'updated' lands before 'completed'
           // — the key still comes ONLY from the recognized paid price.
-          await grantEntitlement({
+          await grantEntitlement(db, {
             eventId: event.id,
             eventType: event.type,
             userId: user.id,
@@ -268,7 +315,7 @@ export async function POST(request: NextRequest) {
         // 'free', non-active subscription → 'free'. A paid tier is only ever
         // set from a recognized price on an ACTIVE subscription.
         const effectiveTier = subscription.status === 'active' ? tier : 'free';
-        await prisma.users.update({
+        await db.users.update({
           where: { id: user.id },
           data: {
             tier: effectiveTier,
@@ -293,7 +340,7 @@ export async function POST(request: NextRequest) {
         const subscription = event.data.object;
         const customerId = subscription.customer as string;
 
-        const user = await prisma.users.findFirst({
+        const user = await db.users.findFirst({
           where: { stripeCustomerId: customerId },
         });
         if (!user || user.email === OWNER_EMAIL) break;
@@ -301,12 +348,12 @@ export async function POST(request: NextRequest) {
         // ENTITLEMENT-WRITER: if this subscription backs entitlement rows,
         // revoke exactly those rows (status → inactive, audit-logged) and do
         // NOT touch the user's tier.
-        const entitlementRows = await prisma.userCategoryEntitlement.findMany({
+        const entitlementRows = await db.userCategoryEntitlement.findMany({
           where: { userId: user.id, stripeSubscriptionId: subscription.id },
         });
         if (entitlementRows.length > 0) {
           for (const row of entitlementRows) {
-            await prisma.userCategoryEntitlement.update({
+            await db.userCategoryEntitlement.update({
               where: { id: row.id },
               data: { status: 'inactive' },
             });
@@ -334,7 +381,7 @@ export async function POST(request: NextRequest) {
           break;
         }
 
-        await prisma.users.update({
+        await db.users.update({
           where: { id: user.id },
           data: {
             tier: 'free',
@@ -356,9 +403,4 @@ export async function POST(request: NextRequest) {
       }
     }
 
-    return NextResponse.json({ received: true });
-  } catch (error) {
-    console.error('Stripe webhook error:', error);
-    return NextResponse.json({ error: 'Webhook failed' }, { status: 400 });
-  }
 }

--- a/src/lib/__tests__/providers.test.ts
+++ b/src/lib/__tests__/providers.test.ts
@@ -41,6 +41,7 @@ test('every ROUTING_RULES provider + resource pair resolves, spelled as the deck
   // RULEBOOK-01: resources come from the book — the deck's rows plus the two added plaid rows.
   assert.equal(PROVIDERS.flatMap((p) => p.resources).length, RULE_BOOK.length);
   assert.deepEqual(providerByDeck('plaid')?.resources, ['transaction', 'account', 'holding', 'security', 'investment_transaction']);
+  assert.deepEqual(providerByDeck('stripe')?.resources, ['payout', 'event']);
   assert.deepEqual(providerByDeck('teller')?.resources, []);
 });
 
@@ -57,7 +58,9 @@ test('the rule book: every deck row verbatim with the deck\'s kind, plus the two
     assert.equal(rule.source, 'deck');
     assert.equal(rule.code, providerCode(provider));
   }
-  assert.deepEqual(ADDED_RULES.map(([p, r, k]) => [p, r, k]), [['plaid', 'security', 'REFERENCE'], ['plaid', 'investment_transaction', 'EVENT']]);
+  assert.deepEqual(ADDED_RULES.map(([p, r, k]) => [p, r, k]), [['plaid', 'security', 'REFERENCE'], ['plaid', 'investment_transaction', 'EVENT'], ['stripe', 'event', 'EVENT']]);
+  assert.equal(kindOf('stripe', 'event'), 'event');
+  assert.equal(kindOf('stripe', 'payout'), 'event');
   assert.equal(ruleFor('plaid', 'security')?.source, 'added');
   assert.equal(new Set(RULE_BOOK.map((r) => `${r.provider} · ${r.resource}`)).size, RULE_BOOK.length, 'one rule per pair');
   assert.ok(RULE_BOOK.every((r) => r.kind !== 'posting'), 'nothing ever arrives as a posting');

--- a/src/lib/__tests__/stripeWebhook.test.ts
+++ b/src/lib/__tests__/stripeWebhook.test.ts
@@ -1,0 +1,206 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import Stripe from 'stripe';
+import { fingerprintOf, sha256 } from '../arrivals/land';
+import { STRIPE, STRIPE_EVENT, StripeSignatureError, customerIdOf, guestRefFor, landStripeEvent, redactClientSecrets, runStripeDelivery, verifyStripeDelivery, type StripeEventLike } from '../arrivals/stripeWebhook';
+import { kindOf } from '../providers';
+import { FakeLanding, snapshotClient } from './fakeLanding';
+
+// REBUILD-01 PR-4 — Stripe webhook events land raw-first. Hermetic: the real Stripe SDK signs
+// and verifies the fixture offline (generateTestHeaderString / constructEvent); the store is
+// the shared fake; the handler is a recorder.
+
+const SECRET = 'whsec_test_rebuild01_pr4';
+const stripe = new Stripe('sk_test_placeholder', { apiVersion: '2026-01-28.clover' });
+const NOW = new Date('2026-09-07T15:00:00Z');
+
+/** A payment_intent.succeeded delivery — the one event family that carries client_secret. */
+const fixture = (over: Record<string, unknown> = {}) => ({
+  id: 'evt_1PR4test0001',
+  object: 'event',
+  api_version: '2026-01-28.clover',
+  created: 1757257200,
+  livemode: false,
+  pending_webhooks: 1,
+  request: { id: 'req_abc', idempotency_key: null },
+  type: 'payment_intent.succeeded',
+  data: {
+    object: {
+      id: 'pi_3PR4test', object: 'payment_intent', amount: 12000, currency: 'usd', status: 'succeeded',
+      customer: 'cus_PR4customer', client_secret: 'pi_3PR4test_secret_DONOTSTORE',
+      metadata: { userId: 'u_alex' },
+      ...over,
+    },
+  },
+});
+const sign = (body: string) => stripe.webhooks.generateTestHeaderString({ payload: body, secret: SECRET });
+const verify = (rawBody: Buffer, signature: string, secret: string) => stripe.webhooks.constructEvent(rawBody, signature, secret) as unknown as StripeEventLike;
+const delivery = (body: string, signature = sign(body)) => ({ rawBody: Buffer.from(body, 'utf8'), signature, secret: SECRET, receivedAt: NOW });
+
+class Recorder {
+  calls: Array<{ event: StripeEventLike; outcome: string }> = [];
+  constructor(public userId: string | null = 'u_alex', private throwOn: string | null = null) {}
+  ports(landing: FakeLanding) {
+    return {
+      landing,
+      userFor: async () => this.userId,
+      handle: async (event: StripeEventLike, outcome: string) => {
+        if (this.throwOn === event.id) throw new Error('handler: Invalid `db.users.update()` invocation');
+        this.calls.push({ event, outcome });
+      },
+      now: () => NOW,
+    };
+  }
+}
+
+test('the rule book names the feed: stripe · event → event', () => {
+  assert.equal(kindOf(STRIPE, STRIPE_EVENT), 'event');
+});
+
+test('a signed fixture lands one response (the exact bytes, sha256) and one arrival (their_id = event.id, kind event, client_secret redacted and declared); the handler runs once, from the table, and never sees the secret', async () => {
+  const landing = new FakeLanding();
+  const rec = new Recorder();
+  const body = JSON.stringify(fixture());
+  const out = await runStripeDelivery(snapshotClient(landing), delivery(body), verify, () => rec.ports(landing));
+  assert.equal(out.ok, true);
+  if (!out.ok) return;
+  assert.deepEqual(out.result, { eventId: 'evt_1PR4test0001', type: 'payment_intent.succeeded', outcome: 'landed', redactions: ['data.object.client_secret'], handled: true, userId: 'u_alex', guestRef: null });
+  // the wire: exact bytes as signed (the secret is inside them — the ruling keeps the wire exact), sha256, 200 as received
+  assert.equal(landing.responses.length, 1);
+  const r = landing.responses[0];
+  assert.equal(r.provider, STRIPE);
+  assert.equal(r.resource, STRIPE_EVENT);
+  assert.equal(r.http_status, 200);
+  assert.equal(r.body.toString('utf8'), body);
+  assert.deepEqual(r.body_sha256, sha256(Buffer.from(body)));
+  assert.equal(r.user_id, 'u_alex');
+  assert.deepEqual(r.asked, NOW);
+  // the arrival: redacted payload, the path declared, the book's kind
+  assert.equal(landing.arrivals.size, 1);
+  const a = [...landing.arrivals.values()][0];
+  assert.equal(a.row.their_id, 'evt_1PR4test0001');
+  assert.equal(a.row.their_id_kind, 'provider');
+  assert.equal(a.row.kind, 'event');
+  assert.equal(a.row.resource, STRIPE_EVENT);
+  assert.deepEqual(a.row.redactions, ['data.object.client_secret']);
+  assert.equal((a.row.payload as { data: { object: { client_secret: unknown } } }).data.object.client_secret, null);
+  assert.equal((a.row.payload as { data: { object: { amount: number } } }).data.object.amount, 12000);
+  assert.equal(a.status, 'done');
+  assert.deepEqual(a.read, NOW);
+  assert.equal(a.row.response_id, r.id);
+  assert.equal(Buffer.compare(Buffer.from(a.row.fingerprint), fingerprintOf(redactClientSecrets(fixture() as never).payload)), 0, 'the fingerprint is over the redacted payload');
+  // the handler: once, from the arrival (no secret), outcome landed
+  assert.equal(rec.calls.length, 1);
+  assert.equal(rec.calls[0].outcome, 'landed');
+  assert.equal((rec.calls[0].event.data.object as { client_secret: unknown }).client_secret, null);
+  assert.equal(rec.calls[0].event.id, 'evt_1PR4test0001');
+});
+
+test('the same delivery again → already_landed, one response more, no new arrival, and the handler is not called twice; a changed redelivery (same id, new content) → corrected and the handler runs', async () => {
+  const landing = new FakeLanding();
+  const rec = new Recorder();
+  const client = snapshotClient(landing);
+  const body = JSON.stringify(fixture());
+  await runStripeDelivery(client, delivery(body), verify, () => rec.ports(landing));
+  const again = await runStripeDelivery(client, delivery(body), verify, () => rec.ports(landing));
+  assert.equal(again.ok, true);
+  if (!again.ok) return;
+  assert.equal(again.result.outcome, 'already_landed');
+  assert.equal(again.result.handled, false);
+  assert.equal(landing.responses.length, 2, 'every delivery is evidence of the delivery');
+  assert.equal(landing.arrivals.size, 1, 'the store\'s UNIQUE is the dedup');
+  assert.equal(rec.calls.length, 1, 'the handler did not re-run');
+  // a client_secret rotates but nothing else changes → same redacted content → still the same thing
+  const rotated = JSON.stringify(fixture({ client_secret: 'pi_3PR4test_secret_ROTATED' }));
+  const r3 = await runStripeDelivery(client, delivery(rotated), verify, () => rec.ports(landing));
+  assert.equal(r3.ok && r3.result.outcome, 'already_landed', 'the fingerprint is over the redacted payload, so a rotated secret is not a correction');
+  assert.equal(rec.calls.length, 1);
+  // Stripe corrects the amount → a new row, the handler runs
+  const changed = JSON.stringify(fixture({ amount: 12500 }));
+  const r4 = await runStripeDelivery(client, delivery(changed), verify, () => rec.ports(landing));
+  assert.equal(r4.ok && r4.result.outcome, 'corrected');
+  assert.equal(r4.ok && r4.result.handled, true);
+  assert.equal(landing.rowsFor('evt_1PR4test0001').length, 2);
+  assert.equal(rec.calls.length, 2);
+  assert.equal(rec.calls[1].outcome, 'corrected');
+  assert.equal((rec.calls[1].event.data.object as { amount: number }).amount, 12500);
+});
+
+test('a tampered signature, a missing header, or a missing secret lands nothing and is declared as a signature failure (the route answers 400)', async () => {
+  const landing = new FakeLanding();
+  const rec = new Recorder();
+  const client = snapshotClient(landing);
+  const body = JSON.stringify(fixture());
+  // the body is altered after signing: the header signs the original, the bytes delivered are not it
+  const tampered = await runStripeDelivery(client, delivery(body + ' ', sign(body)), verify, () => rec.ports(landing));
+  assert.equal(tampered.ok, false);
+  if (tampered.ok) return;
+  assert.equal(tampered.failure, 'signature');
+  assert.ok(tampered.error instanceof StripeSignatureError);
+  assert.match(tampered.error.message, /signature verification failed/);
+  const wrongSecret = await runStripeDelivery(client, { ...delivery(body), secret: 'whsec_other' }, verify, () => rec.ports(landing));
+  assert.equal(!wrongSecret.ok && wrongSecret.failure, 'signature');
+  const missing = await runStripeDelivery(client, delivery(body, null as unknown as string), verify, () => rec.ports(landing));
+  assert.equal(!missing.ok && missing.failure, 'signature');
+  assert.throws(() => verifyStripeDelivery({ ...delivery(body), secret: undefined }, verify), /STRIPE_WEBHOOK_SECRET is not set/);
+  assert.equal(landing.responses.length, 0, 'nothing landed');
+  assert.equal(landing.arrivals.size, 0);
+  assert.equal(rec.calls.length, 0);
+});
+
+test('no user matches → the arrival lands as a guest with guest_ref = the customer id; no customer on the object → event:<id>; never dropped', async () => {
+  const landing = new FakeLanding();
+  const rec = new Recorder(null);
+  const body = JSON.stringify(fixture());
+  const out = await runStripeDelivery(snapshotClient(landing), delivery(body), verify, () => rec.ports(landing));
+  assert.equal(out.ok && out.result.guestRef, 'cus_PR4customer');
+  assert.equal(landing.responses[0].user_id, null);
+  assert.equal(landing.responses[0].guest_ref, 'cus_PR4customer');
+  assert.equal([...landing.arrivals.values()][0].row.guest_ref, 'cus_PR4customer');
+  const noCustomer = fixture({ customer: null });
+  noCustomer.id = 'evt_1PR4nocustomer';
+  const out2 = await runStripeDelivery(snapshotClient(landing), delivery(JSON.stringify(noCustomer)), verify, () => rec.ports(landing));
+  assert.equal(out2.ok && out2.result.guestRef, 'event:evt_1PR4nocustomer');
+  assert.equal(customerIdOf({ id: 'e', type: 't', data: { object: { customer: { id: 'cus_expanded' } } } }), 'cus_expanded');
+  assert.equal(guestRefFor({ id: 'e9', type: 't', data: { object: {} } }), 'event:e9');
+});
+
+test('redactClientSecrets blanks every client_secret at any depth and lists each path; a payload without one is returned equal with no redactions', () => {
+  const nested = {
+    id: 'evt_x', type: 'invoice.paid',
+    data: {
+      object: { id: 'in_1', client_secret: 'top', confirmation_secret: { client_secret: 'cs_inner', type: 'payment_intent' }, lines: [{ id: 'il_1' }, { id: 'il_2', client_secret: 'in_array' }] },
+      previous_attributes: { client_secret: 'prev' },
+    },
+  };
+  const { payload, redactions } = redactClientSecrets(nested);
+  assert.deepEqual(redactions, ['data.object.client_secret', 'data.object.confirmation_secret.client_secret', 'data.object.lines[1].client_secret', 'data.previous_attributes.client_secret']);
+  const p = payload as typeof nested;
+  assert.equal(p.data.object.client_secret, null);
+  assert.equal(p.data.object.confirmation_secret.client_secret, null);
+  assert.equal(p.data.object.lines[1].client_secret, null);
+  assert.equal(p.data.previous_attributes.client_secret, null);
+  assert.equal(p.data.object.confirmation_secret.type, 'payment_intent', 'everything else untouched');
+  assert.equal(nested.data.object.client_secret, 'top', 'the input is not mutated');
+  const clean = { id: 'evt_c', type: 'customer.subscription.updated', data: { object: { id: 'sub_1', customer: 'cus_1', client_secret: null } } };
+  const c = redactClientSecrets(clean);
+  assert.deepEqual(c.redactions, [], 'a null client_secret is not a secret');
+  assert.deepEqual(c.payload, clean);
+});
+
+test('a handler throw rolls the whole delivery back — no response row, no arrival — and is declared as a landing failure', async () => {
+  const landing = new FakeLanding();
+  const rec = new Recorder('u_alex', 'evt_1PR4test0001');
+  const client = snapshotClient(landing);
+  const out = await runStripeDelivery(client, delivery(JSON.stringify(fixture())), verify, () => rec.ports(landing));
+  assert.equal(out.ok, false);
+  if (out.ok) return;
+  assert.equal(out.failure, 'landing');
+  assert.match(String((out.error as Error).message), /handler: Invalid/);
+  assert.equal(landing.responses.length, 0);
+  assert.equal(landing.arrivals.size, 0);
+  // landStripeEvent itself, driven directly: the row lands before the handler, so the throw is the rollback's job
+  const landing2 = new FakeLanding();
+  await assert.rejects(landStripeEvent(rec.ports(landing2), { rawBody: Buffer.from('{}'), event: fixture() as unknown as StripeEventLike, receivedAt: NOW }), /handler: Invalid/);
+  assert.equal(landing2.arrivals.size, 1, 'without a transaction the row would stay — the transaction is what makes it whole');
+});

--- a/src/lib/arrivals/land.ts
+++ b/src/lib/arrivals/land.ts
@@ -9,8 +9,10 @@
  *                    object, fingerprint = sha256 of its RFC 8785 canonical
  *                    bytes (the `canonicalize` package — JCS, never hand-rolled),
  *                    their_id = the provider's own id (their_id_kind
- *                    'provider'), redactions [] (the PR-2 audit found no secret
- *                    in a /transactions/get body), response_id set, status
+ *                    'provider'), redactions = the paths the caller blanked
+ *                    before landing ([] for Plaid — the PR-2 audit found no
+ *                    secret in a /transactions/get body; PR-4 declares the
+ *                    Stripe client_secret paths), response_id set, status
  *                    pending, kind = the rule book's kind for (provider,
  *                    resource) (RULEBOOK-01 — no rule, no row: NoRuleError
  *                    before anything is built). INSERT … ON CONFLICT (provider, their_id,
@@ -160,6 +162,8 @@ export async function landResponse(db: LandingDb, answer: WireAnswer): Promise<L
 export interface ObjectToLand {
   theirId: string;
   payload: JsonObject;
+  /** PR-4: every path blanked in `payload` before landing (a secret never lands); [] when nothing was. */
+  redactions?: string[];
 }
 
 export interface LandObjectsInput {
@@ -208,7 +212,7 @@ export async function landObjects(db: LandingDb, input: LandObjectsInput): Promi
       their_id_kind: 'provider',
       payload: o.payload,
       fingerprint,
-      redactions: [],
+      redactions: o.redactions ?? [],
       asked: input.asked,
       arrived: input.arrived,
       response_id: input.responseId,

--- a/src/lib/arrivals/stripeWebhook.ts
+++ b/src/lib/arrivals/stripeWebhook.ts
@@ -1,0 +1,210 @@
+/**
+ * REBUILD-01 PR-4 — STRIPE WEBHOOK EVENTS LAND RAW-FIRST.
+ *
+ * The deck's step 2 puts card money on Stripe; the webhook route verified the
+ * signature, acted on the event, and dropped the raw body. Now, per delivery:
+ *
+ *   verifyStripeDelivery — the SDK's constructEvent over the exact bytes; a
+ *                          missing or bad signature throws
+ *                          StripeSignatureError BEFORE anything lands (the
+ *                          route answers Stripe's expected 400).
+ *   landStripeEvent      — inside the caller's transaction: landResponse (the
+ *                          verified raw body bytes, http_status 200 as
+ *                          received; asked = arrived = when the delivery hit
+ *                          us) → redactClientSecrets on a copy of the event
+ *                          (every `client_secret` key at any depth blanked,
+ *                          each path declared) → landObjects one arrival
+ *                          (stripe · event, their_id = event.id, kind event by
+ *                          the rule book) → the handler runs FROM THE ARRIVAL
+ *                          PAYLOAD read back from the table, never from the
+ *                          request → markRead. A redelivered event (same id,
+ *                          same fingerprint) is already_landed and the handler
+ *                          does NOT re-run — the store's UNIQUE is the dedup; a
+ *                          changed redelivery (same id, new fingerprint) is
+ *                          corrected and the handler runs.
+ *   runStripeDelivery    — verify, then the transaction; a throw inside rolls
+ *                          the delivery back and comes out declared.
+ *
+ * WHO OWNS AN EVENT: the caller's userFor port (the route: the session's
+ * metadata.userId, else users.stripeCustomerId = the object's customer). No
+ * user → the arrival lands with guest_ref = the customer id (guestRefFor), or
+ * `event:<id>` when the object carries no customer — declared, never dropped.
+ *
+ * THE ONE SECRET: Stripe's own docs on `client_secret` (PaymentIntent,
+ * SetupIntent — "It should not be stored, logged, or exposed to anyone other
+ * than the customer"; the SDK carries the same words on Source and on an
+ * Invoice's confirmation_secret). The redaction is by key name at any depth,
+ * so every carrier is covered; the paths blanked ride `redactions`.
+ *
+ * Pure over ports (LandingDb, verify, userFor, handle) so node:test drives it
+ * with the real SDK's signing helper and a fake store.
+ */
+import type { ArrivalOutcome, JsonObject, LandingDb } from './land';
+import { landObjects, landResponse, markRead } from './land';
+
+export const STRIPE = 'stripe';
+export const STRIPE_EVENT = 'event';
+
+/** The Stripe event fields the landing reads; the SDK's Stripe.Event satisfies it (its data.object is a typed union, so only `customer` is named here). */
+export interface StripeEventLike {
+  id: string;
+  type: string;
+  account?: string | null;
+  data: { object: object };
+}
+
+export class StripeSignatureError extends Error {
+  constructor(reason: string) {
+    super(`stripe webhook: ${reason} — nothing landed`);
+    this.name = 'StripeSignatureError';
+  }
+}
+
+export interface StripeDelivery {
+  rawBody: Buffer;
+  signature: string | null;
+  secret: string | null | undefined;
+  receivedAt: Date;
+}
+
+/** constructEvent, or throw StripeSignatureError. Runs before any transaction: a bad delivery costs no row. */
+export function verifyStripeDelivery<E extends StripeEventLike>(
+  delivery: StripeDelivery,
+  verify: (rawBody: Buffer, signature: string, secret: string) => E,
+): E {
+  if (!delivery.signature) throw new StripeSignatureError('missing stripe-signature header');
+  if (!delivery.secret) throw new StripeSignatureError('STRIPE_WEBHOOK_SECRET is not set');
+  try {
+    return verify(delivery.rawBody, delivery.signature, delivery.secret);
+  } catch (e) {
+    throw new StripeSignatureError(`signature verification failed: ${e instanceof Error ? e.message : String(e)}`);
+  }
+}
+
+const isPlainObject = (v: unknown): v is Record<string, unknown> => typeof v === 'object' && v !== null && !Array.isArray(v);
+
+/** A deep copy with every `client_secret` (any depth, non-null) set to null; the paths blanked, in document order. */
+export function redactClientSecrets(payload: JsonObject): { payload: JsonObject; redactions: string[] } {
+  const redactions: string[] = [];
+  const walk = (v: unknown, path: string): unknown => {
+    if (Array.isArray(v)) return v.map((x, i) => walk(x, `${path}[${i}]`));
+    if (!isPlainObject(v)) return v;
+    const out: Record<string, unknown> = {};
+    for (const [k, x] of Object.entries(v)) {
+      const here = path ? `${path}.${k}` : k;
+      if (k === 'client_secret' && x !== null && x !== undefined) { out[k] = null; redactions.push(here); continue; }
+      out[k] = walk(x, here);
+    }
+    return out;
+  };
+  return { payload: walk(payload, '') as JsonObject, redactions };
+}
+
+/** The customer id the event's object carries (a string or an expanded object), or null. */
+export function customerIdOf(event: StripeEventLike): string | null {
+  const c = (event.data.object as { customer?: unknown }).customer;
+  if (typeof c === 'string' && c) return c;
+  if (isPlainObject(c) && typeof c.id === 'string') return c.id;
+  return null;
+}
+
+/** With no user matched: the customer id, or the event's own id when the object names no customer — declared, never dropped. */
+export function guestRefFor(event: StripeEventLike): string {
+  return customerIdOf(event) ?? `event:${event.id}`;
+}
+
+export interface StripeLandingPorts<E extends StripeEventLike> {
+  landing: LandingDb;
+  /** Who the event belongs to; null → the arrival lands as a guest (guestRefFor). */
+  userFor(event: E): Promise<string | null>;
+  /** The existing handler — runs from the arrival payload, once per new arrival (landed or corrected), never on already_landed. */
+  handle(event: E, outcome: ArrivalOutcome): Promise<void>;
+  now?: () => Date;
+}
+
+export interface StripeLandingResult {
+  eventId: string;
+  type: string;
+  outcome: ArrivalOutcome;
+  /** The paths blanked before landing. */
+  redactions: string[];
+  /** Whether the handler ran for this delivery. */
+  handled: boolean;
+  userId: string | null;
+  guestRef: string | null;
+}
+
+/** Inside the caller's transaction: land the bytes, land the (redacted) event, run the handler from the table, mark read. Throws to roll the delivery back. */
+export async function landStripeEvent<E extends StripeEventLike>(
+  ports: StripeLandingPorts<E>,
+  input: { rawBody: Buffer; event: E; receivedAt: Date },
+): Promise<StripeLandingResult> {
+  const { event } = input;
+  const userId = await ports.userFor(event);
+  const guestRef = userId === null ? guestRefFor(event) : null;
+  const response = await landResponse(ports.landing, {
+    provider: STRIPE,
+    resource: STRIPE_EVENT,
+    userId,
+    guestRef,
+    httpStatus: 200,
+    body: input.rawBody,
+    asked: input.receivedAt,
+    arrived: input.receivedAt,
+  });
+  const redacted = redactClientSecrets(event as unknown as JsonObject);
+  const landed = await landObjects(ports.landing, {
+    provider: STRIPE,
+    resource: STRIPE_EVENT,
+    connection: event.account ?? null,
+    userId,
+    guestRef,
+    responseId: response.id,
+    asked: input.receivedAt,
+    arrived: input.receivedAt,
+    objects: [{ theirId: event.id, payload: redacted.payload, redactions: redacted.redactions }],
+  });
+  const row = landed.rows[0];
+  if (!row) throw new Error(`stripe webhook: ${event.id} landed no row — the table is not answering`);
+  let handled = false;
+  if (row.outcome !== 'already_landed') {
+    // The handler reads the arrival, never the request.
+    await ports.handle(row.payload as E, row.outcome);
+    handled = true;
+    await markRead(ports.landing, [row.id], (ports.now ?? (() => new Date()))());
+  }
+  return { eventId: event.id, type: event.type, outcome: row.outcome, redactions: redacted.redactions, handled, userId, guestRef };
+}
+
+export interface DeliveryClient {
+  $transaction<T>(fn: (tx: unknown) => Promise<T>, options?: { maxWait?: number; timeout?: number }): Promise<T>;
+}
+
+export type StripeDeliveryResult =
+  | { ok: true; result: StripeLandingResult }
+  | { ok: false; failure: 'signature'; error: StripeSignatureError }
+  | { ok: false; failure: 'landing'; error: unknown };
+
+/** Verify (no row), then one transaction: land + handle + mark read. A throw inside rolls the delivery back and is declared. */
+export async function runStripeDelivery<E extends StripeEventLike>(
+  client: DeliveryClient,
+  delivery: StripeDelivery,
+  verify: (rawBody: Buffer, signature: string, secret: string) => E,
+  ports: (tx: unknown) => StripeLandingPorts<E>,
+): Promise<StripeDeliveryResult> {
+  let event: E;
+  try {
+    event = verifyStripeDelivery(delivery, verify);
+  } catch (e) {
+    return { ok: false, failure: 'signature', error: e as StripeSignatureError };
+  }
+  try {
+    const result = await client.$transaction(
+      (tx) => landStripeEvent(ports(tx), { rawBody: delivery.rawBody, event, receivedAt: delivery.receivedAt }),
+      { maxWait: 10_000, timeout: 120_000 },
+    );
+    return { ok: true, result };
+  } catch (error) {
+    return { ok: false, failure: 'landing', error };
+  }
+}

--- a/src/lib/providers.ts
+++ b/src/lib/providers.ts
@@ -17,7 +17,8 @@
  * every (provider, resource) with its KIND — the deck's ROUTING_RULES rows
  * verbatim plus ADDED_RULES, the rows the deck's twenty-row sample omits but
  * the store lands (plaid · security → reference, plaid · investment_transaction
- * → event; plaid · holding → snapshot is already a deck row). Landing consults
+ * → event, stripe · event → event; plaid · holding → snapshot is already a deck
+ * row). Landing consults
  * it (src/lib/arrivals/land.ts kindOf): every arrival carries its kind, and an
  * arrival with no rule is a loud failure — no default, ever. The six kinds are
  * the deck's HANDOFF_KINDS in the essay's order; nothing ever ARRIVES as a
@@ -84,6 +85,8 @@ export const ROUTING_RULES = [
 export const ADDED_RULES = [
   ['plaid', 'security', 'REFERENCE', ''],
   ['plaid', 'investment_transaction', 'EVENT', ''],
+  // REBUILD-01 PR-4: the webhook delivers Stripe EVENTS (the deck's row names the payout the events carry).
+  ['stripe', 'event', 'EVENT', ''],
 ] as const;
 
 /**


### PR DESCRIPTION
**Do not merge — Alex merges after Vercel Preview (SOC 2 gate).**

**Migration-bearing since PR-4b (one column):** `provider_responses.redactions text[] NOT NULL DEFAULT '{}'`, additive, applied by `prisma migrate deploy` at deploy; every existing row reads `'{}'`, which is true of them. Touches the money-event path (the Stripe webhook, the entitlement and tier writer): the handler's logic is unchanged; what changes is that every delivery lands first, with no secret at rest, and the handler reads the arrival. Extra scrutiny asked.

Two commits on this branch: **PR-4** (`d80b6d49`) — events land raw-first; **PR-4b** (the second commit) — the wire row is redacted and declared too.

## WHY

The deck's step 2 puts card money on Stripe; `stripe/webhook/route.ts` verified the signature, acted on the event, and dropped the raw body. Ruled: the signed body is the exact wire, each event is one arrival (their_id = event.id, kind event), the one secret is redacted and declared, the handler reads the arrival, not the request. **PR-4b, ruled (Q3):** secrets are redacted before landing, the fingerprint covers the redacted bytes, and the redaction is declared on the row — for the wire row as for the arrival.

## AUDIT — the webhook route end to end (file:line on `main` before this PR)

| Fact | Where |
|---|---|
| **The route.** `request.text()` → `stripe-signature` header; missing header or `STRIPE_WEBHOOK_SECRET` → 400 "Missing signature"; `getStripe().webhooks.constructEvent(body, signature, secret)` (SDK 20.3.0, API `2026-01-28.clover`, `src/lib/stripe.ts:11-12`); a `switch (event.type)`; any throw → 400 "Webhook failed"; success → `{ received: true }`. The raw body was never stored. | `src/app/api/stripe/webhook/route.ts:125-139, :359-363` |
| **Event types handled**: `checkout.session.completed` (:141-220), `customer.subscription.updated` (:222-290), `customer.subscription.deleted` (:292-356). Every other type fell through the switch — acknowledged, unrecorded. | `route.ts:140-357` |
| **Every write**: `users.update` (tier, stripeSubscriptionId, stripeCustomerId — :195-202, :271-277, :337-343); `userCategoryEntitlement.findUnique / upsert` (`grantEntitlement`, :92-110) and `.findMany / .update` (revoke, :304-311); `writeAuditLog` on every tier or entitlement transition (`auditTierChange` :13-36, `auditEntitlementChange` :41-64), deduped by `request_id = event.id:userId[:key]`. One outbound read: `subscriptions.retrieve` on checkout (:148). | as cited |
| **Which fields can carry a secret.** Stripe's own docs, carried verbatim in the SDK's types: PaymentIntent `client_secret` — "It should not be stored, logged, or exposed to anyone other than the customer" (`node_modules/stripe/types/PaymentIntents.d.ts:76-83`); SetupIntent `client_secret`, the same words (`SetupIntents.d.ts:61-66`). The SDK also carries `client_secret` on `Source` (`Sources.d.ts:57`), on an Invoice's `confirmation_secret` (`Invoices.d.ts:519-521`), and on AccountSession / CustomerSession (never webhook objects). Nothing else in an event is a secret: the endpoint secret signs the header and never rides the body; the API key is ours. **The redaction is by key name at any depth**, so every carrier is covered, not only the two the ruling names. | as cited |
| **The user for an event**: `checkout.session.completed` → `session.metadata.userId` (our stamp, :143) then `users.findUnique` (:170); the subscription events → `users.findFirst({ stripeCustomerId: subscription.customer })` (:228-230, :296-298). No user → the handler `break`s; **nothing was recorded**. | as cited |
| **Idempotency today**: none at the door — Stripe redelivers (at-least-once), and a redelivered event re-ran the handler in full (re-fetched the subscription, re-upserted; only the audit log deduped by `request_id`). `event.id` was never stored. | `route.ts:140-357`; `src/lib/audit/writeAuditLog.ts:67` |
| **`user_category_entitlements` and `users.tier`** are state the handler DERIVES from an event (a row per user × key, upserted across many events), not a mirror of any one event; the arrival IS the event's record. Neither gains `arrival_id`. | `prisma/schema.prisma:1280-1292`, `:529` |
| **The rule book** names `stripe · payout → EVENT` only; the store needs `stripe · event`. | `src/lib/providers.ts:58` |
| **The landing store** already supports a guest owner (`guest_ref`) and a declared `redactions` list on arrivals — the Plaid landings passed `[]`. The wire row had no such column: the exact bytes were the only shape it could hold. | `src/lib/arrivals/land.ts:143, :191, :211`; `prisma/schema.prisma:3617-3629` |
| `/api/stripe/webhook` is public in the middleware (the signature is the gate). | `src/middleware.ts:96` |

## BUILD

| Piece | Change |
|---|---|
| `src/lib/arrivals/stripeWebhook.ts` (new, pure over ports) | `verifyStripeDelivery` — the SDK's `constructEvent` over the exact raw bytes; a missing header, a missing secret, or a bad signature throws `StripeSignatureError` **before any row**. `landStripeEvent`, inside the caller's transaction: `redactClientSecrets` once (a deep copy with every `client_secret` at any depth set to null; each path declared, e.g. `data.object.client_secret`) → **`wireBytesFor`** (PR-4b: the exact raw bytes and `[]` when nothing was blanked; the RFC 8785 canonical bytes of the redacted event and the paths when something was) → `landResponse` (`http_status 200` as received, `asked = arrived =` the moment the delivery hit us, `body_sha256` over the bytes as stored, `redactions` on the row) → `landObjects` one arrival (`stripe · event`, their_id = `event.id`, kind **event** by the rule book, the same `redactions`) → the handler runs **from the arrival payload read back from the table**, once per new arrival (landed or corrected), **never on already_landed** → `markRead`. No user → `guest_ref` = the customer id, or `event:<id>` when the object names no customer — declared, never dropped. `runStripeDelivery` — verify, **one log line** (`[stripe] verified <event id> (<type>) — signed t=<the header's timestamp>, request <the creating request id>`; never a body; Stripe sends no delivery id header), then one transaction; failures declared as `'signature'` or `'landing'`. |
| `src/app/api/stripe/webhook/route.ts` | `request.arrayBuffer()` → the exact bytes; `runStripeDelivery` with `prismaLanding(tx)`, `userForEvent(tx, event)` (the session's `metadata.userId` when it names a user, else `users.stripeCustomerId` = the object's customer), `handleStripeEvent(tx, event)` — **the existing switch, its logic unchanged**, reading the arrival's payload and writing through the transaction client; `writeAuditLog` keeps its own hash-chained transaction, as before; the verification line to `console.log`. Answers: signature failure → **400** `{ error: 'Invalid signature' }` (nothing landed); a rolled-back landing or handler → **500** (Stripe redelivers); success → 200 `{ received, landed, handled }`. |
| `prisma/migrations/20260907220000_provider_responses_redactions/migration.sql` + `schema.prisma` (PR-4b) | `ALTER TABLE provider_responses ADD COLUMN redactions text[] NOT NULL DEFAULT '{}'`; the model gains `redactions String[] @default([])` (last scalar, so the column-for-column proof reads it in migration order). `prisma validate` ✓. |
| `src/lib/arrivals/land.ts`, `prismaLanding.ts` | `ObjectToLand.redactions?` (the arrival's paths; Plaid passes none); PR-4b: `WireAnswer.redactions?` and `ProviderResponseRow.redactions` — the stored body is what the caller hands over, hashed as stored, the paths declared (`[]` = the exact wire; Plaid: always). The Prisma port writes both. |
| `src/lib/providers.ts` | `ADDED_RULES` gains `stripe · event → EVENT`; the rule-book law's call-site scan covers `stripeWebhook.ts` (4 sites). |
| `scripts/assert-tool-registry.ts` (no change needed) | the arrivals law's column proof folds the new `ADD COLUMN` in: **28 columns agree** with the migrations. |
| README (regenerated, byte-stable) | the rule book: 23 rows; row 04 lists the added rules; **the write rule's first line states the wire rule** — "exact bytes, except declared redactions of secrets — then the canonical redacted bytes — with the sha256 of the bytes as stored and every blanked path on `redactions`"; the `provider_responses` table gains the `redactions` row. |
| Tests | `stripeWebhook.test.ts` (8), `providers.test.ts` and `arrivalsLand.test.ts` extended. |

## VERIFY

| Check | Result |
|---|---|
| `npx tsc --noEmit` | exit 0 |
| eslint — changed / new files | 0 / 0 (route baseline 0 / 0) |
| `DATABASE_URL=… npx prisma validate` | valid; `prisma generate` ✓ |
| `npm test` | **149 / 149** |
| asserts + `next build` | showroom ✓ · tool registry ✓ · reachability 67 ✓ · family map ✓ · answers ✓ · **arrivals ✓ — 28 columns agree with the migrations** · **rule book ✓ — 23 rules, 4 landing call sites covered** · kind views ✓ · **BUILD EXIT 0** |
| README generator | exit 0; byte-stable on a second run |

### Tests (node:test) — the real Stripe SDK signs and verifies the fixture offline (`generateTestHeaderString` / `constructEvent`); the store is the shared fake; the handler a recorder

```
ok 94  - the rule book names the feed: stripe · event → event
ok 95  - a signed fixture lands one response (PR-4b: the canonical redacted bytes — no secret, sha256 over the stored bytes, the path declared on the row) and one arrival (their_id = event.id, kind event, client_secret redacted and declared); the handler runs once, from the table, and never sees the secret
ok 96  - PR-4b: a delivery without a client_secret stores the exact wire bytes with an empty redactions; wireBytesFor and signatureTimestamp are pure
ok 97  - the same delivery again → already_landed, one response more, no new arrival, and the handler is not called twice; a changed redelivery (same id, new content) → corrected and the handler runs
ok 98  - a tampered signature, a missing header, or a missing secret lands nothing and is declared as a signature failure (the route answers 400)
ok 99  - no user matches → the arrival lands as a guest with guest_ref = the customer id; no customer on the object → event:<id>; never dropped
ok 100 - redactClientSecrets blanks every client_secret at any depth and lists each path; a payload without one is returned equal with no redactions
ok 101 - a handler throw rolls the whole delivery back — no response row, no arrival — and is declared as a landing failure
```

- **95:** a `payment_intent.succeeded` fixture with `client_secret` — the response row's bytes contain none of it, are not the raw bytes, equal `canonicalBytes` of the redacted event, hash to `body_sha256`, and carry `redactions ['data.object.client_secret']`; the arrival likewise; the verification line names the event id, its type, the header's `t=`, `request req_abc`, and nothing else; the handler was called once with a payload whose secret is null.
- **96:** a `customer.subscription.updated` fixture (no secret) — the stored bytes equal the raw bytes, `redactions []` on both rows; `wireBytesFor` returns the very same Buffer when nothing was redacted and `{"a":null,"b":1}` (keys sorted, no whitespace) when something was.
- **97:** redelivery → `already_landed`, responses 2 / arrivals 1, handler count still 1; a **rotated client_secret alone is not a correction** (same redacted content); a changed `amount` → `corrected`, two rows, the handler runs with the new values.
- **98:** the header signs the original, the bytes delivered are altered; a wrong secret; a null header; an unset env — each a `StripeSignatureError`, zero rows, zero handler calls.
- **100:** secrets at `data.object.client_secret`, `data.object.confirmation_secret.client_secret`, `data.object.lines[1].client_secret`, `data.previous_attributes.client_secret` all blanked and listed in document order; the input is not mutated; a null `client_secret` is not a secret.

### The Postgres probes — throwaway Postgres 16, the real port (`prismaLanding`)

**PR-4b, the column.** The migration file applied in one transaction to a `provider_responses` without the column and with a pre-existing row: `redactions text[] nullable=NO default='{}'::text[]`; the old row reads `{}`; `prisma migrate diff --from-url <db> --to-schema-datamodel` → empty.

**PR-4b, both cases through the real port** (a user with `stripeCustomerId = cus_PR4customer`):

| Delivery | stored `redactions` | `sha256(body) = body_sha256` | secret in the body | the bytes |
|---|---|---|---|---|
| `payment_intent.succeeded` with `client_secret` | `{data.object.client_secret}` | true | **false** | canonical (keys sorted): `{"created":1,"data":{"object":{"amount":12000,"client_secret":null,…` |
| `customer.subscription.updated`, no secret | `{}` | true | false | the exact wire bytes (`{"id":"evt_probe_plain","object":"event",…`) |

Both arrivals read back with `payload…client_secret` NULL and the same `redactions`. Two verification lines were logged, event id and request id only.

**PR-4, the door:** first delivery 1 response / 1 arrival, handled once; the same delivery again 2 / 1, `already_landed`, not handled; tampered bytes with the original header → refused, 2 / 1 unchanged.

## Notes — stated plainly

- Not verified: production (Azure), a live Stripe delivery, the Vercel deploy that applies the column. The endpoint's configured event types in the Stripe Dashboard are unknown to this environment — every delivery lands now, whatever the type; the handler still acts on the three.
- The wire row's byte-exact proof now reads: exact bytes when `redactions = '{}'`; when not, `body_sha256` proves the stored canonical redacted bytes, and the declared paths say what was blanked. A redacted body is re-serialized canonically (RFC 8785), so the same event redelivered with a rotated `client_secret` stores identical wire bytes.
- `subscriptions.retrieve` on `checkout.session.completed` is an outbound Stripe read that runs inside the delivery's transaction (Prisma interactive transaction, 120 s ceiling), as the one-transaction shape requires.
- A redelivered event no longer re-runs the handler. The audit log's `request_id` dedup stays as a second guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc