### PR TITLE
REBUILD-01 PR-2d: Plaid holdings land as snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Twenty-five business tools on one data pipe that ends in one Ledger and one Calendar.
 
-Source-available (BSL 1.1) · built and operated in production by its founder as User #1 · as of 2026-09-02: 114 Prisma models, 289 API route files, 121 feeds from 20 providers (counted August 24, 2026)
+Source-available (BSL 1.1) · built and operated in production by its founder as User #1 · as of 2026-09-02: 115 Prisma models, 289 API route files, 121 feeds from 20 providers (counted August 24, 2026)
 
 ## The system
 
@@ -160,7 +160,7 @@ One written rule per feed — its kind — and the system applies it to every ar
 
 ### The six tables (step 5, views)
 
-Six tables, six names, the kind picks the table — as VIEWS over the typed feed tables (`prisma/migrations/20260907200000_kind_views/migration.sql`, generated from the census in `src/lib/kindViews.ts`; the six are `view` models in `prisma/schema.prisma` under Prisma's `views` preview). The feed tables keep their real columns, constraints and `arrival_id`; each view unions exactly the feed tables of its kind, the kind per table from the rule book, in one common shape. Posting is empty by the deck's own law; snapshot is empty until holdings land. A table whose feed the rule book cannot name is reported, never viewed. Today the six are views over the feed tables — event: transactions, investment transactions, bookings; reference: securities, places, the law corpus; registry: accounts; snapshot: none yet; derived: none yet; posting: empty by law.
+Six tables, six names, the kind picks the table — as VIEWS over the typed feed tables (`prisma/migrations/20260907200000_kind_views/migration.sql`, generated from the census in `src/lib/kindViews.ts`; the six are `view` models in `prisma/schema.prisma` under Prisma's `views` preview; a view changes only through a later migration that drops and recreates it — the snapshot view over holdings, `prisma/migrations/20260908120000_holdings_snapshot/migration.sql` — and the build checks each view's newest text). The feed tables keep their real columns, constraints and `arrival_id`; each view unions exactly the feed tables of its kind, the kind per table from the rule book, in one common shape. Posting is empty by the deck's own law; snapshot holds Plaid holdings (REBUILD-01 PR-2d). A table whose feed the rule book cannot name is reported, never viewed. Today the six are views over the feed tables — event: transactions, investment transactions, bookings; reference: securities, places, the law corpus; registry: accounts; snapshot: holdings; derived: none yet; posting: empty by law.
 
 | Column | Type |
 |---|---|
@@ -179,7 +179,7 @@ Six tables, six names, the kind picks the table — as VIEWS over the typed feed
 | registry | accounts | plaid · account |
 | event | transactions, investment_transactions, reservations | plaid · transaction · plaid · investment_transaction · liteapi · booking |
 | derived | (nothing) |  |
-| snapshot | (nothing) |  |
+| snapshot | holdings | plaid · holding |
 | posting | (nothing) |  |
 
 | Feed table | Kind | Feed | arrival_id | user | arrived | Outside Prisma |
@@ -191,6 +191,7 @@ Six tables, six names, the kind picks the table — as VIEWS over the typed feed
 | transactions | event | plaid · transaction | yes | yes | t."createdAt" |  |
 | investment_transactions | event | plaid · investment_transaction | yes | yes | i."createdAt" |  |
 | reservations | event | liteapi · booking | no | yes | r."createdAt" |  |
+| holdings | snapshot | plaid · holding | yes | yes | h."createdAt" |  |
 
 Reported, not viewed — rows from a provider answer whose feed the rule book does not name:
 
@@ -266,9 +267,9 @@ BLUEPRINT is the step's headline; TODAY is the deck's honest-state line, verbati
 
 | Step | Blueprint | Today | Gap |
 |---|---|---|---|
-| 03 | Store what arrived. Then decide what it means. | the arrivals store holds 9,092 Plaid transactions, 712 investment transactions and 247 securities — every answer word for word, fingerprinted, status done — counted September 7, 2026; rows before September 3, 2026 carry no arrival. | the other providers (tastytrade, the market and law feeds) land parsed; Stripe events (PR-4) and LiteAPI bookings and cancellations (PR-5) land raw-first with no dated count yet; the three old Plaid writers are retired (PR-3). |
-| 04 | One rule per feed. Written down. | rules are rows the system applies — src/lib/providers.ts RULE_BOOK, 24 rows (the deck's 20 plus plaid · security → reference, plaid · investment_transaction → event, stripe · event → event, liteapi · cancellation → event); every Plaid, Stripe and LiteAPI arrival carries its kind (transaction · event, investment_transaction · event, security · reference, stripe event · event, liteapi booking · event, liteapi cancellation · event), stamped on landing and applied by the migration to every row landed before it; a feed with no rule cannot land. | the other providers' arrivals wait on their landing — nothing of theirs has arrived to be labeled; the 121 feeds' classification stays the August 24 census until each lands. |
-| 05 | The kind picks the table. | Today the six are views over the feed tables — event: transactions, investment transactions, bookings; reference: securities, places, the law corpus; registry: accounts; snapshot: none yet; derived: none yet; posting: empty by law. | snapshot waits on holdings (PR-2d); derived has no feed table the rule book names — the AI tables carry no rule-book row; posting is empty by law; 8 tables are reported, not viewed. |
+| 03 | Store what arrived. Then decide what it means. | the arrivals store holds 9,092 Plaid transactions, 712 investment transactions and 247 securities — every answer word for word, fingerprinted, status done — counted September 7, 2026; rows before September 3, 2026 carry no arrival. | the other providers (tastytrade, the market and law feeds) land parsed; Stripe events (PR-4), LiteAPI bookings and cancellations (PR-5) and Plaid holdings (PR-2d) land raw-first with no dated count yet; the three old Plaid writers are retired (PR-3). |
+| 04 | One rule per feed. Written down. | rules are rows the system applies — src/lib/providers.ts RULE_BOOK, 24 rows (the deck's 20 plus plaid · security → reference, plaid · investment_transaction → event, stripe · event → event, liteapi · cancellation → event); every Plaid, Stripe and LiteAPI arrival carries its kind (transaction · event, investment_transaction · event, security · reference, stripe event · event, liteapi booking · event, liteapi cancellation · event, holding · snapshot), stamped on landing and applied by the migration to every row landed before it; a feed with no rule cannot land. | the other providers' arrivals wait on their landing — nothing of theirs has arrived to be labeled; the 121 feeds' classification stays the August 24 census until each lands. |
+| 05 | The kind picks the table. | Today the six are views over the feed tables — event: transactions, investment transactions, bookings; reference: securities, places, the law corpus; registry: accounts; snapshot: holdings; derived: none yet; posting: empty by law. | derived has no feed table the rule book names — the AI tables carry no rule-book row; posting is empty by law; 8 tables are reported, not viewed. |
 | 07 | Every tool runs the same four beats. Discover. Decide. Commit. Record. | This loop is the blueprint — the shape we're building every tool toward. Today, hotel bookings commit for real and an accepted task fires its build; the rest run discover → decide → draft, and commit is the beat we're wiring to the same loop, tool by tool. | commit is real for two tools (hotel bookings, accepted tasks); the other twenty-three stop at draft. |
 | 08 | One table holds everything you do. | The master table is the blueprint. Today each tool keeps its own table; one table holding every document is the shape we're building. | no master table; each tool keeps its own. |
 | 09 | The deposit meets the invoice. The fill meets the order. | (A piece of this is already alive today: card charges find their bookings and propose the match — you approve it.) | one of fourteen matches proposes today (card charge ↔ booking); the other thirteen do not. |
@@ -282,15 +283,15 @@ BLUEPRINT is the step's headline; TODAY is the deck's honest-state line, verbati
 
 | Module | What exists in code |
 |---|---|
-| Travel | stays and flights through LiteAPI, activities through Viator, visa checks through RapidAPI — public routes under src/app/api/travel (15 route files) and src/app/api/flights (3); models `trips` (schema:599) and `reservations` (schema:1355). |
-| Runway | the reservation matcher — src/app/api/runway/match/propose, queue, review (the step-9 piece alive today) — plus src/app/api/runway/route.ts; models `budgets` (schema:569) and `home_expenses` (schema:1609). |
-| Books | Plaid-synced transactions, a chart of accounts, journal and ledger entries — the one Plaid writer, src/app/api/transactions/sync-complete/route.ts, writes `transactions` (schema:430) through src/lib/arrivals/plaidTransactionsPage.ts:114; `journal_entries` (schema:185), `ledger_entries` (schema:224). |
-| Trade | tastytrade connection, quotes and backtests — src/app/api/tastytrade (13 route files); models `trade_cards` (schema:1740) and `scan_snapshots` (schema:1926). |
-| Tax | scenarios, documents and the 2025 export script (`npm run tax:export:2025`) — src/app/api/tax (7 route files); models `tax_scenarios` (schema:1529) and `tax_documents` (schema:1848). |
-| Compliance | the regulatory corpus (eCFR, US Code, Federal Register, IRS bulletins) ingested by Inngest functions with sha256 on write, citations re-verified, and the hash-chained audit log — models `regulatory_sources` (schema:2239), `citations` (schema:2303), `audit_log` (schema:2469). |
-| Routines | scheduled routines evaluated by the `routine-evaluator` Inngest function — models `operations_routines` (schema:3123) and `hub_scheduled_items` (schema:3229); the deck calls the calendar window live in the cockpit (step 12 honest line). |
-| Projects | projects and tasks; accepting a pending task fires the Execute-Task Routine (src/app/api/operations/projects/[id]/tasks/[taskId]/route.ts:395-405) — models `operations_projects` (schema:2947) and `operations_project_tasks` (schema:2992). |
-| Content | scene groups, scenes, pieces and takes — model `operations_content_pieces` (schema:3356); src/app/api/operations carries 50 route files across Routines, Projects and Content. |
+| Travel | stays and flights through LiteAPI, activities through Viator, visa checks through RapidAPI — public routes under src/app/api/travel (15 route files) and src/app/api/flights (3); models `trips` (schema:629) and `reservations` (schema:1385). |
+| Runway | the reservation matcher — src/app/api/runway/match/propose, queue, review (the step-9 piece alive today) — plus src/app/api/runway/route.ts; models `budgets` (schema:599) and `home_expenses` (schema:1639). |
+| Books | Plaid-synced transactions, a chart of accounts, journal and ledger entries — the one Plaid writer, src/app/api/transactions/sync-complete/route.ts, writes `transactions` (schema:460) through src/lib/arrivals/plaidTransactionsPage.ts:114; `journal_entries` (schema:186), `ledger_entries` (schema:225). |
+| Trade | tastytrade connection, quotes and backtests — src/app/api/tastytrade (13 route files); models `trade_cards` (schema:1770) and `scan_snapshots` (schema:1956). |
+| Tax | scenarios, documents and the 2025 export script (`npm run tax:export:2025`) — src/app/api/tax (7 route files); models `tax_scenarios` (schema:1559) and `tax_documents` (schema:1878). |
+| Compliance | the regulatory corpus (eCFR, US Code, Federal Register, IRS bulletins) ingested by Inngest functions with sha256 on write, citations re-verified, and the hash-chained audit log — models `regulatory_sources` (schema:2269), `citations` (schema:2333), `audit_log` (schema:2499). |
+| Routines | scheduled routines evaluated by the `routine-evaluator` Inngest function — models `operations_routines` (schema:3153) and `hub_scheduled_items` (schema:3259); the deck calls the calendar window live in the cockpit (step 12 honest line). |
+| Projects | projects and tasks; accepting a pending task fires the Execute-Task Routine (src/app/api/operations/projects/[id]/tasks/[taskId]/route.ts:395-405) — models `operations_projects` (schema:2977) and `operations_project_tasks` (schema:3022). |
+| Content | scene groups, scenes, pieces and takes — model `operations_content_pieces` (schema:3386); src/app/api/operations carries 50 route files across Routines, Projects and Content. |
 
 ## Architecture
 
@@ -309,7 +310,7 @@ Versions from package.json, read 2026-09-02:
 
 Observed versus authored (step 6): what the world sends is observed; what you do is authored; the blueprint keeps the two apart and matches them on one key. Today the Plaid feeds land word for word, fingerprinted — 9,092 transactions, 712 investment transactions, 247 securities, counted September 7, 2026; the other providers still land parsed — see the gap ledger, step 14.
 
-Scale, as of 2026-09-02: 114 Prisma models, 34 enums, 289 API route files, 37 runtime dependencies, 18 dev dependencies, one test file (`npm test`).
+Scale, as of 2026-09-02: 115 Prisma models, 34 enums, 289 API route files, 37 runtime dependencies, 18 dev dependencies, one test file (`npm test`).
 
 ## Engineering discipline
 
@@ -330,7 +331,7 @@ These are the written laws in `CLAUDE.md`, stated as practice:
 - Middleware: every path not in `PUBLIC_PATHS` requires the verified cookie — `src/middleware.ts:50-160, 162, 165-170`; the two Routine callbacks (`…/audit-ingest`, `…/exec-ingest`) bypass the cookie and validate a shared-secret bearer (`AUDIT_INGEST_SECRET`, `EXEC_INGEST_SECRET`) instead — `src/middleware.ts:173-187`.
 - Route gates: `getCurrentUser` (`src/lib/auth-helpers.ts:11`), `requireTier` (`:42`), `requireAdmin` (`src/lib/require-admin.ts:8`); the working law is that a paid external call is never made before the gate (CLAUDE.md, Security-first).
 - User scoping: every query is scoped to the authed user — e.g. `where: { userId: user.id }` at `src/app/api/tastytrade/connect/route.ts:54`.
-- Rate limits: a durable fixed-window limiter backed by the `rate_limit_hits` table (`src/lib/rateLimit.ts:3-15`; schema:1340), plus `src/lib/scan-rate-limit.ts` and `src/lib/ai-rate-limit.ts`; tuned by `SEARCH_/BOOK_/SCAN_/AI_RATE_LIMIT` and `_WINDOW`, with daily caps `AI_PIPE_DAILY_CAP`, `AI_EXEC_DAILY_CAP`, `AI_ROUTINE_DAILY_CAP`, `AI_DISCOVERY_DAILY_CAP` (USD, from recorded spend — `src/lib/discovery/discoveryGate.ts`), `TRAVEL_SEARCH_DAILY_CAP`, and `GOOGLE_PLACES_MONTHLY_CAP`.
+- Rate limits: a durable fixed-window limiter backed by the `rate_limit_hits` table (`src/lib/rateLimit.ts:3-15`; schema:1370), plus `src/lib/scan-rate-limit.ts` and `src/lib/ai-rate-limit.ts`; tuned by `SEARCH_/BOOK_/SCAN_/AI_RATE_LIMIT` and `_WINDOW`, with daily caps `AI_PIPE_DAILY_CAP`, `AI_EXEC_DAILY_CAP`, `AI_ROUTINE_DAILY_CAP`, `AI_DISCOVERY_DAILY_CAP` (USD, from recorded spend — `src/lib/discovery/discoveryGate.ts`), `TRAVEL_SEARCH_DAILY_CAP`, and `GOOGLE_PLACES_MONTHLY_CAP`.
 - Audit log: a hash chain — each entry stores `prev_hash` and its own sha256 `content_hash` with a `sequence_number` (`prisma/schema.prisma:2441-2443`; written at `src/lib/audit/writeAuditLog.ts:99`); `src/lib/audit/verifyAuditChain.ts:47, 80` recomputes the chain.
 - Citations: `src/lib/citations/verifyCitation.ts:97` re-fetches the source and re-hashes it against `citations.retrieved_content_hash` (`prisma/schema.prisma:2287`); the column's only writer stores an empty string today (`src/lib/discovery/materializeProposal.ts:165`), so the check is structurally dead until the arrivals rebuild lands the real hash.
 - Corpus: the four ingest persisters hash content with sha256 on write — `src/lib/corpus/ingest/ecfr-persist.ts:28`, `uscode-persist.ts:32`, `fedreg-persist.ts:31`, `irb-persist.ts:32`.

--- a/prisma/migrations/20260908120000_holdings_snapshot/migration.sql
+++ b/prisma/migrations/20260908120000_holdings_snapshot/migration.sql
@@ -1,0 +1,74 @@
+-- REBUILD-01 PR-2d: PLAID HOLDINGS LAND AS SNAPSHOTS. The rule book's plaid ·
+-- holding row is SNAPSHOT ("how things stood at one moment"); until now the
+-- holdings answer was read live (/api/investments) and never stored, and the
+-- snapshot view unioned nothing. This migration:
+--
+--   1. creates `holdings` — one row per account + security + as_of (UNIQUE: one
+--      snapshot per moment), typed columns for the answer's fields (the Plaid
+--      SDK's Holding: quantity, cost_basis, institution_price, its as-of date
+--      and datetime, institution_value, the two currency codes), the user
+--      through accounts, and arrival_id NOT NULL — every row is parsed from an
+--      arrival (the table is younger than the store: no cutoff, no backfill).
+--      The DDL below is `prisma migrate diff` from main's schema to this one,
+--      verbatim (schema.prisma moves with it).
+--   2. redefines the snapshot view over it: DROP VIEW + CREATE VIEW, the
+--      generator's text verbatim (src/lib/kindViews.ts kindViewSql('snapshot')
+--      — the census names the composed their_id, holding:<account_id>:
+--      <security_id>:<as_of>). The kind-views law reads each view's NEWEST
+--      definition across the migrations (latestViews); the other five stay as
+--      20260907200000_kind_views created them.
+--
+-- ADDITIVE-ONLY for data: a new table, a view redefined. Zero data rewrites.
+-- Applied by `prisma migrate deploy` at deploy; no hand run.
+
+-- CreateTable
+CREATE TABLE "holdings" (
+    "id" TEXT NOT NULL,
+    "accountId" TEXT NOT NULL,
+    "security_id" TEXT NOT NULL,
+    "as_of" DATE NOT NULL,
+    "quantity" DOUBLE PRECISION NOT NULL,
+    "cost_basis" DOUBLE PRECISION,
+    "institution_price" DOUBLE PRECISION NOT NULL,
+    "institution_price_as_of" DATE,
+    "institution_price_datetime" TIMESTAMP(3),
+    "institution_value" DOUBLE PRECISION NOT NULL,
+    "iso_currency_code" TEXT,
+    "unofficial_currency_code" TEXT,
+    "arrival_id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "holdings_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "holdings_arrival_id_idx" ON "holdings"("arrival_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "holdings_accountId_security_id_as_of_key" ON "holdings"("accountId", "security_id", "as_of");
+
+-- AddForeignKey
+ALTER TABLE "holdings" ADD CONSTRAINT "holdings_accountId_fkey" FOREIGN KEY ("accountId") REFERENCES "accounts"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "holdings" ADD CONSTRAINT "holdings_security_id_fkey" FOREIGN KEY ("security_id") REFERENCES "securities"("securityId") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "holdings" ADD CONSTRAINT "holdings_arrival_id_fkey" FOREIGN KEY ("arrival_id") REFERENCES "arrivals"("id") ON DELETE NO ACTION ON UPDATE NO ACTION;
+
+
+-- The snapshot view, redefined over holdings (drop and recreate — never OR REPLACE).
+DROP VIEW snapshot;
+
+-- snapshot: holdings
+CREATE VIEW snapshot AS
+  SELECT 'snapshot'::arrival_kind AS kind,
+         'plaid · holding' AS feed,
+         'holdings' AS table_name,
+         h.id::text AS row_id,
+         ('holding:' || a."accountId" || ':' || h.security_id || ':' || to_char(h.as_of, 'YYYY-MM-DD'))::text AS their_id,
+         h.arrival_id::text AS arrival_id,
+         a."userId"::text AS user_id,
+         h."createdAt"::timestamptz AS arrived
+  FROM holdings h JOIN accounts a ON a.id = h."accountId";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -57,6 +57,7 @@ model accounts {
   users                   users?                    @relation(fields: [userId], references: [id], onDelete: NoAction, onUpdate: NoAction)
   entity                  entities?                 @relation(fields: [entity_id], references: [id], onDelete: NoAction, onUpdate: NoAction)
   investment_transactions investment_transactions[]
+  holdings                holdings[]
   transactions            transactions[]
   bank_reconciliations    bank_reconciliations[]
 
@@ -386,8 +387,37 @@ model securities {
   /// REBUILD-01 PR-2c: the arrival this row was parsed from; NULL before the cutoff (no backfill).
   arrival_id               String?
   investment_transactions  investment_transactions[]
+  holdings                 holdings[]
   arrival                  arrivals?                 @relation(fields: [arrival_id], references: [id], onDelete: NoAction, onUpdate: NoAction)
 
+  @@index([arrival_id])
+}
+
+/// REBUILD-01 PR-2d: one Plaid holding as it stood at one moment — the SNAPSHOT kind (the rule book's plaid · holding row).
+/// One row per account + security + as_of; the same position on a later day is a new row, never a rewrite. Every row is
+/// parsed from an arrival (arrival_id NOT NULL — the table is younger than the store, so there is no cutoff to honor).
+model holdings {
+  id                         String     @id
+  accountId                  String
+  security_id                String
+  /// The moment the snapshot stands for: the UTC date the answer arrived — the third part of the composed their_id.
+  as_of                      DateTime   @db.Date
+  quantity                   Float
+  cost_basis                 Float?
+  institution_price          Float
+  institution_price_as_of    DateTime?  @db.Date
+  institution_price_datetime DateTime?
+  institution_value          Float
+  iso_currency_code          String?
+  unofficial_currency_code   String?
+  arrival_id                 String
+  createdAt                  DateTime   @default(now())
+  updatedAt                  DateTime
+  accounts                   accounts   @relation(fields: [accountId], references: [id])
+  security                   securities @relation(fields: [security_id], references: [securityId])
+  arrival                    arrivals   @relation(fields: [arrival_id], references: [id], onDelete: NoAction, onUpdate: NoAction)
+
+  @@unique([accountId, security_id, as_of])
   @@index([arrival_id])
 }
 
@@ -3679,6 +3709,7 @@ model arrivals {
   investment_transactions investment_transactions[]
   securities    securities[]
   reservations  reservations[]
+  holdings      holdings[]
 
   /// PR-2: the same thing is the same provider + id + content; a correction is a new row.
   @@unique([provider, their_id, fingerprint])

--- a/scripts/assert-tool-registry.ts
+++ b/scripts/assert-tool-registry.ts
@@ -36,8 +36,11 @@
  * they pass, as constants or literals) has a rule. A feed the book does not
  * name cannot be landed: the build fails before the code does.
  *
- * THE KIND-VIEWS LAW (TABLES-01): src/lib/kindViews.ts KIND_VIEW_CENSUS is the
- * census of the typed feed tables; the *_kind_views migration must be its
+ * THE KIND-VIEWS LAW (TABLES-01; REBUILD-01 PR-2d): src/lib/kindViews.ts
+ * KIND_VIEW_CENSUS is the census of the typed feed tables; the EFFECTIVE text of
+ * the six views — each view's newest CREATE VIEW across the migrations in order
+ * (the *_kind_views migration created them; a later migration drops and
+ * recreates one, as *_holdings_snapshot does the snapshot view) — must be the
  * generator's text verbatim — (a) every census table in exactly one view,
  * (b) that view is the rule book's kind for the table's feed, (c) posting
  * unions nothing, (d) all six views carry the common columns in the same
@@ -74,7 +77,7 @@ import { EXPECTED_STATUS_COUNTS, FAMILIES, FAMILY_PAGES, FAMILY_READS, TOOL_REGI
 import { OWNER_UTILITIES } from '../src/lib/shellMenu';
 import { ANSWERS_HOME, ANSWER_READS, ANSWER_ROWS, NET_WORTH_READ, answersLaw } from '../src/lib/answers';
 import { ARRIVAL_KINDS, PROVIDERS, PROVIDER_CODES, ROUTING_RULES, RULE_BOOK, providersLaw, ruleFor } from '../src/lib/providers';
-import { KIND_VIEWS_HONEST_LINE, KIND_VIEW_CENSUS, STOPPED_TABLES, VIEW_COLUMNS, kindOfTable, kindViewsLaw, parseViews } from '../src/lib/kindViews';
+import { KIND_VIEWS_HONEST_LINE, KIND_VIEW_CENSUS, STOPPED_TABLES, VIEW_COLUMNS, kindOfTable, kindViewsLaw, latestViews, latestViewsSql, parseViews } from '../src/lib/kindViews';
 
 /**
  * Routes whose door is outside the app map: the front door and its marketing
@@ -450,7 +453,10 @@ console.log(`✔ The answers law passed — ${ANSWER_ROWS.length}/4 questions on
 // ── THE KIND-VIEWS LAW (TABLES-01) ──────────────────────────────────────────
 const viewsMigration = ALL_MIGRATIONS.find((m) => m.dir.endsWith('_kind_views'));
 if (!viewsMigration) violations.push('kind views: no prisma/migrations/*_kind_views/migration.sql');
-violations.push(...kindViewsLaw({ throwOnFail: false, migrationSql: viewsMigration?.sql ?? '' }));
+// REBUILD-01 PR-2d: a view is redefined by a later migration that drops and recreates it — the law reads each view's NEWEST text.
+const effectiveViews = latestViews(ALL_MIGRATIONS);
+if (effectiveViews.length !== ARRIVAL_KINDS.length) violations.push(`kind views: ${effectiveViews.length} of ${ARRIVAL_KINDS.length} views have a CREATE VIEW in the migrations`);
+violations.push(...kindViewsLaw({ throwOnFail: false, migrationSql: latestViewsSql(ALL_MIGRATIONS) }));
 // schema.prisma: the six `view` models, the common columns in order, the views preview on
 if (!/previewFeatures\s*=\s*\[[^\]]*"views"/.test(schemaText)) violations.push('kind views: generator client must enable previewFeatures = ["views"]');
 const VIEW_FIELD_TYPES: Record<string, string> = { arrival_kind: 'arrival_kind', text: 'String', timestamptz: 'DateTime' };
@@ -466,7 +472,7 @@ const landingSrc = readFileSync(resolve(ROOT, 'src/components/landing/Landing.ts
 if (!landingSrc.includes('{KIND_VIEWS_HONEST_LINE}')) violations.push("kind views: the deck's step 5 must render KIND_VIEWS_HONEST_LINE (never a retyped line)");
 console.log('THE KIND VIEWS — the census, each table once, the kind from the rule book');
 for (const t of KIND_VIEW_CENSUS) console.log(`${t.table.padEnd(26)} ${kindOfTable(t).padEnd(10)} ${Array.isArray(t.feed) ? `${t.feed[0]} · ${t.feed[1]}` : `by ${t.feed.column}: ${Object.values(t.feed.map).map(([p, r]) => `${p} · ${r}`).join(' | ')}`}`);
-for (const v of parseViews(viewsMigration?.sql ?? '')) console.log(`view ${v.name.padEnd(10)} ← ${v.tables.length ? v.tables.join(', ') : '(nothing)'}`);
+for (const v of effectiveViews) { const p = parseViews(v.sql)[0]; console.log(`view ${v.kind.padEnd(10)} ← ${p && p.tables.length ? p.tables.join(', ') : '(nothing)'}  — ${v.dir}`); }
 console.log(`stopped (reported, not viewed): ${STOPPED_TABLES.map((s) => s.table).join(' · ')}`);
 console.log(`honest line: ${KIND_VIEWS_HONEST_LINE}`);
 

--- a/src/app/api/investments/analyze/route.ts
+++ b/src/app/api/investments/analyze/route.ts
@@ -4,6 +4,8 @@ import { plaidClient } from '@/lib/plaid';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { decryptToken } from '@/lib/secrets/tokenCipher';
 import { failureEnvelope } from '@/lib/plaid/failLoud';
+// REBUILD-01 PR-2d: holdings come from the STORED snapshot — Plaid is never asked for them here.
+import { latestHoldingsSnapshot } from '@/lib/arrivals/holdingsSnapshot';
 
 export async function GET() {
   try {
@@ -21,25 +23,20 @@ export async function GET() {
     let holdings: any[] = [];
     
     const plaidItems = await prisma.plaid_items.findMany({
-      where: { userId: user.id }
+      where: { userId: user.id },
+      include: { accounts: { select: { id: true, accountId: true } } },
     });
 
     for (const item of plaidItems) {
+      // REBUILD-01 PR-2d: the latest stored snapshot per account (never asked live).
+      const snapshot = await latestHoldingsSnapshot(prisma, item.accounts);
+      holdings = holdings.concat(snapshot.holdings);
+
       // HYG-01: STOP AND DECLARE — a failed provider call is the response, never an
       // empty page. `stage` names the call in flight.
-      let stage: 'holdings' | 'investments' = 'holdings';
+      const stage = 'investments';
       try {
-        // Get investment holdings
-        const holdingsResponse = await plaidClient.investmentsHoldingsGet({
-          access_token: decryptToken(item.accessToken)
-        });
-        
-        if (holdingsResponse.data.holdings) {
-          holdings = holdings.concat(holdingsResponse.data.holdings);
-        }
-
         // Get investment transactions
-        stage = 'investments';
         const transactionsResponse = await plaidClient.investmentsTransactionsGet({
           access_token: decryptToken(item.accessToken),
           start_date: '2020-01-01',

--- a/src/app/api/investments/route.ts
+++ b/src/app/api/investments/route.ts
@@ -4,6 +4,9 @@ import { plaidClient } from '@/lib/plaid';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { decryptToken } from '@/lib/secrets/tokenCipher';
 import { failureEnvelope } from '@/lib/plaid/failLoud';
+// REBUILD-01 PR-2d: holdings come from the STORED snapshot (sync-complete's holdings
+// stage lands them raw-first) — Plaid is never asked for holdings here.
+import { latestHoldingsSnapshot } from '@/lib/arrivals/holdingsSnapshot';
 
 export async function GET() {
   try {
@@ -22,21 +25,21 @@ export async function GET() {
     }
 
     const plaidItems = await prisma.plaid_items.findMany({
-      where: { userId: user.id }
+      where: { userId: user.id },
+      include: { accounts: { select: { id: true, accountId: true } } },
     });
 
     const investmentData = [];
-    
+
     for (const item of plaidItems) {
+      // REBUILD-01 PR-2d: the latest stored snapshot per account — `as_of` null means
+      // no snapshot has been stored yet (run a sync), never an empty portfolio.
+      const snapshot = await latestHoldingsSnapshot(prisma, item.accounts);
+
       // HYG-01: STOP AND DECLARE — a failed provider call is the response, never an
       // empty list. `stage` names the call in flight.
-      let stage: 'holdings' | 'investments' = 'holdings';
+      const stage = 'investments';
       try {
-        const holdingsResponse = await plaidClient.investmentsHoldingsGet({
-          access_token: decryptToken(item.accessToken)
-        });
-
-        stage = 'investments';
         const transactionsResponse = await plaidClient.investmentsTransactionsGet({
           access_token: decryptToken(item.accessToken),
           start_date: '2020-01-01',
@@ -45,8 +48,9 @@ export async function GET() {
 
         investmentData.push({
           institution: 'Investment Account', // Default since institutionName doesn't exist
-          holdings: holdingsResponse.data.holdings,
-          securities: holdingsResponse.data.securities,
+          snapshot: { as_of: snapshot.as_of, stored: snapshot.holdings.length },
+          holdings: snapshot.holdings,
+          securities: snapshot.securities,
           transactions: transactionsResponse.data.investment_transactions,
         });
       } catch (error) {

--- a/src/app/api/transactions/sync-complete/route.ts
+++ b/src/app/api/transactions/sync-complete/route.ts
@@ -16,6 +16,10 @@ import { prismaDomain } from '@/lib/arrivals/prismaDomain';
 // transactions as arrivals, the parser reading them, one statement per kind.
 import { INVESTMENT_TRANSACTION, runInvestmentsPage } from '@/lib/arrivals/plaidInvestmentsPage';
 import { prismaInvestmentsDomain } from '@/lib/arrivals/prismaInvestmentsDomain';
+// REBUILD-01 PR-2d: holdings land as SNAPSHOTS — one holdings answer per item per sync,
+// raw-first, the composed their_id labeled, one statement per kind.
+import { HOLDING, runHoldingsPage } from '@/lib/arrivals/plaidHoldingsPage';
+import { prismaHoldingsDomain } from '@/lib/arrivals/prismaHoldingsDomain';
 import type { Prisma } from '@prisma/client';
 
 export const maxDuration = 300; // 5 minutes for Pro plan
@@ -300,12 +304,72 @@ export async function POST() {
       }
     };
 
+    // REBUILD-01 PR-2d: the holdings stage — one /investments/holdings/get per item per
+    // sync (the natural place: the item loop already runs every stage per item under
+    // HYG-03's isolation). Raw-first in ONE transaction: the wire → arrivals (the
+    // answer's securities, one per holding with a COMPOSED their_id —
+    // holding:<account_id>:<security_id>:<as_of>, the as_of being the UTC date the
+    // answer arrived — labeled composed, kind snapshot by the rule book) → the parser
+    // reading the ARRIVAL payloads → holdings rows, one per account + security +
+    // as_of (the same snapshot again is already_landed and writes nothing; a
+    // position moved the same day is corrected; a new day is a new row) → read /
+    // status = done. The batching binding replays the writes as one statement per
+    // kind. /api/investments reads what this stores — Plaid is asked once.
+    const syncHoldings = async (item: PlaidItem): Promise<StageOutcome> => {
+      try {
+        let holdingsResponse;
+        try {
+          holdingsResponse = await plaidClient.investmentsHoldingsGet({
+            access_token: decryptToken(item.accessToken),
+          });
+        } catch (askError) {
+          // A failed ask is evidence of the ask — the non-2xx answer's exact bytes land
+          // (no arrivals) before the stage declares the failure.
+          await recordFailedAnswer(prismaLanding(prisma as unknown as Prisma.TransactionClient), { userId: user.id, err: askError, resource: HOLDING });
+          throw askError;
+        }
+        const wire = wireOf(holdingsResponse, 'investmentsHoldingsGet');
+
+        let batch: ReturnType<typeof prismaHoldingsDomain> | null = null;
+        const started = Date.now();
+        const result = await runHoldingsPage(
+          prisma,
+          (tx) => {
+            batch = prismaHoldingsDomain(tx as Prisma.TransactionClient);
+            return { landing: prismaLanding(tx as Prisma.TransactionClient), domain: batch, finish: () => batch!.finish() };
+          },
+          {
+            userId: user.id,
+            connection: item.itemId,
+            accounts: item.accounts.map((acc) => ({ id: acc.id, accountId: acc.accountId })),
+            wire,
+            httpStatus: holdingsResponse.status,
+            securities: holdingsResponse.data.securities,
+            holdings: holdingsResponse.data.holdings,
+          },
+        );
+        const ms = Date.now() - started;
+        const stats = batch ? (batch as ReturnType<typeof prismaHoldingsDomain>).stats() : { intents: 0, statements: 0 };
+        if (!result.ok) {
+          console.error(`Holdings stage failed for ${bankName(item.institutionName)} after ${ms}ms:`, result.failure.error);
+          return result.failure;
+        }
+        console.log(`[sync] ${bankName(item.institutionName)} holdings as of ${result.asOf}: ${holdingsResponse.data.holdings.length} holdings + ${holdingsResponse.data.securities.length} securities, ${JSON.stringify(result.counts)}, ${stats.intents} domain intents → ${stats.statements} statements, ${ms}ms`);
+        return stageOk('holdings', { ...result.counts });
+      } catch (error) {
+        const failure = await declareStageFailure('holdings', error, item);
+        console.error(`Holdings stage failed for ${bankName(item.institutionName)}:`, failure.error);
+        return failure;
+      }
+    };
+
     const items = await syncEachItem(
       plaidItems,
       (item) => { console.log(`Syncing ${item.institutionName || 'Bank'}...`); return bankName(item.institutionName); },
       [
         ['transactions', syncTransactions],
         ['investments', syncInvestments],
+        ['holdings', syncHoldings],
       ],
     );
     // BANK-03: retired items ride the answer with no stages — the banner says "retired", never "failed".
@@ -314,23 +378,26 @@ export async function POST() {
     // The run's totals — summed over the stages that succeeded (a failed stage has no counts).
     const tx = sumStageCounts(items, 'transactions');
     const inv = sumStageCounts(items, 'investments');
+    const hold = sumStageCounts(items, 'holdings');
     const allOk = items.every((i) => i.stages.every((s) => s.ok));
     const { status, body } = syncItemsEnvelope(items, {
       success: allOk,
       synced: {
         transactions: tx.synced ?? 0,
         investmentTransactions: inv.synced ?? 0,
-        securities: inv.securities ?? 0
+        securities: inv.securities ?? 0,
+        // REBUILD-01 PR-2d: holdings rows written this run (a snapshot already stored writes none).
+        holdings: hold.holdings ?? 0
       },
       skipped: {
         transactions: tx.skipped ?? 0,
         investmentTransactions: inv.skipped ?? 0
       },
-      // REBUILD-01 PR-2 / PR-2c: the store's counts for this run — both phases.
+      // REBUILD-01 PR-2 / PR-2c / PR-2d: the store's counts for this run — all three phases.
       landed: {
-        arrivals: (tx.landed ?? 0) + (inv.landed ?? 0),
-        already_landed: (tx.already_landed ?? 0) + (inv.already_landed ?? 0),
-        corrected: (tx.corrected ?? 0) + (inv.corrected ?? 0)
+        arrivals: (tx.landed ?? 0) + (inv.landed ?? 0) + (hold.landed ?? 0),
+        already_landed: (tx.already_landed ?? 0) + (inv.already_landed ?? 0) + (hold.already_landed ?? 0),
+        corrected: (tx.corrected ?? 0) + (inv.corrected ?? 0) + (hold.corrected ?? 0)
       }
     });
     return NextResponse.json(body, { status });

--- a/src/lib/__tests__/arrivalsHoldings.test.ts
+++ b/src/lib/__tests__/arrivalsHoldings.test.ts
@@ -1,0 +1,279 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import type { Holding, Security } from 'plaid';
+import type { Prisma } from '@prisma/client';
+import { fingerprintOf, sha256 } from '../arrivals/land';
+import {
+  HOLDING, HOLDING_DATA_KEYS, asOfDate, holdingTheirId, holdingWrite, landHoldingsPage, runHoldingsPage,
+  type HoldingRow, type HoldingsDomainDb, type HoldingsPageInput,
+} from '../arrivals/plaidHoldingsPage';
+import { PLAID } from '../arrivals/plaidTransactionsPage';
+import { SECURITY } from '../arrivals/plaidInvestmentsPage';
+import { UnsupportedHoldingsWriteError, holdingsSql, planHoldings, prismaHoldingsDomain } from '../arrivals/prismaHoldingsDomain';
+import { latestHoldingsSnapshot, type HoldingsReadDb } from '../arrivals/holdingsSnapshot';
+import { stageOk, successLine } from '../plaid/failLoud';
+import { kindOf } from '../providers';
+import { FakeLanding, snapshotClient } from './fakeLanding';
+
+// REBUILD-01 PR-2d — Plaid holdings land as snapshots. Hermetic: the shared fake store
+// (fakeLanding.ts), a fake domain port that records the parser's writes and what the
+// holdings table would hold, the batching binding over a fake $executeRaw, and the
+// snapshot reader over a fake of the two tables.
+
+const key = (r: { accountId: string; security_id: string; as_of: string }) => `${r.accountId} ${r.security_id} ${r.as_of}`;
+
+class FakeDomain implements HoldingsDomainDb {
+  calls: string[] = [];
+  secUpserts = 0;
+  secLinks = 0;
+  upserts: HoldingRow[] = [];
+  /** what the holdings table would hold, by (accountId, security_id, as_of) */
+  rows = new Map<string, HoldingRow>();
+  constructor(private throwOnSecurity: string | null = null) {}
+  securities = {
+    upsert: async (args: { where: { securityId: string }; create: Record<string, unknown>; update: Record<string, unknown> }) => {
+      if (this.throwOnSecurity === args.where.securityId) throw new Error('Invalid `prisma.securities.upsert()` invocation: column "arrival_id" of relation "securities" does not exist');
+      this.calls.push(`securities.upsert ${args.where.securityId}`);
+      this.secUpserts += 1;
+      return {};
+    },
+    updateMany: async (args: { where: Record<string, unknown>; data: Record<string, unknown> }) => {
+      this.calls.push(`securities.link ${String(args.where.securityId)}`);
+      this.secLinks += 1;
+      return {};
+    },
+  };
+  holdings = {
+    upsert: async (row: HoldingRow) => {
+      this.calls.push(`holdings.upsert ${key(row)}`);
+      this.upserts.push(row);
+      const prior = this.rows.get(key(row));
+      this.rows.set(key(row), prior ? { ...row, id: prior.id } : row);
+      return {};
+    },
+  };
+}
+
+const ASKED = new Date('2026-09-08T14:00:00Z');
+const ARRIVED = new Date('2026-09-08T14:00:01Z');
+const NOW = new Date('2026-09-08T14:00:02Z');
+const wire = (json: string, arrived = ARRIVED) => ({ body: Buffer.from(json, 'utf8'), asked: ASKED, arrived });
+const sec = (id: string, over: Record<string, unknown> = {}): Security => ({
+  security_id: id, isin: null, cusip: null, sedol: null, institution_security_id: null, institution_id: null, proxy_security_id: null,
+  name: `Security ${id}`, ticker_symbol: id.toUpperCase(), is_cash_equivalent: false, type: 'equity', close_price: 100.5, close_price_as_of: '2026-09-05',
+  iso_currency_code: 'USD', unofficial_currency_code: null, ...over,
+} as unknown as Security);
+/** A holding as the SDK types it (plaid 11.0.0 Holding): no id of its own, no secret. */
+const hold = (account_id: string, security_id: string, over: Record<string, unknown> = {}): Holding => ({
+  account_id, security_id, institution_price: 100.5, institution_price_as_of: '2026-09-05', institution_price_datetime: null,
+  institution_value: 1005, cost_basis: 900, quantity: 10, iso_currency_code: 'USD', unofficial_currency_code: null, ...over,
+} as unknown as Holding);
+const answer = (holdings: Holding[], securities: Security[]) => JSON.stringify({ accounts: [], holdings, securities, item: { item_id: 'item_abc' }, request_id: 'req_1' });
+const input = (over: Partial<HoldingsPageInput>): HoldingsPageInput => ({
+  userId: 'user_1', connection: 'item_abc', accounts: [{ id: 'acc_db_1', accountId: 'acc_plaid_1' }],
+  wire: wire(answer([], [])), httpStatus: 200, securities: [], holdings: [], now: () => NOW, ...over,
+});
+const withObjects = (holdings: Holding[], securities: Security[], arrived = ARRIVED, over: Partial<HoldingsPageInput> = {}) =>
+  input({ wire: wire(answer(holdings, securities), arrived), holdings, securities, ...over });
+
+test('the rule book names the feed (plaid · holding → snapshot); the composed id and the as-of are pure', () => {
+  assert.equal(kindOf(PLAID, HOLDING), 'snapshot');
+  assert.equal(holdingTheirId({ account_id: 'acc_plaid_1', security_id: 'aapl' }, '2026-09-08'), 'holding:acc_plaid_1:aapl:2026-09-08');
+  assert.equal(asOfDate(new Date('2026-09-08T23:59:59Z')), '2026-09-08');
+  assert.equal(asOfDate(new Date('2026-09-09T00:00:00Z')), '2026-09-09');
+});
+
+test('a holdings answer lands: the wire row (resource holding, exact bytes), the answer\'s securities as reference arrivals, one snapshot arrival per holding with a COMPOSED their_id labeled composed and kind snapshot; one holdings row per holding, from the arrival, pointed at it; read once', async () => {
+  const landing = new FakeLanding();
+  const dom = new FakeDomain();
+  const holdings = [hold('acc_plaid_1', 'aapl'), hold('acc_plaid_1', 'msft', { quantity: 3, institution_value: 900, cost_basis: null })];
+  const inp = withObjects(holdings, [sec('aapl'), sec('msft')]);
+  const out = await landHoldingsPage(landing, dom, inp);
+  assert.equal(out.asOf, '2026-09-08');
+  assert.deepEqual(out.counts, { landed: 4, already_landed: 0, corrected: 0, holdings: 2, securities: 2, unmatched: 0 });
+  // the wire row
+  assert.equal(landing.responses.length, 1);
+  const r = landing.responses[0];
+  assert.equal(r.provider, PLAID);
+  assert.equal(r.resource, HOLDING);
+  assert.equal(r.http_status, 200);
+  assert.equal(r.body.toString('utf8'), answer(holdings, [sec('aapl'), sec('msft')]));
+  assert.deepEqual(r.body_sha256, sha256(inp.wire.body));
+  assert.deepEqual(r.redactions, []);
+  assert.equal(r.user_id, 'user_1');
+  // the arrivals: two securities (provider id, reference), two holdings (composed id, snapshot)
+  const secs = landing.rowsOf(SECURITY);
+  assert.equal(secs.length, 2);
+  assert.ok(secs.every((a) => a.row.their_id_kind === 'provider' && a.row.kind === 'reference' && a.row.connection === 'item_abc'));
+  const snaps = landing.rowsOf(HOLDING);
+  assert.equal(snaps.length, 2);
+  const aapl = landing.rowsFor('holding:acc_plaid_1:aapl:2026-09-08')[0];
+  assert.ok(aapl, 'their_id composed from account_id, security_id and the day the answer arrived');
+  assert.equal(aapl.row.their_id_kind, 'composed');
+  assert.equal(aapl.row.kind, 'snapshot');
+  assert.equal(aapl.row.resource, HOLDING);
+  assert.deepEqual(aapl.row.payload, holdings[0]);
+  assert.equal(Buffer.compare(Buffer.from(aapl.row.fingerprint), fingerprintOf(holdings[0])), 0);
+  assert.equal(aapl.row.response_id, r.id);
+  assert.equal(aapl.status, 'done');
+  assert.deepEqual(aapl.read, NOW);
+  // the domain: securities first, then the holdings rows from the arrivals, each pointed at its arrival
+  assert.deepEqual(dom.calls, ['securities.upsert aapl', 'securities.upsert msft', 'holdings.upsert acc_db_1 aapl 2026-09-08', 'holdings.upsert acc_db_1 msft 2026-09-08']);
+  assert.equal(dom.rows.size, 2);
+  const row = dom.rows.get('acc_db_1 aapl 2026-09-08')!;
+  assert.equal(row.data.arrival_id, aapl.row.id);
+  assert.equal(row.accountId, 'acc_db_1');
+  assert.equal(row.security_id, 'aapl');
+  assert.equal(row.as_of, '2026-09-08');
+  assert.deepEqual(row.data, { quantity: 10, cost_basis: 900, institution_price: 100.5, institution_price_as_of: '2026-09-05', institution_price_datetime: null, institution_value: 1005, iso_currency_code: 'USD', unofficial_currency_code: null, arrival_id: aapl.row.id, updatedAt: NOW });
+  assert.match(row.id, /^hold_/);
+  const msft = dom.rows.get('acc_db_1 msft 2026-09-08')!;
+  assert.equal(msft.data.cost_basis, null, 'absent stays null, never invented');
+  assert.equal(msft.data.quantity, 3);
+});
+
+test('the same snapshot again (the same day, the same content) is already_landed: a second wire row, no second arrival, nothing written — the row already points at that arrival', async () => {
+  const landing = new FakeLanding();
+  const dom = new FakeDomain();
+  const holdings = [hold('acc_plaid_1', 'aapl')];
+  await landHoldingsPage(landing, dom, withObjects(holdings, [sec('aapl')]));
+  const again = await landHoldingsPage(landing, dom, withObjects(holdings, [sec('aapl')], new Date('2026-09-08T20:00:00Z')));
+  assert.deepEqual(again.counts, { landed: 0, already_landed: 2, corrected: 0, holdings: 0, securities: 1, unmatched: 0 });
+  assert.equal(landing.responses.length, 2, 'every answer is its own wire row');
+  assert.equal(landing.rowsOf(HOLDING).length, 1, 'the same thing is the same provider, id and content');
+  assert.equal(dom.upserts.length, 1, 'no second write');
+  assert.equal(dom.secLinks, 1, 'the already-landed security is linked, never re-parsed');
+  assert.equal(dom.rows.size, 1);
+});
+
+test('a new as-of (the answer arrived the next day) lands a new arrival and a NEW row — yesterday\'s snapshot is never rewritten', async () => {
+  const landing = new FakeLanding();
+  const dom = new FakeDomain();
+  const holdings = [hold('acc_plaid_1', 'aapl')];
+  const first = await landHoldingsPage(landing, dom, withObjects(holdings, [sec('aapl')]));
+  const next = await landHoldingsPage(landing, dom, withObjects(holdings, [sec('aapl')], new Date('2026-09-09T14:00:01Z')));
+  assert.equal(first.asOf, '2026-09-08');
+  assert.equal(next.asOf, '2026-09-09');
+  assert.deepEqual(next.counts, { landed: 1, already_landed: 1, corrected: 0, holdings: 1, securities: 1, unmatched: 0 });
+  assert.ok(landing.rowsFor('holding:acc_plaid_1:aapl:2026-09-09')[0], 'a new composed key');
+  assert.equal(dom.rows.size, 2, 'two snapshots of the position');
+  assert.notEqual(dom.rows.get('acc_db_1 aapl 2026-09-08')!.data.arrival_id, dom.rows.get('acc_db_1 aapl 2026-09-09')!.data.arrival_id);
+});
+
+test('the same day, the position moved (a new content for the same composed key): corrected — a new arrival, the row takes the latest and its arrival_id moves; the earlier arrival stays', async () => {
+  const landing = new FakeLanding();
+  const dom = new FakeDomain();
+  const first = await landHoldingsPage(landing, dom, withObjects([hold('acc_plaid_1', 'aapl')], [sec('aapl')]));
+  const moved = await landHoldingsPage(landing, dom, withObjects([hold('acc_plaid_1', 'aapl', { quantity: 12, institution_value: 1206 })], [sec('aapl')], new Date('2026-09-08T21:00:00Z')));
+  assert.deepEqual(moved.counts, { landed: 0, already_landed: 1, corrected: 1, holdings: 1, securities: 1, unmatched: 0 });
+  const arrivals = landing.rowsFor('holding:acc_plaid_1:aapl:2026-09-08');
+  assert.equal(arrivals.length, 2, 'a correction is a new row (promise 1)');
+  assert.ok(arrivals.every((a) => a.status === 'done'));
+  assert.equal(dom.rows.size, 1, 'one snapshot per moment');
+  const row = dom.rows.get('acc_db_1 aapl 2026-09-08')!;
+  assert.equal(row.data.quantity, 12);
+  assert.equal(row.id, dom.upserts[0].id, 'the row keeps its identity');
+  assert.notEqual(row.data.arrival_id, dom.upserts[0].data.arrival_id, 'arrival_id moved to the newest arrival');
+  assert.equal(first.counts.holdings, 1);
+});
+
+test('a holding whose account is none of the item\'s accounts is landed and read but writes no row — counted as unmatched, declared', async () => {
+  const landing = new FakeLanding();
+  const dom = new FakeDomain();
+  const out = await landHoldingsPage(landing, dom, withObjects([hold('acc_plaid_9', 'aapl')], [sec('aapl')]));
+  assert.deepEqual(out.counts, { landed: 2, already_landed: 0, corrected: 0, holdings: 0, securities: 1, unmatched: 1 });
+  const a = landing.rowsFor('holding:acc_plaid_9:aapl:2026-09-08')[0];
+  assert.equal(a.status, 'done');
+  assert.equal(dom.rows.size, 0);
+});
+
+test('a parser throw rolls the whole answer back and comes out as the declared failure (stage holdings): no wire row, no arrival, no row', async () => {
+  const landing = new FakeLanding();
+  const dom = new FakeDomain('aapl');
+  let rolledBack = 0;
+  const result = await runHoldingsPage(snapshotClient(landing, () => { rolledBack += 1; }), () => ({ landing, domain: dom }), withObjects([hold('acc_plaid_1', 'aapl')], [sec('aapl')]));
+  assert.equal(result.ok, false);
+  if (result.ok) return;
+  assert.equal(result.failure.stage, 'holdings');
+  assert.equal(result.failure.page, undefined, 'one answer, no pages');
+  assert.match(result.failure.error.message ?? '', /securities\.upsert/);
+  assert.equal(rolledBack, 1);
+  assert.equal(landing.responses.length, 0);
+  assert.equal(landing.arrivals.size, 0);
+  assert.equal(dom.rows.size, 0);
+  // and the ok shape carries the counts and the moment
+  const ok = await runHoldingsPage(snapshotClient(landing), () => ({ landing, domain: new FakeDomain() }), withObjects([hold('acc_plaid_1', 'aapl')], [sec('aapl')]));
+  assert.equal(ok.ok, true);
+  if (ok.ok) { assert.equal(ok.asOf, '2026-09-08'); assert.equal(ok.counts.holdings, 1); }
+});
+
+test('holdingWrite maps every SDK field to a column — null, never undefined; the batching binding replays one statement per kind, refuses a malformed row and a write after finish', async () => {
+  const w = holdingWrite(hold('acc_plaid_1', 'aapl', { institution_price_as_of: null, iso_currency_code: null, unofficial_currency_code: 'BTC' }), 'acc_db_1', '2026-09-08', 'arr_1', NOW);
+  for (const k of HOLDING_DATA_KEYS) assert.notEqual(w.data[k], undefined, `${k} present`);
+  assert.equal(w.data.institution_price_as_of, null);
+  assert.equal(w.data.unofficial_currency_code, 'BTC');
+  // the plan: one row per key — the first id, the last values
+  const a = holdingWrite(hold('acc_plaid_1', 'aapl'), 'acc_db_1', '2026-09-08', 'arr_1', NOW);
+  const b = holdingWrite(hold('acc_plaid_1', 'aapl', { quantity: 11 }), 'acc_db_1', '2026-09-08', 'arr_2', NOW);
+  const c = holdingWrite(hold('acc_plaid_1', 'msft'), 'acc_db_1', '2026-09-08', 'arr_3', NOW);
+  const plan = planHoldings([a, b, c]);
+  assert.equal(plan.length, 2);
+  assert.equal(plan[0].id, a.id);
+  assert.equal(plan[0].data.quantity, 11);
+  assert.equal(plan[0].data.arrival_id, 'arr_2');
+  // the SQL: one INSERT … ON CONFLICT on the snapshot key, the dates cast, the values bound
+  const sql = holdingsSql(plan);
+  assert.match(sql.sql, /^INSERT INTO holdings \("id","accountId","security_id","as_of","quantity","cost_basis","institution_price","institution_price_as_of","institution_price_datetime","institution_value","iso_currency_code","unofficial_currency_code","arrival_id","updatedAt"\) VALUES /);
+  assert.match(sql.sql, /ON CONFLICT \("accountId", security_id, as_of\) DO UPDATE SET "quantity" = EXCLUDED\."quantity"/);
+  assert.match(sql.sql, /VALUES \(\?,\?,\?,\?::date,\?::float8,\?::float8,\?::float8,\?::date,\?::timestamp,\?::float8,\?,\?,\?,\?::timestamp\)/, 'the dates and floats cast, every value bound');
+  assert.equal(sql.values[3], '2026-09-08');
+  assert.equal(sql.values.length, 2 * 14);
+  // the binding over a fake executor: securities first, then holdings — one statement each
+  const ran: string[] = [];
+  const dom = prismaHoldingsDomain({ $executeRaw: async (q: Prisma.Sql) => { ran.push(q.sql.slice(0, 30)); return 1; } });
+  await dom.securities.upsert({ where: { securityId: 'aapl' }, create: { id: 'sec_1', securityId: 'aapl', isin: null, cusip: null, sedol: null, ticker_symbol: 'AAPL', name: 'Apple', type: 'equity', updatedAt: NOW, close_price: 1, close_price_as_of: null, option_contract_type: null, option_strike_price: null, option_expiration_date: null, option_underlying_ticker: null, arrival_id: 'arr_s' }, update: { close_price: 1, close_price_as_of: null, option_contract_type: null, option_strike_price: null, option_expiration_date: null, option_underlying_ticker: null, arrival_id: 'arr_s' } });
+  await dom.holdings.upsert(a);
+  await dom.holdings.upsert(b);
+  await dom.finish();
+  assert.deepEqual(ran.map((s) => s.split(' ').slice(0, 3).join(' ')), ['INSERT INTO securities', 'INSERT INTO holdings']);
+  assert.deepEqual(dom.stats(), { intents: 3, statements: 2 });
+  await assert.rejects(dom.holdings.upsert(c), UnsupportedHoldingsWriteError);
+  const bad = prismaHoldingsDomain({ $executeRaw: async () => 1 });
+  await assert.rejects(bad.holdings.upsert({ ...a, as_of: '2026/09/08' }), /as_of must be YYYY-MM-DD/);
+  await assert.rejects(bad.holdings.upsert({ ...a, data: { ...a.data, quantity: undefined as unknown as number } }), /quantity is undefined/);
+  const { arrival_id: _dropped, ...missing } = a.data;
+  void _dropped;
+  await assert.rejects(bad.holdings.upsert({ ...a, data: missing as HoldingRow['data'] }), /must carry exactly/);
+});
+
+test('the stored snapshot, read: each account\'s latest moment and every row of it (a position sold since an older day is not shown), Plaid field names, the securities named; nothing stored is declared as as_of null', async () => {
+  const d = (s: string) => new Date(`${s}T00:00:00Z`);
+  const stored = [
+    { id: 'h1', accountId: 'acc_db_1', security_id: 'aapl', as_of: d('2026-09-07'), quantity: 10, cost_basis: 900, institution_price: 100, institution_price_as_of: d('2026-09-05'), institution_price_datetime: null, institution_value: 1000, iso_currency_code: 'USD', unofficial_currency_code: null, arrival_id: 'arr_1', createdAt: new Date('2026-09-07T14:00:00Z'), updatedAt: NOW },
+    { id: 'h2', accountId: 'acc_db_1', security_id: 'msft', as_of: d('2026-09-07'), quantity: 3, cost_basis: null, institution_price: 300, institution_price_as_of: null, institution_price_datetime: new Date('2026-09-07T20:00:00Z'), institution_value: 900, iso_currency_code: 'USD', unofficial_currency_code: null, arrival_id: 'arr_2', createdAt: new Date('2026-09-07T14:00:00Z'), updatedAt: NOW },
+    { id: 'h3', accountId: 'acc_db_1', security_id: 'aapl', as_of: d('2026-09-08'), quantity: 12, cost_basis: 1100, institution_price: 101, institution_price_as_of: d('2026-09-08'), institution_price_datetime: null, institution_value: 1212, iso_currency_code: 'USD', unofficial_currency_code: null, arrival_id: 'arr_3', createdAt: new Date('2026-09-08T14:00:00Z'), updatedAt: NOW },
+    { id: 'h4', accountId: 'acc_db_2', security_id: 'btc', as_of: d('2026-09-06'), quantity: 0.5, cost_basis: 20000, institution_price: 60000, institution_price_as_of: null, institution_price_datetime: null, institution_value: 30000, iso_currency_code: null, unofficial_currency_code: 'BTC', arrival_id: 'arr_4', createdAt: new Date('2026-09-06T14:00:00Z'), updatedAt: NOW },
+  ];
+  const asked: unknown[] = [];
+  const db = {
+    holdings: { findMany: async (args: unknown) => { asked.push(args); return [...stored].sort((x, y) => y.as_of.getTime() - x.as_of.getTime()); } },
+    securities: { findMany: async (args: { where: { securityId: { in: string[] } } }) => args.where.securityId.in.map((id) => ({ id: `sec_${id}`, securityId: id, isin: null, cusip: null, sedol: null, ticker_symbol: id.toUpperCase(), name: `Security ${id}`, type: 'equity', close_price: 1, close_price_as_of: d('2026-09-08'), option_contract_type: null, option_strike_price: null, option_expiration_date: null, option_underlying_ticker: null, createdAt: NOW, updatedAt: NOW, arrival_id: null })) },
+  } as unknown as HoldingsReadDb;
+  const snap = await latestHoldingsSnapshot(db, [{ id: 'acc_db_1', accountId: 'acc_plaid_1' }, { id: 'acc_db_2', accountId: 'acc_plaid_2' }]);
+  assert.equal(snap.as_of, '2026-09-08');
+  assert.deepEqual(snap.holdings.map((h) => [h.account_id, h.security_id, h.as_of, h.quantity]), [['acc_plaid_1', 'aapl', '2026-09-08', 12], ['acc_plaid_2', 'btc', '2026-09-06', 0.5]], 'msft (sold since 09-07) is not shown as held; each account at its own latest moment');
+  assert.deepEqual(snap.holdings[0], { account_id: 'acc_plaid_1', security_id: 'aapl', quantity: 12, cost_basis: 1100, institution_price: 101, institution_price_as_of: '2026-09-08', institution_price_datetime: null, institution_value: 1212, iso_currency_code: 'USD', unofficial_currency_code: null, as_of: '2026-09-08', arrival_id: 'arr_3' });
+  assert.deepEqual(snap.securities.map((s) => s.security_id).sort(), ['aapl', 'btc']);
+  assert.deepEqual(snap.securities.find((s) => s.security_id === 'aapl'), { security_id: 'aapl', name: 'Security aapl', ticker_symbol: 'AAPL', type: 'equity', isin: null, cusip: null, sedol: null, close_price: 1, close_price_as_of: '2026-09-08' });
+  assert.deepEqual((asked[0] as { where: unknown }).where, { accountId: { in: ['acc_db_1', 'acc_db_2'] } }, 'scoped to the accounts given');
+  const none = await latestHoldingsSnapshot({ holdings: { findMany: async () => [] }, securities: { findMany: async () => [] } } as unknown as HoldingsReadDb, [{ id: 'acc_db_1', accountId: 'acc_plaid_1' }]);
+  assert.deepEqual(none, { as_of: null, holdings: [], securities: [] }, 'nothing stored yet is declared, never dressed as an empty portfolio');
+  assert.deepEqual(await latestHoldingsSnapshot(db, []), { as_of: null, holdings: [], securities: [] });
+});
+
+test('the banner counts holdings written this run, after the securities; a run that wrote none says nothing about them', () => {
+  const items = [{ institution: 'Robinhood', stages: [stageOk('transactions', { synced: 3, skipped: 0, landed: 3, already_landed: 0, corrected: 0 }), stageOk('investments', { synced: 7, skipped: 0, securities: 2 }), stageOk('holdings', { landed: 14, already_landed: 0, corrected: 0, holdings: 12, securities: 12, unmatched: 0 })] }];
+  assert.equal(successLine(items), 'Robinhood synced: 3 landed, 7 investment transactions, 2 securities, 12 holdings');
+  const quiet = [{ institution: 'Robinhood', stages: [stageOk('transactions', { synced: 0, skipped: 0, landed: 0, already_landed: 3, corrected: 0 }), stageOk('holdings', { landed: 0, already_landed: 14, corrected: 0, holdings: 0, securities: 12, unmatched: 0 })] }];
+  assert.equal(successLine(quiet), 'Robinhood synced: 0 landed, 3 already landed');
+});

--- a/src/lib/__tests__/kindViews.test.ts
+++ b/src/lib/__tests__/kindViews.test.ts
@@ -1,13 +1,17 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { readFileSync, readdirSync } from 'node:fs';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { ARRIVAL_KINDS, kindOf } from '../providers';
-import { KIND_VIEWS_HONEST_LINE, KIND_VIEW_CENSUS, STOPPED_TABLES, VIEW_COLUMNS, kindOfTable, kindViewSql, kindViewsHonestLine, kindViewsLaw, kindViewsSql, parseViews, tablesOfKind, type FeedTable } from '../kindViews';
+import { KIND_VIEWS_HONEST_LINE, KIND_VIEW_CENSUS, STOPPED_TABLES, VIEW_COLUMNS, kindOfTable, kindViewSql, kindViewsHonestLine, kindViewsLaw, kindViewsSql, latestViews, latestViewsSql, parseViews, tablesOfKind, type FeedTable } from '../kindViews';
 
 // TABLES-01 — six views, one per kind, generated from the census; the kind per table from the rule book.
+// REBUILD-01 PR-2d — a view is redefined by a later migration (the snapshot view over holdings); the law reads each view's newest text.
 
 const ROOT = resolve(__dirname, '../../..');
+const allMigrations = () => readdirSync(resolve(ROOT, 'prisma/migrations')).sort()
+  .filter((d) => existsSync(resolve(ROOT, 'prisma/migrations', d, 'migration.sql')))
+  .map((d) => ({ dir: d, sql: readFileSync(resolve(ROOT, 'prisma/migrations', d, 'migration.sql'), 'utf8') }));
 const migration = () => {
   const dir = readdirSync(resolve(ROOT, 'prisma/migrations')).find((d) => d.endsWith('_kind_views'));
   assert.ok(dir, 'the kind_views migration exists');
@@ -20,14 +24,15 @@ test('the census: every table once, its kind from the rule book (never typed), a
     ['transactions', 'event'], ['investment_transactions', 'event'], ['reservations', 'event'],
     ['securities', 'reference'], ['places_cache', 'reference'], ['regulatory_documents', 'reference'],
     ['accounts', 'registry'],
+    ['holdings', 'snapshot'],
   ]);
   for (const t of KIND_VIEW_CENSUS) {
     if (Array.isArray(t.feed)) assert.equal(kindOfTable(t), kindOf(t.feed[0], t.feed[1]));
   }
-  assert.deepEqual(tablesOfKind('snapshot'), []);
+  assert.deepEqual(tablesOfKind('snapshot').map((t) => t.table), ['holdings']);
   assert.deepEqual(tablesOfKind('derived'), []);
   assert.deepEqual(tablesOfKind('posting'), []);
-  assert.equal(KIND_VIEWS_HONEST_LINE, 'Today the six are views over the feed tables — event: transactions, investment transactions, bookings; reference: securities, places, the law corpus; registry: accounts; snapshot: none yet; derived: none yet; posting: empty by law.');
+  assert.equal(KIND_VIEWS_HONEST_LINE, 'Today the six are views over the feed tables — event: transactions, investment transactions, bookings; reference: securities, places, the law corpus; registry: accounts; snapshot: holdings; derived: none yet; posting: empty by law.');
   assert.ok(STOPPED_TABLES.length >= 5, 'the unruled tables are reported');
   assert.ok(STOPPED_TABLES.every((s) => !KIND_VIEW_CENSUS.some((t) => t.table === s.table)), 'a stopped table is never viewed');
 });
@@ -40,13 +45,21 @@ test('the SQL: one CREATE VIEW per kind in the deck\'s order, the common columns
   assert.deepEqual(views.find((v) => v.name === 'event')!.tables, ['transactions', 'investment_transactions', 'reservations']);
   assert.deepEqual(views.find((v) => v.name === 'reference')!.tables, ['securities', 'places_cache', 'regulatory_documents']);
   assert.deepEqual(views.find((v) => v.name === 'registry')!.tables, ['accounts']);
-  for (const k of ['snapshot', 'derived', 'posting']) {
+  assert.deepEqual(views.find((v) => v.name === 'snapshot')!.tables, ['holdings']);
+  for (const k of ['derived', 'posting']) {
     const v = views.find((x) => x.name === k)!;
     assert.deepEqual(v.tables, []);
     assert.match(v.body, /WHERE false/);
   }
   assert.match(kindViewSql('posting'), /^-- posting: empty by the deck's own law/);
-  assert.match(kindViewSql('snapshot'), /plaid · holding lands in REBUILD-01 PR-2d/);
+  // PR-2d: the snapshot view over holdings — the composed their_id rebuilt from the row, the user through accounts
+  const snapshot = kindViewSql('snapshot');
+  assert.match(snapshot, /^-- snapshot: holdings\nCREATE VIEW snapshot AS\n/);
+  assert.match(snapshot, /'snapshot'::arrival_kind AS kind/);
+  assert.match(snapshot, /'plaid · holding' AS feed/);
+  assert.match(snapshot, /\('holding:' \|\| a\."accountId" \|\| ':' \|\| h\.security_id \|\| ':' \|\| to_char\(h\.as_of, 'YYYY-MM-DD'\)\)::text AS their_id/);
+  assert.match(snapshot, /h\.arrival_id::text AS arrival_id/);
+  assert.match(snapshot, /FROM holdings h JOIN accounts a ON a\.id = h\."accountId"/);
   // the branches: the kind is a cast literal, the feed is the rule book's words, the filters keep the feed's rows only
   const event = kindViewSql('event');
   assert.match(event, /'event'::arrival_kind AS kind/);
@@ -61,10 +74,28 @@ test('the SQL: one CREATE VIEW per kind in the deck\'s order, the common columns
   assert.match(kindViewSql('registry'), /WHERE a\.source = 'plaid'/);
 });
 
-test('the migration is the generator\'s text verbatim, and the law passes over it', () => {
-  const sql = migration();
-  assert.ok(sql.includes(kindViewsSql()), 'never typed twice');
-  assert.deepEqual(kindViewsLaw({ throwOnFail: false, migrationSql: sql }), []);
+test('the effective views — each view\'s newest CREATE VIEW across the migrations — are the generator\'s text verbatim, and the law passes over them; the first migration alone no longer is (the snapshot view was redefined by a later one)', () => {
+  const all = allMigrations();
+  assert.equal(latestViewsSql(all), kindViewsSql(), 'never typed twice');
+  assert.deepEqual(kindViewsLaw({ throwOnFail: false, migrationSql: latestViewsSql(all) }), []);
+  const sources = Object.fromEntries(latestViews(all).map((v) => [v.kind, v.dir]));
+  assert.ok(sources.event.endsWith('_kind_views'), 'the five untouched views still come from the first migration');
+  assert.ok(sources.reference.endsWith('_kind_views'));
+  assert.ok(sources.registry.endsWith('_kind_views'));
+  assert.ok(sources.derived.endsWith('_kind_views'));
+  assert.ok(sources.posting.endsWith('_kind_views'));
+  assert.ok(sources.snapshot.endsWith('_holdings_snapshot'), 'the snapshot view comes from the holdings migration');
+  const redefinition = all.find((m) => m.dir === sources.snapshot)!.sql;
+  assert.ok(redefinition.indexOf('DROP VIEW snapshot;') < redefinition.indexOf('CREATE VIEW snapshot AS'), 'dropped, then recreated — never OR REPLACE');
+  // the first migration alone: the old empty snapshot view fails the law now that holdings is a census table
+  const original = migration();
+  const v = kindViewsLaw({ throwOnFail: false, migrationSql: original }).join('\n');
+  assert.match(v, /snapshot unions \[\]; the census \(through the rule book\) says \[holdings\]/);
+  assert.match(v, /holdings appears in 0 views, expected exactly 1/);
+  // latestViews is pure over the texts it is handed: a later migration's block wins, whatever order the list came in
+  const shuffled = [...all].reverse();
+  assert.equal(latestViewsSql(shuffled), latestViewsSql(all));
+  assert.deepEqual(latestViews([{ dir: 'b', sql: 'CREATE VIEW posting AS\n  SELECT 2;' }, { dir: 'a', sql: '-- posting: x\nCREATE VIEW posting AS\n  SELECT 1;' }]), [{ kind: 'posting', dir: 'b', sql: 'CREATE VIEW posting AS\n  SELECT 2;' }]);
 });
 
 test('the law fails when a feed table is missing from every view, in two views, in the wrong kind\'s view, when posting unions a table, or when a view\'s columns drift', () => {
@@ -83,5 +114,6 @@ test('the law fails when a feed table is missing from every view, in two views, 
   const twoKinds: FeedTable = { table: 'mixed', label: 'mixed', feed: { column: 'x.k', map: { a: ['plaid', 'transaction'], b: ['plaid', 'security'] } }, rowId: 'x.id', theirId: 'x.id', arrivalId: null, userId: null, arrived: 'x.at', from: 'mixed x', why: 'test' };
   assert.match(kindViewsLaw({ throwOnFail: false, census: [...KIND_VIEW_CENSUS, twoKinds] }).join('\n'), /mixed resolves to 2 kinds \(event, reference\)/);
   // the honest line follows the census: drop a table and its name leaves the line
-  assert.equal(kindViewsHonestLine(KIND_VIEW_CENSUS.filter((t) => t.table !== 'reservations')), 'Today the six are views over the feed tables — event: transactions, investment transactions; reference: securities, places, the law corpus; registry: accounts; snapshot: none yet; derived: none yet; posting: empty by law.');
+  assert.equal(kindViewsHonestLine(KIND_VIEW_CENSUS.filter((t) => t.table !== 'reservations')), 'Today the six are views over the feed tables — event: transactions, investment transactions; reference: securities, places, the law corpus; registry: accounts; snapshot: holdings; derived: none yet; posting: empty by law.');
+  assert.equal(kindViewsHonestLine(KIND_VIEW_CENSUS.filter((t) => t.table !== 'holdings')), 'Today the six are views over the feed tables — event: transactions, investment transactions, bookings; reference: securities, places, the law corpus; registry: accounts; snapshot: none yet; derived: none yet; posting: empty by law.');
 });

--- a/src/lib/arrivals/holdingsSnapshot.ts
+++ b/src/lib/arrivals/holdingsSnapshot.ts
@@ -1,0 +1,94 @@
+/**
+ * REBUILD-01 PR-2d — THE STORED SNAPSHOT, READ. /api/investments (and the
+ * analysis route) used to ask Plaid for holdings live on every view; the one
+ * asker is sync-complete's holdings stage, and this reads what it stored — never
+ * asked twice. For each account: its latest as_of, and every holdings row of
+ * that moment (a position sold since an older day is not shown as held); the
+ * securities those rows name, from the securities table. Answered in Plaid's
+ * field names — the shape the routes always returned — plus the snapshot's
+ * moment and each row's arrival. No snapshot yet (never synced) is declared
+ * as `as_of: null`, never dressed as an empty portfolio.
+ */
+import type { PrismaClient } from '@prisma/client';
+import type { PageAccount } from './plaidTransactionsPage';
+
+export type HoldingsReadDb = Pick<PrismaClient, 'holdings' | 'securities'>;
+
+export interface StoredHolding {
+  account_id: string;
+  security_id: string;
+  quantity: number;
+  cost_basis: number | null;
+  institution_price: number;
+  institution_price_as_of: string | null;
+  institution_price_datetime: string | null;
+  institution_value: number;
+  iso_currency_code: string | null;
+  unofficial_currency_code: string | null;
+  /** The snapshot's moment (YYYY-MM-DD). */
+  as_of: string;
+  arrival_id: string;
+}
+
+export interface StoredSecurity {
+  security_id: string;
+  name: string | null;
+  ticker_symbol: string | null;
+  type: string | null;
+  isin: string | null;
+  cusip: string | null;
+  sedol: string | null;
+  close_price: number | null;
+  close_price_as_of: string | null;
+}
+
+export interface HoldingsSnapshot {
+  /** The newest moment among the accounts' latest snapshots; null when nothing is stored yet. */
+  as_of: string | null;
+  holdings: StoredHolding[];
+  securities: StoredSecurity[];
+}
+
+const dateStr = (d: Date | null): string | null => (d ? d.toISOString().slice(0, 10) : null);
+
+export async function latestHoldingsSnapshot(db: HoldingsReadDb, accounts: PageAccount[]): Promise<HoldingsSnapshot> {
+  if (accounts.length === 0) return { as_of: null, holdings: [], securities: [] };
+  const rows = await db.holdings.findMany({
+    where: { accountId: { in: accounts.map((a) => a.id) } },
+    orderBy: [{ as_of: 'desc' }, { createdAt: 'desc' }],
+  });
+  // Each account's latest moment — the first row seen per account in as_of-desc order — then every row of that moment.
+  const latestByAccount = new Map<string, number>();
+  for (const r of rows) if (!latestByAccount.has(r.accountId)) latestByAccount.set(r.accountId, r.as_of.getTime());
+  const latest = rows.filter((r) => latestByAccount.get(r.accountId) === r.as_of.getTime());
+  const plaidAccountId = new Map(accounts.map((a) => [a.id, a.accountId]));
+  const holdings: StoredHolding[] = latest.map((r) => ({
+    account_id: plaidAccountId.get(r.accountId) as string,
+    security_id: r.security_id,
+    quantity: r.quantity,
+    cost_basis: r.cost_basis,
+    institution_price: r.institution_price,
+    institution_price_as_of: dateStr(r.institution_price_as_of),
+    institution_price_datetime: r.institution_price_datetime ? r.institution_price_datetime.toISOString() : null,
+    institution_value: r.institution_value,
+    iso_currency_code: r.iso_currency_code,
+    unofficial_currency_code: r.unofficial_currency_code,
+    as_of: dateStr(r.as_of) as string,
+    arrival_id: r.arrival_id,
+  }));
+  const securityIds = [...new Set(latest.map((r) => r.security_id))];
+  const secs = securityIds.length ? await db.securities.findMany({ where: { securityId: { in: securityIds } } }) : [];
+  const securities: StoredSecurity[] = secs.map((s) => ({
+    security_id: s.securityId,
+    name: s.name,
+    ticker_symbol: s.ticker_symbol,
+    type: s.type,
+    isin: s.isin,
+    cusip: s.cusip,
+    sedol: s.sedol,
+    close_price: s.close_price,
+    close_price_as_of: dateStr(s.close_price_as_of),
+  }));
+  const as_of = latest.length ? dateStr(new Date(Math.max(...latest.map((r) => r.as_of.getTime())))) : null;
+  return { as_of, holdings, securities };
+}

--- a/src/lib/arrivals/plaidHoldingsPage.ts
+++ b/src/lib/arrivals/plaidHoldingsPage.ts
@@ -1,0 +1,224 @@
+/**
+ * REBUILD-01 PR-2d — PLAID HOLDINGS LAND AS SNAPSHOTS. One /investments/holdings/get
+ * answer per item per sync, raw-first, in ONE database transaction (the PR-2 shape
+ * of plaidTransactionsPage.ts / plaidInvestmentsPage.ts):
+ *
+ *   landResponse (the exact wire bytes; resource 'holding')
+ *   → landObjects for the answer's securities[] (resource 'security', their_id =
+ *     security_id — the same objects the investments answer carries, landed by
+ *     the same rules; the holdings below reference them, holdings.security_id →
+ *     securities.securityId) and for its holdings[] (resource 'holding', kind
+ *     SNAPSHOT by the rule book's plaid · holding row). A holding has no provider
+ *     id, so its their_id is COMPOSED and labeled composed (their_id_kind):
+ *       holding:<account_id>:<security_id>:<as_of>
+ *     where as_of is the UTC date the answer arrived — the moment the snapshot
+ *     stands for. The answer carries no as-of of its own; a holding's
+ *     institution_price_as_of is the price's date, stored as a column, never the
+ *     snapshot's identity.
+ *   → the parser writes securities (PR-2c's securityWrite, unchanged) and
+ *     holdings rows FROM THE ARRIVAL PAYLOADS — one holdings row per account +
+ *     security + as_of (UNIQUE: one snapshot per moment), pointed at its
+ *     arrival (arrival_id NOT NULL)
+ *   → each new arrival's read = now, status = done.
+ *
+ * Outcomes per holding, counted apart: landed (a new key — a row is written) ·
+ * already_landed (the same snapshot again: same key, same content — the row
+ * already points at this very arrival; nothing written; promise 2) · corrected
+ * (same key, new content — the same day's position moved: a NEW arrival, the
+ * row takes the latest and arrival_id moves to the newest; promise 1). A new
+ * as_of is a new key — a new row, never a rewrite of yesterday's. A holding
+ * whose account_id is none of the item's accounts is landed, read and COUNTED
+ * as unmatched — declared, never silently dropped.
+ *
+ * A parser throw rolls the whole answer back (the response row, the arrivals,
+ * the domain writes); the caller declares the failure with stage 'holdings'. A
+ * non-2xx answer lands as evidence of the ask through recordFailedAnswer
+ * (plaidTransactionsPage.ts) with this resource.
+ */
+import type { Holding, Security } from 'plaid';
+import { stageFailed, type StageFailed } from '@/lib/plaid/failLoud';
+import type { WireStamp } from '@/lib/plaid/wire';
+import { landObjects, landResponse, markRead, type JsonObject, type LandingDb } from './land';
+import { PLAID, type PageAccount, type PageClient } from './plaidTransactionsPage';
+import { SECURITY, newId, securityWrite, type InvestmentsDomainDb, type SecurityPayload } from './plaidInvestmentsPage';
+
+export const HOLDING = 'holding';
+
+/** The UTC date an answer arrived — the snapshot's moment, the composed key's third part. */
+export const asOfDate = (arrived: Date): string => arrived.toISOString().slice(0, 10);
+
+/** The composed their_id of a holding — labeled composed on the arrival (their_id_kind). */
+export const holdingTheirId = (h: { account_id: string; security_id: string }, asOf: string): string => `holding:${h.account_id}:${h.security_id}:${asOf}`;
+
+export const HOLDING_KEY_KEYS = ['id', 'accountId', 'security_id', 'as_of'] as const;
+export const HOLDING_DATA_KEYS = [
+  'quantity', 'cost_basis', 'institution_price', 'institution_price_as_of', 'institution_price_datetime', 'institution_value',
+  'iso_currency_code', 'unofficial_currency_code', 'arrival_id', 'updatedAt',
+] as const;
+
+/** One holdings row as the parser hands it to the domain port: the key (identity) and the values. Dates are ISO strings (as_of and institution_price_as_of: YYYY-MM-DD); the binding casts. Every value is present — null, never undefined. */
+export interface HoldingRow {
+  id: string;
+  accountId: string;
+  security_id: string;
+  as_of: string;
+  data: {
+    quantity: number;
+    cost_basis: number | null;
+    institution_price: number;
+    institution_price_as_of: string | null;
+    institution_price_datetime: string | null;
+    institution_value: number;
+    iso_currency_code: string | null;
+    unofficial_currency_code: string | null;
+    arrival_id: string;
+    updatedAt: Date;
+  };
+}
+
+/** The domain port the parser writes through (a fake and the batching binding stand in). */
+export interface HoldingsDomainDb {
+  securities: InvestmentsDomainDb['securities'];
+  holdings: {
+    /** INSERT … ON CONFLICT ("accountId", security_id, as_of) DO UPDATE — the values and the arrival move to the newest. */
+    upsert(row: HoldingRow): Promise<unknown>;
+  };
+}
+
+export interface HoldingsPageInput {
+  userId: string;
+  /** The Plaid item this answer belongs to — its item_id is the arrival's `connection`. */
+  connection: string;
+  accounts: PageAccount[];
+  wire: WireStamp;
+  httpStatus: number;
+  /** The objects in the answer — landed as they are; the parser never reads them. */
+  securities: Security[];
+  holdings: Holding[];
+  now?: () => Date;
+}
+
+export interface HoldingsPageCounts {
+  landed: number;
+  already_landed: number;
+  corrected: number;
+  /** Holdings rows written (created or corrected) — the banner's count. */
+  holdings: number;
+  /** Security objects in the answer. */
+  securities: number;
+  /** Holdings whose account_id is none of the item's accounts — landed and read, no row; declared. */
+  unmatched: number;
+}
+
+/** The sync's holdings row, from an arrival's payload. */
+export function holdingWrite(h: Holding, accountRowId: string, asOf: string, arrivalId: string, now: Date): HoldingRow {
+  return {
+    id: newId('hold'),
+    accountId: accountRowId,
+    security_id: h.security_id,
+    as_of: asOf,
+    data: {
+      quantity: h.quantity,
+      cost_basis: h.cost_basis ?? null,
+      institution_price: h.institution_price,
+      institution_price_as_of: h.institution_price_as_of ?? null,
+      institution_price_datetime: h.institution_price_datetime ?? null,
+      institution_value: h.institution_value,
+      iso_currency_code: h.iso_currency_code ?? null,
+      unofficial_currency_code: h.unofficial_currency_code ?? null,
+      arrival_id: arrivalId,
+      updatedAt: now,
+    },
+  };
+}
+
+export interface HoldingsLanded {
+  counts: HoldingsPageCounts;
+  /** The snapshot's moment — the composed keys' date. */
+  asOf: string;
+}
+
+/** Inside the caller's transaction: land, parse from the table, mark read. Throws to roll the answer back. */
+export async function landHoldingsPage(landing: LandingDb, domain: HoldingsDomainDb, input: HoldingsPageInput): Promise<HoldingsLanded> {
+  const now = input.now ?? (() => new Date());
+  const asOf = asOfDate(input.wire.arrived);
+  const counts: HoldingsPageCounts = { landed: 0, already_landed: 0, corrected: 0, holdings: 0, securities: input.securities.length, unmatched: 0 };
+
+  const response = await landResponse(landing, {
+    provider: PLAID,
+    resource: HOLDING,
+    userId: input.userId,
+    guestRef: null,
+    httpStatus: input.httpStatus,
+    body: input.wire.body,
+    asked: input.wire.asked,
+    arrived: input.wire.arrived,
+  });
+  const base = { provider: PLAID, connection: input.connection, userId: input.userId, guestRef: null, responseId: response.id, asked: input.wire.asked, arrived: input.wire.arrived };
+
+  const securities = await landObjects(landing, { ...base, resource: SECURITY, objects: input.securities.map((s) => ({ theirId: s.security_id, payload: s as unknown as JsonObject })) });
+  const holdings = await landObjects(landing, {
+    ...base,
+    resource: HOLDING,
+    objects: input.holdings.map((h) => ({ theirId: holdingTheirId(h, asOf), theirIdKind: 'composed' as const, payload: h as unknown as JsonObject })),
+  });
+  counts.landed = securities.landed + holdings.landed;
+  counts.already_landed = securities.alreadyLanded + holdings.alreadyLanded;
+  counts.corrected = securities.corrected + holdings.corrected;
+
+  const at = now();
+  const newRowIds: string[] = [];
+
+  // Securities first — the holdings below reference them (PR-2c's rules, unchanged).
+  for (const row of securities.rows) {
+    if (row.outcome === 'already_landed') {
+      await domain.securities.updateMany({ where: { securityId: row.their_id, arrival_id: null }, data: { arrival_id: row.id } });
+      continue;
+    }
+    newRowIds.push(row.id);
+    await domain.securities.upsert(securityWrite(row.payload as SecurityPayload, row.id, at));
+  }
+
+  for (const row of holdings.rows) {
+    // Promise 2: the same snapshot again — the row already points at this very arrival; nothing to write.
+    if (row.outcome === 'already_landed') continue;
+    newRowIds.push(row.id);
+    const h = row.payload as Holding;
+    const account = input.accounts.find((acc) => acc.accountId === h.account_id);
+    if (!account) { counts.unmatched++; continue; }
+    // landed: a new key — a row; corrected: the same day's position moved — the row takes the latest, arrival_id moves.
+    await domain.holdings.upsert(holdingWrite(h, account.id, asOf, row.id, at));
+    counts.holdings++;
+  }
+
+  await markRead(landing, newRowIds, at);
+  return { counts, asOf };
+}
+
+export type HoldingsPageResult = ({ ok: true } & HoldingsLanded) | { ok: false; failure: StageFailed };
+
+/** The ports an answer runs through. A domain port that BUFFERS its writes (prismaHoldingsDomain) hands back `finish`, replayed inside the same transaction after the parser is done. */
+export interface HoldingsPagePorts {
+  landing: LandingDb;
+  domain: HoldingsDomainDb;
+  finish?: () => Promise<void>;
+}
+
+/** One answer, one transaction. A throw inside rolls it back and comes out as the declared failure (stage 'holdings'). */
+export async function runHoldingsPage(
+  client: PageClient,
+  ports: (tx: unknown) => HoldingsPagePorts,
+  input: HoldingsPageInput,
+): Promise<HoldingsPageResult> {
+  try {
+    const landed = await client.$transaction(async (tx) => {
+      const { landing, domain, finish } = ports(tx);
+      const result = await landHoldingsPage(landing, domain, input);
+      if (finish) await finish();
+      return result;
+    }, { maxWait: 10_000, timeout: 120_000 });
+    return { ok: true, ...landed };
+  } catch (error) {
+    return { ok: false, failure: stageFailed('holdings', error) };
+  }
+}

--- a/src/lib/arrivals/plaidInvestmentsPage.ts
+++ b/src/lib/arrivals/plaidInvestmentsPage.ts
@@ -15,7 +15,8 @@
  * transactions phase's answer carries the same accounts and neither phase
  * lands them as objects today (the rule book's plaid · account · REGISTRY row
  * is unused) — they ride the response bytes, once per answer. Holdings (kind
- * SNAPSHOT) are PR-2d.
+ * SNAPSHOT) land through plaidHoldingsPage.ts (PR-2d), which reuses
+ * securityWrite for the securities the holdings answer carries.
  *
  * Three outcomes per object, counted apart: landed (a new id — parsed; an
  * investment transaction whose domain row PREDATES the store is linked and
@@ -92,7 +93,8 @@ export interface InvestmentsPageCounts {
 }
 
 const dateOrNull = (v: string | null | undefined): Date | null => (v ? new Date(v) : null);
-const newId = (prefix: string) => `${prefix}_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+/** The sync's row id shape (`sec_…`, `inv_…`; PR-2d: `hold_…`). */
+export const newId = (prefix: string) => `${prefix}_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
 
 /** The sync's securities upsert, from an arrival's payload: every column on create; the price and option columns (and the arrival) on update. */
 export function securityWrite(s: SecurityPayload, arrivalId: string, now: Date): { where: { securityId: string }; create: Record<string, unknown>; update: Record<string, unknown> } {

--- a/src/lib/arrivals/prismaHoldingsDomain.ts
+++ b/src/lib/arrivals/prismaHoldingsDomain.ts
@@ -1,0 +1,120 @@
+/**
+ * REBUILD-01 PR-2d — the Prisma-backed HoldingsDomainDb that lands an answer's
+ * domain writes in ONE statement per kind (PERF-01's binding pattern,
+ * prismaInvestmentsDomain.ts, whose securities statements it reuses). The parser
+ * (plaidHoldingsPage.ts) speaks the per-row port; THIS binding buffers, in
+ * order, and `finish()` — called by runHoldingsPage inside the same transaction
+ * — replays as (holdings.security_id references securities.securityId):
+ *
+ *   1. one INSERT … ON CONFLICT ("securityId") DO UPDATE for the securities
+ *      (PR-2c's securitiesSql);
+ *   2. one UPDATE … FROM (VALUES …) linking already-landed securities;
+ *   3. one INSERT … ON CONFLICT ("accountId", security_id, as_of) DO UPDATE for
+ *      the holdings — a new key inserts, the same key (the same day's position,
+ *      corrected) takes the last values and the newest arrival; a key repeated
+ *      in one answer keeps the first row's id and the last write's values.
+ *
+ * Every value the parser hands over is present (null, never undefined); a row
+ * missing a column is a throw, never a per-row fallback.
+ */
+import { Prisma } from '@prisma/client';
+import { planInvestmentsWrites, securitiesSql, securityLinkSql, type Intent } from './prismaInvestmentsDomain';
+import { HOLDING_DATA_KEYS, HOLDING_KEY_KEYS, type HoldingRow, type HoldingsDomainDb } from './plaidHoldingsPage';
+
+export class UnsupportedHoldingsWriteError extends Error {
+  constructor(what: string) {
+    super(`prismaHoldingsDomain: ${what} — the batching binding replays only the parser's intents (the securities upsert and link, the holdings upsert); nothing else is issued`);
+    this.name = 'UnsupportedHoldingsWriteError';
+  }
+}
+
+const DATE_KEYS = new Set<string>(['as_of', 'institution_price_as_of']);
+const TIMESTAMP_KEYS = new Set<string>(['institution_price_datetime', 'updatedAt']);
+const FLOAT_KEYS = new Set<string>(['quantity', 'cost_basis', 'institution_price', 'institution_value']);
+
+const ident = (name: string) => Prisma.raw(`"${name}"`);
+const iso = (v: unknown): string | null => (v === null ? null : v instanceof Date ? v.toISOString() : String(v));
+
+function valueSql(key: string, v: unknown): Prisma.Sql {
+  if (v === undefined) throw new UnsupportedHoldingsWriteError(`${key} is undefined (the parser hands over null, never undefined)`);
+  if (DATE_KEYS.has(key)) return Prisma.sql`${v}::date`;
+  if (TIMESTAMP_KEYS.has(key)) return Prisma.sql`${iso(v)}::timestamp`;
+  if (FLOAT_KEYS.has(key)) return Prisma.sql`${v}::float8`;
+  return Prisma.sql`${v}`;
+}
+
+function assertRow(row: HoldingRow): void {
+  for (const k of HOLDING_KEY_KEYS) if (typeof row[k] !== 'string' || row[k].length === 0) throw new UnsupportedHoldingsWriteError(`holdings.upsert.${k} must be a non-empty string`);
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(row.as_of)) throw new UnsupportedHoldingsWriteError(`holdings.upsert.as_of must be YYYY-MM-DD; got ${row.as_of}`);
+  const have = Object.keys(row.data).sort();
+  const want = [...HOLDING_DATA_KEYS].sort();
+  if (have.join(',') !== want.join(',')) throw new UnsupportedHoldingsWriteError(`holdings.upsert.data must carry exactly [${want.join(', ')}]; got [${have.join(', ')}]`);
+  for (const k of HOLDING_DATA_KEYS) if (row.data[k] === undefined) throw new UnsupportedHoldingsWriteError(`holdings.upsert.data.${k} is undefined`);
+}
+
+/** One row per key (accountId, security_id, as_of): the first row's id, the last write's values. */
+export function planHoldings(rows: HoldingRow[]): HoldingRow[] {
+  const by = new Map<string, HoldingRow>();
+  for (const r of rows) {
+    const k = `${r.accountId} ${r.security_id} ${r.as_of}`;
+    const prior = by.get(k);
+    by.set(k, prior ? { ...r, id: prior.id } : r);
+  }
+  return [...by.values()];
+}
+
+const CHUNK = 500;
+function chunks<T>(list: T[]): T[][] {
+  const out: T[][] = [];
+  for (let i = 0; i < list.length; i += CHUNK) out.push(list.slice(i, i + CHUNK));
+  return out;
+}
+
+/** INSERT … ON CONFLICT ("accountId", security_id, as_of) DO UPDATE — one snapshot per moment; the same moment takes the latest. */
+export function holdingsSql(rows: HoldingRow[]): Prisma.Sql {
+  const names = [...HOLDING_KEY_KEYS, ...HOLDING_DATA_KEYS];
+  const values = rows.map((r) => Prisma.sql`(${Prisma.join([
+    Prisma.sql`${r.id}`, Prisma.sql`${r.accountId}`, Prisma.sql`${r.security_id}`, Prisma.sql`${r.as_of}::date`,
+    ...HOLDING_DATA_KEYS.map((k) => valueSql(k, r.data[k])),
+  ])})`);
+  const set = Prisma.join(HOLDING_DATA_KEYS.map((k) => Prisma.sql`${ident(k)} = EXCLUDED.${ident(k)}`));
+  return Prisma.sql`INSERT INTO holdings (${Prisma.join(names.map(ident))}) VALUES ${Prisma.join(values)} ON CONFLICT ("accountId", security_id, as_of) DO UPDATE SET ${set}`;
+}
+
+export interface BatchingHoldingsDomainDb extends HoldingsDomainDb {
+  /** Replay the buffered intents as the batched statements — inside the answer's transaction. */
+  finish(): Promise<void>;
+  /** For the log line: how many intents the answer issued and how many statements the flush ran. */
+  stats(): { intents: number; statements: number };
+}
+
+/** The executor the binding needs — a Prisma transaction client, or a fake in the tests. */
+export interface RawExecutor {
+  $executeRaw(query: Prisma.Sql): Promise<number>;
+}
+
+export function prismaHoldingsDomain(tx: RawExecutor): BatchingHoldingsDomainDb {
+  const securityIntents: Intent[] = [];
+  const rows: HoldingRow[] = [];
+  let statements = 0;
+  let finished = false;
+  const guard = () => { if (finished) throw new UnsupportedHoldingsWriteError('a write after finish()'); };
+  return {
+    securities: {
+      async upsert(args) { guard(); securityIntents.push({ kind: 'security', args }); return {}; },
+      async updateMany(args) { guard(); securityIntents.push({ kind: 'securityLink', args: args as (Intent & { kind: 'securityLink' })['args'] }); return {}; },
+    },
+    holdings: {
+      async upsert(row) { guard(); assertRow(row); rows.push(row); return {}; },
+    },
+    async finish() {
+      guard();
+      finished = true;
+      const plan = planInvestmentsWrites(securityIntents);
+      for (const batch of chunks(plan.securities)) { await tx.$executeRaw(securitiesSql(batch)); statements += 1; }
+      for (const links of chunks(plan.securityLinks)) { await tx.$executeRaw(securityLinkSql(links)); statements += 1; }
+      for (const batch of chunks(planHoldings(rows))) { await tx.$executeRaw(holdingsSql(batch)); statements += 1; }
+    },
+    stats() { return { intents: securityIntents.length + rows.length, statements }; },
+  };
+}

--- a/src/lib/kindViews.ts
+++ b/src/lib/kindViews.ts
@@ -7,19 +7,24 @@
  * · snapshot · posting — each with ONE common shape (VIEW_COLUMNS), union the
  * feed tables of that kind. The kind per table comes from the rule book
  * (src/lib/providers.ts kindOf) — never typed twice. Posting is empty by the
- * deck's own law (nothing ever arrives as a posting); snapshot is empty until
- * holdings land (PR-2d).
+ * deck's own law (nothing ever arrives as a posting); snapshot holds Plaid
+ * holdings since REBUILD-01 PR-2d.
  *
  * THE CENSUS (KIND_VIEW_CENSUS) is the one source: every table whose rows come
  * from a provider answer AND whose feed the rule book names, with its columns
  * for the common shape. A table whose feed the book cannot name is REPORTED
- * (STOPPED_TABLES), never guessed into a view. The migration
- * (prisma/migrations/*_kind_views) is kindViewsSql() verbatim; the deck's
- * step-5 honest line is KIND_VIEWS_HONEST_LINE; the README extracts both. The
- * build (scripts/assert-tool-registry.ts) runs kindViewsLaw against the
- * migration text: (a) every census table in exactly one view, (b) that view is
- * the rule book's kind for the table's feed, (c) posting unions nothing,
- * (d) all six views carry the common columns in the same order.
+ * (STOPPED_TABLES), never guessed into a view. The first migration
+ * (prisma/migrations/*_kind_views) created the six as kindViewsSql() verbatim;
+ * a view changes only through a later migration that drops and recreates it
+ * (the snapshot view, over holdings — *_holdings_snapshot), so THE EFFECTIVE
+ * TEXT of the six is latestViewsSql(): for each kind, the newest CREATE VIEW
+ * across the migrations in order. The deck's step-5 honest line is
+ * KIND_VIEWS_HONEST_LINE; the README extracts both. The build
+ * (scripts/assert-tool-registry.ts) runs kindViewsLaw against that effective
+ * text: (a) every census table in exactly one view, (b) that view is the rule
+ * book's kind for the table's feed, (c) posting unions nothing, (d) all six
+ * views carry the common columns in the same order, and each view's newest
+ * text is kindViewSql() verbatim.
  *
  * Imports the rule book only; server- and client-safe (the deck renders the line).
  */
@@ -111,6 +116,12 @@ export const KIND_VIEW_CENSUS: readonly FeedTable[] = [
     from: 'accounts a', where: "a.source = 'plaid'",
     why: "src/app/api/plaid/exchange-token/route.ts:118 (create at link); rows with source 'manual' are authored (src/app/api/transactions/manual/route.ts:49) — filtered out; no arrival_id (accounts are never landed as objects)",
   },
+  {
+    table: 'holdings', label: 'holdings', feed: ['plaid', 'holding'],
+    rowId: 'h.id', theirId: `('holding:' || a."accountId" || ':' || h.security_id || ':' || to_char(h.as_of, 'YYYY-MM-DD'))`, arrivalId: 'h.arrival_id', userId: 'a."userId"', arrived: 'h."createdAt"',
+    from: 'holdings h JOIN accounts a ON a.id = h."accountId"',
+    why: 'REBUILD-01 PR-2d: sync-complete → src/lib/arrivals/plaidHoldingsPage.ts (one /investments/holdings/get answer per item per sync); a holding has no provider id, so their_id is composed — holding:<account_id>:<security_id>:<as_of> — and labeled composed; user through accounts.userId; arrival_id NOT NULL (the table is younger than the store); the snapshot view was redefined over it by prisma/migrations/20260908120000_holdings_snapshot',
+  },
 ];
 
 /** Tables whose rows come from a provider answer but whose feed the rule book does not name — reported, never viewed. */
@@ -180,7 +191,6 @@ export function branchSql(t: FeedTable): string {
 
 /** Why a kind's view unions nothing today — the comment the migration carries. */
 export const EMPTY_VIEW_WHY: Readonly<Partial<Record<ArrivalKind, string>>> = {
-  snapshot: 'no feed table holds a snapshot yet — plaid · holding lands in REBUILD-01 PR-2d',
   derived: 'no feed table the rule book names holds a derived row — the AI tables (operations_ai_usage, discovery_proposals, trip_scanner_results, scan_snapshots) carry no rule-book feed (STOPPED_TABLES)',
   posting: "empty by the deck's own law — nothing ever arrives as a posting; the system writes postings from events (step 10)",
 };
@@ -215,6 +225,40 @@ export function kindViewsHonestLine(census: readonly FeedTable[] = KIND_VIEW_CEN
 }
 
 export const KIND_VIEWS_HONEST_LINE = kindViewsHonestLine();
+
+/** One view's newest definition and the migration that holds it. */
+export interface LatestView {
+  kind: ArrivalKind;
+  /** The migration directory the newest CREATE VIEW lives in. */
+  dir: string;
+  /** The block: its `-- kind: …` line and the CREATE VIEW statement, verbatim. */
+  sql: string;
+}
+
+/**
+ * The effective text of the six views: for each kind, the LAST CREATE VIEW block
+ * (with its `-- kind:` line) across the migrations in directory order — a later
+ * migration that drops and recreates a view supersedes the original. Pure over
+ * the texts handed in (no filesystem), so the deck, the assert and the tests share it.
+ */
+export function latestViews(migrations: ReadonlyArray<{ dir: string; sql: string }>): LatestView[] {
+  const ordered = [...migrations].sort((a, b) => a.dir.localeCompare(b.dir));
+  const out: LatestView[] = [];
+  for (const kind of ARRIVAL_KINDS) {
+    const re = new RegExp(`(?:-- ${kind}: [^\\n]*\\n)?CREATE VIEW ${kind} AS\\n[\\s\\S]*?;`, 'g');
+    let last: LatestView | null = null;
+    for (const m of ordered) {
+      for (const hit of m.sql.matchAll(re)) last = { kind, dir: m.dir, sql: hit[0] };
+    }
+    if (last !== null) out.push(last);
+  }
+  return out;
+}
+
+/** The six newest CREATE VIEW blocks joined — what kindViewsLaw checks against the census. */
+export function latestViewsSql(migrations: ReadonlyArray<{ dir: string; sql: string }>): string {
+  return latestViews(migrations).map((v) => v.sql).join('\n\n');
+}
 
 /** Parse CREATE VIEW blocks out of migration text: name → { tables (FROM …), columns (the AS aliases of the first SELECT), unions }. */
 export function parseViews(sql: string): Array<{ name: string; tables: string[]; columns: string[]; body: string }> {

--- a/src/lib/plaid/failLoud.ts
+++ b/src/lib/plaid/failLoud.ts
@@ -181,11 +181,13 @@ export function failedLine(institution: string, failure: StageFailed): string {
   return `${institution} — ${where}${reason}`;
 }
 
-/** "Wells Fargo, Robinhood synced: 14 landed, 2 corrected, 5 investment transactions" — null when nothing succeeded. */
+/** "Wells Fargo, Robinhood synced: 14 landed, 2 corrected, 5 investment transactions, 12 holdings" — null when nothing succeeded. */
 export function successLine(items: ItemOutcome[]): string | null {
   const okItems = items.filter((i) => i.stages.length > 0 && itemStatus(i) === 'ok').map((i) => i.institution);
   const tx = sumStageCounts(items, 'transactions');
   const inv = sumStageCounts(items, 'investments');
+  // REBUILD-01 PR-2d: the holdings stage — rows written this run (a snapshot already stored writes none).
+  const hold = sumStageCounts(items, 'holdings');
   const anyOk = items.some((i) => i.stages.some((s) => s.ok));
   if (!anyOk) return null;
   const parts = [`${tx.landed ?? 0} landed`];
@@ -193,6 +195,7 @@ export function successLine(items: ItemOutcome[]): string | null {
   if (tx.corrected) parts.push(`${tx.corrected} corrected`);
   if (inv.synced) parts.push(`${inv.synced} investment transactions`);
   if (inv.securities) parts.push(`${inv.securities} securities`);
+  if (hold.holdings) parts.push(`${hold.holdings} holdings`);
   const who = okItems.length ? `${okItems.join(', ')} synced` : 'Partial progress';
   return `${who}: ${parts.join(', ')}`;
 }


### PR DESCRIPTION
**Do not merge — Alex merges after Vercel Preview (SOC 2 gate).**

**HARD GATE flags first**
- **Migration-bearing.** `prisma/migrations/20260908120000_holdings_snapshot/migration.sql`: `CREATE TABLE holdings` (the DDL is `prisma migrate diff` from main's schema to this one, verbatim) + `DROP VIEW snapshot` + `CREATE VIEW snapshot` over holdings (the census generator's text verbatim). No data rewrites; a new table and a view redefined. Applied by `migrate deploy` after merge. `schema.prisma` moves with it (lockstep proof below).
- **Branch base.** The ruling said "branch from main after TABLES-01b". TABLES-01b is not on main and no such PR or branch exists (I proposed it in #1661's body). I branched from current main (`ce3c86da`, #1661 merged) and carried the mechanism a view redefinition needs in this PR — for the snapshot view only: the kind-views law now reads each view's newest `CREATE VIEW` across the migrations. The event view's bookings `arrival_id` (TABLES-01b's own change) is untouched: it is now a one-line census change plus one drop-and-recreate migration.
- **Paid calls.** One more Plaid call per item per sync (`investmentsHoldingsGet`), behind the same auth and tab gate as the other two stages. Two view-time Plaid calls are gone (holdings on `/api/investments` and `/api/investments/analyze`). No route gate changed.
- **User data.** Yesterday's snapshot is never rewritten; a correction moves only the same day's row. No raw SQL against user data.

## Audit (read-only; line numbers = `main` at `ce3c86da`)

**The holdings answer shape (the SDK).** plaid 11.0.0, `node_modules/plaid/dist/api.d.ts`: `Holding` :9613-9675 — `account_id`, `security_id`, `institution_price`, `institution_price_as_of?` (date), `institution_price_datetime?`, `institution_value`, `cost_basis | null`, `quantity`, `iso_currency_code | null`, `unofficial_currency_code | null`. No id of its own, no secret, no token. `InvestmentsHoldingsGetResponse` :12806-12838 — `accounts[]`, `holdings[]`, `securities[]`, `item`, `request_id`; **no as-of date of its own**, so the composed key's date is the day the answer arrived. The request takes only `access_token` (+ optional `account_ids`), so one call per item covers every account. This SDK version has no `vested_*` fields; none are modeled.

**Where holdings are read today, and by whom.** `src/app/api/investments/route.ts:35` (`investmentsHoldingsGet` per item, live, returned raw beside a live `investmentsTransactionsGet` :40) and `src/app/api/investments/analyze/route.ts:33` (the same, concatenated). No component fetches `/api/investments` (grep: none under `src/components`); both are API-only. Nothing stores a holding anywhere.

**The sync-complete item loop.** `src/app/api/transactions/sync-complete/route.ts`: `syncEachItem` :303-310 runs `['transactions', syncTransactions]` and `['investments', syncInvestments]` per item under HYG-03's isolation; the investments stage :204-301 is the template (a failed ask lands through `recordFailedAnswer` :243, `wireOf` :246, `runInvestmentsPage` with the batching binding :256-275, the per-item log line :283, `stageOk` :295). The envelope :315-335 sums `transactions` and `investments`; the banner (`successLine`, `src/lib/plaid/failLoud.ts:181-196`) names transactions, investment transactions and securities.

**The store's side.** `plaid · holding → SNAPSHOT` is a deck row (`src/lib/providers.ts:58`), so no rule is added. `landObjects` takes `theirIdKind` since PR-5 (`land.ts:175`). The census `src/lib/kindViews.ts` had no snapshot table (`EMPTY_VIEW_WHY.snapshot` :183 said so); the assert found the one `_kind_views` migration and checked it verbatim (`scripts/assert-tool-registry.ts:451-453`). The holdings answer's `securities[]` are the same objects the investments answer carries; `holdings.security_id` needs a securities row for its FK, so the stage lands them exactly as PR-2c does, first.

## Build

- **`src/lib/arrivals/plaidHoldingsPage.ts` (new).** `landHoldingsPage` :142 — `landResponse` (resource `holding`, the exact bytes) → `landObjects` for the answer's securities (reference) and one arrival per holding with `theirIdKind: 'composed'` :163 — `holdingTheirId` :51 = `holding:<account_id>:<security_id>:<as_of>`, `asOfDate` :48 = the UTC date the answer arrived → securities written by PR-2c's `securityWrite` → holdings rows from the arrival payloads (`holdingWrite` :114: every SDK field a column, null never undefined), one per account + security + as_of, pointed at the arrival → `markRead`. already_landed writes nothing (the row already points at that arrival); corrected takes the latest (arrival_id moves); a new day is a new key. A holding for an account the item does not hold is landed, read and counted `unmatched` :188. `runHoldingsPage` :208 — one answer, one transaction, a throw declared with stage `holdings`.
- **`src/lib/arrivals/prismaHoldingsDomain.ts` (new).** The batching binding: PR-2c's `securitiesSql` / `securityLinkSql` reused, then one `INSERT … ON CONFLICT ("accountId", security_id, as_of) DO UPDATE` (`holdingsSql` :74); `planHoldings` :56 keeps the first row's id and the last values per key; a malformed row throws.
- **`src/lib/arrivals/holdingsSnapshot.ts` (new).** `latestHoldingsSnapshot` :54 — each account's latest as_of and every row of that moment (a position sold since an older day is not shown as held), the securities named, Plaid's field names plus `as_of` and `arrival_id`; nothing stored → `as_of: null`.
- **sync-complete.** `syncHoldings` :318 (one `investmentsHoldingsGet` :322, the failed ask landed as evidence, `wireOf` :331, `runHoldingsPage` :335 with the binding, the per-item log line with `as of <date>`), third runner :372; the envelope gains `synced.holdings` :390 and sums the store's counts over all three phases.
- **`/api/investments` :37 and `/api/investments/analyze` :32** read the stored snapshot; the response gains `snapshot: { as_of, stored }`; the live `investmentsTransactionsGet` in both routes is untouched (see decisions).
- **Banner.** `failLoud.ts:198` adds `N holdings` after the securities, only when rows were written.
- **Migration + schema** as flagged: `model holdings` :399 (typed columns, `arrival_id` NOT NULL, `@@unique([accountId, security_id, as_of])` :420, relations to accounts, securities, arrivals).
- **Kind views.** The census gains holdings :120 (their_id rebuilt from the row: `('holding:' || a."accountId" || ':' || h.security_id || ':' || to_char(h.as_of, 'YYYY-MM-DD'))`, user through accounts, `arrival_id` read); `latestViews` / `latestViewsSql` :244/:259 — pure over migration texts; the assert :457-459 checks the effective six and prints each view's source migration; the README generator and the tests read the same.
- **Tests.** `src/lib/__tests__/arrivalsHoldings.test.ts` (10): the composed id labeled composed and the as-of; an answer lands (wire row, reference + snapshot arrivals, rows from the arrivals pointed at them, read once); the same snapshot again already_landed (nothing written); a new as-of lands a new row; a same-day correction moves the row's arrival; unmatched declared; a throw rolls the answer back with stage `holdings`; `holdingWrite`, `planHoldings`, `holdingsSql` and the binding (one statement per kind, refusals); the reader; the banner. `kindViews.test.ts` updated: holdings in the census, the snapshot SQL, the effective views equal `kindViewsSql()` verbatim, the first migration alone now fails the law, `latestViews` order-independent.
- **README** regenerated (byte-stable): the views section names the redefinition, snapshot: holdings, the census table gains holdings, gap rows 03/04/05.

## Decisions to check
1. **as_of = the UTC date the answer arrived.** The answer has no as-of of its own; `institution_price_as_of` is the price's date and is stored as a column. One snapshot per position per day; two syncs the same day with the same content are one arrival; a moved position the same day is a correction of that day's row.
2. **The holdings answer's securities land** (reference, PR-2c's rules) before the holdings rows — the FK needs them, and the reader names them. The banner still counts securities from the investments stage only, so nothing double-counts.
3. **The view-redefinition mechanism** (newest `CREATE VIEW` per kind across migrations) lives here rather than in a TABLES-01b that does not exist; the event view's bookings `arrival_id` stays as is.
4. **The two view routes still ask Plaid for investment transactions live** — the ruling covered holdings; retiring those calls (the table holds them since PR-2c, but from 2024-01-01 where the live call asks from 2020-01-01) is its own decision.
5. **A bank without investment accounts** gets a declared holdings failure line from Plaid's own error, exactly as the investments stage behaves today for the same bank — not gated, not guessed.
6. **`holdings.arrival_id` is NOT NULL**: the table is younger than the store, so there is no cutoff to honor.

## Verification
| gate | result |
|---|---|
| `npx tsc --noEmit` | exit 0 |
| eslint per changed file vs `origin/main` | unchanged everywhere (`analyze/route.ts` keeps its pre-existing 2 errors); new files 0/0 |
| `npm test` | 169 / 169 (159 + 10 new) |
| `prisma validate` / `generate` | valid / regenerated |
| build with the asserts | `BUILD EXIT 0` — rule book 24 rules / **8 landing call sites**; **kind views 6 views over 8 feed tables**, `view snapshot ← holdings — 20260908120000_holdings_snapshot`, the other five from `20260907200000_kind_views`; honest line "…snapshot: holdings; derived: none yet; posting: empty by law" |
| migration lockstep (throwaway Postgres 16) | main's schema pushed + the corpus table + the six views as main creates them → the new file applied with `psql -1` (CREATE TABLE, indexes, FKs, DROP VIEW, CREATE VIEW) → `migrate diff --to-schema-datamodel` = empty but for `regulatory_documents`, the corpus table Prisma does not model |
| README | regenerated, byte-stable on the second run |

**Probe** (that DB + the promise-1 trigger; real `prismaLanding` + `prismaHoldingsDomain` through `runHoldingsPage`):
```
0 before                                   responses 0 · arrivals 0 · securities 0 · holdings 0 · snapshot view 0
1 day one (aapl 10, msft 3)                landed 4 · holdings 2 · 4 intents → 2 statements · 10 statements in the transaction
                                           responses 1 · arrivals 4 · securities 2 · holdings 2 · snapshot view 2
   arrivals: holding:acc_plaid_1:aapl:2026-09-08 (composed, snapshot, done, read) · …msft… ; every row points at a holding arrival
2 the same answer again (same day)         already_landed 4 · holdings 0 · 1 statement — responses 2, everything else unchanged
3 day two (aapl 12; msft sold)             landed 1 · already_landed 1 (the security) · holdings 1 — holdings 3 · snapshot view 3
4 day two again, aapl 13 (same-day move)   corrected 1 · holdings 1 — holdings still 3, arrivals 6
5 the snapshot view                        3 rows, feed 'plaid · holding', kind snapshot, user u_probe; view rows === holdings rows;
                                           every composed their_id rebuilt by the view === its arrival's their_id
6 the reader                               as_of 2026-09-09; holdings [acc_plaid_1 aapl 13]; securities [aapl] (msft, sold, not shown)
7 promise 1 holds                          "arrivals promise 1: read is set once, from NULL"
8 FK holds                                 deleting the arrival under a holdings row → foreign key constraint
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc

---
_Generated by [Claude Code](https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc)_