### PR TITLE
COA-01: the chart of accounts is extendable in the product; seed the missing accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Twenty-five business tools on one data pipe that ends in one Ledger and one Calendar.
 
-Source-available (BSL 1.1) · built and operated in production by its founder as User #1 · as of 2026-09-02: 115 Prisma models, 289 API route files, 121 feeds from 20 providers (counted August 24, 2026)
+Source-available (BSL 1.1) · built and operated in production by its founder as User #1 · as of 2026-09-02: 115 Prisma models, 291 API route files, 121 feeds from 20 providers (counted August 24, 2026)
 
 ## The system
 
@@ -310,7 +310,7 @@ Versions from package.json, read 2026-09-02:
 
 Observed versus authored (step 6): what the world sends is observed; what you do is authored; the blueprint keeps the two apart and matches them on one key. Today the Plaid feeds land word for word, fingerprinted — 9,092 transactions, 712 investment transactions, 247 securities, counted September 7, 2026; the other providers still land parsed — see the gap ledger, step 14.
 
-Scale, as of 2026-09-02: 115 Prisma models, 34 enums, 289 API route files, 37 runtime dependencies, 18 dev dependencies, one test file (`npm test`).
+Scale, as of 2026-09-02: 115 Prisma models, 34 enums, 291 API route files, 37 runtime dependencies, 18 dev dependencies, one test file (`npm test`).
 
 ## Engineering discipline
 

--- a/src/app/api/chart-of-accounts/[id]/route.ts
+++ b/src/app/api/chart-of-accounts/[id]/route.ts
@@ -2,6 +2,51 @@ import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { requireTabAccess } from '@/lib/auth-helpers';
+import { failClosedResponse } from '@/lib/http/failClosedResponse';
+import { renameAccount, retireAccount, type ChartAccountRow } from '@/lib/coa/accounts';
+import { prismaChartDb } from '@/lib/coa/prismaChartDb';
+
+/**
+ * /api/chart-of-accounts/[id]
+ *
+ * PUT   — rename (COA-01): { name?, code?, family? | accountType?, subType? }.
+ *         A new code obeys the entity's scheme and its family's range and must
+ *         be unique in the entity's chart (src/lib/coa/accounts.ts renameAccount).
+ * PATCH — retire / restore: { archived: boolean }. The flag flips and NOTHING
+ *         else — accounts are never deleted; balance and ledger history stay
+ *         (ledger_entries.account is Restrict; no_ledger_updates refuses edits).
+ *         A retired account leaves every categorization list (the GET routes
+ *         filter it, assign-coa refuses it, the auto-categorizer skips it).
+ *
+ * Same auth chain on both: verified email → user → tab:books → the account is
+ * the user's (defensive 404).
+ */
+
+async function ownedAccount(userId: string, id: string): Promise<ChartAccountRow | null> {
+  const r = await prisma.chart_of_accounts.findFirst({
+    where: { id, userId },
+    select: {
+      id: true, userId: true, entity_id: true, entity_type: true, code: true, name: true,
+      account_type: true, balance_type: true, sub_type: true, module: true, settled_balance: true, is_archived: true,
+    },
+  });
+  return r ? { ...r, userId: r.userId ?? userId } : null;
+}
+
+function serialize(updated: ChartAccountRow) {
+  return {
+    id: updated.id,
+    code: updated.code,
+    name: updated.name,
+    accountType: updated.account_type,
+    balanceType: updated.balance_type,
+    subType: updated.sub_type,
+    settledBalance: Number(updated.settled_balance),
+    entity_id: updated.entity_id,
+    entity_type: updated.entity_type,
+    is_archived: updated.is_archived,
+  };
+}
 
 export async function PUT(
   request: Request,
@@ -24,102 +69,31 @@ export async function PUT(
     if (tabGate) return tabGate;
 
     const { id } = await params;
-    const body = await request.json();
-    // DIM-2 adds subType (the dimensional S segment, nullable — null clears it).
-    const { name, accountType, balanceType, code, subType } = body;
+    const body = await request.json().catch(() => ({}));
+    const { name, code, subType } = body ?? {};
+    const family = body?.family ?? body?.accountType;
 
-    // Verify account exists and belongs to user
-    const existing = await prisma.chart_of_accounts.findFirst({
-      where: { id, userId: user.id },
-    });
+    const existing = await ownedAccount(user.id, id);
     if (!existing) {
       return NextResponse.json({ error: 'Account not found' }, { status: 404 });
     }
 
-    // If code is changing, check uniqueness within entity.
-    // DIM-2 NOTE: code changes on accounts WITH POSTED HISTORY are un-guarded
-    // here today (this pre-DIM-2 capability is preserved as-is) — whether a
-    // posted account's code may change, and what that means for the literal
-    // code matchers (merchant mappings, trading writers), is a DIM-3+ decision.
-    if (code && code !== existing.code) {
-      const duplicate = await prisma.chart_of_accounts.findFirst({
-        where: { userId: user.id, entity_id: existing.entity_id, code, id: { not: id } },
-      });
-      if (duplicate) {
-        return NextResponse.json(
-          { error: `Account code "${code}" already exists for this entity` },
-          { status: 409 }
-        );
-      }
-    }
-
-    const BALANCE_TYPE_MAP: Record<string, string> = {
-      asset: 'D', expense: 'D', liability: 'C', equity: 'C', revenue: 'C',
-    };
-
-    const updateData: Record<string, any> = {};
-    if (name !== undefined) updateData.name = name;
-    if (code !== undefined) updateData.code = code;
-    if (subType !== undefined) {
-      if (subType !== null && typeof subType !== 'string') {
-        return NextResponse.json({ error: 'subType must be a string or null' }, { status: 400 });
-      }
-      updateData.sub_type = typeof subType === 'string' && subType.trim() ? subType.trim() : null;
-    }
-    if (accountType !== undefined) {
-      const normalized = accountType.toLowerCase();
-      const bt = BALANCE_TYPE_MAP[normalized];
-      if (!bt) {
-        return NextResponse.json(
-          { error: 'Invalid accountType. Must be asset, liability, equity, revenue, or expense' },
-          { status: 400 }
-        );
-      }
-      updateData.account_type = normalized;
-      updateData.balance_type = bt;
-    }
-    if (balanceType !== undefined && !accountType) {
-      updateData.balance_type = balanceType;
-    }
-
-    if (Object.keys(updateData).length === 0) {
-      return NextResponse.json({ error: 'No fields to update' }, { status: 400 });
-    }
-
-    const updated = await prisma.chart_of_accounts.update({
-      where: { id },
-      data: updateData,
+    const updated = await renameAccount(prismaChartDb(prisma, user.id), {
+      userId: user.id,
+      entity: { id: existing.entity_id, entity_type: existing.entity_type },
+      account: existing,
+      name,
+      code,
+      family,
+      subType,
     });
 
-    return NextResponse.json({
-      success: true,
-      account: {
-        id: updated.id,
-        code: updated.code,
-        name: updated.name,
-        accountType: updated.account_type,
-        balanceType: updated.balance_type,
-        subType: updated.sub_type,
-        settledBalance: Number(updated.settled_balance),
-        pendingBalance: Number(updated.pending_balance),
-        entity_id: updated.entity_id,
-        entity_type: updated.entity_type,
-        version: Number(updated.version),
-        is_archived: updated.is_archived,
-      },
-    });
+    return NextResponse.json({ success: true, account: serialize(updated) });
   } catch (error) {
-    console.error('COA update error:', error);
-    return NextResponse.json({ error: 'Failed to update account' }, { status: 500 });
+    return failClosedResponse('COA update', 'Failed to update account', error);
   }
 }
 
-// ─── DIM-2: archive / unarchive — accounts are NEVER deleted ─────────────────
-// Removal from the working chart is is_archived = true, full stop: an account
-// with posted ledger history is a permanent financial record (and the DB's
-// ledger_entries.account FK is Restrict — deletion would fail anyway). PATCH
-// { archived: boolean } flips the flag both ways; same auth chain as PUT
-// (verified email → user → tab:books → user-scoped ownership, defensive 404).
 export async function PATCH(
   request: Request,
   { params }: { params: Promise<{ id: string }> }
@@ -143,27 +117,21 @@ export async function PATCH(
     const { id } = await params;
     const body = await request.json().catch(() => ({}));
     if (typeof body?.archived !== 'boolean') {
-      return NextResponse.json({ error: 'archived must be true or false' }, { status: 400 });
+      return NextResponse.json({ error: 'archived must be true or false', field: 'archived' }, { status: 400 });
     }
 
-    const existing = await prisma.chart_of_accounts.findFirst({
-      where: { id, userId: user.id },
-    });
+    const existing = await ownedAccount(user.id, id);
     if (!existing) {
       return NextResponse.json({ error: 'Account not found' }, { status: 404 });
     }
 
-    const updated = await prisma.chart_of_accounts.update({
-      where: { id },
-      data: { is_archived: body.archived },
-    });
+    const updated = await retireAccount(prismaChartDb(prisma, user.id), existing, body.archived);
 
     return NextResponse.json({
       success: true,
       account: { id: updated.id, code: updated.code, is_archived: updated.is_archived },
     });
   } catch (error) {
-    console.error('COA archive error:', error);
-    return NextResponse.json({ error: 'Failed to update archive state' }, { status: 500 });
+    return failClosedResponse('COA archive', 'Failed to update archive state', error);
   }
 }

--- a/src/app/api/chart-of-accounts/balances/route.ts
+++ b/src/app/api/chart-of-accounts/balances/route.ts
@@ -22,12 +22,15 @@ export async function GET(request: Request) {
 
     const { searchParams } = new URL(request.url);
     const entityId = searchParams.get('entityId');
+    // COA-01: retired accounts are hidden unless asked for — the COA page asks,
+    // so a retired account's balance and history stay visible there.
+    const includeArchived = searchParams.get('include_archived') === 'true';
 
     // SECURITY: Scoped to user's COA only
     const accounts = await prisma.chart_of_accounts.findMany({
       where: {
         userId: user.id,
-        is_archived: false,
+        ...(includeArchived ? {} : { is_archived: false }),
         ...(entityId && { entity_id: entityId }),
       },
       orderBy: { code: 'asc' }
@@ -43,7 +46,9 @@ export async function GET(request: Request) {
         settledBalance: acc.settled_balance.toString(),
         pendingBalance: acc.pending_balance.toString(),
         entityId: acc.entity_id,
-        entityType: acc.entity_type
+        entityType: acc.entity_type,
+        subType: acc.sub_type,
+        is_archived: acc.is_archived,
       }))
     });
   } catch (error) {

--- a/src/app/api/chart-of-accounts/reclassify/route.ts
+++ b/src/app/api/chart-of-accounts/reclassify/route.ts
@@ -1,0 +1,123 @@
+import { randomUUID } from 'crypto';
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { ensureBookkeepingInitialized } from '@/lib/ensure-bookkeeping';
+import { requireTabAccess } from '@/lib/auth-helpers';
+import { failClosedResponse } from '@/lib/http/failClosedResponse';
+import { assertPeriodOpen, PeriodClosedError } from '@/lib/period-close-guard';
+import { ValidationError } from '@/lib/errors/ValidationError';
+import { planReclassification, postReclassification } from '@/lib/coa/reclassify';
+import { prismaPostingDb } from '@/lib/coa/prismaChartDb';
+import type { ChartAccountRow } from '@/lib/coa/accounts';
+
+/**
+ * POST /api/chart-of-accounts/reclassify — COA-01: move a balance from one
+ * account to another by POSTING A NEW JOURNAL ENTRY with a memo.
+ *
+ *   { entityId, fromCode, toCode, memo, amountCents?, date? }
+ *
+ * The plan is pure (src/lib/coa/reclassify.ts): same entity, same family,
+ * target active, memo required, amount within the source balance (omitted →
+ * the whole balance); one debit and one credit of the same amount, balance
+ * deltas by the rule every writer uses. Posted in one transaction with
+ * source_type 'reclass' and the memo in the description and metadata. NO
+ * prior entry, line or transaction is edited — the port has no way to.
+ * Period-close is enforced like every other posting path.
+ *
+ * Gate: verified email → user → tab:books → the entity is the user's
+ * (defensive 404) → both accounts in that entity (404).
+ */
+
+const SELECT = {
+  id: true, userId: true, entity_id: true, entity_type: true, code: true, name: true,
+  account_type: true, balance_type: true, sub_type: true, module: true, settled_balance: true, is_archived: true,
+} as const;
+
+export async function POST(request: Request) {
+  try {
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const user = await prisma.users.findFirst({
+      where: { email: { equals: userEmail, mode: 'insensitive' } },
+    });
+    if (!user) {
+      return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    }
+    // TAB-SERVER-GATE: tab:books entitlement (bundle:all included; admin bypass inside).
+    const tabGate = await requireTabAccess(user.id, 'tab:books');
+    if (tabGate) return tabGate;
+
+    await ensureBookkeepingInitialized(user);
+
+    const body = await request.json().catch(() => ({}));
+    const { entityId, fromCode, toCode, memo, amountCents } = body ?? {};
+
+    if (typeof entityId !== 'string' || !entityId) {
+      return NextResponse.json({ error: 'entityId is required', field: 'entityId' }, { status: 400 });
+    }
+    if (typeof fromCode !== 'string' || !fromCode.trim()) {
+      return NextResponse.json({ error: 'fromCode is required', field: 'fromCode' }, { status: 400 });
+    }
+    if (typeof toCode !== 'string' || !toCode.trim()) {
+      return NextResponse.json({ error: 'toCode is required', field: 'toCode' }, { status: 400 });
+    }
+    const date = body?.date === undefined || body?.date === null || body?.date === '' ? new Date() : new Date(String(body.date));
+    if (Number.isNaN(date.getTime())) {
+      return NextResponse.json({ error: 'date is not a date', field: 'date' }, { status: 400 });
+    }
+
+    const entity = await prisma.entities.findFirst({
+      where: { id: entityId, userId: user.id },
+      select: { id: true, entity_type: true },
+    });
+    if (!entity) {
+      return NextResponse.json({ error: 'Entity not found' }, { status: 404 });
+    }
+
+    const load = async (code: string, field: string): Promise<ChartAccountRow> => {
+      const digits = code.trim().toUpperCase().replace(/^[PBT]-/, '');
+      const r = await prisma.chart_of_accounts.findFirst({ where: { userId: user.id, entity_id: entity.id, code: digits }, select: SELECT });
+      if (!r) throw new ValidationError(`no account ${code} in this entity's chart`, { status: 404, field });
+      return { ...r, userId: r.userId ?? user.id };
+    };
+    const from = await load(fromCode, 'fromCode');
+    const to = await load(toCode, 'toCode');
+
+    const plan = planReclassification({ from, to, amountCents, memo, date });
+
+    // Period close enforcement — the same guard every posting path calls.
+    await assertPeriodOpen(prisma, user.id, entity.id, date);
+
+    const requestId = randomUUID();
+    const result = await prisma.$transaction(async (tx) =>
+      postReclassification(prismaPostingDb(tx), { userId: user.id, entityId: entity.id, requestId, createdBy: userEmail }, plan),
+    );
+
+    // READ-AFTER-COMMIT (COA-01 probe 3): a DEFERRED constraint trigger refuses
+    // at COMMIT, and Prisma's interactive $transaction was observed to RESOLVE
+    // through that refusal with nothing written. A reclass is balanced by
+    // construction, so the balance trigger never refuses it — but success is
+    // claimed only from the row itself, never from the transaction's promise.
+    const landed = await prisma.journal_entries.findFirst({ where: { id: result.journalEntryId, userId: user.id }, select: { id: true } });
+    if (!landed) {
+      return failClosedResponse('COA reclassify', 'The database refused the entry at commit — nothing was posted', new Error(`journal entry ${result.journalEntryId} not found after commit`));
+    }
+
+    return NextResponse.json({
+      success: true,
+      journalEntryId: result.journalEntryId,
+      description: plan.description,
+      amountCents: plan.amount.toString(),
+      lines: plan.lines.map((l) => ({ account_id: l.account_id, entry_type: l.entry_type, amount: l.amount.toString(), balanceDelta: l.balanceDelta.toString() })),
+    });
+  } catch (error) {
+    if (error instanceof PeriodClosedError) {
+      return NextResponse.json({ error: error.message }, { status: 409 });
+    }
+    return failClosedResponse('COA reclassify', 'Failed to post the reclassification', error);
+  }
+}

--- a/src/app/api/chart-of-accounts/route.ts
+++ b/src/app/api/chart-of-accounts/route.ts
@@ -1,9 +1,29 @@
-import { randomUUID } from 'crypto';
 import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { ensureBookkeepingInitialized } from '@/lib/ensure-bookkeeping';
 import { requireTabAccess } from '@/lib/auth-helpers';
+import { failClosedResponse } from '@/lib/http/failClosedResponse';
+import { addAccount } from '@/lib/coa/accounts';
+import { prismaChartDb } from '@/lib/coa/prismaChartDb';
+
+/**
+ * /api/chart-of-accounts
+ *
+ * GET  — the user's accounts (optionally one entity); active only unless
+ *        include_archived=true, so every categorization list that reads this
+ *        route hides retired accounts by default (COA-01).
+ * POST — add an account (COA-01): { entityId, code, name, family, subType? }.
+ *        The code follows the ENTITY's scheme (src/lib/coa/scheme.ts): four
+ *        digits or the entity letter and four digits, inside the family's
+ *        range, unique in the entity's chart — a retired account at that code
+ *        is a 409 with the restore hint. `accountType` is accepted as the
+ *        legacy name of `family`. Every refusal is a ValidationError answered
+ *        verbatim at its status; faults are the fixed failClosed line.
+ *
+ * Gate order on both: verified email → user → tab:books → the entity is the
+ * user's (defensive 404).
+ */
 
 export async function GET(request: Request) {
   try {
@@ -28,11 +48,12 @@ export async function GET(request: Request) {
 
     const { searchParams } = new URL(request.url);
     const entityId = searchParams.get('entity_id') || null;
+    const includeArchived = searchParams.get('include_archived') === 'true';
 
     const accounts = await prisma.chart_of_accounts.findMany({
       where: {
         userId: user.id,
-        is_archived: false,
+        ...(includeArchived ? {} : { is_archived: false }),
         ...(entityId && { entity_id: entityId })
       },
       orderBy: [
@@ -62,18 +83,9 @@ export async function GET(request: Request) {
 
     return NextResponse.json({ accounts: serializedAccounts });
   } catch (error) {
-    console.error('COA fetch error:', error);
-    return NextResponse.json({ error: 'Failed to fetch chart of accounts' }, { status: 500 });
+    return failClosedResponse('COA fetch', 'Failed to fetch chart of accounts', error);
   }
 }
-
-const BALANCE_TYPE_MAP: Record<string, string> = {
-  asset: 'D',
-  expense: 'D',
-  liability: 'C',
-  equity: 'C',
-  revenue: 'C',
-};
 
 export async function POST(request: Request) {
   try {
@@ -92,50 +104,32 @@ export async function POST(request: Request) {
     const tabGate = await requireTabAccess(user.id, 'tab:books');
     if (tabGate) return tabGate;
 
-    // DIM-2: subType is optional — the S segment of the dimensional string,
-    // stored in the existing sub_type column (VarChar(50)).
-    const { code, name, accountType, entityId, subType } = await request.json();
+    await ensureBookkeepingInitialized(user);
 
-    if (!code || !name || !accountType || !entityId) {
-      return NextResponse.json({ error: 'code, name, accountType, and entityId are required' }, { status: 400 });
-    }
-    if (subType !== undefined && subType !== null && typeof subType !== 'string') {
-      return NextResponse.json({ error: 'subType must be a string' }, { status: 400 });
-    }
+    const body = await request.json().catch(() => ({}));
+    const { code, name, entityId, subType } = body ?? {};
+    const family = body?.family ?? body?.accountType;
 
-    const balanceType = BALANCE_TYPE_MAP[accountType.toLowerCase()];
-    if (!balanceType) {
-      return NextResponse.json({ error: 'Invalid accountType. Must be asset, liability, equity, revenue, or expense' }, { status: 400 });
+    if (typeof entityId !== 'string' || !entityId) {
+      return NextResponse.json({ error: 'entityId is required', field: 'entityId' }, { status: 400 });
     }
 
-    // Verify entity belongs to user
+    // Verify entity belongs to user — defensive 404.
     const entity = await prisma.entities.findFirst({
-      where: { id: entityId, userId: user.id }
+      where: { id: entityId, userId: user.id },
+      select: { id: true, entity_type: true },
     });
     if (!entity) {
-      return NextResponse.json({ error: 'Entity not found or not owned by user' }, { status: 404 });
+      return NextResponse.json({ error: 'Entity not found' }, { status: 404 });
     }
 
-    // Check compound unique [userId, entity_id, code]
-    const existing = await prisma.chart_of_accounts.findFirst({
-      where: { userId: user.id, entity_id: entityId, code }
-    });
-    if (existing) {
-      return NextResponse.json({ error: `Account code "${code}" already exists for this entity` }, { status: 409 });
-    }
-
-    const account = await prisma.chart_of_accounts.create({
-      data: {
-        id: randomUUID(),
-        code,
-        name,
-        account_type: accountType.toLowerCase(),
-        balance_type: balanceType,
-        sub_type: typeof subType === 'string' && subType.trim() ? subType.trim() : null,
-        entity_id: entityId,
-        entity_type: entity.entity_type,
-        userId: user.id,
-      }
+    const account = await addAccount(prismaChartDb(prisma, user.id), {
+      userId: user.id,
+      entity,
+      code,
+      name,
+      family,
+      subType,
     });
 
     return NextResponse.json({
@@ -156,7 +150,6 @@ export async function POST(request: Request) {
       }
     });
   } catch (error) {
-    console.error('COA create error:', error);
-    return NextResponse.json({ error: 'Failed to create account' }, { status: 500 });
+    return failClosedResponse('COA create', 'Failed to create account', error);
   }
 }

--- a/src/app/api/chart-of-accounts/seed/route.ts
+++ b/src/app/api/chart-of-accounts/seed/route.ts
@@ -1,0 +1,98 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { ensureBookkeepingInitialized } from '@/lib/ensure-bookkeeping';
+import { requireTabAccess } from '@/lib/auth-helpers';
+import { failClosedResponse } from '@/lib/http/failClosedResponse';
+import { applySeed } from '@/lib/coa/accounts';
+import { prismaChartDb } from '@/lib/coa/prismaChartDb';
+import { planSeed, seedSet, seedSetsFor } from '@/lib/coa/seedSets';
+
+/**
+ * POST /api/chart-of-accounts/seed — COA-01's in-product seed, the honest
+ * path (a migration cannot see a user's chart or report a collision).
+ *
+ *   { entityId, setKey, apply: false }  → the plan: every row's fate against
+ *                                        THIS entity's chart, nothing written;
+ *   { entityId, setKey, apply: true }   → inserts the 'create' rows in one
+ *                                        transaction and returns the plan with
+ *                                        what was created. Idempotent: a second
+ *                                        apply creates nothing (every row 'exists').
+ *
+ * A collision (the code holds another name) is reported and never overwritten;
+ * a retired match is reported (restore it — never re-added). The set must
+ * apply to the entity's letter. Gate: verified email → user → tab:books →
+ * the entity is the user's (defensive 404).
+ */
+export async function POST(request: Request) {
+  try {
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const user = await prisma.users.findFirst({
+      where: { email: { equals: userEmail, mode: 'insensitive' } },
+    });
+    if (!user) {
+      return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    }
+    // TAB-SERVER-GATE: tab:books entitlement (bundle:all included; admin bypass inside).
+    const tabGate = await requireTabAccess(user.id, 'tab:books');
+    if (tabGate) return tabGate;
+
+    await ensureBookkeepingInitialized(user);
+
+    const body = await request.json().catch(() => ({}));
+    const { entityId, setKey } = body ?? {};
+    const apply = body?.apply === true;
+
+    if (typeof entityId !== 'string' || !entityId) {
+      return NextResponse.json({ error: 'entityId is required', field: 'entityId' }, { status: 400 });
+    }
+    const set = typeof setKey === 'string' ? seedSet(setKey) : undefined;
+    if (!set) {
+      return NextResponse.json({ error: 'setKey is not a seed set', field: 'setKey' }, { status: 400 });
+    }
+
+    const entity = await prisma.entities.findFirst({
+      where: { id: entityId, userId: user.id },
+      select: { id: true, name: true, entity_type: true },
+    });
+    if (!entity) {
+      return NextResponse.json({ error: 'Entity not found' }, { status: 404 });
+    }
+
+    const existing = await prisma.chart_of_accounts.findMany({
+      where: { userId: user.id, entity_id: entity.id, code: { in: set.accounts.map((a) => a.code) } },
+      select: { id: true, code: true, name: true, is_archived: true },
+    });
+    const plan = planSeed(set, entity, existing);
+
+    let created: string[] = [];
+    if (apply) {
+      created = await prisma.$transaction(async (tx) => {
+        const rows = await applySeed(prismaChartDb(tx, user.id), { userId: user.id, entity }, plan);
+        return rows.map((r) => r.code);
+      });
+    }
+
+    return NextResponse.json({
+      success: true,
+      applied: apply,
+      set: { key: set.key, label: set.label, why: set.why },
+      entity: { id: entity.id, name: entity.name, entity_type: entity.entity_type },
+      plan,
+      created,
+      counts: {
+        create: plan.filter((r) => r.action === 'create').length,
+        exists: plan.filter((r) => r.action === 'exists').length,
+        collision: plan.filter((r) => r.action === 'collision').length,
+        retired: plan.filter((r) => r.action === 'retired').length,
+      },
+      availableSets: seedSetsFor(entity.entity_type).map((s) => s.key),
+    });
+  } catch (error) {
+    return failClosedResponse('COA seed', 'Failed to seed accounts', error);
+  }
+}

--- a/src/app/api/transactions/assign-coa/route.ts
+++ b/src/app/api/transactions/assign-coa/route.ts
@@ -23,6 +23,22 @@ export async function POST(request: Request) {
     if (!transactionIds || !Array.isArray(transactionIds) || transactionIds.length === 0) {
       return NextResponse.json({ error: 'transactionIds required' }, { status: 400 });
     }
+    if (typeof accountCode !== 'string' || !accountCode.trim()) {
+      return NextResponse.json({ error: 'accountCode required', field: 'accountCode' }, { status: 400 });
+    }
+
+    // COA-01: the code must be an ACTIVE account in the user's chart — a
+    // retired account has left categorization; an unknown code never entered it.
+    const matches = await prisma.chart_of_accounts.findMany({
+      where: { userId: user.id, code: accountCode },
+      select: { is_archived: true, name: true },
+    });
+    if (matches.length === 0) {
+      return NextResponse.json({ error: `no account ${accountCode} in your chart`, field: 'accountCode' }, { status: 400 });
+    }
+    if (matches.every((m) => m.is_archived)) {
+      return NextResponse.json({ error: `account ${accountCode} (${matches[0].name}) is retired — restore it or pick another`, field: 'accountCode' }, { status: 400 });
+    }
 
     const ownedTxns = await prisma.transactions.findMany({
       where: { id: { in: transactionIds }, accounts: { userId: user.id } },
@@ -57,7 +73,7 @@ export async function POST(request: Request) {
     }
 
     return NextResponse.json({ success: true, updated: updateCount });
-  } catch (error: any) {
+  } catch (error) {
     return failClosedResponse('Assign COA', 'Assign COA failed', error);
   }
 }

--- a/src/app/chart-of-accounts/page.tsx
+++ b/src/app/chart-of-accounts/page.tsx
@@ -1,94 +1,91 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { AppLayout } from '@/components/ui';
+import BookkeepingSection from '@/components/bookkeeping/BookkeepingSection';
+import COAManagementTable from '@/components/bookkeeping/COAManagementTable';
+import { FAMILIES, FAMILY_RULES, letterFor } from '@/lib/coa/scheme';
 
-interface Account {
-  code: string;
+/**
+ * /chart-of-accounts — COA-01: THE chart of accounts page (the registry's
+ * Bookkeeping link, src/lib/toolRegistry.ts). One management table per
+ * entity — add, rename, retire / restore, reclassify, the ruled seed sets —
+ * with the entity's REAL type driving its code letter. Reads /api/entities
+ * (user-scoped) and, per entity, the two chart routes the table calls.
+ * Every failure renders as the server's own words; nothing is swallowed.
+ */
+
+interface Entity {
+  id: string;
   name: string;
-  accountType: string;
-  balanceType: string;
-  settledBalance: string;
-  entityType: string;
+  entity_type: string;
+  is_default: boolean;
 }
 
+const TYPE_ORDER: Record<string, number> = { personal: 0, sole_prop: 1, trading: 2 };
+
 export default function ChartOfAccountsPage() {
-  const [accounts, setAccounts] = useState<Account[]>([]);
-  const [loading, setLoading] = useState(true);
+  const [entities, setEntities] = useState<Entity[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    fetch('/api/chart-of-accounts/balances')
-      .then(res => res.json())
-      .then(data => {
-        setAccounts(data.accounts || []);
-        setLoading(false);
+    let cancelled = false;
+    fetch('/api/entities')
+      .then(async (res) => {
+        if (!res.ok) {
+          const data = await res.json().catch(() => ({}));
+          throw new Error(typeof data?.error === 'string' ? data.error : `entities: HTTP ${res.status}`);
+        }
+        const data = await res.json();
+        const list: Entity[] = (data.entities || []).slice().sort((a: Entity, b: Entity) => {
+          if (a.is_default !== b.is_default) return a.is_default ? -1 : 1;
+          return (TYPE_ORDER[a.entity_type] ?? 9) - (TYPE_ORDER[b.entity_type] ?? 9) || a.name.localeCompare(b.name);
+        });
+        if (!cancelled) setEntities(list);
       })
-      .catch(err => {
-        console.error(err);
-        setLoading(false);
-      });
+      .catch((err: Error) => { if (!cancelled) setError(err.message); });
+    return () => { cancelled = true; };
   }, []);
 
-  const personal = accounts.filter(a => a.entityType === 'personal');
-  const business = accounts.filter(a => a.entityType === 'sole_prop');
-
-  const formatBalance = (cents: string) => {
-    const amount = parseInt(cents) / 100;
-    return amount.toLocaleString('en-US', { style: 'currency', currency: 'USD' });
-  };
-
-  if (loading) return <div className="p-8">Loading accounts...</div>;
-
   return (
-    <div className="p-8 max-w-7xl mx-auto">
-      <h1 className="text-3xl font-bold mb-8">Chart of Accounts</h1>
+    <AppLayout>
+      <div className="max-w-6xl mx-auto px-4 py-3 space-y-3" data-coa-page>
+        <div className="py-2">
+          <p className="font-mono text-[10px] font-semibold uppercase tracking-wider text-text-faint">Books · the chart</p>
+          <h1 className="text-xl font-medium tracking-tight text-text-primary">Chart of accounts</h1>
+          <p className="mt-1 text-xs text-text-muted font-mono" data-scheme-line>
+            {FAMILIES.map((f) => `${String(FAMILY_RULES[f].from)[0]}xxx ${FAMILY_RULES[f].label.toLowerCase()} ${FAMILY_RULES[f].from}–${FAMILY_RULES[f].to}`).join(' · ')} · the letter is the entity&apos;s (P personal · B business · T trading)
+          </p>
+        </div>
 
-      <div className="mb-12">
-        <h2 className="text-sm font-semibold mb-4 text-purple-600">Personal Accounts</h2>
-        <table className="w-full border">
-          <thead className="bg-bg-row">
-            <tr>
-              <th className="p-3 text-left">Code</th>
-              <th className="p-3 text-left">Account Name</th>
-              <th className="p-3 text-left">Type</th>
-              <th className="p-3 text-right">Balance</th>
-            </tr>
-          </thead>
-          <tbody>
-            {personal.map(acc => (
-              <tr key={acc.code} className="border-t">
-                <td className="p-3 font-mono">{acc.code}</td>
-                <td className="p-3">{acc.name}</td>
-                <td className="p-3">{acc.accountType}</td>
-                <td className="p-3 text-right font-semibold">{formatBalance(acc.settledBalance)}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
+        {error && (
+          <div className="text-sm text-red-500" role="alert">Failed to load entities: {error}</div>
+        )}
+        {!error && entities === null && (
+          <div className="flex justify-center py-6">
+            <div className="w-5 h-5 border-2 border-brand-purple border-t-transparent rounded-full animate-spin" />
+          </div>
+        )}
+        {entities !== null && entities.length === 0 && (
+          <div className="text-sm text-text-muted">No entity yet — open Books once and the Personal entity is created with the default chart.</div>
+        )}
+        {entities?.map((entity) => {
+          const letter = letterFor(entity.entity_type);
+          return (
+            <BookkeepingSection
+              key={entity.id}
+              title={`${entity.name} — ${letter ? `${letter}- chart` : entity.entity_type}`}
+              pipelineKey="COA"
+              subtitle={entity.entity_type}
+              status="complete"
+            >
+              <div className="p-3">
+                <COAManagementTable entityId={entity.id} entityName={entity.name} entityType={entity.entity_type} />
+              </div>
+            </BookkeepingSection>
+          );
+        })}
       </div>
-
-      <div>
-        <h2 className="text-sm font-semibold mb-4 text-brand-purple">Business Accounts</h2>
-        <table className="w-full border">
-          <thead className="bg-bg-row">
-            <tr>
-              <th className="p-3 text-left">Code</th>
-              <th className="p-3 text-left">Account Name</th>
-              <th className="p-3 text-left">Type</th>
-              <th className="p-3 text-right">Balance</th>
-            </tr>
-          </thead>
-          <tbody>
-            {business.map(acc => (
-              <tr key={acc.code} className="border-t">
-                <td className="p-3 font-mono">{acc.code}</td>
-                <td className="p-3">{acc.name}</td>
-                <td className="p-3">{acc.accountType}</td>
-                <td className="p-3 text-right font-semibold">{formatBalance(acc.settledBalance)}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
-    </div>
+    </AppLayout>
   );
 }

--- a/src/components/bookkeeping/COAManagementTable.tsx
+++ b/src/components/bookkeeping/COAManagementTable.tsx
@@ -1,11 +1,25 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { deriveAccountString } from '@/lib/accountString';
+import { FAMILIES, FAMILY_RULES, letterFor, schemeHint, type Family } from '@/lib/coa/scheme';
+import { seedSetsFor, type SeedPlanRow } from '@/lib/coa/seedSets';
+
+/**
+ * COA-01 — the chart of accounts is extendable in the product. One table per
+ * entity: add (the scheme's family + code, validated server-side and hinted
+ * here), rename, retire / restore (never delete — history stays and shows
+ * under "retired"), reclassify (a new journal entry with a memo moving a
+ * balance to another account of the same family), and the ruled seed sets
+ * (preview every row's fate, then apply — only the absent rows are written).
+ * Every failure renders inline with the server's own words; nothing is
+ * swallowed.
+ */
 
 interface COAManagementTableProps {
   entityId: string;
   entityName: string;
+  /** entities.entity_type — personal | sole_prop | trading; drives the code letter and the scheme hint. */
   entityType: string;
 }
 
@@ -21,6 +35,7 @@ interface COAAccount {
   pendingBalance: string;
   entityId: string;
   entityType: string;
+  is_archived: boolean;
 }
 
 interface DrilldownTxn {
@@ -32,18 +47,16 @@ interface DrilldownTxn {
   accountCode: string | null;
 }
 
-const ACCOUNT_TYPE_ORDER = ['asset', 'liability', 'equity', 'revenue', 'expense'];
-const ACCOUNT_TYPE_LABELS: Record<string, string> = {
-  asset: 'Assets',
-  liability: 'Liabilities',
-  equity: 'Equity',
-  revenue: 'Revenue',
-  expense: 'Expenses',
-};
+interface SeedResult {
+  applied: boolean;
+  set: { key: string; label: string; why: string };
+  plan: SeedPlanRow[];
+  created: string[];
+  counts: { create: number; exists: number; collision: number; retired: number };
+}
 
-const BALANCE_TYPE_MAP: Record<string, string> = {
-  asset: 'D', expense: 'D', liability: 'C', equity: 'C', revenue: 'C',
-};
+const ACCOUNT_TYPE_ORDER = [...FAMILIES];
+const ACCOUNT_TYPE_LABELS: Record<string, string> = Object.fromEntries(FAMILIES.map((f) => [f, FAMILY_RULES[f].label]));
 
 function formatCurrency(cents: string | number): string {
   const val = typeof cents === 'string' ? parseInt(cents, 10) : cents;
@@ -59,64 +72,97 @@ function formatDate(d: string): string {
   return new Date(d).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
 }
 
+/** The server's own words from a failed response — the error line, its field when named, else the status. */
+async function failureText(res: Response, fallback: string): Promise<string> {
+  const data = await res.json().catch(() => ({}));
+  const line = typeof data?.error === 'string' ? data.error : typeof data?.message === 'string' ? data.message : `${fallback} (HTTP ${res.status})`;
+  return data?.field ? `${data.field}: ${line}` : line;
+}
+
+const today = () => new Date().toISOString().slice(0, 10);
+
+const messageOf = (err: unknown): string => (err instanceof Error ? err.message : String(err));
+
 export default function COAManagementTable({ entityId, entityName, entityType }: COAManagementTableProps) {
   const [accounts, setAccounts] = useState<COAAccount[]>([]);
   const [allCoaOptions, setAllCoaOptions] = useState<COAAccount[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [showZeroBalances, setShowZeroBalances] = useState(false);
+  const [showRetired, setShowRetired] = useState(false);
 
   // Inline edit state
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editForm, setEditForm] = useState({ code: '', name: '', subType: '' });
   const [editSaving, setEditSaving] = useState(false);
   const [editError, setEditError] = useState<string | null>(null);
-  // DIM-2: archive action state — every failure surfaces inline, never swallowed.
+  // Retire / restore action state — every failure surfaces inline, never swallowed.
   const [archiving, setArchiving] = useState<string | null>(null);
   const [archiveError, setArchiveError] = useState<string | null>(null);
 
-  // Add new account state
+  // Add new account state — COA-01: the family drives the scheme hint.
   const [showAddForm, setShowAddForm] = useState(false);
-  const [addForm, setAddForm] = useState({ code: '', name: '', accountType: 'expense', subType: '' });
+  const [addForm, setAddForm] = useState<{ code: string; name: string; family: Family; subType: string }>({ code: '', name: '', family: 'expense', subType: '' });
   const [addSaving, setAddSaving] = useState(false);
   const [addError, setAddError] = useState<string | null>(null);
+
+  // Reclassify state — one open form at a time, keyed by the source account.
+  const [reclassId, setReclassId] = useState<string | null>(null);
+  const [reclassForm, setReclassForm] = useState({ toCode: '', amount: '', memo: '', date: today() });
+  const [reclassSaving, setReclassSaving] = useState(false);
+  const [reclassError, setReclassError] = useState<string | null>(null);
+  const [reclassDone, setReclassDone] = useState<string | null>(null);
+
+  // Seed sets state — preview first, apply second.
+  const seedSets = useMemo(() => seedSetsFor(entityType), [entityType]);
+  const [seedKey, setSeedKey] = useState<string>('');
+  const [seedResult, setSeedResult] = useState<SeedResult | null>(null);
+  const [seedBusy, setSeedBusy] = useState(false);
+  const [seedError, setSeedError] = useState<string | null>(null);
 
   // Drill-down state
   const [expandedCode, setExpandedCode] = useState<string | null>(null);
   const [drilldownTxns, setDrilldownTxns] = useState<DrilldownTxn[]>([]);
   const [drilldownLoading, setDrilldownLoading] = useState(false);
+  const [drilldownError, setDrilldownError] = useState<string | null>(null);
   const [reassigning, setReassigning] = useState<string | null>(null);
+  const [reassignError, setReassignError] = useState<string | null>(null);
+
+  const letter = letterFor(entityType);
 
   const fetchAccounts = useCallback(async () => {
     try {
       setError(null);
-      const res = await fetch(`/api/chart-of-accounts/balances?entityId=${entityId}`);
-      if (!res.ok) throw new Error('Failed to fetch accounts');
+      const res = await fetch(`/api/chart-of-accounts/balances?entityId=${encodeURIComponent(entityId)}&include_archived=true`);
+      if (!res.ok) throw new Error(await failureText(res, 'Failed to fetch accounts'));
       const data = await res.json();
       setAccounts(data.accounts || []);
-    } catch (err: any) {
-      setError(err.message);
+    } catch (err) {
+      setError(messageOf(err));
     } finally {
       setLoading(false);
     }
   }, [entityId]);
 
-  // Fetch all COA options for reassignment dropdown
+  // The categorization list — ACTIVE accounts only (the route hides retired ones).
   const fetchAllCoa = useCallback(async () => {
     try {
-      const res = await fetch(`/api/chart-of-accounts?entity_id=${entityId}`);
-      if (res.ok) {
-        const data = await res.json();
-        setAllCoaOptions(data.accounts || []);
-      }
-    } catch (err) { /* silent */ }
+      const res = await fetch(`/api/chart-of-accounts?entity_id=${encodeURIComponent(entityId)}`);
+      if (!res.ok) throw new Error(await failureText(res, 'Failed to fetch the account list'));
+      const data = await res.json();
+      setAllCoaOptions(data.accounts || []);
+    } catch (err) {
+      setError(messageOf(err));
+    }
   }, [entityId]);
 
   useEffect(() => { fetchAccounts(); fetchAllCoa(); }, [fetchAccounts, fetchAllCoa]);
 
-  const nonZeroAccounts = accounts.filter(a => parseInt(a.settledBalance, 10) !== 0);
-  const zeroCount = accounts.length - nonZeroAccounts.length;
-  const displayAccounts = showZeroBalances ? accounts : nonZeroAccounts;
+  const active = accounts.filter((a) => !a.is_archived);
+  const retired = accounts.filter((a) => a.is_archived);
+  const nonZeroAccounts = active.filter(a => parseInt(a.settledBalance, 10) !== 0);
+  const zeroCount = active.length - nonZeroAccounts.length;
+  const displayAccounts = [...(showZeroBalances ? active : nonZeroAccounts), ...(showRetired ? retired : [])];
 
   const grouped = ACCOUNT_TYPE_ORDER.reduce<Record<string, COAAccount[]>>((acc, type) => {
     const items = displayAccounts.filter(a => a.accountType === type);
@@ -148,14 +194,12 @@ export default function COAManagementTable({ entityId, entityName, entityType }:
           subType: editForm.subType.trim() ? editForm.subType.trim() : null,
         }),
       });
-      if (!res.ok) {
-        const data = await res.json();
-        throw new Error(data.error || 'Failed to update');
-      }
+      if (!res.ok) throw new Error(await failureText(res, 'Failed to update'));
       setEditingId(null);
       await fetchAccounts();
-    } catch (err: any) {
-      setEditError(err.message);
+      await fetchAllCoa();
+    } catch (err) {
+      setEditError(messageOf(err));
     } finally {
       setEditSaving(false);
     }
@@ -172,47 +216,101 @@ export default function COAManagementTable({ entityId, entityName, entityType }:
         body: JSON.stringify({
           code: addForm.code,
           name: addForm.name,
-          accountType: addForm.accountType,
+          family: addForm.family,
           ...(addForm.subType.trim() ? { subType: addForm.subType.trim() } : {}),
           entityId,
         }),
       });
-      if (!res.ok) {
-        const data = await res.json();
-        throw new Error(data.error || 'Failed to create account');
-      }
+      if (!res.ok) throw new Error(await failureText(res, 'Failed to create account'));
       setShowAddForm(false);
-      setAddForm({ code: '', name: '', accountType: 'expense', subType: '' });
+      setAddForm({ code: '', name: '', family: 'expense', subType: '' });
       await fetchAccounts();
       await fetchAllCoa();
-    } catch (err: any) {
-      setAddError(err.message);
+    } catch (err) {
+      setAddError(messageOf(err));
     } finally {
       setAddSaving(false);
     }
   };
 
-  // DIM-2: archive-only removal — accounts are NEVER deleted (posted history is
-  // a permanent financial record; the server PATCH enforces ownership + gate).
-  const archiveAccount = async (id: string) => {
+  // Retire / restore — accounts are NEVER deleted (posted history is a
+  // permanent financial record; the server PATCH enforces ownership + gate).
+  const setRetired = async (id: string, archived: boolean) => {
     setArchiving(id);
     setArchiveError(null);
     try {
       const res = await fetch(`/api/chart-of-accounts/${id}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ archived: true }),
+        body: JSON.stringify({ archived }),
       });
-      if (!res.ok) {
-        const data = await res.json().catch(() => ({}));
-        throw new Error(data.error || 'Failed to archive account');
-      }
+      if (!res.ok) throw new Error(await failureText(res, archived ? 'Failed to retire account' : 'Failed to restore account'));
+      if (archived) setShowRetired(true);
       await fetchAccounts();
       await fetchAllCoa();
-    } catch (err: any) {
-      setArchiveError(err.message);
+    } catch (err) {
+      setArchiveError(messageOf(err));
     } finally {
       setArchiving(null);
+    }
+  };
+
+  const openReclass = (account: COAAccount) => {
+    const cents = Math.abs(parseInt(account.settledBalance, 10) || 0);
+    setReclassId(account.id);
+    setReclassForm({ toCode: '', amount: (cents / 100).toFixed(2), memo: '', date: today() });
+    setReclassError(null);
+    setReclassDone(null);
+  };
+
+  const submitReclass = async (account: COAAccount) => {
+    setReclassSaving(true);
+    setReclassError(null);
+    try {
+      const dollars = Number(reclassForm.amount);
+      if (!Number.isFinite(dollars)) throw new Error('amount: enter dollars, e.g. 120.00');
+      const res = await fetch('/api/chart-of-accounts/reclassify', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          entityId,
+          fromCode: account.code,
+          toCode: reclassForm.toCode,
+          amountCents: Math.round(dollars * 100),
+          memo: reclassForm.memo,
+          date: reclassForm.date,
+        }),
+      });
+      if (!res.ok) throw new Error(await failureText(res, 'Failed to post the reclassification'));
+      const data = await res.json();
+      setReclassDone(`Posted ${data.description} — journal entry ${data.journalEntryId}`);
+      setReclassId(null);
+      await fetchAccounts();
+    } catch (err) {
+      setReclassError(messageOf(err));
+    } finally {
+      setReclassSaving(false);
+    }
+  };
+
+  const runSeed = async (apply: boolean) => {
+    if (!seedKey) { setSeedError('pick a set first'); return; }
+    setSeedBusy(true);
+    setSeedError(null);
+    try {
+      const res = await fetch('/api/chart-of-accounts/seed', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ entityId, setKey: seedKey, apply }),
+      });
+      if (!res.ok) throw new Error(await failureText(res, apply ? 'Failed to apply the set' : 'Failed to preview the set'));
+      const data: SeedResult = await res.json();
+      setSeedResult(data);
+      if (apply) { await fetchAccounts(); await fetchAllCoa(); }
+    } catch (err) {
+      setSeedError(messageOf(err));
+    } finally {
+      setSeedBusy(false);
     }
   };
 
@@ -224,31 +322,33 @@ export default function COAManagementTable({ entityId, entityName, entityType }:
     }
     setExpandedCode(code);
     setDrilldownLoading(true);
+    setDrilldownError(null);
     try {
       const res = await fetch(`/api/transactions?accountCode=${encodeURIComponent(code)}&entityId=${encodeURIComponent(entityId)}`);
-      if (res.ok) {
-        const data = await res.json();
-        setDrilldownTxns(data.transactions || []);
-      }
-    } catch (err) { /* silent */ }
-    finally { setDrilldownLoading(false); }
+      if (!res.ok) throw new Error(await failureText(res, 'Failed to load transactions'));
+      const data = await res.json();
+      setDrilldownTxns(data.transactions || []);
+    } catch (err) {
+      setDrilldownError(messageOf(err));
+    } finally { setDrilldownLoading(false); }
   };
 
   const reassignTransaction = async (txnId: string, newCode: string) => {
     setReassigning(txnId);
+    setReassignError(null);
     try {
       const res = await fetch('/api/transactions/assign-coa', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ transactionIds: [txnId], accountCode: newCode }),
       });
-      if (res.ok) {
-        // Refresh drilldown and balances
-        if (expandedCode) await toggleDrilldown(expandedCode);
-        await fetchAccounts();
-      }
-    } catch (err) { /* silent */ }
-    finally { setReassigning(null); }
+      if (!res.ok) throw new Error(await failureText(res, 'Failed to reassign'));
+      // Refresh drilldown and balances
+      if (expandedCode) await toggleDrilldown(expandedCode);
+      await fetchAccounts();
+    } catch (err) {
+      setReassignError(messageOf(err));
+    } finally { setReassigning(null); }
   };
 
   const balanceColor = (type: string) => {
@@ -267,14 +367,16 @@ export default function COAManagementTable({ entityId, entityName, entityType }:
 
   if (error) {
     return (
-      <div className="text-center py-8 text-sm text-red-500">
+      <div className="text-center py-8 text-sm text-red-500" role="alert">
         Failed to load chart of accounts: {error}
       </div>
     );
   }
 
+  const addHint = schemeHint(entityType, addForm.family);
+
   return (
-    <div className="space-y-2">
+    <div className="space-y-2" data-coa-table={entityId} data-entity-type={entityType}>
       <div className="border border-gray-200/50 rounded-lg overflow-hidden">
         <table className="w-full text-sm">
           <thead>
@@ -282,7 +384,7 @@ export default function COAManagementTable({ entityId, entityName, entityType }:
               <th className="text-left px-3 py-2 text-xs font-semibold text-text-secondary">Code</th>
               <th className="text-left px-3 py-2 text-xs font-semibold text-text-secondary">Account Name</th>
               <th className="text-right px-3 py-2 text-xs font-semibold text-text-secondary">Balance</th>
-              <th className="text-right px-3 py-2 text-xs font-semibold text-text-secondary w-[100px]">Actions</th>
+              <th className="text-right px-3 py-2 text-xs font-semibold text-text-secondary w-[190px]">Actions</th>
             </tr>
           </thead>
           <tbody>
@@ -300,15 +402,22 @@ export default function COAManagementTable({ entityId, entityName, entityType }:
                     type={type}
                     isEditing={isEditing}
                     isExpanded={isExpanded}
+                    isReclassifying={reclassId === account.id}
+                    reclassTargets={active.filter((a) => a.accountType === account.accountType && a.id !== account.id)}
+                    reclassForm={reclassForm}
+                    reclassSaving={reclassSaving}
+                    reclassError={reclassError}
                     editForm={editForm}
                     editSaving={editSaving}
                     editError={editError}
                     balanceColor={balanceColor}
                     rowIndex={i}
                     drilldownLoading={drilldownLoading}
+                    drilldownError={drilldownError}
                     drilldownTxns={drilldownTxns}
                     allCoaOptions={allCoaOptions}
                     reassigning={reassigning}
+                    reassignError={reassignError}
                     archiving={archiving}
                     onEditFormChange={setEditForm}
                     onStartEdit={startEdit}
@@ -316,7 +425,12 @@ export default function COAManagementTable({ entityId, entityName, entityType }:
                     onSaveEdit={saveEdit}
                     onToggleDrilldown={toggleDrilldown}
                     onReassign={reassignTransaction}
-                    onArchive={archiveAccount}
+                    onRetire={(id) => setRetired(id, true)}
+                    onRestore={(id) => setRetired(id, false)}
+                    onOpenReclass={openReclass}
+                    onReclassFormChange={setReclassForm}
+                    onCancelReclass={() => { setReclassId(null); setReclassError(null); }}
+                    onSubmitReclass={submitReclass}
                   />
                 );
               })
@@ -332,36 +446,67 @@ export default function COAManagementTable({ entityId, entityName, entityType }:
         </table>
       </div>
 
-      {/* Zero balance toggle */}
-      {zeroCount > 0 && (
-        <button
-          onClick={() => setShowZeroBalances(v => !v)}
-          className="text-[11px] text-text-muted hover:text-brand-purple-deep"
-        >
-          {showZeroBalances
-            ? `Hide ${zeroCount} account${zeroCount !== 1 ? 's' : ''} with $0 balance`
-            : `${zeroCount} account${zeroCount !== 1 ? 's' : ''} with $0 balance hidden — show`}
-        </button>
-      )}
+      <div className="flex flex-wrap items-center gap-x-4 gap-y-1">
+        {/* Zero balance toggle */}
+        {zeroCount > 0 && (
+          <button
+            onClick={() => setShowZeroBalances(v => !v)}
+            className="text-[11px] text-text-muted hover:text-brand-purple-deep"
+          >
+            {showZeroBalances
+              ? `Hide ${zeroCount} account${zeroCount !== 1 ? 's' : ''} with $0 balance`
+              : `${zeroCount} account${zeroCount !== 1 ? 's' : ''} with $0 balance hidden — show`}
+          </button>
+        )}
+        {/* COA-01: retired accounts stay — their balances and history are one click away. */}
+        {retired.length > 0 && (
+          <button
+            onClick={() => setShowRetired(v => !v)}
+            className="text-[11px] text-text-muted hover:text-brand-purple-deep"
+            data-retired-toggle
+          >
+            {showRetired
+              ? `Hide ${retired.length} retired account${retired.length !== 1 ? 's' : ''}`
+              : `${retired.length} retired account${retired.length !== 1 ? 's' : ''} hidden — show`}
+          </button>
+        )}
+      </div>
 
-      {/* DIM-2: archive failures surface inline, never swallowed. */}
-      {archiveError && <div className="text-xs text-red-500">{archiveError}</div>}
+      {archiveError && <div className="text-xs text-red-500" role="alert">{archiveError}</div>}
+      {reclassDone && <div className="text-xs text-emerald-700" data-reclass-done>{reclassDone}</div>}
 
-      {/* Add Account Form */}
+      {/* Add Account Form — COA-01: the family sets the range; the code carries the entity letter. */}
       {showAddForm ? (
-        <form onSubmit={addAccount} className="border border-gray-200/50 rounded-lg p-3 bg-white space-y-3">
-          <div className="text-xs font-semibold text-text-primary mb-1">New Account</div>
+        <form onSubmit={addAccount} className="border border-gray-200/50 rounded-lg p-3 bg-white space-y-3" data-add-form>
+          <div className="text-xs font-semibold text-text-primary mb-1">New account in {entityName}</div>
           <div className="grid grid-cols-4 gap-2">
             <div>
-              <label className="text-[10px] text-text-muted uppercase tracking-wider block mb-1">Code</label>
-              <input
-                type="text"
-                value={addForm.code}
-                onChange={e => setAddForm(f => ({ ...f, code: e.target.value }))}
+              <label className="text-[10px] text-text-muted uppercase tracking-wider block mb-1">Family</label>
+              <select
+                value={addForm.family}
+                onChange={e => setAddForm(f => ({ ...f, family: e.target.value as Family }))}
                 className="w-full px-2 py-1.5 text-xs border border-gray-200 rounded focus:outline-none focus:ring-1 focus:ring-brand-purple-deep"
-                placeholder="e.g. 5030"
                 required
-              />
+              >
+                {ACCOUNT_TYPE_ORDER.map(t => (
+                  <option key={t} value={t}>{ACCOUNT_TYPE_LABELS[t]} ({FAMILY_RULES[t].balanceType === 'D' ? 'Debit' : 'Credit'}) · {FAMILY_RULES[t].from}–{FAMILY_RULES[t].to}</option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <label className="text-[10px] text-text-muted uppercase tracking-wider block mb-1">Code</label>
+              <div className="flex items-center">
+                {letter && <span className="px-1.5 py-1.5 text-xs font-mono border border-r-0 border-gray-200 rounded-l bg-bg-row text-text-muted" data-code-letter>{letter}-</span>}
+                <input
+                  type="text"
+                  inputMode="numeric"
+                  value={addForm.code}
+                  onChange={e => setAddForm(f => ({ ...f, code: e.target.value }))}
+                  className={`w-full px-2 py-1.5 text-xs border border-gray-200 focus:outline-none focus:ring-1 focus:ring-brand-purple-deep font-mono ${letter ? 'rounded-r' : 'rounded'}`}
+                  placeholder={`${FAMILY_RULES[addForm.family].from}–${FAMILY_RULES[addForm.family].to}`}
+                  required
+                />
+              </div>
             </div>
             <div>
               <label className="text-[10px] text-text-muted uppercase tracking-wider block mb-1">Name</label>
@@ -370,21 +515,9 @@ export default function COAManagementTable({ entityId, entityName, entityType }:
                 value={addForm.name}
                 onChange={e => setAddForm(f => ({ ...f, name: e.target.value }))}
                 className="w-full px-2 py-1.5 text-xs border border-gray-200 rounded focus:outline-none focus:ring-1 focus:ring-brand-purple-deep"
-                placeholder="e.g. Office Supplies"
+                placeholder="e.g. Finnhub Premium (quarterly plan)"
                 required
               />
-            </div>
-            <div>
-              <label className="text-[10px] text-text-muted uppercase tracking-wider block mb-1">Type</label>
-              <select
-                value={addForm.accountType}
-                onChange={e => setAddForm(f => ({ ...f, accountType: e.target.value }))}
-                className="w-full px-2 py-1.5 text-xs border border-gray-200 rounded focus:outline-none focus:ring-1 focus:ring-brand-purple-deep"
-              >
-                {ACCOUNT_TYPE_ORDER.map(t => (
-                  <option key={t} value={t}>{ACCOUNT_TYPE_LABELS[t]} ({BALANCE_TYPE_MAP[t] === 'D' ? 'Debit' : 'Credit'})</option>
-                ))}
-              </select>
             </div>
             <div>
               <label className="text-[10px] text-text-muted uppercase tracking-wider block mb-1">Sub (optional)</label>
@@ -393,11 +526,12 @@ export default function COAManagementTable({ entityId, entityName, entityType }:
                 value={addForm.subType}
                 onChange={e => setAddForm(f => ({ ...f, subType: e.target.value }))}
                 className="w-full px-2 py-1.5 text-xs border border-gray-200 rounded focus:outline-none focus:ring-1 focus:ring-brand-purple-deep font-mono"
-                placeholder="e.g. 10"
+                placeholder="e.g. fixed"
               />
             </div>
           </div>
-          {addError && <div className="text-xs text-red-500">{addError}</div>}
+          <p className="text-[11px] text-text-muted font-mono" data-scheme-hint>{addHint}</p>
+          {addError && <div className="text-xs text-red-500" role="alert" data-add-error>{addError}</div>}
           <div className="flex gap-2">
             <button
               type="submit"
@@ -419,15 +553,71 @@ export default function COAManagementTable({ entityId, entityName, entityType }:
         <button
           onClick={() => setShowAddForm(true)}
           className="px-3 py-1.5 text-xs font-semibold bg-brand-gold text-white rounded hover:bg-brand-gold/90"
+          data-add-account
         >
           + Add Account
         </button>
+      )}
+
+      {/* COA-01: the ruled seed sets — preview every row's fate, then apply only the absent rows. */}
+      {seedSets.length > 0 && (
+        <div className="border border-gray-200/50 rounded-lg p-3 bg-white space-y-2" data-seed-panel>
+          <div className="text-xs font-semibold text-text-primary">Standard sets for this chart</div>
+          <div className="flex flex-wrap items-center gap-2">
+            <select
+              value={seedKey}
+              onChange={e => { setSeedKey(e.target.value); setSeedResult(null); setSeedError(null); }}
+              className="px-2 py-1.5 text-xs border border-gray-200 rounded focus:outline-none focus:ring-1 focus:ring-brand-purple-deep"
+            >
+              <option value="">— pick a set —</option>
+              {seedSets.map(s => <option key={s.key} value={s.key}>{s.label}</option>)}
+            </select>
+            <button type="button" disabled={seedBusy || !seedKey} onClick={() => runSeed(false)} className="px-3 py-1.5 text-xs font-medium border border-gray-200 text-text-secondary rounded hover:bg-bg-row disabled:opacity-50">
+              {seedBusy ? '…' : 'Preview'}
+            </button>
+            <button
+              type="button"
+              disabled={seedBusy || !seedResult || seedResult.applied || seedResult.counts.create === 0}
+              onClick={() => runSeed(true)}
+              className="px-3 py-1.5 text-xs font-semibold bg-brand-gold text-white rounded hover:bg-brand-gold/90 disabled:opacity-50"
+              title={seedResult && seedResult.counts.create === 0 ? 'Nothing to create — every row exists, collides or is retired' : 'Insert the rows marked create'}
+            >
+              Apply
+            </button>
+          </div>
+          {seedKey && <p className="text-[11px] text-text-muted">{seedSets.find(s => s.key === seedKey)?.why}</p>}
+          {seedError && <div className="text-xs text-red-500" role="alert">{seedError}</div>}
+          {seedResult && (
+            <div className="space-y-1" data-seed-plan>
+              <p className="text-[11px] text-text-secondary">
+                {seedResult.applied ? `Applied — created ${seedResult.created.length}.` : 'Preview — nothing written.'}{' '}
+                {seedResult.counts.create} to create · {seedResult.counts.exists} already there · {seedResult.counts.collision} collision{seedResult.counts.collision === 1 ? '' : 's'} · {seedResult.counts.retired} retired
+              </p>
+              <table className="w-full text-[11px]">
+                <tbody>
+                  {seedResult.plan.map(row => (
+                    <tr key={row.code} className="border-t border-gray-200/50" data-seed-row={row.action}>
+                      <td className="py-1 font-mono">{deriveAccountString({ entityType, code: row.code, subType: row.subType })}</td>
+                      <td className="py-1">{row.name}</td>
+                      <td className="py-1">
+                        {row.action === 'create' && <span className="text-emerald-700">{seedResult.applied && seedResult.created.includes(row.code) ? 'created' : 'will be created'}</span>}
+                        {row.action === 'exists' && <span className="text-text-muted">already there</span>}
+                        {row.action === 'retired' && <span className="text-amber-700">retired as &ldquo;{row.existingName}&rdquo; — restore it, it is not re-added</span>}
+                        {row.action === 'collision' && <span className="text-red-600">collision — {row.code} is &ldquo;{row.existingName}&rdquo;; not overwritten</span>}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
       )}
     </div>
   );
 }
 
-// Individual row with optional group header and drill-down
+// Individual row with optional group header, the reclassify form and drill-down
 function GroupedRow({
   account,
   entityType,
@@ -435,15 +625,22 @@ function GroupedRow({
   type,
   isEditing,
   isExpanded,
+  isReclassifying,
+  reclassTargets,
+  reclassForm,
+  reclassSaving,
+  reclassError,
   editForm,
   editSaving,
   editError,
   balanceColor,
   rowIndex,
   drilldownLoading,
+  drilldownError,
   drilldownTxns,
   allCoaOptions,
   reassigning,
+  reassignError,
   archiving,
   onEditFormChange,
   onStartEdit,
@@ -451,7 +648,12 @@ function GroupedRow({
   onSaveEdit,
   onToggleDrilldown,
   onReassign,
-  onArchive,
+  onRetire,
+  onRestore,
+  onOpenReclass,
+  onReclassFormChange,
+  onCancelReclass,
+  onSubmitReclass,
 }: {
   account: COAAccount;
   /** DIM-2: the entity's type (from the parent prop — drives the E segment). */
@@ -460,15 +662,22 @@ function GroupedRow({
   type: string;
   isEditing: boolean;
   isExpanded: boolean;
+  isReclassifying: boolean;
+  reclassTargets: COAAccount[];
+  reclassForm: { toCode: string; amount: string; memo: string; date: string };
+  reclassSaving: boolean;
+  reclassError: string | null;
   editForm: { code: string; name: string; subType: string };
   editSaving: boolean;
   editError: string | null;
   balanceColor: (type: string) => string;
   rowIndex: number;
   drilldownLoading: boolean;
+  drilldownError: string | null;
   drilldownTxns: DrilldownTxn[];
   allCoaOptions: COAAccount[];
   reassigning: string | null;
+  reassignError: string | null;
   archiving: string | null;
   onEditFormChange: (f: { code: string; name: string; subType: string }) => void;
   onStartEdit: (account: COAAccount) => void;
@@ -476,8 +685,15 @@ function GroupedRow({
   onSaveEdit: (id: string) => void;
   onToggleDrilldown: (code: string) => void;
   onReassign: (txnId: string, newCode: string) => void;
-  onArchive: (id: string) => void;
+  onRetire: (id: string) => void;
+  onRestore: (id: string) => void;
+  onOpenReclass: (account: COAAccount) => void;
+  onReclassFormChange: (f: { toCode: string; amount: string; memo: string; date: string }) => void;
+  onCancelReclass: () => void;
+  onSubmitReclass: (account: COAAccount) => void;
 }) {
+  const retired = account.is_archived;
+  const hasBalance = (parseInt(account.settledBalance, 10) || 0) !== 0;
   return (
     <>
       {/* Group header */}
@@ -491,7 +707,7 @@ function GroupedRow({
         </tr>
       )}
       {/* Account row */}
-      <tr className={rowIndex % 2 === 0 ? 'bg-white' : 'bg-bg-row/50'}>
+      <tr className={`${rowIndex % 2 === 0 ? 'bg-white' : 'bg-bg-row/50'}${retired ? ' opacity-70' : ''}`} data-account={account.code} data-retired={retired ? 'true' : undefined}>
         <td className="px-3 py-2 font-mono text-xs">
           {isEditing ? (
             <div>
@@ -524,12 +740,15 @@ function GroupedRow({
                 type="text"
                 value={editForm.subType}
                 onChange={e => onEditFormChange({ ...editForm, subType: e.target.value })}
-                placeholder="sub (optional, e.g. 10)"
+                placeholder="sub (optional, e.g. fixed)"
                 className="w-full px-1.5 py-1 text-xs border border-gray-200 rounded focus:outline-none focus:ring-1 focus:ring-brand-purple-deep font-mono"
               />
             </div>
           ) : (
-            account.name
+            <>
+              {account.name}
+              {retired && <span className="ml-2 rounded border border-amber-300 bg-amber-50 px-1.5 py-0.5 text-[9px] font-mono uppercase tracking-wider text-amber-700">retired</span>}
+            </>
           )}
         </td>
         <td className={`px-3 py-2 text-right font-mono font-semibold text-xs ${balanceColor(account.accountType)}`}>
@@ -544,7 +763,7 @@ function GroupedRow({
         <td className="px-3 py-2 text-right">
           {isEditing ? (
             <div className="flex items-center justify-end gap-1.5">
-              {editError && <span className="text-[10px] text-red-500 mr-1">{editError}</span>}
+              {editError && <span className="text-[10px] text-red-500 mr-1" role="alert">{editError}</span>}
               <button
                 onClick={() => onSaveEdit(account.id)}
                 disabled={editSaving}
@@ -559,6 +778,26 @@ function GroupedRow({
                 Cancel
               </button>
             </div>
+          ) : retired ? (
+            <div className="flex items-center justify-end gap-1.5">
+              {hasBalance && (
+                <button
+                  onClick={() => onOpenReclass(account)}
+                  className="px-2 py-1 text-[10px] font-medium border border-gray-200 text-text-secondary rounded hover:bg-bg-row"
+                  title="Move this balance to another account with a new journal entry"
+                >
+                  Reclassify
+                </button>
+              )}
+              <button
+                onClick={() => onRestore(account.id)}
+                disabled={archiving === account.id}
+                className="px-2 py-1 text-[10px] font-medium border border-gray-200 text-text-muted rounded hover:bg-bg-row disabled:opacity-50"
+                title="Restore this account to the working chart"
+              >
+                {archiving === account.id ? '...' : 'Restore'}
+              </button>
+            </div>
           ) : (
             <div className="flex items-center justify-end gap-1.5">
               <button
@@ -567,19 +806,99 @@ function GroupedRow({
               >
                 Edit
               </button>
-              {/* DIM-2: archive-only removal — never delete. */}
               <button
-                onClick={() => onArchive(account.id)}
+                onClick={() => onOpenReclass(account)}
+                disabled={!hasBalance}
+                className="px-2 py-1 text-[10px] font-medium border border-gray-200 text-text-secondary rounded hover:bg-bg-row disabled:opacity-40"
+                title={hasBalance ? 'Move this balance to another account with a new journal entry' : 'Nothing to move — zero balance'}
+              >
+                Reclassify
+              </button>
+              {/* Retire-only removal — never delete. */}
+              <button
+                onClick={() => onRetire(account.id)}
                 disabled={archiving === account.id}
                 className="px-2 py-1 text-[10px] font-medium border border-gray-200 text-text-muted rounded hover:bg-bg-row disabled:opacity-50"
-                title="Archive this account (it is never deleted; posted history remains)"
+                title="Retire this account — it leaves categorization; its balance and history stay"
               >
-                {archiving === account.id ? '...' : 'Archive'}
+                {archiving === account.id ? '...' : 'Retire'}
               </button>
             </div>
           )}
         </td>
       </tr>
+      {/* Reclassify form — a NEW journal entry; nothing old is edited. */}
+      {isReclassifying && (
+        <tr>
+          <td colSpan={4} className="p-0">
+            <form
+              onSubmit={(e) => { e.preventDefault(); onSubmitReclass(account); }}
+              className="bg-amber-50/60 border-l-4 border-brand-gold px-4 py-3 space-y-2"
+              data-reclass-form={account.code}
+            >
+              <div className="text-xs font-semibold text-text-primary">
+                Reclassify {deriveAccountString({ entityType, code: account.code, subType: account.subType })} — posts a new journal entry with your memo; the old entries stay as they are.
+              </div>
+              <div className="grid grid-cols-4 gap-2">
+                <div>
+                  <label className="text-[10px] text-text-muted uppercase tracking-wider block mb-1">To account (same family)</label>
+                  <select
+                    value={reclassForm.toCode}
+                    onChange={e => onReclassFormChange({ ...reclassForm, toCode: e.target.value })}
+                    className="w-full px-2 py-1.5 text-xs border border-gray-200 rounded focus:outline-none focus:ring-1 focus:ring-brand-purple-deep"
+                    required
+                  >
+                    <option value="">— pick —</option>
+                    {reclassTargets.map(t => (
+                      <option key={t.id} value={t.code}>{deriveAccountString({ entityType, code: t.code, subType: t.subType })} — {t.name}</option>
+                    ))}
+                  </select>
+                </div>
+                <div>
+                  <label className="text-[10px] text-text-muted uppercase tracking-wider block mb-1">Amount (USD)</label>
+                  <input
+                    type="number" step="0.01" min="0.01"
+                    value={reclassForm.amount}
+                    onChange={e => onReclassFormChange({ ...reclassForm, amount: e.target.value })}
+                    className="w-full px-2 py-1.5 text-xs border border-gray-200 rounded focus:outline-none focus:ring-1 focus:ring-brand-purple-deep font-mono"
+                    required
+                  />
+                </div>
+                <div>
+                  <label className="text-[10px] text-text-muted uppercase tracking-wider block mb-1">Date</label>
+                  <input
+                    type="date"
+                    value={reclassForm.date}
+                    onChange={e => onReclassFormChange({ ...reclassForm, date: e.target.value })}
+                    className="w-full px-2 py-1.5 text-xs border border-gray-200 rounded focus:outline-none focus:ring-1 focus:ring-brand-purple-deep font-mono"
+                    required
+                  />
+                </div>
+                <div>
+                  <label className="text-[10px] text-text-muted uppercase tracking-wider block mb-1">Memo</label>
+                  <input
+                    type="text"
+                    value={reclassForm.memo}
+                    onChange={e => onReclassFormChange({ ...reclassForm, memo: e.target.value })}
+                    placeholder="why the balance moves"
+                    className="w-full px-2 py-1.5 text-xs border border-gray-200 rounded focus:outline-none focus:ring-1 focus:ring-brand-purple-deep"
+                    required
+                  />
+                </div>
+              </div>
+              {reclassError && <div className="text-xs text-red-500" role="alert" data-reclass-error>{reclassError}</div>}
+              <div className="flex gap-2">
+                <button type="submit" disabled={reclassSaving} className="px-3 py-1.5 text-xs font-semibold bg-brand-gold text-white rounded hover:bg-brand-gold/90 disabled:opacity-50">
+                  {reclassSaving ? 'Posting…' : 'Post reclassification'}
+                </button>
+                <button type="button" onClick={onCancelReclass} className="px-3 py-1.5 text-xs font-medium border border-gray-200 text-text-secondary rounded hover:bg-bg-row">
+                  Cancel
+                </button>
+              </div>
+            </form>
+          </td>
+        </tr>
+      )}
       {/* Drill-down panel */}
       {isExpanded && (
         <tr>
@@ -590,6 +909,8 @@ function GroupedRow({
                   <div className="w-4 h-4 border-2 border-brand-purple border-t-transparent rounded-full animate-spin" />
                   <span className="text-xs text-text-muted">Loading transactions...</span>
                 </div>
+              ) : drilldownError ? (
+                <div className="text-xs text-red-500 py-2" role="alert">{drilldownError}</div>
               ) : drilldownTxns.length === 0 ? (
                 <div className="text-xs text-text-muted py-2">No transactions assigned to this account.</div>
               ) : (
@@ -607,7 +928,7 @@ function GroupedRow({
                     {drilldownTxns.map(txn => (
                       <tr key={txn.id} className="border-t border-gray-200/50">
                         <td className="py-1.5 font-mono text-text-secondary">{formatDate(txn.date)}</td>
-                        <td className="py-1.5 text-text-primary">{txn.merchantName || '\u2014'}</td>
+                        <td className="py-1.5 text-text-primary">{txn.merchantName || '—'}</td>
                         <td className="py-1.5 text-text-muted truncate max-w-[200px]">{txn.name}</td>
                         <td className="py-1.5 text-right font-mono font-semibold">{formatAmount(txn.amount)}</td>
                         <td className="py-1.5 text-right">
@@ -627,6 +948,7 @@ function GroupedRow({
                   </tbody>
                 </table>
               )}
+              {reassignError && <div className="text-xs text-red-500 pt-2" role="alert">{reassignError}</div>}
             </div>
           </td>
         </tr>

--- a/src/components/dashboard/BudgetingPage.tsx
+++ b/src/components/dashboard/BudgetingPage.tsx
@@ -44,6 +44,9 @@ export default function BudgetingPage({ category, emoji, apiPath }: BudgetingPag
   const [form, setForm] = useState({ name: '', coa_code: '', amount: '', cadence: 'monthly', target_date: new Date().toISOString().split('T')[0] });
   const [actionLoading, setActionLoading] = useState<string | null>(null);
   const [entityId, setEntityId] = useState<string | null>(null);
+  // COA-01: the entity's REAL type ('sole_prop', not the page's 'business'
+  // label) — the code letter and the scheme derive from it.
+  const [entityType, setEntityType] = useState<string>('');
 
   useEffect(() => { loadExpenses(); loadEntity(); }, []);
 
@@ -57,7 +60,7 @@ export default function BudgetingPage({ category, emoji, apiPath }: BudgetingPag
           ? ['business', 'sole_prop']
           : [categoryLower];
         const entity = (data.entities || []).find((e: any) => matchTypes.includes(e.entity_type));
-        if (entity) setEntityId(entity.id);
+        if (entity) { setEntityId(entity.id); setEntityType(entity.entity_type); }
       }
     } catch (err) { console.error('Failed to load entity:', err); }
   };
@@ -143,7 +146,7 @@ export default function BudgetingPage({ category, emoji, apiPath }: BudgetingPag
               <COAManagementTable
                 entityId={entityId}
                 entityName={category}
-                entityType={category.toLowerCase()}
+                entityType={entityType}
               />
             </div>
           </BookkeepingSection>

--- a/src/lib/__tests__/coa.test.ts
+++ b/src/lib/__tests__/coa.test.ts
@@ -1,0 +1,328 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { ValidationError } from '../errors/ValidationError';
+import {
+  EXPENSE_BLOCKS,
+  FAMILY_RULES,
+  assertCodeInFamily,
+  familyOfCode,
+  letterFor,
+  parseCode,
+  renderCode,
+  schemeHint,
+} from '../coa/scheme';
+import { SEED_SETS, assertSeedSetsLaw, planSeed, seedSet, seedSetsFor } from '../coa/seedSets';
+import { addAccount, applySeed, renameAccount, retireAccount } from '../coa/accounts';
+import { planReclassification, postReclassification } from '../coa/reclassify';
+import { FakeChart } from './fakeChart';
+
+// COA-01 — the chart of accounts is extendable in the product. Hermetic: the
+// scheme and the reclass plan are pure; add / rename / retire / seed run over
+// the fake chart (fakeChart.ts) with the table's own UNIQUE rule.
+
+const ENTITY_B = { id: 'ent-b', entity_type: 'sole_prop' };
+const ENTITY_P = { id: 'ent-p', entity_type: 'personal' };
+
+async function rejects(fn: () => Promise<unknown>, status: number, re: RegExp) {
+  await assert.rejects(fn, (err: unknown) => {
+    assert.ok(err instanceof ValidationError, `expected a ValidationError, got ${String(err)}`);
+    assert.equal(err.status, status);
+    assert.match(err.message, re);
+    return true;
+  });
+}
+
+function throws(fn: () => unknown, re: RegExp) {
+  assert.throws(fn, (err: unknown) => {
+    assert.ok(err instanceof ValidationError, `expected a ValidationError, got ${String(err)}`);
+    assert.match(err.message, re);
+    return true;
+  });
+}
+
+// ── the scheme ──────────────────────────────────────────────────────────────
+
+test('the scheme: the entity letter is the entity type\'s, the code is four digits, the first digit is the family', () => {
+  assert.equal(letterFor('personal'), 'P');
+  assert.equal(letterFor('sole_prop'), 'B');
+  assert.equal(letterFor('trading'), 'T');
+  assert.equal(letterFor('business'), null);
+  assert.equal(parseCode('6250', 'sole_prop'), '6250');
+  assert.equal(parseCode(' b-6250 ', 'sole_prop'), '6250');
+  assert.equal(parseCode('8210', 'personal'), '8210');
+  assert.equal(familyOfCode('1010'), 'asset');
+  assert.equal(familyOfCode('2020'), 'liability');
+  assert.equal(familyOfCode('3110'), 'equity');
+  assert.equal(familyOfCode('4010'), 'revenue');
+  for (const c of ['5130', '6250', '7100', '8210', '9840']) assert.equal(familyOfCode(c), 'expense');
+  assert.equal(renderCode('6250', 'sole_prop'), 'B-6250');
+  assert.equal(renderCode('9840', 'personal', 'travel'), 'P-9840-travel');
+  assert.equal(FAMILY_RULES.expense.from, 5000);
+  assert.equal(FAMILY_RULES.expense.to, 9999);
+  assert.ok(EXPENSE_BLOCKS.B.some((b) => b.from === 6200 && b.to === 6299));
+  assert.match(schemeHint('sole_prop', 'expense'), /B-5000–B-9999/);
+  assert.match(schemeHint('sole_prop', 'expense'), /6200–6299 Fixed costs/);
+  assert.match(schemeHint('personal', 'asset'), /P-1000–P-1999 · Balance sheet/);
+});
+
+test('add rejects a bad code: the wrong letter, not four digits, outside every family, outside its family\'s range', () => {
+  throws(() => parseCode('P-6250', 'sole_prop'), /carries the P- letter; this is a B- chart/);
+  throws(() => parseCode('B-6250', 'personal'), /carries the B- letter; this is a P- chart/);
+  throws(() => parseCode('B-6250', 'business'), /has no code letter/);
+  throws(() => parseCode('62500', 'sole_prop'), /not in the scheme/);
+  throws(() => parseCode('ABC', 'sole_prop'), /not in the scheme/);
+  throws(() => parseCode('', 'sole_prop'), /code is required/);
+  throws(() => parseCode(undefined, 'sole_prop'), /code is required/);
+  throws(() => parseCode('0999', 'sole_prop'), /outside every family/);
+  throws(() => assertCodeInFamily('4010', 'expense'), /outside the expense range 5000–9999 — it reads as revenue/);
+  throws(() => assertCodeInFamily('6250', 'asset'), /outside the asset range 1000–1999 — it reads as expense/);
+  assertCodeInFamily('6250', 'expense');
+  assertCodeInFamily('1010', 'asset');
+});
+
+test('add rejects a bad code and a duplicate through the policy; a good add stores the digits with the family\'s normal balance', async () => {
+  const db = new FakeChart();
+  db.seed([{ code: '6210', name: 'Software & Subscriptions', account_type: 'expense' }]);
+  await rejects(() => addAccount(db, { userId: 'user-a', entity: ENTITY_B, code: 'P-6250', name: 'Finnhub', family: 'expense' }), 400, /P- letter/);
+  await rejects(() => addAccount(db, { userId: 'user-a', entity: ENTITY_B, code: '4010', name: 'Finnhub', family: 'expense' }), 400, /outside the expense range/);
+  await rejects(() => addAccount(db, { userId: 'user-a', entity: ENTITY_B, code: '6250', name: 'Finnhub', family: 'costs' }), 400, /family "costs" is not one of/);
+  await rejects(() => addAccount(db, { userId: 'user-a', entity: ENTITY_B, code: '6250', name: 'Finnhub' , family: undefined }), 400, /family is required/);
+  await rejects(() => addAccount(db, { userId: 'user-a', entity: ENTITY_B, code: '6250', name: '   ', family: 'expense' }), 400, /name is required/);
+  // the duplicate — the code already holds Software & Subscriptions
+  await rejects(() => addAccount(db, { userId: 'user-a', entity: ENTITY_B, code: 'B-6210', name: 'Vercel', family: 'expense' }), 409, /B-6210 is already "Software & Subscriptions"/);
+  assert.equal(db.accounts.length, 1, 'nothing was written by the refusals');
+
+  const added = await addAccount(db, { userId: 'user-a', entity: ENTITY_B, code: 'B-6250', name: '  Finnhub Premium   (quarterly plan) ', family: 'expense', subType: 'fixed' });
+  assert.equal(added.code, '6250');
+  assert.equal(added.name, 'Finnhub Premium (quarterly plan)');
+  assert.equal(added.account_type, 'expense');
+  assert.equal(added.balance_type, 'D');
+  assert.equal(added.sub_type, 'fixed');
+  assert.equal(added.entity_type, 'sole_prop');
+  assert.equal(added.settled_balance, BigInt(0));
+  // the same code in ANOTHER entity is a different account — the unique is per entity
+  const personal = await addAccount(db, { userId: 'user-a', entity: ENTITY_P, code: '6250', name: 'Something personal', family: 'expense' });
+  assert.equal(personal.entity_id, 'ent-p');
+  // a liability gets the credit normal balance
+  const ap = await addAccount(db, { userId: 'user-a', entity: ENTITY_B, code: '2030', name: 'Card payable', family: 'liability' });
+  assert.equal(ap.balance_type, 'C');
+});
+
+test('add rejects a duplicate of a RETIRED account with the restore hint — never re-added', async () => {
+  const db = new FakeChart();
+  db.seed([{ code: '5130', name: 'Finnhub API calls', account_type: 'expense', is_archived: true }]);
+  await rejects(() => addAccount(db, { userId: 'user-a', entity: ENTITY_B, code: '5130', name: 'Finnhub API calls', family: 'expense' }), 409, /B-5130 is retired as "Finnhub API calls" — restore it/);
+  assert.equal(db.accounts.length, 1);
+});
+
+test('rename: a new code obeys the scheme, the range and uniqueness; a family change needs a code that fits', async () => {
+  const db = new FakeChart();
+  const [a, b] = db.seed([
+    { code: '6210', name: 'Software & Subscriptions', account_type: 'expense' },
+    { code: '6220', name: 'Azure Postgres', account_type: 'expense' },
+  ]);
+  await rejects(() => renameAccount(db, { userId: 'user-a', entity: ENTITY_B, account: a, code: '6220' }), 409, /B-6220 is already "Azure Postgres"/);
+  await rejects(() => renameAccount(db, { userId: 'user-a', entity: ENTITY_B, account: a, code: '4010' }), 400, /outside the expense range/);
+  await rejects(() => renameAccount(db, { userId: 'user-a', entity: ENTITY_B, account: a, family: 'asset' }), 400, /outside the asset range/);
+  await rejects(() => renameAccount(db, { userId: 'user-a', entity: ENTITY_B, account: a }), 400, /nothing to change/);
+  const renamed = await renameAccount(db, { userId: 'user-a', entity: ENTITY_B, account: a, name: 'Vercel', code: 'B-6215', subType: 'fixed' });
+  assert.equal(renamed.code, '6215');
+  assert.equal(renamed.name, 'Vercel');
+  assert.equal(renamed.sub_type, 'fixed');
+  assert.equal(b.code, '6220', 'the other account is untouched');
+  // a family change WITH a fitting code
+  const moved = await renameAccount(db, { userId: 'user-a', entity: ENTITY_B, account: b, code: '1300', family: 'asset' });
+  assert.equal(moved.account_type, 'asset');
+  assert.equal(moved.balance_type, 'D');
+  // a legacy caller may still say accountType (the route maps it to family)
+});
+
+// ── retire ──────────────────────────────────────────────────────────────────
+
+test('retire keeps history: the flag flips and nothing else — balance, ledger lines and the row stay; restore flips it back', async () => {
+  const db = new FakeChart();
+  const [finnhub, cash] = db.seed([
+    { code: '5130', name: 'Finnhub API calls', account_type: 'expense', settled_balance: BigInt(12000) },
+    { code: '1010', name: 'Business Checking', account_type: 'asset', settled_balance: BigInt(500000) },
+  ]);
+  db.postLine({ journal_entry_id: 'je-old', account_id: finnhub.id, entry_type: 'D', amount: BigInt(12000), created_by: null });
+  db.postLine({ journal_entry_id: 'je-old', account_id: cash.id, entry_type: 'C', amount: BigInt(12000), created_by: null });
+  const before = db.snapshotLedger();
+
+  const retired = await retireAccount(db, finnhub, true);
+  assert.equal(retired.is_archived, true);
+  assert.equal(retired.settled_balance, BigInt(12000), 'the balance is untouched');
+  assert.deepEqual(db.updates, [{ id: finnhub.id, patch: { is_archived: true } }], 'the ONLY write is the flag');
+  assert.equal(db.snapshotLedger(), before, 'no ledger line moved');
+  assert.equal(db.accounts.length, 2, 'nothing was deleted');
+  assert.equal(db.increments.length, 0);
+
+  // idempotent: retiring a retired account writes nothing
+  await retireAccount(db, finnhub, true);
+  assert.equal(db.updates.length, 1);
+
+  const restored = await retireAccount(db, finnhub, false);
+  assert.equal(restored.is_archived, false);
+  assert.equal(restored.settled_balance, BigInt(12000));
+});
+
+// ── reclassify ──────────────────────────────────────────────────────────────
+
+const FROM = { id: 'acct-5130', userId: 'user-a', entity_id: 'ent-b', entity_type: 'sole_prop', code: '5130', name: 'Finnhub API calls', account_type: 'expense', balance_type: 'D', sub_type: null, module: null, settled_balance: BigInt(12000), is_archived: true };
+const TO = { ...FROM, id: 'acct-6250', code: '6250', name: 'Finnhub Premium (quarterly plan)', sub_type: 'fixed', settled_balance: BigInt(0), is_archived: false };
+const DATE = new Date('2026-09-08T00:00:00Z');
+
+test('reclassify plans a balanced entry: one credit off the source, one debit onto the target, the whole balance by default', () => {
+  const plan = planReclassification({ from: FROM, to: TO, memo: '  Finnhub is a quarterly plan,  not per-call ', date: DATE });
+  assert.equal(plan.amount, BigInt(12000));
+  assert.equal(plan.memo, 'Finnhub is a quarterly plan, not per-call');
+  assert.equal(plan.description, 'Reclassify B-5130 → B-6250-fixed: Finnhub is a quarterly plan, not per-call');
+  assert.deepEqual(plan.lines, [
+    { account_id: 'acct-5130', entry_type: 'C', amount: BigInt(12000), balanceDelta: BigInt(-12000) },
+    { account_id: 'acct-6250', entry_type: 'D', amount: BigInt(12000), balanceDelta: BigInt(12000) },
+  ]);
+  const debits = plan.lines.filter((l) => l.entry_type === 'D').reduce((s, l) => s + l.amount, BigInt(0));
+  const credits = plan.lines.filter((l) => l.entry_type === 'C').reduce((s, l) => s + l.amount, BigInt(0));
+  assert.equal(debits, credits, 'balanced');
+  assert.equal(plan.lines[0].balanceDelta + plan.lines[1].balanceDelta, BigInt(0), 'the family total does not change');
+  assert.deepEqual(plan.metadata, { reclass: { from_id: 'acct-5130', from_code: '5130', to_id: 'acct-6250', to_code: '6250', amount_cents: '12000', memo: 'Finnhub is a quarterly plan, not per-call' } });
+  // a partial amount, given as cents in any of the accepted shapes
+  assert.equal(planReclassification({ from: FROM, to: TO, memo: 'part', date: DATE, amountCents: 5_000 }).amount, BigInt(5000));
+  assert.equal(planReclassification({ from: FROM, to: TO, memo: 'part', date: DATE, amountCents: '5000' }).amount, BigInt(5000));
+  // a NEGATIVE balance on a debit account moves with the mirror-image lines
+  const negative = planReclassification({ from: { ...FROM, settled_balance: BigInt(-3000) }, to: TO, memo: 'contra', date: DATE });
+  assert.deepEqual(negative.lines.map((l) => [l.entry_type, l.balanceDelta]), [['D', BigInt(3000)], ['C', BigInt(-3000)]]);
+  // a credit-normal family (revenue) moves the other way round
+  const rev = { ...FROM, id: 'r1', code: '4010', account_type: 'revenue', balance_type: 'C', settled_balance: BigInt(9000), is_archived: false };
+  const rev2 = { ...rev, id: 'r2', code: '4020' };
+  const r = planReclassification({ from: rev, to: rev2, memo: 'consulting, not service', date: DATE });
+  assert.deepEqual(r.lines.map((l) => [l.entry_type, l.balanceDelta]), [['D', BigInt(-9000)], ['C', BigInt(9000)]]);
+});
+
+test('reclassify fails loud: across families, into a retired account, into itself, across entities, no memo, zero balance, more than the balance, bad amount', () => {
+  throws(() => planReclassification({ from: FROM, to: { ...TO, account_type: 'revenue', balance_type: 'C', code: '4010' }, memo: 'x', date: DATE }), /within one family — B-5130 is expense, B-4010-fixed is revenue/);
+  throws(() => planReclassification({ from: FROM, to: { ...TO, is_archived: true }, memo: 'x', date: DATE }), /B-6250-fixed is retired — restore it/);
+  throws(() => planReclassification({ from: FROM, to: FROM, memo: 'x', date: DATE }), /into itself/);
+  throws(() => planReclassification({ from: FROM, to: { ...TO, entity_id: 'ent-p' }, memo: 'x', date: DATE }), /different entities/);
+  throws(() => planReclassification({ from: FROM, to: TO, memo: '   ', date: DATE }), /a memo is required/);
+  throws(() => planReclassification({ from: { ...FROM, settled_balance: BigInt(0) }, to: TO, memo: 'x', date: DATE }), /zero balance — nothing to move/);
+  throws(() => planReclassification({ from: FROM, to: TO, memo: 'x', date: DATE, amountCents: 12_001 }), /more than B-5130's balance of 12000 cents/);
+  throws(() => planReclassification({ from: FROM, to: TO, memo: 'x', date: DATE, amountCents: 0 }), /more than zero/);
+  throws(() => planReclassification({ from: FROM, to: TO, memo: 'x', date: DATE, amountCents: 'twelve' }), /not a whole number of cents/);
+  throws(() => planReclassification({ from: FROM, to: TO, memo: 'x', date: new Date('nope') }), /date is not a date/);
+});
+
+test('reclassify posts a balanced entry and never updates old rows: one journal entry, two new lines, two balance increments, the prior lines byte-identical', async () => {
+  const db = new FakeChart();
+  const [from, to, cash] = db.seed([
+    { id: 'acct-5130', code: '5130', name: 'Finnhub API calls', account_type: 'expense', settled_balance: BigInt(12000), is_archived: true },
+    { id: 'acct-6250', code: '6250', name: 'Finnhub Premium (quarterly plan)', account_type: 'expense', sub_type: 'fixed' },
+    { id: 'acct-1010', code: '1010', name: 'Business Checking', account_type: 'asset', settled_balance: BigInt(988000) },
+  ]);
+  // the history: the original per-call postings
+  db.postLine({ journal_entry_id: 'je-1', account_id: from.id, entry_type: 'D', amount: BigInt(7000), created_by: null });
+  db.postLine({ journal_entry_id: 'je-1', account_id: cash.id, entry_type: 'C', amount: BigInt(7000), created_by: null });
+  db.postLine({ journal_entry_id: 'je-2', account_id: from.id, entry_type: 'D', amount: BigInt(5000), created_by: null });
+  db.postLine({ journal_entry_id: 'je-2', account_id: cash.id, entry_type: 'C', amount: BigInt(5000), created_by: null });
+  const before = db.snapshotLedger();
+  const oldCount = db.ledger.length;
+
+  const plan = planReclassification({ from, to, memo: 'Finnhub is a quarterly plan', date: DATE });
+  const result = await postReclassification(db, { userId: 'user-a', entityId: 'ent-b', requestId: 'req-1', createdBy: 'alex@example.com' }, plan);
+
+  assert.equal(db.journal.length, 1);
+  const je = db.journal[0];
+  assert.equal(je.id, result.journalEntryId);
+  assert.equal(je.source_type, 'reclass');
+  assert.equal(je.status, 'posted');
+  assert.equal(je.entity_id, 'ent-b');
+  assert.equal(je.request_id, 'req-1');
+  assert.equal(je.description, 'Reclassify B-5130 → B-6250-fixed: Finnhub is a quarterly plan');
+  assert.deepEqual(je.metadata, plan.metadata);
+
+  assert.equal(db.ledger.length, oldCount + 2, 'two NEW lines');
+  assert.equal(JSON.stringify(db.ledger.slice(0, oldCount).map((l) => ({ ...l, amount: l.amount.toString() }))), before, 'the old lines are byte-identical');
+  const fresh = db.ledger.slice(oldCount);
+  assert.deepEqual(fresh.map((l) => [l.journal_entry_id, l.account_id, l.entry_type, l.amount]), [
+    [je.id, 'acct-5130', 'C', BigInt(12000)],
+    [je.id, 'acct-6250', 'D', BigInt(12000)],
+  ]);
+  assert.deepEqual(db.increments, [{ accountId: 'acct-5130', delta: BigInt(-12000) }, { accountId: 'acct-6250', delta: BigInt(12000) }]);
+  assert.equal(from.settled_balance, BigInt(0));
+  assert.equal(to.settled_balance, BigInt(12000));
+  assert.equal(cash.settled_balance, BigInt(988000), 'cash is untouched — a reclass never crosses the balance sheet');
+  assert.equal(db.updates.length, 0, 'no account row was edited — balances move only through increments');
+  assert.equal(Object.isFrozen(db.ledger[0]), true);
+});
+
+// ── the seed ────────────────────────────────────────────────────────────────
+
+test('the seed sets obey the law: every code in its family, unique per set, Finnhub at 6250 in the B-6200 family, the ruled names verbatim', () => {
+  assertSeedSetsLaw();
+  const platform = seedSet('platform-fixed-costs')!;
+  assert.deepEqual(platform.entityLetters, ['B']);
+  assert.deepEqual(platform.accounts.map((a) => `${a.code} ${a.name}`), [
+    '6210 Vercel', '6220 Azure Postgres', '6230 GitHub', '6240 Claude seat',
+    '6250 Finnhub Premium (quarterly plan)', '6260 tastytrade data', '6270 Resend', '6280 Voyage',
+  ]);
+  assert.ok(platform.accounts.every((a) => a.family === 'expense' && a.subType === 'fixed' && a.module === null));
+  assert.ok(platform.accounts.every((a) => Number(a.code) >= 6200 && Number(a.code) <= 6299), 'inside the fixed-cost block');
+  const travel = seedSet('travel-intl-fees')!;
+  assert.deepEqual(travel.entityLetters, ['P', 'B']);
+  assert.deepEqual(travel.accounts.map((a) => [a.code, a.name, a.subType, a.module]), [['9840', 'International transaction fees', 'travel', 'trips']]);
+  const personal = seedSet('personal-additions')!;
+  assert.deepEqual(personal.accounts.map((a) => `${a.code} ${a.name}`), ['8210 Gym membership', '8220 Pet supplies & food']);
+  assert.deepEqual(seedSetsFor('sole_prop').map((s) => s.key), ['platform-fixed-costs', 'travel-intl-fees']);
+  assert.deepEqual(seedSetsFor('personal').map((s) => s.key), ['travel-intl-fees', 'personal-additions']);
+  assert.deepEqual(seedSetsFor('trading'), []);
+  assert.equal(SEED_SETS.length, 3);
+  // the law refuses a set that puts Finnhub elsewhere, a code outside its family, or a repeated code
+  assert.throws(() => assertSeedSetsLaw([{ ...platform, accounts: platform.accounts.map((a) => (a.code === '6250' ? { ...a, code: '6290' } : a)) }]), /Finnhub Premium must sit at 6250/);
+  assert.throws(() => assertSeedSetsLaw([{ ...platform, accounts: [...platform.accounts, { code: '4010', name: 'Wrong', family: 'expense', subType: null, module: null }] }]), /outside the expense range/);
+  assert.throws(() => assertSeedSetsLaw([{ ...platform, accounts: [...platform.accounts, { code: '6210', name: 'Again', family: 'expense', subType: null, module: null }] }]), /repeats code 6210/);
+});
+
+test('seed is idempotent: the plan names every fate, apply inserts only the absent rows, a second apply inserts nothing, a collision is never overwritten', async () => {
+  const db = new FakeChart();
+  db.seed([
+    { code: '6210', name: 'Software & Subscriptions', account_type: 'expense' },          // collision — another name at 6210
+    { code: '6220', name: 'azure  postgres', account_type: 'expense' },                   // exists — same name, spacing/case aside
+    { code: '6230', name: 'GitHub', account_type: 'expense', is_archived: true },         // retired — restore, never re-add
+  ]);
+  const set = seedSet('platform-fixed-costs')!;
+  throws(() => planSeed(set, ENTITY_P, []), /applies to B- charts; this entity is P-/);
+
+  const plan = planSeed(set, ENTITY_B, db.accounts);
+  assert.deepEqual(plan.map((r) => `${r.code} ${r.action}${r.existingName ? ` (${r.existingName})` : ''}`), [
+    '6210 collision (Software & Subscriptions)',
+    '6220 exists (azure  postgres)',
+    '6230 retired (GitHub)',
+    '6240 create', '6250 create', '6260 create', '6270 create', '6280 create',
+  ]);
+
+  const created = await applySeed(db, { userId: 'user-a', entity: ENTITY_B }, plan);
+  assert.deepEqual(created.map((r) => `${r.code} ${r.name}`), ['6240 Claude seat', '6250 Finnhub Premium (quarterly plan)', '6260 tastytrade data', '6270 Resend', '6280 Voyage']);
+  assert.ok(created.every((r) => r.sub_type === 'fixed' && r.account_type === 'expense' && r.balance_type === 'D' && r.entity_type === 'sole_prop'));
+  assert.equal(db.accounts.find((a) => a.code === '6210')!.name, 'Software & Subscriptions', 'the collision is untouched');
+  assert.equal(db.accounts.find((a) => a.code === '6230')!.is_archived, true, 'the retired row is untouched');
+  assert.equal(db.updates.length, 0, 'apply never updates');
+  assert.equal(db.accounts.length, 8);
+
+  // the second pass
+  const again = planSeed(set, ENTITY_B, db.accounts);
+  assert.deepEqual(again.filter((r) => r.action === 'create'), []);
+  assert.equal(again.filter((r) => r.action === 'exists').length, 6);
+  const createdAgain = await applySeed(db, { userId: 'user-a', entity: ENTITY_B }, again);
+  assert.deepEqual(createdAgain, []);
+  assert.equal(db.accounts.length, 8, 'idempotent');
+
+  // the travel set on both letters; the personal set's rows land with no sub
+  const p = new FakeChart();
+  await applySeed(p, { userId: 'user-a', entity: ENTITY_P }, planSeed(seedSet('travel-intl-fees')!, ENTITY_P, []));
+  await applySeed(p, { userId: 'user-a', entity: ENTITY_P }, planSeed(seedSet('personal-additions')!, ENTITY_P, []));
+  assert.deepEqual(p.accounts.map((a) => [a.code, a.name, a.sub_type, a.module, a.entity_type]), [
+    ['9840', 'International transaction fees', 'travel', 'trips', 'personal'],
+    ['8210', 'Gym membership', null, null, 'personal'],
+    ['8220', 'Pet supplies & food', null, null, 'personal'],
+  ]);
+});

--- a/src/lib/__tests__/fakeChart.ts
+++ b/src/lib/__tests__/fakeChart.ts
@@ -1,0 +1,112 @@
+import type { ChartAccountRow, ChartDb, ChartPatch, NewChartAccount } from '../coa/accounts';
+import type { PostingDb } from '../coa/reclassify';
+
+/**
+ * COA-01 — the test fake of the chart and the posting port, shared by the COA
+ * tests. Hermetic, with the tables' own rules: UNIQUE on (userId, entity_id,
+ * code); ledger lines are append-only (there is no update on the port, and the
+ * fake's `ledger` array is frozen row by row so a test can prove nothing old
+ * moved); balances change only through incrementBalance. Not a test file (no
+ * .test suffix): npm test's glob skips it.
+ */
+export interface FakeJournalRow {
+  id: string;
+  userId: string;
+  entity_id: string;
+  date: Date;
+  description: string;
+  source_type: string;
+  status: string;
+  request_id: string;
+  created_by: string | null;
+  metadata: unknown;
+}
+
+export interface FakeLedgerRow {
+  id: string;
+  journal_entry_id: string;
+  account_id: string;
+  entry_type: 'D' | 'C';
+  amount: bigint;
+  created_by: string | null;
+}
+
+export class FakeChart implements ChartDb, PostingDb {
+  accounts: ChartAccountRow[] = [];
+  journal: FakeJournalRow[] = [];
+  ledger: readonly Readonly<FakeLedgerRow>[] = [];
+  updates: Array<{ id: string; patch: ChartPatch }> = [];
+  increments: Array<{ accountId: string; delta: bigint }> = [];
+  private seq = 0;
+
+  private nextId(prefix: string) { this.seq += 1; return `${prefix}-${this.seq}`; }
+
+  seed(rows: Array<Partial<ChartAccountRow> & { code: string; name: string; account_type: string }>): ChartAccountRow[] {
+    return rows.map((r) => {
+      const row: ChartAccountRow = {
+        id: r.id ?? this.nextId('acct'),
+        userId: r.userId ?? 'user-a',
+        entity_id: r.entity_id ?? 'ent-b',
+        entity_type: r.entity_type ?? 'sole_prop',
+        code: r.code,
+        name: r.name,
+        account_type: r.account_type,
+        balance_type: r.balance_type ?? (r.account_type === 'asset' || r.account_type === 'expense' ? 'D' : 'C'),
+        sub_type: r.sub_type ?? null,
+        module: r.module ?? null,
+        settled_balance: r.settled_balance ?? BigInt(0),
+        is_archived: r.is_archived ?? false,
+      };
+      this.accounts.push(row);
+      return row;
+    });
+  }
+
+  postLine(row: Omit<FakeLedgerRow, 'id'>): FakeLedgerRow {
+    const line = Object.freeze({ ...row, id: this.nextId('line') });
+    this.ledger = [...this.ledger, line];
+    return line;
+  }
+
+  async findByCode(userId: string, entityId: string, code: string) {
+    return this.accounts.find((a) => a.userId === userId && a.entity_id === entityId && a.code === code) ?? null;
+  }
+
+  async insert(a: NewChartAccount) {
+    if (await this.findByCode(a.userId, a.entity_id, a.code)) {
+      throw new Error(`fake chart: UNIQUE (userId, entity_id, code) violated for ${a.code}`);
+    }
+    const row: ChartAccountRow = { ...a, id: this.nextId('acct'), settled_balance: BigInt(0), is_archived: false };
+    this.accounts.push(row);
+    return row;
+  }
+
+  async update(id: string, patch: ChartPatch) {
+    const row = this.accounts.find((a) => a.id === id);
+    if (!row) throw new Error(`fake chart: no account ${id}`);
+    this.updates.push({ id, patch: { ...patch } });
+    Object.assign(row, patch);
+    return row;
+  }
+
+  async insertJournalEntry(r: Omit<FakeJournalRow, 'id'>) {
+    const je: FakeJournalRow = { ...r, id: this.nextId('je') };
+    this.journal.push(je);
+    return { id: je.id };
+  }
+
+  async insertLedgerLine(r: Omit<FakeLedgerRow, 'id'>) {
+    return { id: this.postLine(r).id };
+  }
+
+  async incrementBalance(accountId: string, delta: bigint) {
+    const row = this.accounts.find((a) => a.id === accountId);
+    if (!row) throw new Error(`fake chart: no account ${accountId}`);
+    this.increments.push({ accountId, delta });
+    row.settled_balance = BigInt(row.settled_balance) + delta;
+  }
+
+  snapshotLedger(): string {
+    return JSON.stringify(this.ledger.map((l) => ({ ...l, amount: l.amount.toString() })));
+  }
+}

--- a/src/lib/accountString.ts
+++ b/src/lib/accountString.ts
@@ -28,6 +28,11 @@ const ENTITY_LETTER: Record<string, string> = {
   trading: 'T',
 };
 
+/** COA-01: the E segment alone — the entity's code letter, or null when the type has none. */
+export function entityLetter(entityType: string | null | undefined): string | null {
+  return (entityType && ENTITY_LETTER[entityType]) || null;
+}
+
 export interface AccountStringParts {
   /** entities.entity_type ('personal' | 'sole_prop' | 'trading' | other). */
   entityType?: string | null;

--- a/src/lib/auto-categorization-service.ts
+++ b/src/lib/auto-categorization-service.ts
@@ -43,7 +43,15 @@ export class AutoCategorizationService {
         }
       });
 
-      if (merchantMapping && merchantMapping.confidence_score.toNumber() > 0.5) {
+      // COA-01: a mapping onto a RETIRED account is skipped — retiring hides an
+      // account from categorization; the mapping row stays (history), it just
+      // no longer predicts. A mapping onto a code the chart never had is skipped
+      // the same way (nothing to categorize into).
+      if (
+        merchantMapping &&
+        merchantMapping.confidence_score.toNumber() > 0.5 &&
+        (await this.isActiveCode(userId, merchantMapping.entity_id, merchantMapping.coa_code))
+      ) {
         return {
           coaCode: merchantMapping.coa_code,
           confidence: merchantMapping.confidence_score.toNumber(),
@@ -73,7 +81,9 @@ export class AutoCategorizationService {
       };
 
       const coaCode = categoryMap[categoryPrimary];
-      if (coaCode) {
+      // COA-01: the category default must also be an ACTIVE account somewhere
+      // in the user's chart (the caller resolves the entity to personal).
+      if (coaCode && (await this.isActiveCode(userId, null, coaCode))) {
         return {
           coaCode,
           confidence: 0.6,
@@ -85,6 +95,15 @@ export class AutoCategorizationService {
 
     // No prediction available
     return null;
+  }
+
+  /** COA-01: is this code an active (not retired) account in the user's chart — in the entity when one is given. */
+  private async isActiveCode(userId: string, entityId: string | null, code: string): Promise<boolean> {
+    const active = await prisma.chart_of_accounts.findFirst({
+      where: { userId, code, is_archived: false, ...(entityId ? { entity_id: entityId } : {}) },
+      select: { id: true },
+    });
+    return active !== null;
   }
 
   /**

--- a/src/lib/coa/accounts.ts
+++ b/src/lib/coa/accounts.ts
@@ -1,0 +1,186 @@
+import { ValidationError } from '@/lib/errors/ValidationError';
+import { FAMILY_RULES, assertCodeInFamily, familyOfAccountType, isFamily, parseCode, renderCode, type Family } from './scheme';
+import type { SeedPlanRow } from './seedSets';
+
+/**
+ * COA-01 — add / rename / retire an account, and apply a seed plan, over a
+ * small port (ChartDb) so the policies run hermetically in node:test and the
+ * routes bind them to Prisma (prismaChartDb.ts). Every rule fails loud with a
+ * ValidationError the route answers verbatim at its status (failClosed).
+ *
+ *   add     — the code follows the ENTITY's scheme (parseCode), sits in its
+ *             family's range (assertCodeInFamily), and is unique in the
+ *             entity's chart — a retired account at that code is a 409 with
+ *             the restore hint, never silently re-added;
+ *   rename  — name / code / sub / family; a new code obeys the same rules;
+ *   retire  — is_archived flips, NOTHING else: the row, its balance and its
+ *             ledger history stay (ledger_entries.account is Restrict; the
+ *             no_ledger_updates trigger refuses edits) — retired accounts
+ *             leave every categorization list and the auto-categorizer skips
+ *             their mappings.
+ */
+
+export interface ChartAccountRow {
+  id: string;
+  userId: string;
+  entity_id: string;
+  entity_type: string | null;
+  code: string;
+  name: string;
+  account_type: string;
+  balance_type: string;
+  sub_type: string | null;
+  module: string | null;
+  settled_balance: bigint;
+  is_archived: boolean;
+}
+
+export interface NewChartAccount {
+  userId: string;
+  entity_id: string;
+  entity_type: string | null;
+  code: string;
+  name: string;
+  account_type: Family;
+  balance_type: 'D' | 'C';
+  sub_type: string | null;
+  module: string | null;
+}
+
+export type ChartPatch = Partial<Pick<ChartAccountRow, 'name' | 'code' | 'sub_type' | 'account_type' | 'balance_type' | 'is_archived'>>;
+
+export interface ChartDb {
+  findByCode(userId: string, entityId: string, code: string): Promise<ChartAccountRow | null>;
+  insert(row: NewChartAccount): Promise<ChartAccountRow>;
+  update(id: string, patch: ChartPatch): Promise<ChartAccountRow>;
+}
+
+export interface EntityRef {
+  id: string;
+  entity_type: string | null;
+}
+
+const NAME_MAX = 255;
+const SUB_MAX = 50;
+
+function parseName(input: unknown): string {
+  const name = typeof input === 'string' ? input.trim().replace(/\s+/g, ' ') : '';
+  if (!name) throw new ValidationError('name is required', { field: 'name' });
+  if (name.length > NAME_MAX) throw new ValidationError(`name is longer than ${NAME_MAX} characters`, { field: 'name' });
+  return name;
+}
+
+function parseSub(input: unknown): string | null {
+  if (input === undefined || input === null) return null;
+  if (typeof input !== 'string') throw new ValidationError('subType must be a string or null', { field: 'subType' });
+  const s = input.trim();
+  if (s.length > SUB_MAX) throw new ValidationError(`subType is longer than ${SUB_MAX} characters`, { field: 'subType' });
+  return s || null;
+}
+
+function parseFamily(input: unknown): Family {
+  const f = typeof input === 'string' ? input.trim().toLowerCase() : '';
+  if (!f) throw new ValidationError('family is required — asset, liability, equity, revenue or expense', { field: 'family' });
+  if (!isFamily(f)) throw new ValidationError(`family "${input}" is not one of asset, liability, equity, revenue, expense`, { field: 'family' });
+  return f;
+}
+
+/** 409 on a code already in the entity's chart — active or retired, each with its own line. */
+async function assertCodeFree(db: ChartDb, userId: string, entity: EntityRef, code: string, exceptId?: string): Promise<void> {
+  const existing = await db.findByCode(userId, entity.id, code);
+  if (!existing || existing.id === exceptId) return;
+  const rendered = renderCode(code, entity.entity_type);
+  if (existing.is_archived) {
+    throw new ValidationError(`code ${rendered} is retired as "${existing.name}" — restore it instead of adding it again`, { status: 409, field: 'code' });
+  }
+  throw new ValidationError(`code ${rendered} is already "${existing.name}"`, { status: 409, field: 'code' });
+}
+
+export interface AddAccountInput {
+  userId: string;
+  entity: EntityRef;
+  code: unknown;
+  name: unknown;
+  family: unknown;
+  subType?: unknown;
+}
+
+export async function addAccount(db: ChartDb, input: AddAccountInput): Promise<ChartAccountRow> {
+  const family = parseFamily(input.family);
+  const code = parseCode(input.code, input.entity.entity_type);
+  assertCodeInFamily(code, family);
+  const name = parseName(input.name);
+  const sub = parseSub(input.subType);
+  await assertCodeFree(db, input.userId, input.entity, code);
+  return db.insert({
+    userId: input.userId,
+    entity_id: input.entity.id,
+    entity_type: input.entity.entity_type,
+    code,
+    name,
+    account_type: family,
+    balance_type: FAMILY_RULES[family].balanceType,
+    sub_type: sub,
+    module: null,
+  });
+}
+
+export interface RenameAccountInput {
+  userId: string;
+  entity: EntityRef;
+  account: ChartAccountRow;
+  name?: unknown;
+  code?: unknown;
+  family?: unknown;
+  subType?: unknown;
+}
+
+export async function renameAccount(db: ChartDb, input: RenameAccountInput): Promise<ChartAccountRow> {
+  const { account } = input;
+  const patch: ChartPatch = {};
+  const family = input.family === undefined ? familyOfAccountType(account.account_type) : parseFamily(input.family);
+  const code = input.code === undefined ? account.code : parseCode(input.code, input.entity.entity_type);
+  if (code !== account.code || input.family !== undefined) {
+    assertCodeInFamily(code, family);
+  }
+  if (code !== account.code) {
+    await assertCodeFree(db, input.userId, input.entity, code, account.id);
+    patch.code = code;
+  }
+  if (input.family !== undefined && family !== account.account_type) {
+    patch.account_type = family;
+    patch.balance_type = FAMILY_RULES[family].balanceType;
+  }
+  if (input.name !== undefined) patch.name = parseName(input.name);
+  if (input.subType !== undefined) patch.sub_type = parseSub(input.subType);
+  if (Object.keys(patch).length === 0) throw new ValidationError('nothing to change — send a name, code, family or subType', { status: 400 });
+  return db.update(account.id, patch);
+}
+
+/** Retire (or restore) — the archived flag only; balance and history untouched by construction. */
+export async function retireAccount(db: ChartDb, account: ChartAccountRow, retired: boolean): Promise<ChartAccountRow> {
+  if (account.is_archived === retired) return account;
+  return db.update(account.id, { is_archived: retired });
+}
+
+/** Insert the plan's 'create' rows; every other fate is left exactly as found. */
+export async function applySeed(db: ChartDb, ctx: { userId: string; entity: EntityRef }, plan: readonly SeedPlanRow[]): Promise<ChartAccountRow[]> {
+  const created: ChartAccountRow[] = [];
+  for (const row of plan) {
+    if (row.action !== 'create') continue;
+    assertCodeInFamily(row.code, row.family);
+    await assertCodeFree(db, ctx.userId, ctx.entity, row.code);
+    created.push(await db.insert({
+      userId: ctx.userId,
+      entity_id: ctx.entity.id,
+      entity_type: ctx.entity.entity_type,
+      code: row.code,
+      name: row.name,
+      account_type: row.family,
+      balance_type: FAMILY_RULES[row.family].balanceType,
+      sub_type: row.subType,
+      module: row.module,
+    }));
+  }
+  return created;
+}

--- a/src/lib/coa/prismaChartDb.ts
+++ b/src/lib/coa/prismaChartDb.ts
@@ -1,0 +1,92 @@
+import { randomUUID } from 'crypto';
+import type { PrismaClient } from '@prisma/client';
+import type { ChartAccountRow, ChartDb, ChartPatch, NewChartAccount } from './accounts';
+import type { PostingDb } from './reclassify';
+
+/**
+ * COA-01 — the Prisma bindings of the two ports (accounts.ts ChartDb,
+ * reclassify.ts PostingDb). A route hands the client (or a $transaction
+ * context) in; the policies never import prisma.
+ */
+
+type Client = Pick<PrismaClient, 'chart_of_accounts' | 'journal_entries' | 'ledger_entries'>;
+
+const SELECT = {
+  id: true, userId: true, entity_id: true, entity_type: true, code: true, name: true,
+  account_type: true, balance_type: true, sub_type: true, module: true, settled_balance: true, is_archived: true,
+} as const;
+
+type Selected = {
+  id: string; userId: string | null; entity_id: string; entity_type: string | null; code: string; name: string;
+  account_type: string; balance_type: string; sub_type: string | null; module: string | null; settled_balance: bigint; is_archived: boolean;
+};
+
+function row(r: Selected, userId: string): ChartAccountRow {
+  return { ...r, userId: r.userId ?? userId };
+}
+
+export function prismaChartDb(client: Client, userId: string): ChartDb {
+  return {
+    async findByCode(uid, entityId, code) {
+      const r = await client.chart_of_accounts.findFirst({ where: { userId: uid, entity_id: entityId, code }, select: SELECT });
+      return r ? row(r, uid) : null;
+    },
+    async insert(a: NewChartAccount) {
+      const r = await client.chart_of_accounts.create({
+        data: {
+          id: randomUUID(),
+          userId: a.userId,
+          entity_id: a.entity_id,
+          entity_type: a.entity_type,
+          code: a.code,
+          name: a.name,
+          account_type: a.account_type,
+          balance_type: a.balance_type,
+          sub_type: a.sub_type,
+          module: a.module,
+          settled_balance: 0,
+          pending_balance: 0,
+          version: 0,
+          is_archived: false,
+        },
+        select: SELECT,
+      });
+      return row(r, userId);
+    },
+    async update(id, patch: ChartPatch) {
+      const r = await client.chart_of_accounts.update({ where: { id }, data: { ...patch, updated_at: new Date() }, select: SELECT });
+      return row(r, userId);
+    },
+  };
+}
+
+export function prismaPostingDb(client: Client): PostingDb {
+  return {
+    async insertJournalEntry(r) {
+      const je = await client.journal_entries.create({
+        data: {
+          userId: r.userId,
+          entity_id: r.entity_id,
+          date: r.date,
+          description: r.description,
+          source_type: r.source_type,
+          status: r.status,
+          request_id: r.request_id,
+          created_by: r.created_by,
+          metadata: r.metadata,
+        },
+        select: { id: true },
+      });
+      return je;
+    },
+    async insertLedgerLine(r) {
+      return client.ledger_entries.create({ data: r, select: { id: true } });
+    },
+    async incrementBalance(accountId, delta) {
+      await client.chart_of_accounts.update({
+        where: { id: accountId },
+        data: { settled_balance: { increment: delta }, version: { increment: 1 }, updated_at: new Date() },
+      });
+    },
+  };
+}

--- a/src/lib/coa/reclassify.ts
+++ b/src/lib/coa/reclassify.ts
@@ -1,0 +1,149 @@
+import { ValidationError } from '@/lib/errors/ValidationError';
+import { renderCode } from './scheme';
+import type { ChartAccountRow } from './accounts';
+
+/**
+ * COA-01 — reclassify: move a balance from one account to another by POSTING
+ * A NEW JOURNAL ENTRY with a memo. Nothing old is edited: the prior entries,
+ * lines and transactions stay exactly as posted (the no_ledger_updates trigger
+ * would refuse an edit anyway — src/lib/journal-entry-service.ts's doctrine).
+ * Used for Finnhub B-5130 → B-6250 once the fixed-cost family exists.
+ *
+ * planReclassification is pure and fails loud: same entity, same family (an
+ * expense balance moves to an expense account — across families is a manual
+ * entry, not a reclass), the target active, a memo, an amount within the
+ * source balance. The entry it plans is balanced by construction — one debit
+ * and one credit of the same amount — and the balance deltas follow the same
+ * rule every writer uses (journal-entry-service.ts:50-53, manual/route.ts:98-100):
+ * an entry of the account's own balance_type adds, the other subtracts.
+ */
+
+export interface ReclassInput {
+  from: ChartAccountRow;
+  to: ChartAccountRow;
+  /** Cents to move; omitted → the whole balance. */
+  amountCents?: bigint | number | string | null;
+  memo: unknown;
+  date: Date;
+}
+
+export interface ReclassLine {
+  account_id: string;
+  entry_type: 'D' | 'C';
+  amount: bigint;
+  /** What the line does to chart_of_accounts.settled_balance. */
+  balanceDelta: bigint;
+}
+
+export interface ReclassPlan {
+  amount: bigint;
+  memo: string;
+  date: Date;
+  description: string;
+  lines: [ReclassLine, ReclassLine];
+  metadata: { reclass: { from_id: string; from_code: string; to_id: string; to_code: string; amount_cents: string; memo: string } };
+}
+
+function toCents(input: ReclassInput['amountCents'], whole: bigint): bigint {
+  if (input === undefined || input === null || input === '') return whole;
+  let n: bigint;
+  try {
+    n = typeof input === 'bigint' ? input : BigInt(typeof input === 'number' ? Math.round(input) : String(input).trim());
+  } catch {
+    throw new ValidationError(`amountCents "${String(input)}" is not a whole number of cents`, { field: 'amountCents' });
+  }
+  return n;
+}
+
+const other = (t: 'D' | 'C'): 'D' | 'C' => (t === 'D' ? 'C' : 'D');
+
+export function planReclassification(input: ReclassInput): ReclassPlan {
+  const { from, to } = input;
+  const fromCode = renderCode(from.code, from.entity_type, from.sub_type);
+  const toCode = renderCode(to.code, to.entity_type, to.sub_type);
+  if (from.id === to.id) throw new ValidationError(`${fromCode} cannot be reclassified into itself`, { field: 'toCode' });
+  if (from.entity_id !== to.entity_id) throw new ValidationError(`${fromCode} and ${toCode} are in different entities — a reclass stays inside one chart`, { field: 'toCode' });
+  if (from.account_type !== to.account_type) {
+    throw new ValidationError(
+      `a reclass moves a balance within one family — ${fromCode} is ${from.account_type}, ${toCode} is ${to.account_type}; use a manual journal entry across families`,
+      { field: 'toCode' },
+    );
+  }
+  if (from.balance_type !== to.balance_type) {
+    throw new ValidationError(`${fromCode} (${from.balance_type}) and ${toCode} (${to.balance_type}) carry different normal balances — not a reclass`, { field: 'toCode' });
+  }
+  if (to.is_archived) throw new ValidationError(`${toCode} is retired — restore it before moving a balance into it`, { field: 'toCode' });
+  const memo = typeof input.memo === 'string' ? input.memo.trim().replace(/\s+/g, ' ') : '';
+  if (!memo) throw new ValidationError('a memo is required — say why the balance moves', { field: 'memo' });
+  if (!(input.date instanceof Date) || Number.isNaN(input.date.getTime())) throw new ValidationError('date is not a date', { field: 'date' });
+
+  const balance = BigInt(from.settled_balance);
+  if (balance === BigInt(0)) throw new ValidationError(`${fromCode} has a zero balance — nothing to move`, { field: 'fromCode' });
+  const whole = balance < BigInt(0) ? -balance : balance;
+  const amount = toCents(input.amountCents, whole);
+  if (amount <= BigInt(0)) throw new ValidationError('amountCents must be more than zero', { field: 'amountCents' });
+  if (amount > whole) throw new ValidationError(`amountCents ${amount} is more than ${fromCode}'s balance of ${whole} cents`, { field: 'amountCents' });
+
+  const normal = from.balance_type as 'D' | 'C';
+  // A positive balance sits on the account's normal side: take it OFF with the
+  // other side and put it ON the target with the normal side. A negative
+  // balance is the mirror image.
+  const fromType: 'D' | 'C' = balance > BigInt(0) ? other(normal) : normal;
+  const toType: 'D' | 'C' = other(fromType);
+  const delta = (entryType: 'D' | 'C', balanceType: string) => (entryType === balanceType ? amount : -amount);
+  const lines: [ReclassLine, ReclassLine] = [
+    { account_id: from.id, entry_type: fromType, amount, balanceDelta: delta(fromType, from.balance_type) },
+    { account_id: to.id, entry_type: toType, amount, balanceDelta: delta(toType, to.balance_type) },
+  ];
+  return {
+    amount,
+    memo,
+    date: input.date,
+    description: `Reclassify ${fromCode} → ${toCode}: ${memo}`,
+    lines,
+    metadata: { reclass: { from_id: from.id, from_code: from.code, to_id: to.id, to_code: to.code, amount_cents: amount.toString(), memo } },
+  };
+}
+
+/** The write port a reclass needs — inserts and balance increments only; there is no way to edit a prior row through it. */
+export interface PostingDb {
+  insertJournalEntry(row: {
+    userId: string;
+    entity_id: string;
+    date: Date;
+    description: string;
+    source_type: 'reclass';
+    status: 'posted';
+    request_id: string;
+    created_by: string | null;
+    metadata: ReclassPlan['metadata'];
+  }): Promise<{ id: string }>;
+  insertLedgerLine(row: { journal_entry_id: string; account_id: string; entry_type: 'D' | 'C'; amount: bigint; created_by: string | null }): Promise<{ id: string }>;
+  incrementBalance(accountId: string, delta: bigint): Promise<void>;
+}
+
+export interface PostingContext {
+  userId: string;
+  entityId: string;
+  requestId: string;
+  createdBy: string | null;
+}
+
+export async function postReclassification(db: PostingDb, ctx: PostingContext, plan: ReclassPlan): Promise<{ journalEntryId: string }> {
+  const je = await db.insertJournalEntry({
+    userId: ctx.userId,
+    entity_id: ctx.entityId,
+    date: plan.date,
+    description: plan.description,
+    source_type: 'reclass',
+    status: 'posted',
+    request_id: ctx.requestId,
+    created_by: ctx.createdBy,
+    metadata: plan.metadata,
+  });
+  for (const line of plan.lines) {
+    await db.insertLedgerLine({ journal_entry_id: je.id, account_id: line.account_id, entry_type: line.entry_type, amount: line.amount, created_by: ctx.createdBy });
+    await db.incrementBalance(line.account_id, line.balanceDelta);
+  }
+  return { journalEntryId: je.id };
+}

--- a/src/lib/coa/scheme.ts
+++ b/src/lib/coa/scheme.ts
@@ -1,0 +1,173 @@
+import { ValidationError } from '@/lib/errors/ValidationError';
+import { deriveAccountString, entityLetter } from '@/lib/accountString';
+
+/**
+ * COA-01 — the chart of accounts' code scheme, in ONE place.
+ *
+ * A code renders as <letter>-<four digits> (src/lib/accountString.ts): the
+ * letter is the ENTITY's — personal → P, sole_prop → B, trading → T — and is
+ * never stored; chart_of_accounts.code holds the four digits. The first digit
+ * is the statement family, the rule every seed in the repo follows
+ * (prisma/seed-coa-complete.ts:41-143 · prisma/seed-trading-coa.ts:6-60 ·
+ * src/lib/coaDefaults.ts:14-51 · prisma/migrations/20260324110000_add_travel_coa_codes):
+ *
+ *   1xxx asset · 2xxx liability · 3xxx equity · 4xxx revenue · 5xxx–9xxx expense
+ *
+ * The family range is THE gate: a code outside its family's range fails loud
+ * (assertCodeInFamily), a letter that is not the entity's fails loud
+ * (parseCode), anything but four digits fails loud. The expense blocks under
+ * the family (EXPENSE_BLOCKS) are the conventions the seeds evidence per
+ * letter — they guide the add form and the seed sets; they are not a gate.
+ *
+ * Client-safe: no prisma, no server-only import (the add form reads it).
+ */
+
+export type Family = 'asset' | 'liability' | 'equity' | 'revenue' | 'expense';
+export const FAMILIES: readonly Family[] = ['asset', 'liability', 'equity', 'revenue', 'expense'];
+
+export interface FamilyRule {
+  readonly family: Family;
+  readonly label: string;
+  readonly from: number;
+  readonly to: number;
+  /** The normal balance — D for asset/expense, C for liability/equity/revenue (chart_of_accounts.balance_type). */
+  readonly balanceType: 'D' | 'C';
+  readonly statement: 'Balance sheet' | 'Income statement';
+}
+
+export const FAMILY_RULES: Readonly<Record<Family, FamilyRule>> = {
+  asset: { family: 'asset', label: 'Assets', from: 1000, to: 1999, balanceType: 'D', statement: 'Balance sheet' },
+  liability: { family: 'liability', label: 'Liabilities', from: 2000, to: 2999, balanceType: 'C', statement: 'Balance sheet' },
+  equity: { family: 'equity', label: 'Equity', from: 3000, to: 3999, balanceType: 'C', statement: 'Balance sheet' },
+  revenue: { family: 'revenue', label: 'Revenue', from: 4000, to: 4999, balanceType: 'C', statement: 'Income statement' },
+  expense: { family: 'expense', label: 'Expenses', from: 5000, to: 9999, balanceType: 'D', statement: 'Income statement' },
+};
+
+export function isFamily(x: unknown): x is Family {
+  return typeof x === 'string' && (FAMILIES as readonly string[]).includes(x);
+}
+
+export type EntityLetter = 'P' | 'B' | 'T';
+
+export interface CodeBlock {
+  readonly from: number;
+  readonly to: number;
+  readonly label: string;
+  /** Where the repo evidences the block — a seed, a migration, a ruling. */
+  readonly evidence: string;
+}
+
+/** The expense blocks each letter's seeds use. Guidance for the form and the seed sets; the family range is the gate. */
+export const EXPENSE_BLOCKS: Readonly<Record<EntityLetter, readonly CodeBlock[]>> = {
+  P: [
+    { from: 5000, to: 5999, label: 'Trading & investment costs', evidence: 'prisma/seed-coa-complete.ts:78-80' },
+    { from: 6000, to: 6999, label: 'Variable living costs', evidence: 'prisma/seed-coa-complete.ts:81-88' },
+    { from: 7000, to: 7999, label: 'Travel (the default chart, legacy codes)', evidence: 'src/lib/coaDefaults.ts:43-50' },
+    { from: 8000, to: 8999, label: 'Fixed & personal costs', evidence: 'prisma/seed-coa-complete.ts:89-100' },
+    { from: 9000, to: 9999, label: 'Travel', evidence: 'src/lib/travelCOA.ts coaPersonal · migration 20260324110000' },
+  ],
+  B: [
+    { from: 6000, to: 6999, label: 'Operating expenses', evidence: 'prisma/seed-coa-complete.ts:126-142' },
+    { from: 6200, to: 6299, label: 'Fixed costs — the platform\'s own bills', evidence: 'COA-01 ruling: the B-6200 fixed-cost family' },
+    { from: 9000, to: 9999, label: 'Travel', evidence: 'src/lib/travelCOA.ts coaBusiness · migration 20260324110000' },
+  ],
+  T: [
+    { from: 5000, to: 5999, label: 'Trading losses', evidence: 'prisma/seed-trading-coa.ts:39-47' },
+    { from: 6000, to: 6999, label: 'Trading expenses', evidence: 'prisma/seed-trading-coa.ts:48-59' },
+  ],
+};
+
+/** The entity's code letter, or null for an entity type the scheme does not letter (accountString.ts renders no letter for it). */
+export function letterFor(entityType: string | null | undefined): EntityLetter | null {
+  const l = entityLetter(entityType);
+  return l === 'P' || l === 'B' || l === 'T' ? l : null;
+}
+
+const BARE = /^(\d{4})$/;
+const LETTERED = /^([PBT])-(\d{4})$/;
+
+/**
+ * The four stored digits from what a user typed — "6250" or "B-6250". A letter
+ * must be THIS entity's; a code outside 1000–9999 or not four digits fails.
+ */
+export function parseCode(input: unknown, entityType: string | null | undefined): string {
+  const raw = typeof input === 'string' ? input.trim().toUpperCase() : '';
+  if (!raw) throw new ValidationError('code is required — four digits (6250) or the entity letter and four digits (B-6250)', { field: 'code' });
+  let digits: string;
+  let letter: EntityLetter | null = null;
+  const bare = BARE.exec(raw);
+  if (bare) {
+    digits = bare[1];
+  } else {
+    const m = LETTERED.exec(raw);
+    if (!m) {
+      throw new ValidationError(`code "${raw}" is not in the scheme — four digits (6250) or the entity letter and four digits (B-6250)`, { field: 'code' });
+    }
+    letter = m[1] as EntityLetter;
+    digits = m[2];
+  }
+  const mine = letterFor(entityType);
+  if (letter && !mine) {
+    throw new ValidationError(`this entity (${entityType ?? 'unknown type'}) has no code letter — enter the four digits only`, { field: 'code' });
+  }
+  if (letter && mine && letter !== mine) {
+    throw new ValidationError(`code ${raw} carries the ${letter}- letter; this is a ${mine}- chart (${entityType}) — enter ${mine}-${digits} or ${digits}`, { field: 'code' });
+  }
+  if (digits[0] === '0') {
+    throw new ValidationError(`code ${digits} is outside every family — codes run 1000–9999`, { field: 'code' });
+  }
+  return digits;
+}
+
+/** The family a four-digit code reads as, from its first digit. */
+export function familyOfCode(code: string): Family {
+  switch (code[0]) {
+    case '1': return 'asset';
+    case '2': return 'liability';
+    case '3': return 'equity';
+    case '4': return 'revenue';
+    case '5': case '6': case '7': case '8': case '9': return 'expense';
+    default:
+      throw new ValidationError(`code ${code} is outside every family — codes run 1000–9999`, { field: 'code' });
+  }
+}
+
+/** Fail loud on a code outside its family's range. */
+export function assertCodeInFamily(code: string, family: Family): void {
+  const rule = FAMILY_RULES[family];
+  const n = Number(code);
+  if (!Number.isInteger(n) || n < rule.from || n > rule.to) {
+    throw new ValidationError(
+      `code ${code} is outside the ${family} range ${rule.from}–${rule.to} — it reads as ${familyOfCode(code)}`,
+      { field: 'code' },
+    );
+  }
+}
+
+/** The family a stored account_type names, or a loud failure for a value outside the five. */
+export function familyOfAccountType(accountType: string): Family {
+  const f = accountType.toLowerCase();
+  if (!isFamily(f)) throw new ValidationError(`account_type "${accountType}" is not one of ${FAMILIES.join(', ')}`, { field: 'family' });
+  return f;
+}
+
+/** The rendered code — the entity letter and the digits (accountString.ts). */
+export function renderCode(code: string, entityType: string | null | undefined, subType?: string | null): string {
+  return deriveAccountString({ entityType, code, subType });
+}
+
+export function blocksFor(entityType: string | null | undefined): readonly CodeBlock[] {
+  const l = letterFor(entityType);
+  return l ? EXPENSE_BLOCKS[l] : [];
+}
+
+/** One line for the add form: the family's range, and for expenses this letter's blocks. */
+export function schemeHint(entityType: string | null | undefined, family: Family): string {
+  const rule = FAMILY_RULES[family];
+  const l = letterFor(entityType);
+  const prefix = l ? `${l}-` : '';
+  const range = `${prefix}${rule.from}–${prefix}${rule.to}`;
+  if (family !== 'expense') return `${rule.label} · ${range} · ${rule.statement}`;
+  const blocks = blocksFor(entityType).map((b) => `${b.from}–${b.to} ${b.label}`).join(' · ');
+  return blocks ? `${rule.label} · ${range} · ${blocks}` : `${rule.label} · ${range} · ${rule.statement}`;
+}

--- a/src/lib/coa/seedSets.ts
+++ b/src/lib/coa/seedSets.ts
@@ -1,0 +1,152 @@
+import { ValidationError } from '@/lib/errors/ValidationError';
+import { FAMILY_RULES, assertCodeInFamily, letterFor, type EntityLetter, type Family } from './scheme';
+
+/**
+ * COA-01 — the ruled seed sets, as data. Applied IN THE PRODUCT (POST
+ * /api/chart-of-accounts/seed), per user, per entity, only where absent — the
+ * honest path: a migration cannot see a user's chart, cannot tell "absent"
+ * from "this code is already something else", and reports nothing. planSeed
+ * names every row's fate (create / exists / collision / retired) BEFORE a
+ * single insert; a collision is never overwritten.
+ *
+ * Codes come from the scheme, not invented:
+ *   • the B-6200 fixed-cost family (the ruling's words) — the eight bills in
+ *     the ruling's order at steps of ten from 6210, which puts Finnhub at
+ *     B-6250, the code the ruling names for it;
+ *   • International transaction fees — the next travel code after the 98xx
+ *     fees block (9810 communication · 9820 insurance & fees · 9830 groceries,
+ *     src/lib/travelCOA.ts) → 9840, sub_type 'travel' / module 'trips' like
+ *     every travel row the 20260324110000 migration wrote;
+ *   • Gym membership, Pet supplies & food — the next fixed & personal codes
+ *     after 8200 Phone & Internet (prisma/seed-coa-complete.ts:99) → 8210, 8220.
+ */
+
+export interface SeedAccount {
+  readonly code: string;
+  readonly name: string;
+  readonly family: Family;
+  readonly subType: string | null;
+  readonly module: string | null;
+}
+
+export interface SeedSet {
+  readonly key: string;
+  readonly label: string;
+  /** The entity letters this set may be applied to. */
+  readonly entityLetters: readonly EntityLetter[];
+  readonly why: string;
+  readonly accounts: readonly SeedAccount[];
+}
+
+const fixed = (code: string, name: string): SeedAccount => ({ code, name, family: 'expense', subType: 'fixed', module: null });
+const travel = (code: string, name: string): SeedAccount => ({ code, name, family: 'expense', subType: 'travel', module: 'trips' });
+const personal = (code: string, name: string): SeedAccount => ({ code, name, family: 'expense', subType: null, module: null });
+
+export const SEED_SETS: readonly SeedSet[] = [
+  {
+    key: 'platform-fixed-costs',
+    label: 'Platform fixed costs — the B-6200 family',
+    entityLetters: ['B'],
+    why: "The platform's own bills, one account each, so a quarterly plan is one line — not a per-call account.",
+    accounts: [
+      fixed('6210', 'Vercel'),
+      fixed('6220', 'Azure Postgres'),
+      fixed('6230', 'GitHub'),
+      fixed('6240', 'Claude seat'),
+      fixed('6250', 'Finnhub Premium (quarterly plan)'),
+      fixed('6260', 'tastytrade data'),
+      fixed('6270', 'Resend'),
+      fixed('6280', 'Voyage'),
+    ],
+  },
+  {
+    key: 'travel-intl-fees',
+    label: 'Travel — International transaction fees',
+    entityLetters: ['P', 'B'],
+    why: 'Card and ATM fees abroad are a travel cost of their own, not insurance.',
+    accounts: [travel('9840', 'International transaction fees')],
+  },
+  {
+    key: 'personal-additions',
+    label: 'Personal — Gym membership, Pet supplies & food',
+    entityLetters: ['P'],
+    why: 'Two fixed personal costs the default chart lacks.',
+    accounts: [personal('8210', 'Gym membership'), personal('8220', 'Pet supplies & food')],
+  },
+];
+
+export function seedSet(key: string): SeedSet | undefined {
+  return SEED_SETS.find((s) => s.key === key);
+}
+
+export function seedSetsFor(entityType: string | null | undefined): SeedSet[] {
+  const l = letterFor(entityType);
+  return l ? SEED_SETS.filter((s) => s.entityLetters.includes(l)) : [];
+}
+
+export type SeedAction = 'create' | 'exists' | 'collision' | 'retired';
+
+export interface SeedPlanRow {
+  readonly code: string;
+  readonly name: string;
+  readonly family: Family;
+  readonly subType: string | null;
+  readonly module: string | null;
+  readonly action: SeedAction;
+  /** For exists / collision / retired: the row already at that code. */
+  readonly existingId?: string;
+  readonly existingName?: string;
+}
+
+const norm = (s: string) => s.trim().replace(/\s+/g, ' ').toLowerCase();
+
+/**
+ * Every row's fate against the entity's chart, before any write:
+ *   create    — no account at that code;
+ *   exists    — the same name at that code, active (nothing to do);
+ *   retired   — the same name at that code, archived (restore it; never re-add);
+ *   collision — another name at that code (never overwritten; reported).
+ */
+export function planSeed(
+  set: SeedSet,
+  entity: { entity_type: string | null },
+  existing: ReadonlyArray<{ id: string; code: string; name: string; is_archived: boolean }>,
+): SeedPlanRow[] {
+  const letter = letterFor(entity.entity_type);
+  if (!letter || !set.entityLetters.includes(letter)) {
+    throw new ValidationError(
+      `the set "${set.label}" applies to ${set.entityLetters.map((l) => `${l}-`).join(' / ')} charts; this entity is ${letter ? `${letter}-` : entity.entity_type ?? 'unlettered'}`,
+      { field: 'setKey' },
+    );
+  }
+  const byCode = new Map(existing.map((a) => [a.code, a]));
+  return set.accounts.map((a) => {
+    const row = byCode.get(a.code);
+    if (!row) return { ...a, action: 'create' };
+    if (norm(row.name) !== norm(a.name)) return { ...a, action: 'collision', existingId: row.id, existingName: row.name };
+    return { ...a, action: row.is_archived ? 'retired' : 'exists', existingId: row.id, existingName: row.name };
+  });
+}
+
+/** The law over the sets — runs at import: every code in its family's range, unique within its set, Finnhub at 6250. */
+export function assertSeedSetsLaw(sets: readonly SeedSet[] = SEED_SETS): void {
+  const keys = new Set<string>();
+  for (const set of sets) {
+    if (keys.has(set.key)) throw new Error(`seed sets law: duplicate set key ${set.key}`);
+    keys.add(set.key);
+    if (set.entityLetters.length === 0) throw new Error(`seed sets law: ${set.key} applies to no entity letter`);
+    const codes = new Set<string>();
+    for (const a of set.accounts) {
+      if (!/^\d{4}$/.test(a.code)) throw new Error(`seed sets law: ${set.key} code ${a.code} is not four digits`);
+      if (codes.has(a.code)) throw new Error(`seed sets law: ${set.key} repeats code ${a.code}`);
+      codes.add(a.code);
+      assertCodeInFamily(a.code, a.family);
+      if (!a.name.trim()) throw new Error(`seed sets law: ${set.key} code ${a.code} has no name`);
+      if (!FAMILY_RULES[a.family]) throw new Error(`seed sets law: ${set.key} code ${a.code} has no family`);
+    }
+  }
+  const finnhub = sets.flatMap((s) => s.accounts).find((a) => a.name.startsWith('Finnhub'));
+  if (!finnhub || finnhub.code !== '6250') throw new Error('seed sets law: Finnhub Premium must sit at 6250 — the code the ruling names');
+}
+
+assertSeedSetsLaw();


### PR DESCRIPTION
**Do not merge — Alex merges after Vercel Preview (SOC 2 gate).**

## HARD GATE items (read first)

| # | What | Where | Why it needs Alex's eyes |
|---|---|---|---|
| 1 | **User financial data is written — through the product's own posting path, never raw SQL.** Reclassify posts a NEW journal entry (`source_type 'reclass'`, one debit + one credit of the same amount, the memo in the description and metadata) and moves `settled_balance` by the rule every writer uses. No prior entry, line or transaction is edited: the port has no update at all, and the DB's `no_ledger_updates` trigger refuses one anyway (probe below). | `src/lib/coa/reclassify.ts`, `src/app/api/chart-of-accounts/reclassify/route.ts` | User-initiated, period-close enforced (`assertPeriodOpen`), same gate chain as every Books route (verified email → user → `tab:books` → the entity is the user's, 404). |
| 2 | **No migration — the seed is in-product, run by Alex.** The ruling allowed either "whichever the audit shows is the honest one". The audit shows a migration cannot be honest here: (a) it cannot tell "absent" from "this code is already something else" and reports nothing — the travel-codes precedent (`prisma/migrations/20260324110000_add_travel_coa_codes/migration.sql:46`) filters `entity_type = 'business'` while the app writes `'sole_prop'` (`src/lib/seed-entities.ts:14`), so it silently seeded nothing for business charts; (b) the migration history does not replay from empty (`prisma migrate deploy` on a throwaway stops at `20251002001200`) and the `chart_of_accounts` table on Azure was rebuilt outside the migrations (the composite unique `[userId, entity_id, code]` in `schema.prisma:178` appears in no migration file) — so what a seed migration would meet on Azure is **not verified**. The in-product path previews every row's fate before a write and reports collisions. | `src/lib/coa/seedSets.ts`, `src/app/api/chart-of-accounts/seed/route.ts` | Alex applies each set from `/chart-of-accounts` (Preview → Apply). Nothing runs at deploy. |
| 3 | **Categorization tightened, not relaxed.** `POST /api/transactions/assign-coa` now refuses an unknown code (400) or a retired one (400 with the name); the auto-categorizer skips a merchant mapping (and the category default) whose code is retired for the user. | `src/app/api/transactions/assign-coa/route.ts:30-40`, `src/lib/auto-categorization-service.ts` (`isActiveCode`) | This is what "retiring hides an account from categorization" has to mean for the two paths that bypass the dropdowns. The mapping rows stay (history). |
| 4 | **No schema change, no new env, no paid call.** | — | `prisma validate` untouched; the three new tables columns used (`sub_type`, `module`, `metadata`) already exist. |

## Audit (read-only, against `origin/main` = `c76b70a0`)

**The model.** `prisma/schema.prisma:153-181` — `chart_of_accounts`: `code VarChar(50)` free text, `@@unique([userId, entity_id, code])` (per entity), `is_archived`, `sub_type`, `tax_form_line`, `module`, `entity_type VarChar(10)`. The original DDL carried `CHECK (entity_type IN ('personal','business'))` (`migrations/20250930_double_entry_foundation:12`, `20251001010100_merchant_mapping:27`) while the app writes `'sole_prop'` and `'trading'` into that column (`api/chart-of-accounts/route.ts:136`, `api/admin/seed-missing-coa/route.ts:67`, `lib/seed-entities.ts:96`) — whether that CHECK is live on Azure is **not verified** (see gate 2); one query settles it: `SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'chart_of_accounts'::regclass;`

**The seed.** `src/lib/ensure-bookkeeping.ts:11-42` creates one `Personal` entity and calls `seedDefaultCOA` (`src/lib/seedDefaultCOA.ts:4-46`) with `DEFAULT_COA` (`src/lib/coaDefaults.ts:14-51`: 4xxx income, 6xxx/8xxx expenses, 7xxx travel) — the only in-product seed; it derives `balance_type` as `revenue ? 'C' : 'D'` (:29), which is wrong for any asset/liability/equity default (none in that list today). Three CLI seeds run by hand against a named user: `prisma/seed-coa.ts`, `prisma/seed-coa-complete.ts` (personal 1xxx–8xxx, business 1xxx–6xxx, all `findFirst` + `create`), `prisma/seed-trading-coa.ts` (T 1xxx–6xxx). `src/lib/seed-entities.ts` seeds from `coa_templates` (never populated in the repo — `coa_template_accounts` has no seed file). `api/admin/seed-missing-coa/route.ts` re-seeds nine trading accounts.

**The scheme in use.** Codes are stored as four digits; the `P-/B-/T-` letter is a RENDER from the entity's type (`src/lib/accountString.ts:25-52`, `deriveAccountString`). The first digit is the family in every seed (`seed-coa-complete.ts:41-143`: "PERSONAL ASSETS (1000-1999)", "LIABILITIES (2000-2999)", "EQUITY (3000-3999)", "INCOME (4000-4999)", "EXPENSES (5000-8999)"; `seed-trading-coa.ts:39-59`: 5xxx losses, 6xxx trading expenses; travel 9xxx in `travelCOA.ts` and the 20260324 migration). Families map to statements by `account_type` (`schedule-c-service.ts:186-274` reads `account_type` + `account_tax_mappings`; `form-1040-service.ts:197` reads code `'4000'` literally). **No code validation existed anywhere**: `POST /api/chart-of-accounts` (`route.ts:97-125`) accepted any string as `code`; `PUT [id]` (`[id]/route.ts:44-54`) let a posted account's code change with only a uniqueness check.

**Routes on the chart.** `GET` (`route.ts:8-68`, `is_archived: false`), `POST` (:78-162), `PUT [id]` rename/code/sub (:6-115), `PATCH [id] {archived}` (:123-169, both ways, never delete), `GET balances` (`balances/route.ts`, `is_archived: false`), `POST transactions/assign-coa` (:20-57 — any `accountCode`, no existence check), `admin/seed-missing-coa`.

**The Books COA page.** The registry's Bookkeeping link `/chart-of-accounts` (`src/lib/toolRegistry.ts:157`) rendered a READ-ONLY table (`src/app/chart-of-accounts/page.tsx:41-92`: no add, no rename, no retire). The management table `COAManagementTable.tsx` (add :164-193, rename :138-162, archive :197-217) mounts only inside `BudgetingPage.tsx:143` — reached from `/personal`, `/business`, `/home`, `/auto`, `/health`, `/growth` — and is handed `entityType={category.toLowerCase()}` (:146), i.e. `'business'`, which `deriveAccountString` renders with NO letter (`accountString.ts:25-29` has `sole_prop`, not `business`). `ChartOfAccountsTab.tsx` / `ChartOfAccountsSection.tsx` are mounted nowhere. SpendingTab's "Create New COA Account" modal (`SpendingTab.tsx:361-368`) POSTs `{ code, name, accountType, entityType }` with no `entityId` → the route's 400 — broken on main, unchanged here (its own fix).

**merchant_coa_mappings / how a new account becomes categorizable.** `schema.prisma:292-311` maps `merchant_name` + Plaid category → `coa_code` (a bare code string, user-scoped, optionally entity-scoped). Written by `commit-to-ledger/route.ts:287-340` and `auto-categorization-service.ts:241` on commit; read by `auto-categorization-service.ts:39-55` (tier 1) then a hardcoded category map (:60-73). A new account is categorizable the moment `GET /api/chart-of-accounts` lists it — every picker reads that route (`SpendingTab`, `BooksPipeline.tsx:150`, `CoaSelect.tsx:37`, `TaskList.tsx:107`, `AdjustingEntriesTab`, `hub/itinerary`). An archived account left the pickers but a mapping onto it still predicted (:39-55 checked nothing) and `assign-coa` still accepted it — fixed here (gate 3).

**Tax mapping tables reading codes.** `account_tax_mappings` (`schema.prisma:134-147`) maps `account_id` (not code) → `tax_form` / `form_line` / `tax_year`; written by `seed-entities.ts:102-130` from template `tax_form_line` and by `api/account-tax-mappings/route.ts` (POST upsert); read by `schedule-c-service.ts:193-274` (unmapped expense accounts fall to line 27a, logged :274). A new account therefore needs a mapping row before it reaches a Schedule C line — the Tax module's `AccountTaxMappings.tsx` does that per account; nothing here changes it.

## Build

- `src/lib/coa/scheme.ts` — the scheme in one place: `FAMILY_RULES` (1xxx asset D · 2xxx liability C · 3xxx equity C · 4xxx revenue C · 5xxx–9xxx expense D), `EXPENSE_BLOCKS` per letter with the evidence cited, `parseCode` (four digits or the entity's letter + four digits; the wrong letter, five digits, `0xxx` fail loud), `assertCodeInFamily` (outside the range fails loud), `schemeHint` for the form.
- `src/lib/coa/accounts.ts` — `addAccount` / `renameAccount` / `retireAccount` / `applySeed` over a `ChartDb` port; `src/lib/coa/prismaChartDb.ts` binds it (and the posting port) to Prisma.
- `src/lib/coa/reclassify.ts` — `planReclassification` (pure: same entity, same family, target active, memo required, amount ≤ |balance|, whole balance by default; a negative balance moves with mirror-image lines) + `postReclassification` over a `PostingDb` with inserts and increments only.
- `src/lib/coa/seedSets.ts` — the three ruled sets, codes from the scheme: **B-6200 family** at steps of ten from 6210 in the ruling's order → Vercel 6210 · Azure Postgres 6220 · GitHub 6230 · Claude seat 6240 · **Finnhub Premium (quarterly plan) 6250** (the code the ruling names — the law asserts it) · tastytrade data 6260 · Resend 6270 · Voyage 6280, `sub_type 'fixed'`; **International transaction fees 9840** (next after the 98xx fees block 9810/9820/9830 in `travelCOA.ts`; `sub_type 'travel'`, `module 'trips'` like every travel row the 20260324 migration wrote) for P and B charts; **Gym membership 8210, Pet supplies & food 8220** (next after 8200 Phone & Internet, `seed-coa-complete.ts:99`) for P. `planSeed` names every row's fate: create / exists / collision / retired.
- Routes: `POST /api/chart-of-accounts` (family required — `accountType` accepted as its legacy name; code parsed against the entity's scheme), `PUT [id]` (a new code obeys the same rules), `PATCH [id]` unchanged contract, both GETs take `include_archived=true`, `POST …/seed { entityId, setKey, apply }`, `POST …/reclassify { entityId, fromCode, toCode, memo, amountCents?, date? }`. Every refusal is a `ValidationError` answered verbatim at its status; faults are the fixed failClosed line.
- `/chart-of-accounts` is now THE COA page: one management table per entity (real `entity_type` from `/api/entities`) with the add form (family select → range hint, the entity letter as a fixed prefix), rename, **Retire / Restore** (retired rows one toggle away, balance shown), **Reclassify** (target = same-family active accounts, amount defaults to the balance, memo, date), and the seed panel (Preview → Apply). `BudgetingPage` now passes the entity's real type.
- Read-after-commit guard on reclassify (probe 3, below).

## Verify

| Check | Result |
|---|---|
| `npx tsc --noEmit` | 0 errors |
| eslint, every changed file vs its main baseline | 0 new; rewritten files at 0/0 (`COAManagementTable.tsx` 4e/4w → 0/0, `[id]/route.ts` 1e → 0, `assign-coa` 1e → 0); pre-existing and unchanged: `auto-categorization-service.ts` 3e, `BudgetingPage.tsx` 3e/1w |
| `npm test` | 189/189 (178 + 11 in `src/lib/__tests__/coa.test.ts`) |
| Build with the asserts | showroom ✓ · tool registry 25/25 · reachability 67 · family map 6/6 · answers 4/4 · arrivals 28 · rule book 24/8 · kind views 6/8 · offer law ✓ · `next build` exit 0 |
| README regen | route census 289 → 291 (the two new routes); byte-stable on the second run; committed |

Ruled tests → where they live:

| Ruled test | `coa.test.ts` (hermetic, `fakeChart.ts`) | Throwaway Postgres 16 built from `schema.prisma` + the ledger triggers of `20260226000100` / `20260226000500`, the REAL Prisma bindings |
|---|---|---|
| add rejects a bad code | wrong letter, five digits, `0999`, `4010` as expense — 400 with the scheme's words | `400 code P-6250 carries the P- letter; this is a B- chart (sole_prop) — enter B-6250 or 6250` · `400 code 4010 is outside the expense range 5000–9999 — it reads as revenue` |
| add rejects a duplicate | active → 409; retired → 409 with the restore hint; nothing written by a refusal | `409 code B-5130 is already "Finnhub API calls"` · `409 code B-5130 is retired as "Finnhub API calls" — restore it instead of adding it again` |
| retire keeps history | the ONLY write is `{ is_archived: true }`; balance, ledger snapshot and row count unchanged; restore flips back | B-5130 retired: `is_archived true`, balance still 12000, 4 ledger rows before and after |
| reclassify posts a balanced entry and never updates old rows | one JE `source_type 'reclass'`, two new lines C 12000 / D 12000, increments −12000/+12000, the prior lines byte-identical, cash untouched, zero account-row updates | B-5130 → B-6250: JE landed with the memo in `metadata.reclass`, balances 12000 → 0 and 0 → 12000, the 4 old lines byte-identical, 6 rows after; `UPDATE`/`DELETE ledger_entries` → `Ledger entries cannot be modified or deleted after posting`; with the deferred balance trigger live a second reclass (300¢) committed |
| seed is idempotent | plan: collision / exists / retired / create; apply writes only `create`; second apply creates 0; the collision untouched | on the probe chart (6210 = "Software & Subscriptions", 6250 already added): plan `6210 collision · 6220–6240 create · 6250 exists · 6260–6280 create`, created 6, second apply created 0, 6210's name untouched |

**Browser, the real routes** (next dev on the throwaway DB, viewer holds `tab:books`, nothing on `/api` mocked): `/chart-of-accounts` → one table per entity; the add form's hint `Expenses · B-5000–B-9999 · 6000–6999 Operating expenses · 6200–6299 Fixed costs — the platform's own bills · 9000–9999 Travel`; a refused add renders the server's words (`code: code 4010 is outside the expense range 5000–9999 — it reads as revenue`); the duplicate 409; the good add lands as `B-6291-fixed`; seed preview `0 to create · 7 already there · 1 collision · 0 retired` with `collision — 6210 is "Software & Subscriptions"; not overwritten`; reclassify 6250 → 6220 of $1.00 posted (`journal entry 5280757b…`, balances 116.00 / 4.00); retire → `data-retired="true"` under the toggle → restore. Screenshots are in the session chat (not committed — the repo is public).

## Findings outside this PR's fence (reported, not fixed)

1. **Prisma resolves through a commit-time refusal (probe 3).** With the DEFERRED balance trigger (`20260226000500`) live, an unbalanced posting inside `prisma.$transaction(async tx => …)` RESOLVED with the new id while nothing landed (rows before = after, journal entry absent). psql refuses the same COMMIT loudly. Every posting path that relies on that trigger for balance (`journal-entries/manual`, `journal-entry-service.ts`) would report success on a rolled-back write. Reclassify is balanced by construction and now reads the row back after commit before claiming success; the general fix is its own PR.
2. `SpendingTab.tsx:361-368` "Create New COA Account" sends no `entityId` → always 400 on main.
3. `seedDefaultCOA.ts:29` derives `balance_type` as `revenue ? 'C' : 'D'` — wrong for liability/equity defaults, harmless today (none in `DEFAULT_COA`).
4. The 20260324 travel migration seeded nothing for `sole_prop` charts (`entity_type = 'business'`); the in-product `travel-intl-fees` set is the first travel code a B chart gets from the product.
5. `coa_templates` / `coa_template_accounts` have no seed in the repo; `seed-entities.ts` throws without them.
6. Whether the `entity_type IN ('personal','business')` CHECK is live on Azure: not verified (query above).

## For Alex, after merge
On `/chart-of-accounts`, Business chart: Preview the "Platform fixed costs" set (expect collisions where your chart already uses 62xx codes — rename or retire those first, nothing is overwritten), Apply; then on the retired/renamed B-5130 row, Reclassify → B-6250 with the memo. Personal chart: Preview + Apply the two personal sets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc

---
_Generated by [Claude Code](https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc)_