### PR TITLE
feat(arrivals): no secret at rest in the wire row either (REBUILD-01 …

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ The arrival row above as tables — `prisma/migrations/20260903000000_arrivals/m
 | body_sha256 | bytea | NOT NULL |
 | asked | timestamptz | NOT NULL |
 | arrived | timestamptz | NOT NULL |
+| redactions | text[] | NOT NULL DEFAULT '{}' — `prisma/migrations/20260907220000_provider_responses_redactions/migration.sql`: every path blanked in body; '{}' = the exact wire bytes |
 |  | CHECK / KEY | CHECK (octet_length(body_sha256) = 32) |
 |  | CHECK / KEY | CHECK (octet_length(body) <= 1048576) |
 |  | CHECK / KEY | CHECK (user_id IS NOT NULL OR guest_ref IS NOT NULL) |
@@ -107,7 +108,7 @@ Promise 1 is a database law, not a convention: the `arrivals_promise_1` BEFORE U
 
 The write rule (PR-2 — one Plaid writer, `src/app/api/transactions/sync-complete/route.ts`, through `src/lib/arrivals/land.ts`):
 
-1. Every HTTP answer lands first, as the exact wire bytes, in `provider_responses` with the sha256 of those bytes (the Plaid SDK runs through an axios instance that keeps the body as bytes — `src/lib/plaid/wire.ts`).
+1. Every HTTP answer lands first in `provider_responses` — exact bytes, except declared redactions of secrets — then the canonical redacted bytes — with the sha256 of the bytes as stored and every blanked path on `redactions` (the Plaid SDK runs through an axios instance that keeps the body as bytes — `src/lib/plaid/wire.ts`; the Stripe webhook blanks `client_secret` — `src/lib/arrivals/stripeWebhook.ts`).
 2. Every object in the answer lands as one `arrivals` row: payload as sent, fingerprint = sha256 of its RFC 8785 canonical bytes (the `canonicalize` package), their_id = the provider's own id, redactions `[]` — `INSERT … ON CONFLICT (provider, their_id, fingerprint) DO NOTHING` — the same thing is the same provider, id and content, so a duplicate is promise 2 working, not an error, and a provider's correction is a new row (promise 1); three outcomes, counted apart: landed · already_landed (linked, not re-parsed) · corrected (parsed — latest-arrived wins and `transactions.arrival_id` moves to the newest row); a non-2xx answer lands as a `provider_responses` row with no arrivals — a failed ask is evidence of the ask; a duplicate is promise 2 working, reported as `already_landed`, never an error.
 3. The parser reads the arrival row, never the HTTP object, and points the domain row at it (`transactions.arrival_id`).
 4. Landing, parsing and `read` / `status` (once each) happen in ONE database transaction per page; a parser failure rolls that page back and is declared in the response (stage, page, summarized error) while earlier pages stay.

--- a/prisma/migrations/20260907220000_provider_responses_redactions/migration.sql
+++ b/prisma/migrations/20260907220000_provider_responses_redactions/migration.sql
@@ -1,0 +1,15 @@
+-- REBUILD-01 PR-4b: NO SECRET AT REST IN THE WIRE ROW EITHER. Ruled (Q3):
+-- secrets are redacted before landing, the fingerprint covers the redacted
+-- bytes, and the redaction is declared on the row — for the wire row as for
+-- the arrival. provider_responses.redactions declares every path blanked in
+-- the stored body: '{}' means the body is the exact wire bytes; a non-empty
+-- list means the body is the canonical (RFC 8785) re-serialization of the
+-- redacted answer and body_sha256 is over THOSE stored bytes
+-- (src/lib/arrivals/land.ts landResponse; the Stripe landing declares
+-- client_secret paths, src/lib/arrivals/stripeWebhook.ts).
+--
+-- ADDITIVE-ONLY: one column with a default; every existing row reads '{}' —
+-- true of them: nothing was ever redacted before this. Zero data rewrites.
+-- Applied by `prisma migrate deploy` at deploy (schema.prisma moves with it).
+
+ALTER TABLE provider_responses ADD COLUMN redactions text[] NOT NULL DEFAULT '{}';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -3640,6 +3640,8 @@ model provider_responses {
   body_sha256 Bytes            @db.ByteA
   asked       DateTime         @db.Timestamptz(6)
   arrived     DateTime         @db.Timestamptz(6)
+  /// REBUILD-01 PR-4b: every path blanked in `body` before it was stored ('{}' = the exact wire bytes; else the canonical redacted bytes, sha256'd as stored).
+  redactions  String[]         @default([])
   user        users?           @relation(fields: [user_id], references: [id], onDelete: NoAction, onUpdate: NoAction)
   arrivals    arrivals[]
 

--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -165,6 +165,7 @@ export async function POST(request: NextRequest) {
         handle: (event) => handleStripeEvent(db, event),
       };
     },
+    (line) => console.log(line),
   );
 
   if (!outcome.ok && outcome.failure === 'signature') {

--- a/src/lib/__tests__/arrivalsLand.test.ts
+++ b/src/lib/__tests__/arrivalsLand.test.ts
@@ -151,6 +151,7 @@ test('the parser reads the arrival row, never the HTTP object, and every new arr
   // structuredClone hands back a plain Uint8Array — compare the bytes, not the class.
   assert.equal(Buffer.compare(Buffer.from(a.row.fingerprint), fingerprintOf({ ...t, name: 'As landed' })), 0);
   assert.equal(landing.responses[0].http_status, 200);
+  assert.deepEqual(landing.responses[0].redactions, [], 'PR-4b: a Plaid answer declares no redaction — the exact wire bytes');
   await assert.rejects(landing.markRead([a.row.id], new Date()), /read is set once/);
 });
 

--- a/src/lib/__tests__/stripeWebhook.test.ts
+++ b/src/lib/__tests__/stripeWebhook.test.ts
@@ -1,8 +1,8 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import Stripe from 'stripe';
-import { fingerprintOf, sha256 } from '../arrivals/land';
-import { STRIPE, STRIPE_EVENT, StripeSignatureError, customerIdOf, guestRefFor, landStripeEvent, redactClientSecrets, runStripeDelivery, verifyStripeDelivery, type StripeEventLike } from '../arrivals/stripeWebhook';
+import { canonicalBytes, fingerprintOf, sha256 } from '../arrivals/land';
+import { STRIPE, STRIPE_EVENT, StripeSignatureError, customerIdOf, guestRefFor, landStripeEvent, redactClientSecrets, runStripeDelivery, signatureTimestamp, verifyStripeDelivery, wireBytesFor, type StripeEventLike } from '../arrivals/stripeWebhook';
 import { kindOf } from '../providers';
 import { FakeLanding, snapshotClient } from './fakeLanding';
 
@@ -57,24 +57,32 @@ test('the rule book names the feed: stripe · event → event', () => {
   assert.equal(kindOf(STRIPE, STRIPE_EVENT), 'event');
 });
 
-test('a signed fixture lands one response (the exact bytes, sha256) and one arrival (their_id = event.id, kind event, client_secret redacted and declared); the handler runs once, from the table, and never sees the secret', async () => {
+test('a signed fixture lands one response (PR-4b: the canonical redacted bytes — no secret, sha256 over the stored bytes, the path declared on the row) and one arrival (their_id = event.id, kind event, client_secret redacted and declared); the handler runs once, from the table, and never sees the secret', async () => {
   const landing = new FakeLanding();
   const rec = new Recorder();
+  const lines: string[] = [];
   const body = JSON.stringify(fixture());
-  const out = await runStripeDelivery(snapshotClient(landing), delivery(body), verify, () => rec.ports(landing));
+  const out = await runStripeDelivery(snapshotClient(landing), delivery(body), verify, () => rec.ports(landing), (l) => lines.push(l));
   assert.equal(out.ok, true);
   if (!out.ok) return;
   assert.deepEqual(out.result, { eventId: 'evt_1PR4test0001', type: 'payment_intent.succeeded', outcome: 'landed', redactions: ['data.object.client_secret'], handled: true, userId: 'u_alex', guestRef: null });
-  // the wire: exact bytes as signed (the secret is inside them — the ruling keeps the wire exact), sha256, 200 as received
+  // the wire row: the secret is nowhere in the stored bytes; the bytes are the RFC 8785 canonical form of the redacted event; the hash is over those bytes; the path is declared
   assert.equal(landing.responses.length, 1);
   const r = landing.responses[0];
   assert.equal(r.provider, STRIPE);
   assert.equal(r.resource, STRIPE_EVENT);
   assert.equal(r.http_status, 200);
-  assert.equal(r.body.toString('utf8'), body);
-  assert.deepEqual(r.body_sha256, sha256(Buffer.from(body)));
+  assert.ok(!r.body.toString('utf8').includes('secret_DONOTSTORE'), 'no secret at rest in the wire row');
+  assert.notEqual(r.body.toString('utf8'), body, 'not the raw bytes — those carried the secret');
+  assert.equal(Buffer.compare(r.body, canonicalBytes(redactClientSecrets(fixture() as never).payload)), 0, 'the canonical redacted bytes');
+  assert.deepEqual(r.body_sha256, sha256(r.body), 'sha256 over the stored bytes');
+  assert.deepEqual(r.redactions, ['data.object.client_secret'], 'declared on the row');
   assert.equal(r.user_id, 'u_alex');
   assert.deepEqual(r.asked, NOW);
+  // the verification line: the event id, the signature's t=, the request id — never a body
+  assert.equal(lines.length, 1);
+  assert.match(lines[0], /^\[stripe\] verified evt_1PR4test0001 \(payment_intent\.succeeded\) — signed t=\d+, request req_abc$/);
+  assert.ok(!lines[0].includes('secret') && !lines[0].includes('12000'));
   // the arrival: redacted payload, the path declared, the book's kind
   assert.equal(landing.arrivals.size, 1);
   const a = [...landing.arrivals.values()][0];
@@ -94,6 +102,26 @@ test('a signed fixture lands one response (the exact bytes, sha256) and one arri
   assert.equal(rec.calls[0].outcome, 'landed');
   assert.equal((rec.calls[0].event.data.object as { client_secret: unknown }).client_secret, null);
   assert.equal(rec.calls[0].event.id, 'evt_1PR4test0001');
+});
+
+test('PR-4b: a delivery without a client_secret stores the exact wire bytes with an empty redactions; wireBytesFor and signatureTimestamp are pure', async () => {
+  const landing = new FakeLanding();
+  const rec = new Recorder();
+  const sub = { ...fixture(), id: 'evt_1PR4sub', type: 'customer.subscription.updated', data: { object: { id: 'sub_1', object: 'subscription', customer: 'cus_PR4customer', status: 'active', items: { data: [{ price: { id: 'price_x' } }] } } } };
+  const body = JSON.stringify(sub);
+  const out = await runStripeDelivery(snapshotClient(landing), delivery(body), verify, () => rec.ports(landing));
+  assert.equal(out.ok && out.result.redactions.length, 0);
+  const r = landing.responses[0];
+  assert.equal(r.body.toString('utf8'), body, 'the exact wire bytes');
+  assert.deepEqual(r.body_sha256, sha256(Buffer.from(body)));
+  assert.deepEqual(r.redactions, []);
+  assert.deepEqual([...landing.arrivals.values()][0].row.redactions, []);
+  const raw = Buffer.from('{"b":1,"a":2}');
+  assert.equal(wireBytesFor(raw, { payload: { b: 1, a: 2 }, redactions: [] }).body, raw, 'nothing redacted → the very same bytes');
+  const red = wireBytesFor(raw, { payload: { b: 1, a: null }, redactions: ['a'] });
+  assert.equal(red.body.toString('utf8'), '{"a":null,"b":1}', 'redacted → canonical (keys sorted, no whitespace)');
+  assert.equal(signatureTimestamp('t=1757257200,v1=abc'), '1757257200');
+  assert.equal(signatureTimestamp(null), null);
 });
 
 test('the same delivery again → already_landed, one response more, no new arrival, and the handler is not called twice; a changed redelivery (same id, new content) → corrected and the handler runs', async () => {

--- a/src/lib/arrivals/land.ts
+++ b/src/lib/arrivals/land.ts
@@ -4,7 +4,9 @@
  *
  *   landResponse() — one provider_responses row per HTTP answer: the exact
  *                    wire bytes, sha256 of those bytes, http_status, asked,
- *                    arrived.
+ *                    arrived. PR-4b: except declared redactions of secrets —
+ *                    then the canonical (RFC 8785) redacted bytes, sha256'd
+ *                    as stored, with the paths on `redactions`.
  *   landObjects()  — one arrivals row per object in the answer: payload = the
  *                    object, fingerprint = sha256 of its RFC 8785 canonical
  *                    bytes (the `canonicalize` package — JCS, never hand-rolled),
@@ -50,6 +52,8 @@ export interface ProviderResponseRow {
   body_sha256: Buffer;
   asked: Date;
   arrived: Date;
+  /** PR-4b: every path blanked in `body` before it was stored — [] means the exact wire bytes; else the canonical redacted bytes, sha256'd as stored. */
+  redactions: string[];
 }
 
 export interface ArrivalRow {
@@ -130,9 +134,12 @@ export interface WireAnswer {
   userId: string | null;
   guestRef: string | null;
   httpStatus: number;
+  /** The bytes to STORE: the exact wire when nothing was redacted; the canonical redacted bytes when something was. body_sha256 is over these. */
   body: Buffer;
   asked: Date;
   arrived: Date;
+  /** PR-4b: the paths blanked in `body`; omitted = [] (the exact wire). A caller that redacts hands the redacted bytes AND their paths — never one without the other. */
+  redactions?: string[];
 }
 
 export interface LandedResponse {
@@ -154,6 +161,7 @@ export async function landResponse(db: LandingDb, answer: WireAnswer): Promise<L
     body_sha256: sha256(answer.body),
     asked: answer.asked,
     arrived: answer.arrived,
+    redactions: answer.redactions ?? [],
   };
   await db.insertResponse(row);
   return { id: row.id, bodySha256: row.body_sha256 };

--- a/src/lib/arrivals/prismaLanding.ts
+++ b/src/lib/arrivals/prismaLanding.ts
@@ -28,6 +28,7 @@ export function prismaLanding(tx: Tx): LandingDb {
           body_sha256: row.body_sha256,
           asked: row.asked,
           arrived: row.arrived,
+          redactions: row.redactions,
         },
       });
     },

--- a/src/lib/arrivals/stripeWebhook.ts
+++ b/src/lib/arrivals/stripeWebhook.ts
@@ -8,12 +8,15 @@
  *                          missing or bad signature throws
  *                          StripeSignatureError BEFORE anything lands (the
  *                          route answers Stripe's expected 400).
- *   landStripeEvent      — inside the caller's transaction: landResponse (the
- *                          verified raw body bytes, http_status 200 as
- *                          received; asked = arrived = when the delivery hit
- *                          us) → redactClientSecrets on a copy of the event
- *                          (every `client_secret` key at any depth blanked,
- *                          each path declared) → landObjects one arrival
+ *   landStripeEvent      — inside the caller's transaction: redactClientSecrets
+ *                          on a copy of the event (every `client_secret` key
+ *                          at any depth blanked, each path declared) →
+ *                          landResponse (PR-4b — the wire row: the exact raw
+ *                          bytes when nothing was redacted; the canonical
+ *                          RFC 8785 bytes of the redacted event when something
+ *                          was, sha256'd as stored, the paths declared on the
+ *                          row; http_status 200 as received; asked = arrived =
+ *                          when the delivery hit us) → landObjects one arrival
  *                          (stripe · event, their_id = event.id, kind event by
  *                          the rule book) → the handler runs FROM THE ARRIVAL
  *                          PAYLOAD read back from the table, never from the
@@ -40,7 +43,7 @@
  * with the real SDK's signing helper and a fake store.
  */
 import type { ArrivalOutcome, JsonObject, LandingDb } from './land';
-import { landObjects, landResponse, markRead } from './land';
+import { canonicalBytes, landObjects, landResponse, markRead } from './land';
 
 export const STRIPE = 'stripe';
 export const STRIPE_EVENT = 'event';
@@ -100,6 +103,18 @@ export function redactClientSecrets(payload: JsonObject): { payload: JsonObject;
   return { payload: walk(payload, '') as JsonObject, redactions };
 }
 
+/** The bytes the wire row stores: the exact raw bytes when nothing was redacted; the RFC 8785 canonical bytes of the redacted event when something was. */
+export function wireBytesFor(rawBody: Buffer, redacted: { payload: JsonObject; redactions: string[] }): { body: Buffer; redactions: string[] } {
+  if (redacted.redactions.length === 0) return { body: rawBody, redactions: [] };
+  return { body: canonicalBytes(redacted.payload), redactions: redacted.redactions };
+}
+
+/** The `t=` timestamp of a stripe-signature header, or null. */
+export function signatureTimestamp(signature: string | null): string | null {
+  const m = signature?.match(/(?:^|,)t=(\d+)/);
+  return m ? m[1] : null;
+}
+
 /** The customer id the event's object carries (a string or an expanded object), or null. */
 export function customerIdOf(event: StripeEventLike): string | null {
   const c = (event.data.object as { customer?: unknown }).customer;
@@ -115,6 +130,8 @@ export function guestRefFor(event: StripeEventLike): string {
 
 export interface StripeLandingPorts<E extends StripeEventLike> {
   landing: LandingDb;
+  /** One line per verified delivery (event id, the signature's timestamp, the creating request id — never a body); default silent. */
+  log?: (line: string) => void;
   /** Who the event belongs to; null → the arrival lands as a guest (guestRefFor). */
   userFor(event: E): Promise<string | null>;
   /** The existing handler — runs from the arrival payload, once per new arrival (landed or corrected), never on already_landed. */
@@ -142,17 +159,21 @@ export async function landStripeEvent<E extends StripeEventLike>(
   const { event } = input;
   const userId = await ports.userFor(event);
   const guestRef = userId === null ? guestRefFor(event) : null;
+  const redacted = redactClientSecrets(event as unknown as JsonObject);
+  // PR-4b: the wire row never holds the secret either — the stored bytes are the exact wire
+  // when nothing was blanked, else the canonical bytes of the redacted event, hashed as stored.
+  const wire = wireBytesFor(input.rawBody, redacted);
   const response = await landResponse(ports.landing, {
     provider: STRIPE,
     resource: STRIPE_EVENT,
     userId,
     guestRef,
     httpStatus: 200,
-    body: input.rawBody,
+    body: wire.body,
     asked: input.receivedAt,
     arrived: input.receivedAt,
+    redactions: wire.redactions,
   });
-  const redacted = redactClientSecrets(event as unknown as JsonObject);
   const landed = await landObjects(ports.landing, {
     provider: STRIPE,
     resource: STRIPE_EVENT,
@@ -191,6 +212,7 @@ export async function runStripeDelivery<E extends StripeEventLike>(
   delivery: StripeDelivery,
   verify: (rawBody: Buffer, signature: string, secret: string) => E,
   ports: (tx: unknown) => StripeLandingPorts<E>,
+  log?: (line: string) => void,
 ): Promise<StripeDeliveryResult> {
   let event: E;
   try {
@@ -198,6 +220,11 @@ export async function runStripeDelivery<E extends StripeEventLike>(
   } catch (e) {
     return { ok: false, failure: 'signature', error: e as StripeSignatureError };
   }
+  // One line records the verification — the event id, the delivery's signature timestamp and
+  // the creating request id; never a body. Stripe sends no delivery id header (the signature's
+  // t= and the event's request id are what a delivery carries).
+  const req = (event as { request?: { id?: string | null } | null }).request;
+  log?.(`[stripe] verified ${event.id} (${event.type}) — signed t=${signatureTimestamp(delivery.signature) ?? '?'}, request ${req?.id ?? 'none'}`);
   try {
     const result = await client.$transaction(
       (tx) => landStripeEvent(ports(tx), { rawBody: delivery.rawBody, event, receivedAt: delivery.receivedAt }),


### PR DESCRIPTION
…PR-4b)

Ruled (Q3): secrets are redacted before landing, the fingerprint covers the redacted bytes, and the redaction is declared on the row — for the wire row as for the arrival. provider_responses.body held the exact Stripe delivery, client_secret included.

- migration 20260907220000_provider_responses_redactions: ALTER TABLE provider_responses ADD COLUMN redactions text[] NOT NULL DEFAULT '{}' (additive; every existing row reads '{}', true of them). Schema in lockstep; the arrivals law's column proof now agrees on 28 columns.
- landResponse takes optional redactions: the stored body is what the caller hands over — the exact wire bytes when nothing was redacted (Plaid: always, [] declared), the canonical (RFC 8785) re-serialization of the redacted answer when something was — and body_sha256 is over the bytes as stored.
- stripeWebhook: one redaction (redactClientSecrets) serves both rows — wireBytesFor hands landResponse the canonical redacted bytes and the paths when a client_secret was blanked at any depth, the raw bytes and [] when not. The signature is verified on the raw bytes before any of this; one log line records the verification (event id, type, the signature's t=, the creating request id — never a body; Stripe sends no delivery id header).
- README: the write rule's first line states the wire rule — exact bytes, except declared redactions of secrets — then the canonical redacted bytes; the provider_responses table gains the column row.
- tests: a delivery with a client_secret stores a body containing none of it, a sha256 that matches the stored bytes, the canonical form, and the declared path on the row; the verification line carries the id and no body; a delivery without one stores the exact bytes with []; a Plaid answer's wire row declares []. 149/149.
- Postgres probe (real port, the migrated column): with a secret — redactions {data.object.client_secret}, sha256(body) = body_sha256, no secret in the body, canonical bytes; without — '{}', the exact wire bytes.


Claude-Session: https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc