### PR TITLE
HYG-04: no posting path may report success on a rolled-back write

### DIFF
--- a/scripts/assert-tool-registry.ts
+++ b/scripts/assert-tool-registry.ts
@@ -471,6 +471,30 @@ for (const o of OFFERS) {
 console.log(`free with an account: ${FREE_TOOLS.map((t) => `${t.name} (${TOOL_GATE[t.name] ?? 'no gate'})`).join(', ')}`);
 console.log(`hero: ${heroCountsLine()}`);
 
+// ── HYG-04: the posting law — no posting path may report success on a rolled-back
+// write. Every journal_entries / ledger_entries row is created by
+// src/lib/posting/postJournal.ts (SET CONSTRAINTS ALL IMMEDIATE first, the lines
+// in one statement, the entry id read back after commit); a create anywhere
+// else in src/ (tests excluded) fails the build, and a raw $transaction that
+// names those tables fails too.
+const POSTING_HOME = 'src/lib/posting/postJournal.ts';
+// A word boundary before the table name: trade_journal_entries (a different table) is not the ledger.
+const POSTING_WRITES = [/(?<![A-Za-z0-9_])journal_entries\s*\.\s*create(?:Many)?\s*\(/, /(?<![A-Za-z0-9_])ledger_entries\s*\.\s*create(?:Many)?\s*\(/, /(?<![A-Za-z0-9_])ledger_entries\s*:\s*\{\s*create\b/];
+const postingPaths = new Set<string>();
+for (const { file, src } of srcFiles) {
+  if (file === POSTING_HOME) continue;
+  for (const re of POSTING_WRITES) {
+    if (re.test(src)) violations.push(`posting: ${file} creates a journal or ledger row outside ${POSTING_HOME} — every posting path routes through postJournal()`);
+  }
+  if (/postJournal\s*\(/.test(src)) postingPaths.add(file);
+}
+if (!srcFiles.some(({ file }) => file === POSTING_HOME)) violations.push(`posting: ${POSTING_HOME} is missing`);
+const postingHome = srcFiles.find(({ file }) => file === POSTING_HOME)?.src ?? '';
+if (!postingHome.includes("'SET CONSTRAINTS ALL IMMEDIATE'")) violations.push('posting: postJournal.ts does not issue SET CONSTRAINTS ALL IMMEDIATE');
+if (!/ledger_entries\.createMany\(/.test(postingHome)) violations.push('posting: postJournal.ts does not insert the lines in one statement');
+if (!/PostingNotLandedError/.test(postingHome)) violations.push('posting: postJournal.ts has no read-back failure');
+if (postingPaths.size < 12) violations.push(`posting: only ${postingPaths.size} files route through postJournal() — the audit counted 12`);
+
 if (violations.length) {
   console.error('\n✖ TOOL REGISTRY LAW FAILED:');
   for (const v of violations) console.error(`  ${v}`);
@@ -509,4 +533,5 @@ console.log(`honest line: ${KIND_VIEWS_HONEST_LINE}`);
 console.log(`✔ The arrivals law passed — ${PROVIDERS.length} providers, enum === codes, ${arrivalsRows.length} columns agree with the migrations.`);
 console.log(`✔ The rule book law passed — ${RULE_BOOK.length} rules, ${callSites.length} landing call sites covered, enum arrival_kind === the six kinds, the migration applies ${applied.length} rules the book holds.`);
 console.log(`✔ The kind views law passed — ${ARRIVAL_KINDS.length} views over ${KIND_VIEW_CENSUS.length} feed tables, each once, the kind from the rule book; posting unions nothing; ${STOPPED_TABLES.length} tables reported, not viewed.`);
+console.log(`✔ The posting law passed — every journal and ledger row is created by postJournal.ts (SET CONSTRAINTS ALL IMMEDIATE first, one statement for the lines, read back after commit); ${postingPaths.size} files post through it.`);
 console.log(`✔ The offer law passed — ${OFFERS.length} offers over ${new Set(OFFERS.flatMap((o) => o.tools)).size} tools (LIVE or PARTIAL only), ${FREE_TOOLS.length} free; the purchasable keys are the offers'; "built and running" typed nowhere but offer.ts; ${SELLING_SURFACES.length} selling surfaces render the offer.`);

--- a/src/app/api/admin/fix-entity-assignment/route.ts
+++ b/src/app/api/admin/fix-entity-assignment/route.ts
@@ -7,14 +7,12 @@ import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { ADMIN_USER_ID } from '@/lib/tiers';
 import { assertPeriodOpen, PeriodClosedError } from '@/lib/period-close-guard';
+import { balanceDeltaOf, postJournal } from '@/lib/posting/postJournal';
 
 function dollarsToCents(amount: number): bigint {
   return BigInt(Math.round(amount * 100));
 }
 
-function updateBalance(entryType: string, accountBalanceType: string, amountCents: bigint): bigint {
-  return entryType === accountBalanceType ? amountCents : -amountCents;
-}
 
 /**
  * POST /api/admin/fix-entity-assignment
@@ -88,7 +86,8 @@ export async function POST(request: NextRequest) {
 
     for (const txn of ownedTxns) {
       try {
-        await prisma.$transaction(async (tx) => {
+        // HYG-04: the reversal and the new entry post through postJournal's `post` — both ids read back after commit.
+        await postJournal(prisma, async (tx, post) => {
           // 1. Find the original journal entry
           const original = await tx.journal_entries.findFirst({
             where: {
@@ -113,9 +112,9 @@ export async function POST(request: NextRequest) {
           await assertPeriodOpen(tx, user.id, original.entity_id, now);
           await assertPeriodOpen(tx, user.id, targetEntityId, new Date(txn.date));
 
-          // 3. Create reversal for original
-          const reversalEntry = await tx.journal_entries.create({
-            data: {
+          // 3. Create reversal for original — the opposite line for every original line
+          const reversalEntry = await post({
+            entry: {
               userId: user.id,
               entity_id: original.entity_id,
               date: now,
@@ -128,30 +127,17 @@ export async function POST(request: NextRequest) {
               request_id: `${batchId}-rev-${txn.transactionId}`,
               created_by: userEmail,
             },
-          });
-
-          // Reverse ledger entries and COA balances
-          for (const entry of original.ledger_entries) {
-            const oppositeType = entry.entry_type === 'D' ? 'C' : 'D';
-
-            await tx.ledger_entries.create({
-              data: {
-                journal_entry_id: reversalEntry.id,
+            lines: original.ledger_entries.map((entry) => {
+              const oppositeType: 'D' | 'C' = entry.entry_type === 'D' ? 'C' : 'D';
+              return {
                 account_id: entry.account_id,
                 entry_type: oppositeType,
                 amount: entry.amount,
+                balanceDelta: balanceDeltaOf(oppositeType, entry.account.balance_type, entry.amount),
                 created_by: userEmail,
-              },
-            });
-
-            await tx.chart_of_accounts.update({
-              where: { id: entry.account.id },
-              data: {
-                settled_balance: { increment: updateBalance(oppositeType, entry.account.balance_type, entry.amount) },
-                version: { increment: 1 },
-              },
-            });
-          }
+              };
+            }),
+          });
 
           // Mark original as reversed
           await tx.journal_entries.update({
@@ -186,8 +172,8 @@ export async function POST(request: NextRequest) {
           const debitBalanceType = isExpense ? targetCoaAccount.balance_type : bankAccount.balance_type;
           const creditBalanceType = isExpense ? bankAccount.balance_type : targetCoaAccount.balance_type;
 
-          const newJe = await tx.journal_entries.create({
-            data: {
+          const newJe = await post({
+            entry: {
               userId: user.id,
               entity_id: targetEntityId,
               date: new Date(txn.date),
@@ -198,22 +184,10 @@ export async function POST(request: NextRequest) {
               request_id: `${batchId}-new-${txn.transactionId}`,
               created_by: userEmail,
             },
-          });
-
-          await tx.ledger_entries.create({
-            data: { journal_entry_id: newJe.id, account_id: debitAccountId, entry_type: 'D', amount: amountCents, created_by: userEmail },
-          });
-          await tx.ledger_entries.create({
-            data: { journal_entry_id: newJe.id, account_id: creditAccountId, entry_type: 'C', amount: amountCents, created_by: userEmail },
-          });
-
-          await tx.chart_of_accounts.update({
-            where: { id: debitAccountId },
-            data: { settled_balance: { increment: updateBalance('D', debitBalanceType, amountCents) }, version: { increment: 1 } },
-          });
-          await tx.chart_of_accounts.update({
-            where: { id: creditAccountId },
-            data: { settled_balance: { increment: updateBalance('C', creditBalanceType, amountCents) }, version: { increment: 1 } },
+            lines: [
+              { account_id: debitAccountId, entry_type: 'D', amount: amountCents, balanceDelta: balanceDeltaOf('D', debitBalanceType, amountCents), created_by: userEmail },
+              { account_id: creditAccountId, entry_type: 'C', amount: amountCents, balanceDelta: balanceDeltaOf('C', creditBalanceType, amountCents), created_by: userEmail },
+            ],
           });
 
           // 6. Update transaction's entity_id and accountCode

--- a/src/app/api/chart-of-accounts/reclassify/route.ts
+++ b/src/app/api/chart-of-accounts/reclassify/route.ts
@@ -8,7 +8,7 @@ import { failClosedResponse } from '@/lib/http/failClosedResponse';
 import { assertPeriodOpen, PeriodClosedError } from '@/lib/period-close-guard';
 import { ValidationError } from '@/lib/errors/ValidationError';
 import { planReclassification, postReclassification } from '@/lib/coa/reclassify';
-import { prismaPostingDb } from '@/lib/coa/prismaChartDb';
+import { postJournal } from '@/lib/posting/postJournal';
 import type { ChartAccountRow } from '@/lib/coa/accounts';
 
 /**
@@ -23,7 +23,8 @@ import type { ChartAccountRow } from '@/lib/coa/accounts';
  * deltas by the rule every writer uses. Posted in one transaction with
  * source_type 'reclass' and the memo in the description and metadata. NO
  * prior entry, line or transaction is edited — the port has no way to.
- * Period-close is enforced like every other posting path.
+ * Period-close is enforced like every other posting path; the posting itself
+ * is postJournal's (HYG-04).
  *
  * Gate: verified email → user → tab:books → the entity is the user's
  * (defensive 404) → both accounts in that entity (404).
@@ -92,20 +93,13 @@ export async function POST(request: Request) {
     // Period close enforcement — the same guard every posting path calls.
     await assertPeriodOpen(prisma, user.id, entity.id, date);
 
+    // HYG-04: ONE posting discipline — postJournal (SET CONSTRAINTS ALL
+    // IMMEDIATE first, the lines in one statement, the id read back after
+    // commit); the reclass plan is posted through its `post`.
     const requestId = randomUUID();
-    const result = await prisma.$transaction(async (tx) =>
-      postReclassification(prismaPostingDb(tx), { userId: user.id, entityId: entity.id, requestId, createdBy: userEmail }, plan),
+    const { result } = await postJournal(prisma, async (_tx, post) =>
+      postReclassification({ postEntry: post }, { userId: user.id, entityId: entity.id, requestId, createdBy: userEmail }, plan),
     );
-
-    // READ-AFTER-COMMIT (COA-01 probe 3): a DEFERRED constraint trigger refuses
-    // at COMMIT, and Prisma's interactive $transaction was observed to RESOLVE
-    // through that refusal with nothing written. A reclass is balanced by
-    // construction, so the balance trigger never refuses it — but success is
-    // claimed only from the row itself, never from the transaction's promise.
-    const landed = await prisma.journal_entries.findFirst({ where: { id: result.journalEntryId, userId: user.id }, select: { id: true } });
-    if (!landed) {
-      return failClosedResponse('COA reclassify', 'The database refused the entry at commit — nothing was posted', new Error(`journal entry ${result.journalEntryId} not found after commit`));
-    }
 
     return NextResponse.json({
       success: true,

--- a/src/app/api/investment-transactions/commit-to-ledger/route.ts
+++ b/src/app/api/investment-transactions/commit-to-ledger/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { failClosedResponse } from '@/lib/http/failClosedResponse';
 import { prisma } from '@/lib/prisma';
+import { postJournal } from '@/lib/posting/postJournal';
 import { positionTrackerService } from '@/lib/position-tracker-service';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { assertPeriodOpen, PeriodClosedError } from '@/lib/period-close-guard';
@@ -107,22 +108,22 @@ export async function POST(request: Request) {
       await assertPeriodOpen(prisma, user.id, resolvedEntityId, new Date(leg.date));
     }
 
-    const result = await prisma.$transaction(
-      async (tx) => {
-        return await positionTrackerService.commitOptionsTrade({
+    // HYG-04: the whole commit posts through postJournal (every entry the
+    // tracker writes goes through `post`; each id is read back after commit).
+    const { result } = await postJournal(
+      prisma,
+      async (tx, post) =>
+        positionTrackerService.commitOptionsTrade({
           legs,
           strategy,
           tradeNum,
           userId: user.id,
           entityId: resolvedEntityId,
           tx,
+          post,
           createdBy: userEmail,
-        });
-      },
-      {
-        maxWait: 30000,
-        timeout: 120000,
-      }
+        }),
+      { maxWait: 30000, timeout: 120000 },
     );
 
     return NextResponse.json({

--- a/src/app/api/investment-transactions/uncommit/route.ts
+++ b/src/app/api/investment-transactions/uncommit/route.ts
@@ -4,6 +4,7 @@ import { failClosedResponse } from '@/lib/http/failClosedResponse';
 import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { assertPeriodOpen, PeriodClosedError } from '@/lib/period-close-guard';
+import { balanceDeltaOf, postJournal } from '@/lib/posting/postJournal';
 
 export async function POST(request: Request) {
   try {
@@ -39,7 +40,8 @@ export async function POST(request: Request) {
     const batchId = randomUUID();
     const reversalIds: string[] = [];
 
-    await prisma.$transaction(async (tx) => {
+    // HYG-04: every reversal posts through postJournal's `post`; each id is read back after commit.
+    await postJournal(prisma, async (tx, post) => {
       // Clean up trading positions and stock lots (these are operational, not accounting records)
       const positions = await tx.trading_positions.findMany({
         where: {
@@ -97,9 +99,10 @@ export async function POST(request: Request) {
 
       // Create reversing entries for each original journal entry
       for (const original of journals) {
-        // Create the reversing journal entry
-        const reversalEntry = await tx.journal_entries.create({
-          data: {
+        // Create the reversing journal entry — the opposite line for every
+        // original line, the balances moved back by the same rule.
+        const reversalEntry = await post({
+          entry: {
             userId: user.id,
             entity_id: original.entity_id,
             date: now,
@@ -111,38 +114,20 @@ export async function POST(request: Request) {
             reverses_entry_id: original.id,
             request_id: `${batchId}-${original.id}`,
             created_by: userEmail,
-          }
+          },
+          lines: original.ledger_entries.map((entry) => {
+            const oppositeType: 'D' | 'C' = entry.entry_type === 'D' ? 'C' : 'D';
+            return {
+              account_id: entry.account_id,
+              entry_type: oppositeType,
+              amount: entry.amount,
+              balanceDelta: balanceDeltaOf(oppositeType, entry.account.balance_type, entry.amount),
+              created_by: userEmail,
+            };
+          }),
         });
 
         reversalIds.push(reversalEntry.id);
-
-        // Create reversing ledger entries (opposite debit/credit)
-        for (const entry of original.ledger_entries) {
-          const oppositeType = entry.entry_type === 'D' ? 'C' : 'D';
-
-          await tx.ledger_entries.create({
-            data: {
-              journal_entry_id: reversalEntry.id,
-              account_id: entry.account_id,
-              amount: entry.amount,
-              entry_type: oppositeType,
-              created_by: userEmail,
-            }
-          });
-
-          // Update COA balance: opposite direction from original
-          const balanceChange = oppositeType === entry.account.balance_type
-            ? entry.amount
-            : -entry.amount;
-
-          await tx.chart_of_accounts.update({
-            where: { id: entry.account.id },
-            data: {
-              settled_balance: { increment: balanceChange },
-              version: { increment: 1 }
-            }
-          });
-        }
 
         // Mark original as reversed
         await tx.journal_entries.update({

--- a/src/app/api/journal-entries/manual/route.ts
+++ b/src/app/api/journal-entries/manual/route.ts
@@ -5,6 +5,8 @@ import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { ensureBookkeepingInitialized } from '@/lib/ensure-bookkeeping';
 import { assertPeriodOpen, PeriodClosedError } from '@/lib/period-close-guard';
 import { requireTabAccess } from '@/lib/auth-helpers';
+import { failClosedResponse } from '@/lib/http/failClosedResponse';
+import { balanceDeltaOf, postJournal } from '@/lib/posting/postJournal';
 
 export async function POST(request: Request) {
   try {
@@ -65,11 +67,13 @@ export async function POST(request: Request) {
     // Period close enforcement
     await assertPeriodOpen(prisma, user.id, entityId, new Date(date));
 
-    // Create journal entry in transaction
+    // HYG-04: ONE posting discipline — postJournal: SET CONSTRAINTS ALL
+    // IMMEDIATE first, every line in one statement, the entry read back after
+    // commit. An unbalanced entry the DB refuses throws inside the transaction.
     const requestId = randomUUID();
-    const result = await prisma.$transaction(async (tx) => {
-      const journalEntry = await tx.journal_entries.create({
-        data: {
+    const { result } = await postJournal(prisma, async (_tx, post) =>
+      post({
+        entry: {
           userId: user.id,
           entity_id: entityId,
           date: new Date(date),
@@ -79,44 +83,25 @@ export async function POST(request: Request) {
           request_id: requestId,
           created_by: userEmail,
         },
-      });
-
-      for (const line of lines) {
-        const account = accounts.find((a) => a.code === line.accountCode)!;
-        const amountCents = BigInt(Math.round(line.amount));
-
-        await tx.ledger_entries.create({
-          data: {
-            journal_entry_id: journalEntry.id,
+        lines: lines.map((line: { accountCode: string; entryType: 'D' | 'C'; amount: number }) => {
+          const account = accounts.find((a) => a.code === line.accountCode)!;
+          const amountCents = BigInt(Math.round(line.amount));
+          return {
             account_id: account.id,
             entry_type: line.entryType,
             amount: amountCents,
+            balanceDelta: balanceDeltaOf(line.entryType, account.balance_type, amountCents),
             created_by: userEmail,
-          },
-        });
-
-        const balanceChange = line.entryType === account.balance_type
-          ? amountCents
-          : -amountCents;
-
-        await tx.chart_of_accounts.update({
-          where: { id: account.id },
-          data: {
-            settled_balance: { increment: balanceChange },
-            version: { increment: 1 },
-          },
-        });
-      }
-
-      return journalEntry;
-    });
+          };
+        }),
+      }),
+    );
 
     return NextResponse.json({ success: true, journalEntryId: result.id });
   } catch (error) {
     if (error instanceof PeriodClosedError) {
       return NextResponse.json({ error: error.message }, { status: 409 });
     }
-    console.error('Manual journal entry error:', error);
-    return NextResponse.json({ error: 'Failed to create journal entry' }, { status: 500 });
+    return failClosedResponse('Manual journal entry', 'Failed to create journal entry', error);
   }
 }

--- a/src/app/api/journal-entries/route.ts
+++ b/src/app/api/journal-entries/route.ts
@@ -1,9 +1,11 @@
 import { randomUUID } from 'crypto';
 import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
+import { failClosedResponse } from '@/lib/http/failClosedResponse';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { ensureBookkeepingInitialized } from '@/lib/ensure-bookkeeping';
 import { assertPeriodOpen, PeriodClosedError } from '@/lib/period-close-guard';
+import { balanceDeltaOf, postJournal } from '@/lib/posting/postJournal';
 import { requireTabAccess } from '@/lib/auth-helpers';
 
 export async function GET() {
@@ -82,7 +84,7 @@ export async function POST(request: Request) {
     const uniqueAccountIds = [...new Set(accountIds)];
     const ownedAccounts = await prisma.chart_of_accounts.findMany({
       where: { id: { in: uniqueAccountIds }, userId: user.id, entity_id: entityId },
-      select: { id: true },
+      select: { id: true, balance_type: true },
     });
     if (ownedAccounts.length !== uniqueAccountIds.length) {
       // Defensive 404 — do not confirm which accounts exist for another user.
@@ -92,32 +94,39 @@ export async function POST(request: Request) {
     // Period close enforcement
     await assertPeriodOpen(prisma, user.id, entityId, new Date(date));
 
-    const entry = await prisma.journal_entries.create({
-      data: {
-        userId: user.id,
-        entity_id: entityId,
-        date: new Date(date),
-        description: description || 'Manual journal entry',
-        source_type: 'manual',
-        status: entryStatus || 'posted',
-        request_id: randomUUID(),
-        created_by: userEmail,
-        ledger_entries: {
-          create: lines.map((l: any) => {
-            const debitAmt = parseFloat(l.debit) || 0;
-            const creditAmt = parseFloat(l.credit) || 0;
-            const isDebit = debitAmt > 0;
-            const amountCents = Math.round((isDebit ? debitAmt : creditAmt) * 100);
-            return {
-              account_id: l.accountId,
-              entry_type: isDebit ? 'D' : 'C',
-              amount: BigInt(amountCents),
-              created_by: userEmail,
-            };
-          })
-        }
-      },
-      include: { ledger_entries: { include: { account: true } } }
+    // HYG-04: ONE posting discipline — postJournal (SET CONSTRAINTS ALL
+    // IMMEDIATE first, every line in one statement, read back after commit).
+    // The lines move settled_balance by the rule every writer uses — this
+    // route's nested create never did, so its entries left the balances behind.
+    const { result: entry } = await postJournal(prisma, async (tx, post) => {
+      const posted = await post({
+        entry: {
+          userId: user.id,
+          entity_id: entityId,
+          date: new Date(date),
+          description: description || 'Manual journal entry',
+          source_type: 'manual',
+          status: entryStatus || 'posted',
+          request_id: randomUUID(),
+          created_by: userEmail,
+        },
+        lines: lines.map((l: any) => {
+          const debitAmt = parseFloat(l.debit) || 0;
+          const creditAmt = parseFloat(l.credit) || 0;
+          const isDebit = debitAmt > 0;
+          const entryType: 'D' | 'C' = isDebit ? 'D' : 'C';
+          const amountCents = BigInt(Math.round((isDebit ? debitAmt : creditAmt) * 100));
+          const account = ownedAccounts.find((a) => a.id === l.accountId)!;
+          return {
+            account_id: l.accountId,
+            entry_type: entryType,
+            amount: amountCents,
+            balanceDelta: balanceDeltaOf(entryType, account.balance_type, amountCents),
+            created_by: userEmail,
+          };
+        }),
+      });
+      return tx.journal_entries.findUniqueOrThrow({ where: { id: posted.id }, include: { ledger_entries: { include: { account: true } } } });
     });
 
     return NextResponse.json({ entry });
@@ -125,7 +134,6 @@ export async function POST(request: Request) {
     if (error instanceof PeriodClosedError) {
       return NextResponse.json({ error: error.message }, { status: 409 });
     }
-    console.error('Error:', error);
-    return NextResponse.json({ error: 'Failed to create journal entry' }, { status: 500 });
+    return failClosedResponse('Journal entry', 'Failed to create journal entry', error);
   }
 }

--- a/src/app/api/stock-lots/commit/route.ts
+++ b/src/app/api/stock-lots/commit/route.ts
@@ -3,6 +3,7 @@ import { ValidationError } from '@/lib/errors/ValidationError';
 import { NextResponse } from 'next/server';
 import { failClosedResponse } from '@/lib/http/failClosedResponse';
 import { prisma } from '@/lib/prisma';
+import { postJournal } from '@/lib/posting/postJournal';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { assertPeriodOpen, PeriodClosedError } from '@/lib/period-close-guard';
 
@@ -115,7 +116,8 @@ export async function POST(request: Request) {
     // Period close enforcement
     await assertPeriodOpen(prisma, user.id, entityId, saleDateObj);
 
-    const result = await prisma.$transaction(async (tx) => {
+    // HYG-04: the sale's entry posts through postJournal's `post` (read back after commit).
+    const { result } = await postJournal(prisma, async (tx, post) => {
       const dispositions = [];
       let remaining = saleQuantity;
       let totalCostBasis = 0;
@@ -251,9 +253,18 @@ export async function POST(request: Request) {
         throw new ValidationError(`Missing required accounts: ${TRADING_CASH}, ${STOCK_POSITION}, ${PL_ACCOUNT}`);
       }
 
-      // Create journal entry
-      const journalEntry = await tx.journal_entries.create({
-        data: {
+      // Balance guard: verify debits === credits before writing any ledger entries
+      const totalDebits = proceedsCents + (plCents < 0 ? Math.abs(plCents) : 0);
+      const totalCredits = costBasisCents + (plCents >= 0 ? plCents : 0);
+      if (totalDebits !== totalCredits) {
+        throw new Error(`UNBALANCED JOURNAL ENTRY: debits=${totalDebits} credits=${totalCredits} — refusing to commit`);
+      }
+
+      // HYG-04: the entry — DR cash (proceeds), CR position (cost), the P&L
+      // line (gain = credit 4100, loss = debit 5100) — through `post`.
+      const plBalanceChange = totalGainLoss >= 0 ? BigInt(Math.abs(plCents)) : BigInt(-Math.abs(plCents));
+      const journalEntry = await post({
+        entry: {
           userId: user.id,
           entity_id: entityId,
           date: saleDateObj,
@@ -264,60 +275,12 @@ export async function POST(request: Request) {
           metadata: { strategy: 'stock-long', tradeNum },
           request_id: randomUUID(),
           created_by: userEmail,
-        }
-      });
-
-      // Balance guard: verify debits === credits before writing any ledger entries
-      const totalDebits = proceedsCents + (plCents < 0 ? Math.abs(plCents) : 0);
-      const totalCredits = costBasisCents + (plCents >= 0 ? plCents : 0);
-      if (totalDebits !== totalCredits) {
-        throw new Error(`UNBALANCED JOURNAL ENTRY: debits=${totalDebits} credits=${totalCredits} — refusing to commit`);
-      }
-
-      // DR Trading Cash (proceeds received)
-      await tx.ledger_entries.create({
-        data: {
-          journal_entry_id: journalEntry.id,
-          account_id: cashAccount.id,
-          amount: BigInt(proceedsCents),
-          entry_type: 'D',
-          created_by: userEmail,
-        }
-      });
-      await tx.chart_of_accounts.update({
-        where: { id: cashAccount.id },
-        data: { settled_balance: { increment: BigInt(proceedsCents) }, version: { increment: 1 } }
-      });
-
-      // CR Stock Position (cost basis removed)
-      await tx.ledger_entries.create({
-        data: {
-          journal_entry_id: journalEntry.id,
-          account_id: stockAccount.id,
-          amount: BigInt(costBasisCents),
-          entry_type: 'C',
-          created_by: userEmail,
-        }
-      });
-      await tx.chart_of_accounts.update({
-        where: { id: stockAccount.id },
-        data: { settled_balance: { increment: BigInt(-costBasisCents) }, version: { increment: 1 } }
-      });
-
-      // P&L entry (gain = credit 4100, loss = debit 5100)
-      await tx.ledger_entries.create({
-        data: {
-          journal_entry_id: journalEntry.id,
-          account_id: plAccount.id,
-          amount: BigInt(Math.abs(plCents)),
-          entry_type: totalGainLoss >= 0 ? 'C' : 'D',
-          created_by: userEmail,
-        }
-      });
-      const plBalanceChange = totalGainLoss >= 0 ? BigInt(Math.abs(plCents)) : BigInt(-Math.abs(plCents));
-      await tx.chart_of_accounts.update({
-        where: { id: plAccount.id },
-        data: { settled_balance: { increment: plBalanceChange }, version: { increment: 1 } }
+        },
+        lines: [
+          { account_id: cashAccount.id, entry_type: 'D', amount: BigInt(proceedsCents), balanceDelta: BigInt(proceedsCents), created_by: userEmail },
+          { account_id: stockAccount.id, entry_type: 'C', amount: BigInt(costBasisCents), balanceDelta: BigInt(-costBasisCents), created_by: userEmail },
+          { account_id: plAccount.id, entry_type: totalGainLoss >= 0 ? 'C' : 'D', amount: BigInt(Math.abs(plCents)), balanceDelta: plBalanceChange, created_by: userEmail },
+        ],
       });
 
       // Update sale investment transaction with tradeNum

--- a/src/app/api/stock-lots/route.ts
+++ b/src/app/api/stock-lots/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { failClosedResponse } from '@/lib/http/failClosedResponse';
 import { prisma } from '@/lib/prisma';
+import { postJournal } from '@/lib/posting/postJournal';
 import { positionTrackerService } from '@/lib/position-tracker-service';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 
@@ -163,19 +164,21 @@ export async function POST(request: Request) {
     });
 
     // Use position tracker service to create lots + journal entries
-    const result = await prisma.$transaction(
-      async (tx) => {
-        return await positionTrackerService.commitStockTrade({
+    // HYG-04: lots + journal entries post through postJournal (read back after commit).
+    const { result } = await postJournal(
+      prisma,
+      async (tx, post) =>
+        positionTrackerService.commitStockTrade({
           legs,
           strategy,
           tradeNum: actualTradeNum,
           userId: user.id,
           entityId,
           tx,
+          post,
           createdBy: userEmail,
-        });
-      },
-      { maxWait: 30000, timeout: 120000 }
+        }),
+      { maxWait: 30000, timeout: 120000 },
     );
 
     return NextResponse.json({

--- a/src/app/api/trading/commit-to-ledger/route.ts
+++ b/src/app/api/trading/commit-to-ledger/route.ts
@@ -6,14 +6,12 @@ import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { assertPeriodOpen, PeriodClosedError } from '@/lib/period-close-guard';
 import { requireTabAccess } from '@/lib/auth-helpers';
+import { balanceDeltaOf, postJournal } from '@/lib/posting/postJournal';
 
 function dollarsToCents(amount: number): bigint {
   return BigInt(Math.round(amount * 100));
 }
 
-function updateBalance(entryType: string, accountBalanceType: string, amountCents: bigint): bigint {
-  return entryType === accountBalanceType ? amountCents : -amountCents;
-}
 
 export async function POST(request: NextRequest) {
   try {
@@ -165,10 +163,11 @@ export async function POST(request: NextRequest) {
         // Period close enforcement
         await assertPeriodOpen(prisma, user.id, entityId, closeDate);
 
-        // Create JE + ledger entries + update balances in a single transaction
-        await prisma.$transaction(async (tx) => {
-          const journalEntry = await tx.journal_entries.create({
-            data: {
+        // HYG-04: JE + lines + balances through postJournal — SET CONSTRAINTS
+        // ALL IMMEDIATE first, one statement for the lines, read back after commit.
+        await postJournal(prisma, async (_tx, post) =>
+          post({
+            entry: {
               userId: user.id,
               entity_id: entityId,
               date: closeDate,
@@ -178,48 +177,12 @@ export async function POST(request: NextRequest) {
               status: 'posted',
               created_by: userEmail,
             },
-          });
-
-          // Debit ledger entry
-          await tx.ledger_entries.create({
-            data: {
-              journal_entry_id: journalEntry.id,
-              account_id: debitAccount.id,
-              entry_type: 'D',
-              amount: amountCents,
-              created_by: userEmail,
-            },
-          });
-
-          // Credit ledger entry
-          await tx.ledger_entries.create({
-            data: {
-              journal_entry_id: journalEntry.id,
-              account_id: creditAccount.id,
-              entry_type: 'C',
-              amount: amountCents,
-              created_by: userEmail,
-            },
-          });
-
-          // Update settled_balance on debit account
-          await tx.chart_of_accounts.update({
-            where: { id: debitAccount.id },
-            data: {
-              settled_balance: { increment: updateBalance('D', debitAccount.balance_type, amountCents) },
-              version: { increment: 1 },
-            },
-          });
-
-          // Update settled_balance on credit account
-          await tx.chart_of_accounts.update({
-            where: { id: creditAccount.id },
-            data: {
-              settled_balance: { increment: updateBalance('C', creditAccount.balance_type, amountCents) },
-              version: { increment: 1 },
-            },
-          });
-        });
+            lines: [
+              { account_id: debitAccount.id, entry_type: 'D', amount: amountCents, balanceDelta: balanceDeltaOf('D', debitAccount.balance_type, amountCents), created_by: userEmail },
+              { account_id: creditAccount.id, entry_type: 'C', amount: amountCents, balanceDelta: balanceDeltaOf('C', creditAccount.balance_type, amountCents), created_by: userEmail },
+            ],
+          }),
+        );
 
         committed++;
       } catch (err) {

--- a/src/app/api/year-end-close/route.ts
+++ b/src/app/api/year-end-close/route.ts
@@ -4,6 +4,8 @@ import { Prisma } from '@prisma/client';
 import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { requireTabAccess } from '@/lib/auth-helpers';
+import { ValidationError } from '@/lib/errors/ValidationError';
+import { postJournal, type JournalLineInput } from '@/lib/posting/postJournal';
 
 // GAAP Year-End Close API
 //
@@ -172,10 +174,73 @@ export async function POST(request: NextRequest) {
     // PATHWAY 8: Year-end close bypasses period close enforcement.
     // Closing entries are the privileged reason periods are closed.
     // Audit trail: source_type = 'year_end_close', created_by = userEmail
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const result = await prisma.$transaction(async (tx: any) => {
-      const journalEntry = await tx.journal_entries.create({
-        data: {
+    // HYG-04: the closing entry is built line by line with no write, checked
+    // (SOC2 BAL), then posted ONCE through postJournal — SET CONSTRAINTS ALL
+    // IMMEDIATE first, every line in one statement, read back after commit.
+    const lines: JournalLineInput[] = [];
+    let totalLedgerDebits = BigInt(0);
+    let totalLedgerCredits = BigInt(0);
+    let accountsClosed = 0;
+
+    // Close each revenue and expense account
+    for (const row of rows) {
+      const debits = BigInt(row.total_debits);
+      const credits = BigInt(row.total_credits);
+
+      if (row.account_type === 'revenue') {
+        // Revenue is credit-normal: balance = credits - debits
+        const balance = credits - debits;
+        if (balance === BigInt(0)) continue;
+
+        // Debit revenue account to zero it out
+        const absBalance = balance > BigInt(0) ? balance : -balance;
+        const entryType: 'D' | 'C' = balance > BigInt(0) ? 'D' : 'C';
+        // Debiting a credit-normal account decreases its balance
+        const balanceChange = entryType === 'C' ? absBalance : -absBalance;
+        lines.push({ account_id: row.account_id, entry_type: entryType, amount: absBalance, balanceDelta: balanceChange, created_by: userEmail });
+        if (entryType === 'D') totalLedgerDebits += absBalance; else totalLedgerCredits += absBalance;
+      } else {
+        // Expense is debit-normal: balance = debits - credits
+        const balance = debits - credits;
+        if (balance === BigInt(0)) continue;
+
+        // Credit expense account to zero it out
+        const absBalance = balance > BigInt(0) ? balance : -balance;
+        const entryType: 'D' | 'C' = balance > BigInt(0) ? 'C' : 'D';
+        // Crediting a debit-normal account decreases its balance
+        const balanceChange = entryType === 'D' ? absBalance : -absBalance;
+        lines.push({ account_id: row.account_id, entry_type: entryType, amount: absBalance, balanceDelta: balanceChange, created_by: userEmail });
+        if (entryType === 'D') totalLedgerDebits += absBalance; else totalLedgerCredits += absBalance;
+      }
+
+      accountsClosed++;
+    }
+
+    // Retained Earnings line
+    if (netIncome !== BigInt(0)) {
+      const absNetIncome = netIncome > BigInt(0) ? netIncome : -netIncome;
+      // Profit: CREDIT RE; Loss: DEBIT RE
+      const reEntryType: 'D' | 'C' = netIncome > BigInt(0) ? 'C' : 'D';
+      // RE is credit-normal (balance_type 'C')
+      const reBalanceChange = reEntryType === 'C' ? absNetIncome : -absNetIncome;
+      lines.push({ account_id: retainedEarnings!.id, entry_type: reEntryType, amount: absNetIncome, balanceDelta: reBalanceChange, created_by: userEmail });
+      if (reEntryType === 'D') totalLedgerDebits += absNetIncome; else totalLedgerCredits += absNetIncome;
+    }
+
+    if (lines.length === 0) {
+      throw new ValidationError(`Nothing to close for ${year}: every revenue and expense account is already at zero`, { status: 409 });
+    }
+
+    // CRITICAL: Balance verification (SOC2 BAL control) — before any write.
+    if (totalLedgerDebits !== totalLedgerCredits) {
+      throw new Error(
+        `Year-end closing entry is unbalanced: debits=${totalLedgerDebits.toString()}, credits=${totalLedgerCredits.toString()}. Refusing to post.`
+      );
+    }
+
+    const { result } = await postJournal(prisma, async (_tx, post) => {
+      const posted = await post({
+        entry: {
           userId: user.id,
           entity_id: entityId,
           date: new Date(year, 11, 31), // Dec 31
@@ -186,138 +251,13 @@ export async function POST(request: NextRequest) {
           is_reversal: false,
           created_by: userEmail,
         },
+        lines,
       });
-
-      let totalLedgerDebits = BigInt(0);
-      let totalLedgerCredits = BigInt(0);
-      let accountsClosed = 0;
-
-      // Close each revenue and expense account
-      for (const row of rows) {
-        const debits = BigInt(row.total_debits);
-        const credits = BigInt(row.total_credits);
-
-        if (row.account_type === 'revenue') {
-          // Revenue is credit-normal: balance = credits - debits
-          const balance = credits - debits;
-          if (balance === BigInt(0)) continue;
-
-          // Debit revenue account to zero it out
-          const absBalance = balance > BigInt(0) ? balance : -balance;
-          const entryType = balance > BigInt(0) ? 'D' : 'C';
-
-          await tx.ledger_entries.create({
-            data: {
-              journal_entry_id: journalEntry.id,
-              account_id: row.account_id,
-              entry_type: entryType,
-              amount: absBalance,
-              created_by: userEmail,
-            },
-          });
-
-          if (entryType === 'D') {
-            totalLedgerDebits += absBalance;
-          } else {
-            totalLedgerCredits += absBalance;
-          }
-
-          // Update account settled_balance
-          // Debiting a credit-normal account decreases its balance
-          const balanceChange = entryType === 'C' ? absBalance : -absBalance;
-          await tx.chart_of_accounts.update({
-            where: { id: row.account_id },
-            data: {
-              settled_balance: { increment: balanceChange },
-              version: { increment: 1 },
-            },
-          });
-        } else {
-          // Expense is debit-normal: balance = debits - credits
-          const balance = debits - credits;
-          if (balance === BigInt(0)) continue;
-
-          // Credit expense account to zero it out
-          const absBalance = balance > BigInt(0) ? balance : -balance;
-          const entryType = balance > BigInt(0) ? 'C' : 'D';
-
-          await tx.ledger_entries.create({
-            data: {
-              journal_entry_id: journalEntry.id,
-              account_id: row.account_id,
-              entry_type: entryType,
-              amount: absBalance,
-              created_by: userEmail,
-            },
-          });
-
-          if (entryType === 'D') {
-            totalLedgerDebits += absBalance;
-          } else {
-            totalLedgerCredits += absBalance;
-          }
-
-          // Update account settled_balance
-          // Crediting a debit-normal account decreases its balance
-          const balanceChange = entryType === 'D' ? absBalance : -absBalance;
-          await tx.chart_of_accounts.update({
-            where: { id: row.account_id },
-            data: {
-              settled_balance: { increment: balanceChange },
-              version: { increment: 1 },
-            },
-          });
-        }
-
-        accountsClosed++;
-      }
-
-      // Retained Earnings line
-      if (netIncome !== BigInt(0)) {
-        const absNetIncome = netIncome > BigInt(0) ? netIncome : -netIncome;
-        // Profit: CREDIT RE; Loss: DEBIT RE
-        const reEntryType = netIncome > BigInt(0) ? 'C' : 'D';
-
-        await tx.ledger_entries.create({
-          data: {
-            journal_entry_id: journalEntry.id,
-            account_id: retainedEarnings!.id,
-            entry_type: reEntryType,
-            amount: absNetIncome,
-            created_by: userEmail,
-          },
-        });
-
-        if (reEntryType === 'D') {
-          totalLedgerDebits += absNetIncome;
-        } else {
-          totalLedgerCredits += absNetIncome;
-        }
-
-        // Update RE settled_balance
-        // RE is credit-normal (balance_type 'C')
-        const reBalanceChange = reEntryType === 'C' ? absNetIncome : -absNetIncome;
-        await tx.chart_of_accounts.update({
-          where: { id: retainedEarnings!.id },
-          data: {
-            settled_balance: { increment: reBalanceChange },
-            version: { increment: 1 },
-          },
-        });
-      }
-
-      // CRITICAL: Balance verification (SOC2 BAL control)
-      if (totalLedgerDebits !== totalLedgerCredits) {
-        throw new Error(
-          `Year-end closing entry is unbalanced: debits=${totalLedgerDebits.toString()}, credits=${totalLedgerCredits.toString()}. Rolling back.`
-        );
-      }
-
-      return { journalEntry, accountsClosed };
+      return { journalEntryId: posted.id, accountsClosed };
     });
 
     return NextResponse.json({
-      closingEntryId: result.journalEntry.id,
+      closingEntryId: result.journalEntryId,
       netIncome: Number(netIncome),
       accountsClosed: result.accountsClosed,
       year,

--- a/src/lib/__tests__/fakeChart.ts
+++ b/src/lib/__tests__/fakeChart.ts
@@ -6,7 +6,7 @@ import type { PostingDb } from '../coa/reclassify';
  * tests. Hermetic, with the tables' own rules: UNIQUE on (userId, entity_id,
  * code); ledger lines are append-only (there is no update on the port, and the
  * fake's `ledger` array is frozen row by row so a test can prove nothing old
- * moved); balances change only through incrementBalance. Not a test file (no
+ * moved); balances change only through postEntry's balance moves. Not a test file (no
  * .test suffix): npm test's glob skips it.
  */
 export interface FakeJournalRow {
@@ -89,21 +89,18 @@ export class FakeChart implements ChartDb, PostingDb {
     return row;
   }
 
-  async insertJournalEntry(r: Omit<FakeJournalRow, 'id'>) {
-    const je: FakeJournalRow = { ...r, id: this.nextId('je') };
+  /** HYG-04: the one posting — the journal row, then every line, then every balance move (what postJournal's `post` does in production). */
+  async postEntry(input: { entry: Omit<FakeJournalRow, 'id'>; lines: Array<{ account_id: string; entry_type: 'D' | 'C'; amount: bigint; balanceDelta: bigint; created_by: string | null }> }) {
+    const je: FakeJournalRow = { ...input.entry, id: this.nextId('je') };
     this.journal.push(je);
+    for (const l of input.lines) this.postLine({ journal_entry_id: je.id, account_id: l.account_id, entry_type: l.entry_type, amount: l.amount, created_by: l.created_by });
+    for (const l of input.lines) {
+      const row = this.accounts.find((a) => a.id === l.account_id);
+      if (!row) throw new Error(`fake chart: no account ${l.account_id}`);
+      this.increments.push({ accountId: l.account_id, delta: l.balanceDelta });
+      row.settled_balance = BigInt(row.settled_balance) + l.balanceDelta;
+    }
     return { id: je.id };
-  }
-
-  async insertLedgerLine(r: Omit<FakeLedgerRow, 'id'>) {
-    return { id: this.postLine(r).id };
-  }
-
-  async incrementBalance(accountId: string, delta: bigint) {
-    const row = this.accounts.find((a) => a.id === accountId);
-    if (!row) throw new Error(`fake chart: no account ${accountId}`);
-    this.increments.push({ accountId, delta });
-    row.settled_balance = BigInt(row.settled_balance) + delta;
   }
 
   snapshotLedger(): string {

--- a/src/lib/__tests__/postJournal.test.ts
+++ b/src/lib/__tests__/postJournal.test.ts
@@ -1,0 +1,147 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { ValidationError } from '../errors/ValidationError';
+import { PostingNotLandedError, balanceDeltaOf, postJournal, type PostingTx } from '../posting/postJournal';
+
+// HYG-04 — no posting path may report success on a rolled-back write.
+// Hermetic: a fake client that records every statement in order, can drop the
+// commit silently (the prisma/prisma#26366 shape), and answers the read-back.
+
+interface Op { kind: string; detail?: unknown }
+
+function fakeClient(opts: { landed?: boolean; failOn?: 'createMany' | 'set' } = {}) {
+  const ops: Op[] = [];
+  const written = new Set<string>();
+  const tx = {
+    $executeRawUnsafe: async (sql: string) => { ops.push({ kind: 'raw', detail: sql }); if (opts.failOn === 'set') throw new Error('SET refused'); return 0; },
+    journal_entries: {
+      create: async (args: { data: Record<string, unknown> }) => { const id = `je-${ops.filter((o) => o.kind === 'je.create').length + 1}`; ops.push({ kind: 'je.create', detail: args.data }); written.add(id); return { id }; },
+    },
+    ledger_entries: {
+      createMany: async (args: { data: unknown[] }) => { ops.push({ kind: 'lines.createMany', detail: args.data }); if (opts.failOn === 'createMany') throw new Error('Transaction must be balanced: debits=100 credits=90'); return { count: args.data.length }; },
+      create: async () => { throw new Error('a line must never be inserted one at a time'); },
+    },
+    chart_of_accounts: {
+      update: async (args: { where: { id: string }; data: unknown }) => { ops.push({ kind: 'balance', detail: { id: args.where.id, data: args.data } }); return {}; },
+    },
+    other: { update: async (args: unknown) => { ops.push({ kind: 'other.update', detail: args }); return {}; } },
+  };
+  const client = {
+    $transaction: async (fn: (t: PostingTx) => Promise<unknown>, options?: unknown) => {
+      ops.push({ kind: 'BEGIN', detail: options });
+      try {
+        const r = await fn(tx as unknown as PostingTx);
+        ops.push({ kind: 'COMMIT' });
+        if (opts.landed === false) written.clear(); // the #26366 shape: the client resolves, the database rolled back
+        return r;
+      } catch (e) {
+        ops.push({ kind: 'ROLLBACK' });
+        written.clear();
+        throw e;
+      }
+    },
+    journal_entries: {
+      findMany: async (args: { where: { id: { in: string[] } } }) => { ops.push({ kind: 'readback', detail: args.where.id.in }); return args.where.id.in.filter((id) => written.has(id)).map((id) => ({ id })); },
+    },
+  };
+  return { client, ops, written };
+}
+
+const ENTRY = { userId: 'user-a', entity_id: 'ent-b', date: new Date('2026-09-08'), description: 'test', source_type: 'manual', request_id: 'req-1', created_by: 'alex' };
+const LINES = [
+  { account_id: 'acct-6220', entry_type: 'D' as const, amount: BigInt(100), balanceDelta: BigInt(100) },
+  { account_id: 'acct-1010', entry_type: 'C' as const, amount: BigInt(100), balanceDelta: BigInt(-100) },
+];
+
+test('postJournal: SET CONSTRAINTS ALL IMMEDIATE is the first statement, the lines go in as ONE createMany, balances move, and the id is read back after commit', async () => {
+  const { client, ops } = fakeClient();
+  const out = await postJournal(client as never, async (tx, post) => {
+    const posted = await post({ entry: ENTRY, lines: LINES });
+    await (tx as unknown as { other: { update: (a: unknown) => Promise<unknown> } }).other.update({ after: posted.id });
+    return { posted };
+  }, { maxWait: 5000, timeout: 10000 });
+
+  assert.deepEqual(ops.map((o) => o.kind), ['BEGIN', 'raw', 'je.create', 'lines.createMany', 'balance', 'balance', 'other.update', 'COMMIT', 'readback']);
+  assert.equal(ops[1].detail, 'SET CONSTRAINTS ALL IMMEDIATE');
+  assert.deepEqual(ops[0].detail, { maxWait: 5000, timeout: 10000 }, 'transaction options pass through');
+  const lines = ops[3].detail as Array<Record<string, unknown>>;
+  assert.equal(lines.length, 2);
+  assert.equal(lines[0].journal_entry_id, 'je-1');
+  assert.deepEqual(lines.map((l) => [l.account_id, l.entry_type, l.amount, l.created_by]), [['acct-6220', 'D', BigInt(100), 'alex'], ['acct-1010', 'C', BigInt(100), 'alex']]);
+  assert.deepEqual(out.result.posted.lineIds, [lines[0].id, lines[1].id], 'the line ids are the ones written');
+  assert.deepEqual(ops[4].detail, { id: 'acct-6220', data: { settled_balance: { increment: BigInt(100) }, version: { increment: 1 } } });
+  assert.deepEqual(ops[5].detail, { id: 'acct-1010', data: { settled_balance: { increment: BigInt(-100) }, version: { increment: 1 } } });
+  assert.deepEqual(ops[8].detail, ['je-1']);
+  assert.deepEqual(out.journalEntryIds, ['je-1']);
+  const je = ops[2].detail as Record<string, unknown>;
+  assert.equal(je.status, 'posted');
+  assert.equal(je.is_reversal, false);
+  assert.equal(je.source_id, null);
+});
+
+test('postJournal: a commit the database rolled back is NEVER a success — the read-back throws PostingNotLandedError', async () => {
+  const { client, ops } = fakeClient({ landed: false });
+  await assert.rejects(
+    () => postJournal(client as never, async (_tx, post) => post({ entry: ENTRY, lines: LINES })),
+    (err: unknown) => {
+      assert.ok(err instanceof PostingNotLandedError);
+      assert.deepEqual(err.journalEntryIds, ['je-1']);
+      assert.match(err.message, /absent after commit/);
+      return true;
+    },
+  );
+  assert.deepEqual(ops.map((o) => o.kind).slice(-2), ['COMMIT', 'readback']);
+});
+
+test('postJournal: an unbalanced entry is refused INSIDE the transaction (the immediate trigger throws on the createMany), the transaction rolls back, nothing is read back as landed', async () => {
+  const { client, ops } = fakeClient({ failOn: 'createMany' });
+  await assert.rejects(
+    () => postJournal(client as never, async (_tx, post) => post({ entry: ENTRY, lines: [LINES[0], { ...LINES[1], amount: BigInt(90) }] })),
+    /Transaction must be balanced: debits=100 credits=90/,
+  );
+  assert.deepEqual(ops.map((o) => o.kind), ['BEGIN', 'raw', 'je.create', 'lines.createMany', 'ROLLBACK']);
+});
+
+test('postJournal: the structural refusals happen before any write; a body that posts nothing reads nothing back', async () => {
+  const { client, ops } = fakeClient();
+  await assert.rejects(() => postJournal(client as never, async (_tx, post) => post({ entry: ENTRY, lines: [LINES[0]] })), (e: unknown) => e instanceof ValidationError && /at least two lines/.test(e.message));
+  await assert.rejects(() => postJournal(client as never, async (_tx, post) => post({ entry: ENTRY, lines: [LINES[0], { ...LINES[1], amount: BigInt(0) }] })), (e: unknown) => e instanceof ValidationError && /positive number of cents/.test(e.message));
+  assert.equal(ops.filter((o) => o.kind === 'je.create').length, 0, 'no journal row was written by a refusal');
+  ops.length = 0;
+  const out = await postJournal(client as never, async () => 'nothing to post');
+  assert.equal(out.result, 'nothing to post');
+  assert.deepEqual(out.journalEntryIds, []);
+  assert.deepEqual(ops.map((o) => o.kind), ['BEGIN', 'raw', 'COMMIT'], 'no read-back when nothing was posted');
+});
+
+test('postJournal: several entries in one transaction are each read back; one missing fails the whole call', async () => {
+  const { client, ops, written } = fakeClient();
+  const out = await postJournal(client as never, async (_tx, post) => {
+    const a = await post({ entry: { ...ENTRY, description: 'reversal', is_reversal: true, reverses_entry_id: 'je-old' }, lines: LINES });
+    const b = await post({ entry: { ...ENTRY, description: 'new' }, lines: LINES });
+    return [a.id, b.id];
+  });
+  assert.deepEqual(out.result, ['je-1', 'je-2']);
+  assert.deepEqual(out.journalEntryIds, ['je-1', 'je-2']);
+  assert.deepEqual(ops[ops.length - 1].detail, ['je-1', 'je-2']);
+  const je1 = ops.find((o) => o.kind === 'je.create')!.detail as Record<string, unknown>;
+  assert.equal(je1.is_reversal, true);
+  assert.equal(je1.reverses_entry_id, 'je-old');
+
+  // one of two missing after commit
+  const partial = fakeClient();
+  const origTx = partial.client.$transaction;
+  partial.client.$transaction = async (fn, options) => { const r = await origTx(fn, options); partial.written.delete('je-2'); return r; };
+  await assert.rejects(
+    () => postJournal(partial.client as never, async (_tx, post) => { await post({ entry: ENTRY, lines: LINES }); await post({ entry: ENTRY, lines: LINES }); }),
+    (err: unknown) => err instanceof PostingNotLandedError && err.journalEntryIds.length === 1 && err.journalEntryIds[0] === 'je-2',
+  );
+  assert.equal(written.size, 2);
+});
+
+test('balanceDeltaOf is the rule every writer used: the account\'s own side adds, the other subtracts', () => {
+  assert.equal(balanceDeltaOf('D', 'D', BigInt(500)), BigInt(500));
+  assert.equal(balanceDeltaOf('C', 'D', BigInt(500)), BigInt(-500));
+  assert.equal(balanceDeltaOf('C', 'C', BigInt(500)), BigInt(500));
+  assert.equal(balanceDeltaOf('D', 'C', BigInt(500)), BigInt(-500));
+});

--- a/src/lib/batch-trade-processor.ts
+++ b/src/lib/batch-trade-processor.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'crypto';
 import { ValidationError } from '@/lib/errors/ValidationError';
 import { prisma } from '@/lib/prisma';
 import { positionTrackerService } from '@/lib/position-tracker-service';
+import { postJournal } from '@/lib/posting/postJournal';
 
 // ═══════════════════════════════════════════════════════════════
 // Classification categories for investment transactions
@@ -494,10 +495,10 @@ export async function processStockBuys(
     const tradeNum = `${ticker}-${String(globalMaxNum).padStart(4, '0')}`;
 
     try {
-      const commitResult = await prisma.$transaction(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        async (tx: any) => {
-          return await positionTrackerService.commitStockTrade({
+      const { result: commitResult } = await postJournal(
+        prisma,
+        async (tx, post) =>
+          positionTrackerService.commitStockTrade({
             legs: [{
               id: txn.id,
               date: txn.date,
@@ -513,9 +514,9 @@ export async function processStockBuys(
             userId,
             entityId,
             tx,
+            post,
             createdBy: 'batch-trade-processor',
-          });
-        },
+          }),
         { maxWait: 10000, timeout: 30000 }
       );
 
@@ -722,19 +723,19 @@ export async function processOptions(
     const tradeNum = `${underlying}-${String(globalMaxNum).padStart(4, '0')}`;
 
     try {
-      const commitResult = await prisma.$transaction(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        async (tx: any) => {
-          return await positionTrackerService.commitOptionsTrade({
+      const { result: commitResult } = await postJournal(
+        prisma,
+        async (tx, post) =>
+          positionTrackerService.commitOptionsTrade({
             legs,
             strategy,
             tradeNum,
             userId,
             entityId,
             tx,
+            post,
             createdBy: 'batch-trade-processor',
-          });
-        },
+          }),
         { maxWait: 10000, timeout: 30000 }
       );
 
@@ -891,9 +892,9 @@ export async function processStockSells(
     const tradeNum = `${ticker}-${String(globalMaxNum).padStart(4, '0')}`;
 
     try {
-      await prisma.$transaction(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        async (tx: any) => {
+      await postJournal(
+        prisma,
+        async (tx, post) => {
           // Find open lots FIFO
           const lots = await tx.stock_lots.findMany({
             where: {
@@ -982,8 +983,11 @@ export async function processStockSells(
             throw new ValidationError(`Missing required accounts: ${TRADING_CASH}, ${STOCK_POSITION}, ${PL_ACCOUNT}`);
           }
 
-          const journalEntry = await tx.journal_entries.create({
-            data: {
+          // HYG-04: one entry, three lines, through `post` (the deltas as before:
+          // cash +proceeds, position −cost, P&L ±).
+          const plBalanceChange = plCents >= 0 ? BigInt(Math.abs(plCents)) : BigInt(-Math.abs(plCents));
+          await post({
+            entry: {
               userId,
               entity_id: entityId,
               date: saleDateObj,
@@ -995,52 +999,11 @@ export async function processStockSells(
               request_id: randomUUID(),
               created_by: 'batch-trade-processor',
             },
-          });
-
-          // DR Trading Cash
-          await tx.ledger_entries.create({
-            data: {
-              journal_entry_id: journalEntry.id,
-              account_id: cashAccount.id,
-              amount: BigInt(proceedsCents),
-              entry_type: 'D',
-              created_by: 'batch-trade-processor',
-            },
-          });
-          await tx.chart_of_accounts.update({
-            where: { id: cashAccount.id },
-            data: { settled_balance: { increment: BigInt(proceedsCents) }, version: { increment: 1 } },
-          });
-
-          // CR Stock Position
-          await tx.ledger_entries.create({
-            data: {
-              journal_entry_id: journalEntry.id,
-              account_id: stockAccount.id,
-              amount: BigInt(costBasisCents),
-              entry_type: 'C',
-              created_by: 'batch-trade-processor',
-            },
-          });
-          await tx.chart_of_accounts.update({
-            where: { id: stockAccount.id },
-            data: { settled_balance: { increment: BigInt(-costBasisCents) }, version: { increment: 1 } },
-          });
-
-          // P&L entry
-          await tx.ledger_entries.create({
-            data: {
-              journal_entry_id: journalEntry.id,
-              account_id: plAccount.id,
-              amount: BigInt(Math.abs(plCents)),
-              entry_type: plCents >= 0 ? 'C' : 'D',
-              created_by: 'batch-trade-processor',
-            },
-          });
-          const plBalanceChange = plCents >= 0 ? BigInt(Math.abs(plCents)) : BigInt(-Math.abs(plCents));
-          await tx.chart_of_accounts.update({
-            where: { id: plAccount.id },
-            data: { settled_balance: { increment: plBalanceChange }, version: { increment: 1 } },
+            lines: [
+              { account_id: cashAccount.id, entry_type: 'D', amount: BigInt(proceedsCents), balanceDelta: BigInt(proceedsCents), created_by: 'batch-trade-processor' },
+              { account_id: stockAccount.id, entry_type: 'C', amount: BigInt(costBasisCents), balanceDelta: BigInt(-costBasisCents), created_by: 'batch-trade-processor' },
+              { account_id: plAccount.id, entry_type: plCents >= 0 ? 'C' : 'D', amount: BigInt(Math.abs(plCents)), balanceDelta: plBalanceChange, created_by: 'batch-trade-processor' },
+            ],
           });
 
           // Update investment_transaction
@@ -1211,9 +1174,9 @@ export async function processDividends(
     if (amountCents === 0) continue;
 
     try {
-      await prisma.$transaction(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        async (tx: any) => {
+      await postJournal(
+        prisma,
+        async (tx, post) => {
           const accounts = await tx.chart_of_accounts.findMany({
             where: { code: { in: [TRADING_CASH, DIVIDEND_INCOME] }, userId, entity_id: entityId },
           });
@@ -1224,9 +1187,9 @@ export async function processDividends(
             throw new ValidationError(`Missing COA accounts: ${TRADING_CASH} or ${DIVIDEND_INCOME}. Ensure trading entity has dividend income account (4300).`);
           }
 
-          // DR Trading Cash, CR Dividend Income
-          const journalEntry = await tx.journal_entries.create({
-            data: {
+          // DR Trading Cash, CR Dividend Income — HYG-04: through `post`.
+          await post({
+            entry: {
               userId,
               entity_id: entityId,
               date: txn.date,
@@ -1238,34 +1201,10 @@ export async function processDividends(
               request_id: randomUUID(),
               created_by: 'batch-trade-processor',
             },
-          });
-
-          await tx.ledger_entries.create({
-            data: {
-              journal_entry_id: journalEntry.id,
-              account_id: cashAccount.id,
-              amount: BigInt(amountCents),
-              entry_type: 'D',
-              created_by: 'batch-trade-processor',
-            },
-          });
-          await tx.chart_of_accounts.update({
-            where: { id: cashAccount.id },
-            data: { settled_balance: { increment: BigInt(amountCents) }, version: { increment: 1 } },
-          });
-
-          await tx.ledger_entries.create({
-            data: {
-              journal_entry_id: journalEntry.id,
-              account_id: divAccount.id,
-              amount: BigInt(amountCents),
-              entry_type: 'C',
-              created_by: 'batch-trade-processor',
-            },
-          });
-          await tx.chart_of_accounts.update({
-            where: { id: divAccount.id },
-            data: { settled_balance: { increment: BigInt(amountCents) }, version: { increment: 1 } },
+            lines: [
+              { account_id: cashAccount.id, entry_type: 'D', amount: BigInt(amountCents), balanceDelta: BigInt(amountCents), created_by: 'batch-trade-processor' },
+              { account_id: divAccount.id, entry_type: 'C', amount: BigInt(amountCents), balanceDelta: BigInt(amountCents), created_by: 'batch-trade-processor' },
+            ],
           });
 
           await tx.investment_transactions.update({
@@ -1367,9 +1306,9 @@ export async function processRemainingCloses(
     const tradeNum = `${underlying}-${String(globalMaxNum).padStart(4, '0')}`;
 
     try {
-      await prisma.$transaction(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        async (tx: any) => {
+      await postJournal(
+        prisma,
+        async (tx, post) => {
           const leg = {
             id: txn.id,
             date: txn.date,
@@ -1395,6 +1334,7 @@ export async function processRemainingCloses(
             userId,
             entityId,
             tx,
+            post,
             createdBy: 'batch-trade-processor',
           });
         },
@@ -1622,9 +1562,9 @@ export async function processCallSpreadAssignments(
       const tradeNum = `${symbol}-${String(globalMaxNum).padStart(4, '0')}`;
 
       try {
-        await prisma.$transaction(
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          async (tx: any) => {
+        await postJournal(
+          prisma,
+          async (tx, post) => {
             // Build all legs as close legs and route through commitOptionsTrade
             // which will detect the exercise/assignment pattern via name parsing
             // and use closeSpreadAtomically()
@@ -1757,8 +1697,11 @@ export async function processCallSpreadAssignments(
               // Journal entry: reverse the position, book P&L
               // Exercise (LONG): CR position (remove asset), DR loss (premium lost)
               // Assignment (SHORT): DR position (remove liability), CR gain (premium kept)
-              const journalEntry = await tx.journal_entries.create({
-                data: {
+              // HYG-04: one entry through `post` — exercise (LONG): CR position,
+              // DR loss; assignment (SHORT): DR position, CR gain; the deltas as before.
+              const cost = BigInt(originalCostCents);
+              await post({
+                entry: {
                   userId,
                   entity_id: entityId,
                   date: txn.date,
@@ -1770,67 +1713,16 @@ export async function processCallSpreadAssignments(
                   request_id: randomUUID(),
                   created_by: 'batch-trade-processor',
                 },
+                lines: isExercise
+                  ? [
+                      { account_id: posAcct.id, entry_type: 'C', amount: cost, balanceDelta: -cost, created_by: 'batch-trade-processor' },
+                      { account_id: plAcct.id, entry_type: 'D', amount: cost, balanceDelta: -cost, created_by: 'batch-trade-processor' },
+                    ]
+                  : [
+                      { account_id: posAcct.id, entry_type: 'D', amount: cost, balanceDelta: cost, created_by: 'batch-trade-processor' },
+                      { account_id: plAcct.id, entry_type: 'C', amount: cost, balanceDelta: cost, created_by: 'batch-trade-processor' },
+                    ],
               });
-
-              if (isExercise) {
-                // Remove LONG asset: CR position, DR loss
-                await tx.ledger_entries.create({
-                  data: {
-                    journal_entry_id: journalEntry.id,
-                    account_id: posAcct.id,
-                    amount: BigInt(originalCostCents),
-                    entry_type: 'C',
-                    created_by: 'batch-trade-processor',
-                  },
-                });
-                await tx.chart_of_accounts.update({
-                  where: { id: posAcct.id },
-                  data: { settled_balance: { increment: BigInt(-originalCostCents) }, version: { increment: 1 } },
-                });
-
-                await tx.ledger_entries.create({
-                  data: {
-                    journal_entry_id: journalEntry.id,
-                    account_id: plAcct.id,
-                    amount: BigInt(originalCostCents),
-                    entry_type: 'D',
-                    created_by: 'batch-trade-processor',
-                  },
-                });
-                await tx.chart_of_accounts.update({
-                  where: { id: plAcct.id },
-                  data: { settled_balance: { increment: BigInt(-originalCostCents) }, version: { increment: 1 } },
-                });
-              } else {
-                // Remove SHORT liability: DR position, CR gain
-                await tx.ledger_entries.create({
-                  data: {
-                    journal_entry_id: journalEntry.id,
-                    account_id: posAcct.id,
-                    amount: BigInt(originalCostCents),
-                    entry_type: 'D',
-                    created_by: 'batch-trade-processor',
-                  },
-                });
-                await tx.chart_of_accounts.update({
-                  where: { id: posAcct.id },
-                  data: { settled_balance: { increment: BigInt(originalCostCents) }, version: { increment: 1 } },
-                });
-
-                await tx.ledger_entries.create({
-                  data: {
-                    journal_entry_id: journalEntry.id,
-                    account_id: plAcct.id,
-                    amount: BigInt(originalCostCents),
-                    entry_type: 'C',
-                    created_by: 'batch-trade-processor',
-                  },
-                });
-                await tx.chart_of_accounts.update({
-                  where: { id: plAcct.id },
-                  data: { settled_balance: { increment: BigInt(originalCostCents) }, version: { increment: 1 } },
-                });
-              }
 
               result.journal_entries_created++;
 

--- a/src/lib/coa/prismaChartDb.ts
+++ b/src/lib/coa/prismaChartDb.ts
@@ -1,15 +1,15 @@
 import { randomUUID } from 'crypto';
 import type { PrismaClient } from '@prisma/client';
 import type { ChartAccountRow, ChartDb, ChartPatch, NewChartAccount } from './accounts';
-import type { PostingDb } from './reclassify';
 
 /**
- * COA-01 — the Prisma bindings of the two ports (accounts.ts ChartDb,
- * reclassify.ts PostingDb). A route hands the client (or a $transaction
- * context) in; the policies never import prisma.
+ * COA-01 — the Prisma binding of the chart port (accounts.ts ChartDb). A
+ * route hands the client (or a $transaction context) in; the policies never
+ * import prisma. HYG-04: the reclass posting port is postJournal's `post`
+ * (src/lib/posting/postJournal.ts) — no ledger write lives here.
  */
 
-type Client = Pick<PrismaClient, 'chart_of_accounts' | 'journal_entries' | 'ledger_entries'>;
+type Client = Pick<PrismaClient, 'chart_of_accounts'>;
 
 const SELECT = {
   id: true, userId: true, entity_id: true, entity_type: true, code: true, name: true,
@@ -56,37 +56,6 @@ export function prismaChartDb(client: Client, userId: string): ChartDb {
     async update(id, patch: ChartPatch) {
       const r = await client.chart_of_accounts.update({ where: { id }, data: { ...patch, updated_at: new Date() }, select: SELECT });
       return row(r, userId);
-    },
-  };
-}
-
-export function prismaPostingDb(client: Client): PostingDb {
-  return {
-    async insertJournalEntry(r) {
-      const je = await client.journal_entries.create({
-        data: {
-          userId: r.userId,
-          entity_id: r.entity_id,
-          date: r.date,
-          description: r.description,
-          source_type: r.source_type,
-          status: r.status,
-          request_id: r.request_id,
-          created_by: r.created_by,
-          metadata: r.metadata,
-        },
-        select: { id: true },
-      });
-      return je;
-    },
-    async insertLedgerLine(r) {
-      return client.ledger_entries.create({ data: r, select: { id: true } });
-    },
-    async incrementBalance(accountId, delta) {
-      await client.chart_of_accounts.update({
-        where: { id: accountId },
-        data: { settled_balance: { increment: delta }, version: { increment: 1 }, updated_at: new Date() },
-      });
     },
   };
 }

--- a/src/lib/coa/reclassify.ts
+++ b/src/lib/coa/reclassify.ts
@@ -105,21 +105,27 @@ export function planReclassification(input: ReclassInput): ReclassPlan {
   };
 }
 
-/** The write port a reclass needs — inserts and balance increments only; there is no way to edit a prior row through it. */
+/**
+ * The write port a reclass needs — ONE posting of the whole entry (HYG-04:
+ * postJournal's `post` in production — the journal row, every line in one
+ * statement, the balance moves, the id read back after commit). There is no
+ * way to edit a prior row through it.
+ */
 export interface PostingDb {
-  insertJournalEntry(row: {
-    userId: string;
-    entity_id: string;
-    date: Date;
-    description: string;
-    source_type: 'reclass';
-    status: 'posted';
-    request_id: string;
-    created_by: string | null;
-    metadata: ReclassPlan['metadata'];
+  postEntry(input: {
+    entry: {
+      userId: string;
+      entity_id: string;
+      date: Date;
+      description: string;
+      source_type: 'reclass';
+      status: 'posted';
+      request_id: string;
+      created_by: string | null;
+      metadata: ReclassPlan['metadata'];
+    };
+    lines: Array<{ account_id: string; entry_type: 'D' | 'C'; amount: bigint; balanceDelta: bigint; created_by: string | null }>;
   }): Promise<{ id: string }>;
-  insertLedgerLine(row: { journal_entry_id: string; account_id: string; entry_type: 'D' | 'C'; amount: bigint; created_by: string | null }): Promise<{ id: string }>;
-  incrementBalance(accountId: string, delta: bigint): Promise<void>;
 }
 
 export interface PostingContext {
@@ -130,20 +136,19 @@ export interface PostingContext {
 }
 
 export async function postReclassification(db: PostingDb, ctx: PostingContext, plan: ReclassPlan): Promise<{ journalEntryId: string }> {
-  const je = await db.insertJournalEntry({
-    userId: ctx.userId,
-    entity_id: ctx.entityId,
-    date: plan.date,
-    description: plan.description,
-    source_type: 'reclass',
-    status: 'posted',
-    request_id: ctx.requestId,
-    created_by: ctx.createdBy,
-    metadata: plan.metadata,
+  const je = await db.postEntry({
+    entry: {
+      userId: ctx.userId,
+      entity_id: ctx.entityId,
+      date: plan.date,
+      description: plan.description,
+      source_type: 'reclass',
+      status: 'posted',
+      request_id: ctx.requestId,
+      created_by: ctx.createdBy,
+      metadata: plan.metadata,
+    },
+    lines: plan.lines.map((line) => ({ account_id: line.account_id, entry_type: line.entry_type, amount: line.amount, balanceDelta: line.balanceDelta, created_by: ctx.createdBy })),
   });
-  for (const line of plan.lines) {
-    await db.insertLedgerLine({ journal_entry_id: je.id, account_id: line.account_id, entry_type: line.entry_type, amount: line.amount, created_by: ctx.createdBy });
-    await db.incrementBalance(line.account_id, line.balanceDelta);
-  }
   return { journalEntryId: je.id };
 }

--- a/src/lib/journal-entry-service.ts
+++ b/src/lib/journal-entry-service.ts
@@ -1,8 +1,7 @@
 import { PrismaClient, journal_entries } from '@prisma/client';
 import { ValidationError } from '@/lib/errors/ValidationError';
 import { assertPeriodOpen } from '@/lib/period-close-guard';
-
-type Tx = Omit<PrismaClient, '$connect' | '$disconnect' | '$on' | '$transaction' | '$use' | '$extends'>;
+import { balanceDeltaOf, postJournal } from '@/lib/posting/postJournal';
 
 export type CommitResult = journal_entries & { alreadyExisted?: boolean };
 
@@ -47,11 +46,13 @@ function dollarsToCents(amount: number): bigint {
   return BigInt(Math.round(amount * 100));
 }
 
-function updateBalance(entryType: string, accountBalanceType: string, amountCents: bigint): bigint {
-  // If entry_type matches account's balance_type, ADD; otherwise SUBTRACT
-  return entryType === accountBalanceType ? amountCents : -amountCents;
-}
-
+/**
+ * HYG-04: both writers post through postJournal — SET CONSTRAINTS ALL
+ * IMMEDIATE first, the lines in one statement, the entry id read back after
+ * commit. The guards (idempotency, period close, account lookups) and the
+ * follow-up writes (links, the transaction's status) run inside the same
+ * transaction, exactly where they ran before.
+ */
 export async function commitPlaidTransaction(
   prisma: PrismaClient,
   params: CommitPlaidTransactionParams
@@ -72,7 +73,7 @@ export async function commitPlaidTransaction(
     links,
   } = params;
 
-  return prisma.$transaction(async (tx: Tx) => {
+  const { result } = await postJournal(prisma, async (tx, post): Promise<CommitResult> => {
     // ═══════════════════════════════════════════════════════════════════
     // IDEMPOTENCY GUARD — Prevent duplicate JEs on retry
     // If a JE with this request_id already exists, return it immediately.
@@ -121,16 +122,15 @@ export async function commitPlaidTransaction(
     // Plaid positive = money left account = EXPENSE: DR expense, CR bank
     // Plaid negative = money entered account = INCOME: DR bank, CR income/revenue
 
-    const debitAccountId = isExpense ? expenseOrIncomeAccount.id : bankAccount.id;
-    const creditAccountId = isExpense ? bankAccount.id : expenseOrIncomeAccount.id;
-    const debitBalanceType = isExpense ? expenseOrIncomeAccount.balance_type : bankAccount.balance_type;
-    const creditBalanceType = isExpense ? bankAccount.balance_type : expenseOrIncomeAccount.balance_type;
+    const debitAccount = isExpense ? expenseOrIncomeAccount : bankAccount;
+    const creditAccount = isExpense ? bankAccount : expenseOrIncomeAccount;
 
-    // Create journal entry
+    // Create the journal entry — one debit line, one credit line, the balance
+    // moves by the rule every writer uses.
     // DIM-3: vendor_id is born WITH the entry (null = dimensionless, the
     // legacy-epoch semantic — never backfilled, never imputed).
-    const journalEntry = await tx.journal_entries.create({
-      data: {
+    const posted = await post({
+      entry: {
         userId,
         entity_id: entityId,
         date,
@@ -138,44 +138,26 @@ export async function commitPlaidTransaction(
         source_type: 'plaid_txn',
         source_id: transactionId,
         status: 'posted',
-        request_id: requestId,
+        request_id: requestId ?? null,
         created_by: createdBy || null,
         vendor_id: vendorId || null,
       },
-    });
-
-    // Create debit ledger entry
-    const debitEntry = await tx.ledger_entries.create({
-      data: {
-        journal_entry_id: journalEntry.id,
-        account_id: debitAccountId,
-        entry_type: 'D',
-        amount: amountCents,
-        created_by: createdBy || null,
-      },
-    });
-
-    // Create credit ledger entry
-    const creditEntry = await tx.ledger_entries.create({
-      data: {
-        journal_entry_id: journalEntry.id,
-        account_id: creditAccountId,
-        entry_type: 'C',
-        amount: amountCents,
-        created_by: createdBy || null,
-      },
+      lines: [
+        { account_id: debitAccount.id, entry_type: 'D', amount: amountCents, balanceDelta: balanceDeltaOf('D', debitAccount.balance_type, amountCents), created_by: createdBy || null },
+        { account_id: creditAccount.id, entry_type: 'C', amount: amountCents, balanceDelta: balanceDeltaOf('C', creditAccount.balance_type, amountCents), created_by: createdBy || null },
+      ],
     });
 
     // ─── DIM-3: allocation links on the EXPENSE-SIDE line ────────────────────
-    // This service builds exactly ONE D + ONE C line; the categorized
+    // The entry has exactly ONE D + ONE C line; the categorized
     // (expense/income) account rides the DEBIT when the Plaid amount is
     // positive (expense) and the CREDIT when negative (income) — so the
     // links' line is always unambiguously identifiable. Created INSIDE this
-    // $transaction: a link-write failure (including the DIM-1 CHECK/partial-
+    // transaction: a link-write failure (including the DIM-1 CHECK/partial-
     // unique constraints) rolls back the WHOLE entry, loudly — the entry's
     // atomicity is sacred; dimensions are born with it or not at all.
     if (links && links.length > 0) {
-      const expenseSideEntryId = isExpense ? debitEntry.id : creditEntry.id;
+      const expenseSideEntryId = isExpense ? posted.lineIds[0] : posted.lineIds[1];
       await tx.ledger_line_links.createMany({
         data: links.map((l) => ({
           ledger_entry_id: expenseSideEntryId,
@@ -189,24 +171,6 @@ export async function commitPlaidTransaction(
       });
     }
 
-    // Update settled_balance on debit account
-    await tx.chart_of_accounts.update({
-      where: { id: debitAccountId },
-      data: {
-        settled_balance: { increment: updateBalance('D', debitBalanceType, amountCents) },
-        version: { increment: 1 },
-      },
-    });
-
-    // Update settled_balance on credit account
-    await tx.chart_of_accounts.update({
-      where: { id: creditAccountId },
-      data: {
-        settled_balance: { increment: updateBalance('C', creditBalanceType, amountCents) },
-        version: { increment: 1 },
-      },
-    });
-
     // Update transaction status
     await tx.transactions.update({
       where: { transactionId },
@@ -216,8 +180,10 @@ export async function commitPlaidTransaction(
       },
     });
 
-    return journalEntry;
+    return tx.journal_entries.findUniqueOrThrow({ where: { id: posted.id } });
   });
+
+  return result;
 }
 
 export async function reversePlaidTransaction(
@@ -226,7 +192,7 @@ export async function reversePlaidTransaction(
 ) {
   const { userId, journalEntryId, transactionId, requestId, createdBy } = params;
 
-  return prisma.$transaction(async (tx: Tx) => {
+  const { result } = await postJournal(prisma, async (tx, post) => {
     // Look up original journal entry with its ledger entries and linked accounts
     const original = await tx.journal_entries.findUnique({
       where: { id: journalEntryId },
@@ -259,9 +225,10 @@ export async function reversePlaidTransaction(
     const reversalDate = new Date();
     await assertPeriodOpen(tx, userId, original.entity_id, reversalDate);
 
-    // Create reversal journal entry
-    const reversalEntry = await tx.journal_entries.create({
-      data: {
+    // Create the reversal: the opposite line for every original line, the
+    // balances moved back by the same rule.
+    const reversal = await post({
+      entry: {
         userId,
         entity_id: original.entity_id,
         date: reversalDate,
@@ -271,43 +238,27 @@ export async function reversePlaidTransaction(
         status: 'posted',
         is_reversal: true,
         reverses_entry_id: original.id,
-        request_id: requestId,
+        request_id: requestId ?? null,
         created_by: createdBy || null,
       },
-    });
-
-    // Create opposite ledger entries and reverse COA balances
-    for (const entry of original.ledger_entries) {
-      const oppositeType = entry.entry_type === 'D' ? 'C' : 'D';
-
-      await tx.ledger_entries.create({
-        data: {
-          journal_entry_id: reversalEntry.id,
+      lines: original.ledger_entries.map((entry) => {
+        const oppositeType: 'D' | 'C' = entry.entry_type === 'D' ? 'C' : 'D';
+        return {
           account_id: entry.account_id,
           entry_type: oppositeType,
           amount: entry.amount,
+          balanceDelta: balanceDeltaOf(oppositeType, entry.account.balance_type, entry.amount),
           created_by: createdBy || null,
-        },
-      });
-
-      // Reverse the balance: opposite entry type applied to account
-      await tx.chart_of_accounts.update({
-        where: { id: entry.account.id },
-        data: {
-          settled_balance: {
-            increment: updateBalance(oppositeType, entry.account.balance_type, entry.amount),
-          },
-          version: { increment: 1 },
-        },
-      });
-    }
+        };
+      }),
+    });
 
     // Mark original as reversed
     await tx.journal_entries.update({
       where: { id: original.id },
       data: {
         status: 'reversed',
-        reversed_by_entry_id: reversalEntry.id,
+        reversed_by_entry_id: reversal.id,
       },
     });
 
@@ -320,6 +271,8 @@ export async function reversePlaidTransaction(
       },
     });
 
-    return { originalId: original.id, reversalId: reversalEntry.id };
+    return { originalId: original.id, reversalId: reversal.id };
   });
+
+  return result;
 }

--- a/src/lib/position-tracker-service.ts
+++ b/src/lib/position-tracker-service.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'crypto';
 import { ValidationError } from '@/lib/errors/ValidationError';
 import { PrismaClient } from '@prisma/client';
 import { prisma } from '@/lib/prisma';
+import { postJournal, type PostEntry } from '@/lib/posting/postJournal';
 
 interface InvestmentLeg {
   id: string;
@@ -30,11 +31,13 @@ export class PositionTrackerService {
     tradeNum: string;
     userId: string;
     entityId: string;
-    tx?: TransactionContext;
+    tx: TransactionContext;
+    /** HYG-04: every journal entry goes through postJournal's `post` — the caller opened the transaction with postJournal. */
+    post: PostEntry;
     createdBy?: string;
   }) {
-    const { legs, strategy, tradeNum, userId, entityId, tx, createdBy } = params;
-    const db = tx || prisma;
+    const { legs, strategy, tradeNum, userId, entityId, tx, post, createdBy } = params;
+    const db = tx;
     const results = [];
     const skipped = [];
 
@@ -44,7 +47,7 @@ export class PositionTrackerService {
     for (const leg of legs) {
       if (leg.positionEffect === 'open') {
         console.log(`  [OPEN] ${leg.symbol} $${leg.strike} ${leg.contractType} ${leg.expiry?.toLocaleDateString()}`);
-        const result = await this.openPosition(leg, strategy, tradeNum, userId, entityId, db, createdBy);
+        const result = await this.openPosition(leg, strategy, tradeNum, userId, entityId, db, post, createdBy);
         results.push(result);
       }
     }
@@ -63,7 +66,7 @@ export class PositionTrackerService {
       // This handles spread closes where multiple positions close together via stock
       // settlement, and expirations where positions expire worthless.
       console.log(`  [ATOMIC CLOSE] ${closeLegs.length} legs for Trade #${tradeNum}`);
-      const spreadResult = await this.closeSpreadAtomically(closeLegs, strategy, tradeNum, userId, entityId, db, createdBy);
+      const spreadResult = await this.closeSpreadAtomically(closeLegs, strategy, tradeNum, userId, entityId, db, post, createdBy);
       results.push(...spreadResult.results);
       skipped.push(...spreadResult.skipped);
     } else {
@@ -101,6 +104,7 @@ export class PositionTrackerService {
             userId,
             entityId,
             db,
+            post,
             createdBy
           );
           results.push(result);
@@ -137,6 +141,7 @@ export class PositionTrackerService {
     userId: string,
     entityId: string,
     db: TransactionContext,
+    post: PostEntry,
     createdBy?: string
   ) {
     const TRADING_CASH = '1010';
@@ -166,7 +171,7 @@ export class PositionTrackerService {
       date: leg.date,
       description: `OPEN ${positionType}: ${leg.symbol} ${leg.strike} ${leg.contractType?.toUpperCase()} ${leg.expiry?.toLocaleDateString()}`,
       lines, externalTransactionId: leg.id, strategy, tradeNum, amount: costBasis,
-      userId, entityId, db, createdBy
+      userId, entityId, db, post, createdBy
     });
     await db.trading_positions.create({
       data: {
@@ -186,6 +191,7 @@ export class PositionTrackerService {
     userId: string,
     entityId: string,
     db: TransactionContext,
+    post: PostEntry,
     createdBy?: string
   ) {
     const TRADING_CASH = '1010';
@@ -301,7 +307,7 @@ export class PositionTrackerService {
       date: leg.date,
       description: `${isFullClose ? 'CLOSE' : 'PARTIAL CLOSE'} ${openPosition.position_type}: ${closeQty}x ${leg.symbol} ${leg.strike} ${leg.contractType?.toUpperCase()} - ${isGain ? 'GAIN' : 'LOSS'} $${(Math.abs(realizedPL) / 100).toFixed(2)}`,
       lines, externalTransactionId: leg.id, strategy, tradeNum, amount: proceeds,
-      userId, entityId, db, createdBy
+      userId, entityId, db, post, createdBy
     });
 
     // Update position with new remaining quantity
@@ -363,6 +369,7 @@ export class PositionTrackerService {
     userId: string,
     entityId: string,
     db: TransactionContext,
+    post: PostEntry,
     createdBy?: string
   ): Promise<{ results: any[]; skipped: any[] }> {
     const TRADING_CASH = '1010';
@@ -482,6 +489,7 @@ export class PositionTrackerService {
       userId,
       entityId,
       db,
+      post,
       createdBy
     });
 
@@ -583,9 +591,9 @@ export class PositionTrackerService {
     date: Date; description: string;
     lines: Array<{ accountCode: string; amount: number; entryType: 'D' | 'C' }>;
     externalTransactionId?: string; strategy?: string; tradeNum?: string; amount?: number;
-    userId: string; entityId: string; db: TransactionContext; requestId?: string; createdBy?: string;
+    userId: string; entityId: string; db: TransactionContext; post: PostEntry; requestId?: string; createdBy?: string;
   }) {
-    const { date, description, lines, externalTransactionId, strategy, tradeNum, userId, entityId, db, requestId, createdBy } = params;
+    const { date, description, lines, externalTransactionId, strategy, tradeNum, userId, entityId, db, post, requestId, createdBy } = params;
     const debits = lines.filter(l => l.entryType === 'D').reduce((sum, l) => sum + l.amount, 0);
     const credits = lines.filter(l => l.entryType === 'C').reduce((sum, l) => sum + l.amount, 0);
     if (debits !== credits) throw new Error(`Unbalanced entry: debits=${debits} credits=${credits}`);
@@ -598,9 +606,10 @@ export class PositionTrackerService {
       throw new ValidationError(`Account codes not found: ${missing.join(', ')}`);
     }
 
-    // Create journal entry
-    const journalEntry = await db.journal_entries.create({
-      data: {
+    // HYG-04: the entry, its lines (one statement) and the balance moves go
+    // through postJournal's `post`; the id is read back after commit.
+    const posted = await post({
+      entry: {
         userId,
         entity_id: entityId,
         date,
@@ -611,32 +620,21 @@ export class PositionTrackerService {
         metadata: (strategy || tradeNum) ? { strategy, trade_num: tradeNum } : undefined,
         request_id: requestId || randomUUID(),
         created_by: createdBy || null,
-      }
+      },
+      lines: lines.map((line) => {
+        const account = accounts.find(a => a.code === line.accountCode)!;
+        const amount = BigInt(line.amount);
+        return {
+          account_id: account.id,
+          entry_type: line.entryType,
+          amount,
+          balanceDelta: line.entryType === account.balance_type ? amount : -amount,
+          created_by: createdBy || null,
+        };
+      }),
     });
 
-    // Create ledger entries and update account balances
-    for (const line of lines) {
-      const account = accounts.find(a => a.code === line.accountCode)!;
-      await db.ledger_entries.create({
-        data: {
-          journal_entry_id: journalEntry.id,
-          account_id: account.id,
-          amount: BigInt(line.amount),
-          entry_type: line.entryType,
-          created_by: createdBy || null,
-        }
-      });
-      const balanceChange = line.entryType === account.balance_type ? BigInt(line.amount) : BigInt(-line.amount);
-      await db.chart_of_accounts.update({
-        where: { id: account.id },
-        data: {
-          settled_balance: { increment: balanceChange },
-          version: { increment: 1 }
-        }
-      });
-    }
-
-    return journalEntry;
+    return { id: posted.id };
   }
 
   async handleAssignmentExercise(params: {
@@ -668,24 +666,29 @@ export class PositionTrackerService {
       lines.push({ accountCode: positionAccount, amount: originalCost, entryType: 'D' });
       lines.push({ accountCode: plAccount, amount: originalCost, entryType: 'C' });
     }
-    const journalEntry = await this.createJournalEntry({
-      date: exerciseTransfer.date,
-      description: `${isExercise ? 'EXERCISE' : 'ASSIGNMENT'}: ${symbol} $${strike} ${openPosition.option_type}`,
-      lines, externalTransactionId: exerciseTransfer.id, strategy, tradeNum, amount: originalCost,
-      userId, entityId, db: prisma, createdBy
+    // HYG-04: the entry and the position/transaction updates land in ONE
+    // postJournal transaction (they ran outside any transaction before).
+    const { result } = await postJournal(prisma, async (tx, post) => {
+      const journalEntry = await this.createJournalEntry({
+        date: exerciseTransfer.date,
+        description: `${isExercise ? 'EXERCISE' : 'ASSIGNMENT'}: ${symbol} $${strike} ${openPosition.option_type}`,
+        lines, externalTransactionId: exerciseTransfer.id, strategy, tradeNum, amount: originalCost,
+        userId, entityId, db: tx, post, createdBy
+      });
+      await tx.trading_positions.update({
+        where: { id: openPosition.id },
+        data: { status: 'CLOSED', close_investment_txn_id: exerciseTransfer.id,
+          close_date: exerciseTransfer.date, realized_pl: realizedPL / 100 }
+      });
+      await tx.investment_transactions.update({
+        where: { id: exerciseTransfer.id }, data: { strategy, tradeNum, accountCode: plAccount }
+      });
+      await tx.investment_transactions.update({
+        where: { id: stockTransaction.id }, data: { strategy, tradeNum, accountCode: '1100' }
+      });
+      return { type: isExercise ? 'EXERCISE' : 'ASSIGNMENT', symbol, strike, journalId: journalEntry.id, realizedPL };
     });
-    await prisma.trading_positions.update({
-      where: { id: openPosition.id },
-      data: { status: 'CLOSED', close_investment_txn_id: exerciseTransfer.id,
-        close_date: exerciseTransfer.date, realized_pl: realizedPL / 100 }
-    });
-    await prisma.investment_transactions.update({
-      where: { id: exerciseTransfer.id }, data: { strategy, tradeNum, accountCode: plAccount }
-    });
-    await prisma.investment_transactions.update({
-      where: { id: stockTransaction.id }, data: { strategy, tradeNum, accountCode: '1100' }
-    });
-    return { type: isExercise ? 'EXERCISE' : 'ASSIGNMENT', symbol, strike, journalId: journalEntry.id, realizedPL };
+    return result;
   }
 
   // Commit stock purchases as lots with journal entries
@@ -704,11 +707,13 @@ export class PositionTrackerService {
     tradeNum: string;
     userId: string;
     entityId: string;
-    tx?: TransactionContext;
+    tx: TransactionContext;
+    /** HYG-04: every journal entry goes through postJournal's `post` — the caller opened the transaction with postJournal. */
+    post: PostEntry;
     createdBy?: string;
   }) {
-    const { legs, strategy, tradeNum, userId, entityId, tx, createdBy } = params;
-    const db = tx || prisma;
+    const { legs, strategy, tradeNum, userId, entityId, tx, post, createdBy } = params;
+    const db = tx;
     const results = [];
     const TRADING_CASH = '1010';
     const STOCK_POSITION = '1100';
@@ -746,7 +751,7 @@ export class PositionTrackerService {
           strategy,
           tradeNum,
           amount: costBasis,
-          userId, entityId, db, createdBy
+          userId, entityId, db, post, createdBy
         });
 
         // Update investment transaction

--- a/src/lib/posting/postJournal.ts
+++ b/src/lib/posting/postJournal.ts
@@ -1,0 +1,177 @@
+import { randomUUID } from 'crypto';
+import type { Prisma, PrismaClient } from '@prisma/client';
+import { ValidationError } from '@/lib/errors/ValidationError';
+
+/**
+ * HYG-04 — NO POSTING PATH MAY REPORT SUCCESS ON A ROLLED-BACK WRITE.
+ *
+ * The ledger's balance check is a DEFERRABLE INITIALLY DEFERRED constraint
+ * trigger (prisma/migrations/20260226000500_fix_balance_trigger_deferred): it
+ * fires at COMMIT. Prisma's interactive $transaction resolves through a
+ * commit-time refusal without throwing (prisma/prisma#26366 — "the
+ * transaction is rolled back but no JavaScript error is thrown"; reproduced
+ * on this repo's Prisma 5.22 in the COA-01 / HYG-04 probes), so every path
+ * that posted through $transaction could return 200 on nothing.
+ *
+ * ONE discipline, carried here and nowhere else:
+ *   1. `SET CONSTRAINTS ALL IMMEDIATE` is the FIRST statement of the
+ *      transaction — the balance check fires at write time and throws inside
+ *      the transaction, where Prisma reports it. In immediate mode the row
+ *      trigger runs at the end of the STATEMENT that inserted the row, so an
+ *      entry's lines go in as ONE createMany (two separate INSERTs would be
+ *      refused after the first — probe case B);
+ *   2. after COMMIT, every posted entry id is READ BACK; an id that is not
+ *      there is a PostingNotLandedError — never a success.
+ *
+ * `postJournal(client, body)` opens the transaction, hands the body a `post`
+ * that writes one entry (journal row + lines in one statement + the balance
+ * increments the caller computed) and records its id, runs the body's other
+ * writes in the same transaction, commits, reads back, and only then returns.
+ * The build's posting law (scripts/assert-tool-registry.ts) fails if a
+ * journal or ledger row is created anywhere else in src/.
+ */
+
+export type PostingTx = Prisma.TransactionClient;
+
+export interface JournalEntryInput {
+  userId: string;
+  entity_id: string;
+  date: Date;
+  description: string;
+  source_type: string;
+  source_id?: string | null;
+  status?: string;
+  is_reversal?: boolean;
+  reverses_entry_id?: string | null;
+  request_id?: string | null;
+  created_by?: string | null;
+  vendor_id?: string | null;
+  metadata?: Prisma.InputJsonValue;
+}
+
+export interface JournalLineInput {
+  account_id: string;
+  entry_type: 'D' | 'C';
+  /** Cents, positive. */
+  amount: bigint;
+  /** What this line does to chart_of_accounts.settled_balance — the caller's rule (balanceDeltaOf). */
+  balanceDelta: bigint;
+  created_by?: string | null;
+}
+
+export interface PostedEntry {
+  id: string;
+  /** One id per line, in the order given. */
+  lineIds: string[];
+}
+
+export interface PostEntryInput {
+  entry: JournalEntryInput;
+  lines: JournalLineInput[];
+}
+
+/** The one write a posting path makes: journal row + its lines + the balance moves, inside postJournal's transaction. */
+export type PostEntry = (input: PostEntryInput) => Promise<PostedEntry>;
+
+export interface PostJournalResult<T> {
+  result: T;
+  /** Every entry `post` wrote in this transaction, each read back after commit. */
+  journalEntryIds: string[];
+}
+
+export type PostJournalOptions = { maxWait?: number; timeout?: number };
+
+/** The transaction committed on the client's side, but the entry is not in the database: a commit-time refusal Prisma did not surface. */
+export class PostingNotLandedError extends Error {
+  readonly journalEntryIds: string[];
+  constructor(missing: string[]) {
+    super(`posting not landed: journal entr${missing.length === 1 ? 'y' : 'ies'} ${missing.join(', ')} absent after commit — the database refused the transaction at commit and nothing was written`);
+    this.name = 'PostingNotLandedError';
+    this.journalEntryIds = missing;
+  }
+}
+
+/** The balance rule every writer uses: an entry of the account's own normal side adds, the other side subtracts. */
+export function balanceDeltaOf(entryType: 'D' | 'C', accountBalanceType: string, amount: bigint): bigint {
+  return entryType === accountBalanceType ? amount : -amount;
+}
+
+/** Structural checks before any write — the balance itself is the database's word (the trigger), not duplicated here. */
+function assertLines(lines: JournalLineInput[]): void {
+  if (lines.length < 2) throw new ValidationError('a journal entry needs at least two lines', { field: 'lines' });
+  for (const l of lines) {
+    if (l.entry_type !== 'D' && l.entry_type !== 'C') throw new ValidationError(`line entry_type must be D or C, got ${String(l.entry_type)}`, { field: 'lines' });
+    if (typeof l.amount !== 'bigint' || l.amount <= BigInt(0)) throw new ValidationError('line amount must be a positive number of cents', { field: 'lines' });
+    if (typeof l.balanceDelta !== 'bigint') throw new ValidationError('line balanceDelta must be cents', { field: 'lines' });
+    if (!l.account_id) throw new ValidationError('line account_id is required', { field: 'lines' });
+  }
+}
+
+type Client = Pick<PrismaClient, '$transaction' | 'journal_entries'>;
+
+export async function postJournal<T>(
+  client: Client,
+  body: (tx: PostingTx, post: PostEntry) => Promise<T>,
+  options: PostJournalOptions = {},
+): Promise<PostJournalResult<T>> {
+  const posted: string[] = [];
+
+  const result = await client.$transaction(async (tx) => {
+    // 1. The FIRST statement: the deferred balance trigger fires at write time from here on.
+    await tx.$executeRawUnsafe('SET CONSTRAINTS ALL IMMEDIATE');
+
+    const post: PostEntry = async ({ entry, lines }) => {
+      assertLines(lines);
+      const je = await tx.journal_entries.create({
+        data: {
+          userId: entry.userId,
+          entity_id: entry.entity_id,
+          date: entry.date,
+          description: entry.description,
+          source_type: entry.source_type,
+          source_id: entry.source_id ?? null,
+          status: entry.status ?? 'posted',
+          is_reversal: entry.is_reversal ?? false,
+          reverses_entry_id: entry.reverses_entry_id ?? null,
+          request_id: entry.request_id ?? null,
+          created_by: entry.created_by ?? null,
+          vendor_id: entry.vendor_id ?? null,
+          metadata: entry.metadata,
+        },
+        select: { id: true },
+      });
+      const lineIds = lines.map(() => randomUUID());
+      // ONE statement for every line: the immediate row trigger checks the whole entry at the end of it.
+      await tx.ledger_entries.createMany({
+        data: lines.map((l, i) => ({
+          id: lineIds[i],
+          journal_entry_id: je.id,
+          account_id: l.account_id,
+          entry_type: l.entry_type,
+          amount: l.amount,
+          created_by: l.created_by ?? entry.created_by ?? null,
+        })),
+      });
+      for (const l of lines) {
+        await tx.chart_of_accounts.update({
+          where: { id: l.account_id },
+          data: { settled_balance: { increment: l.balanceDelta }, version: { increment: 1 } },
+        });
+      }
+      posted.push(je.id);
+      return { id: je.id, lineIds };
+    };
+
+    return body(tx, post);
+  }, options);
+
+  // 2. READ-BACK: success is claimed from the rows, never from the transaction's promise.
+  if (posted.length > 0) {
+    const found = await client.journal_entries.findMany({ where: { id: { in: posted } }, select: { id: true } });
+    const seen = new Set(found.map((r) => r.id));
+    const missing = posted.filter((id) => !seen.has(id));
+    if (missing.length > 0) throw new PostingNotLandedError(missing);
+  }
+
+  return { result, journalEntryIds: posted };
+}


### PR DESCRIPTION
**Do not merge — Alex merges after Vercel Preview (SOC 2 gate).**

## HARD GATE items (read first)

| # | What | Where | Why it needs Alex's eyes |
|---|---|---|---|
| 1 | **Every path that writes user financial data changes shape** — 13 files now post through one helper. Each path's entry data, lines, balance deltas, guards (idempotency, period close, ownership) and follow-up writes were carried over one by one; the probes below post through the real bindings on a throwaway Postgres with the real triggers. | `src/lib/posting/postJournal.ts` + the 13 files in the table below | The blast radius is the whole ledger. Nothing is written differently, only through one door — but that door is new. |
| 2 | **Two behavior changes, both corrections, declared:** (a) `POST /api/journal-entries` (the non-manual route) used a nested `ledger_entries: { create }` and **never moved `settled_balance`** (`journal-entries/route.ts:95-120` on main) — through `post` its lines now move balances like every other writer; (b) `POST /api/year-end-close` with nothing to close used to write an **empty** closing entry (no lines, so the balance trigger never fired) — it now answers 409 "Nothing to close for {year}" and writes nothing. | `src/app/api/journal-entries/route.ts`, `src/app/api/year-end-close/route.ts` | Both are the discipline applied honestly; neither invents data. |
| 3 | **`SET CONSTRAINTS ALL IMMEDIATE` is issued inside every posting transaction.** It changes the timing of the DB's own balance check from COMMIT to the statement that inserts the lines — for that transaction only; the trigger's definition on Azure is untouched (probe case E). No other deferrable constraint exists in the migrations (`grep DEFERRABLE prisma/migrations` → only the balance trigger). | `postJournal.ts:110` | No migration. Nothing runs on Azure. |
| 4 | **No schema, no migration, no new env, no paid call.** | — | — |

## The finding (why this PR exists)

The ledger's balance check is a `DEFERRABLE INITIALLY DEFERRED` **constraint trigger** — it fires at COMMIT. Prisma's interactive `$transaction` resolves through a commit-time refusal **without throwing**; the database rolls the transaction back and the caller gets its return value. Every posting path used `$transaction`, so every one could answer 200 on nothing.

- **Prisma:** [prisma/prisma#26366](https://github.com/prisma/prisma/issues/26366) — "Prisma doesn't throw an error when Postgres deferred exclusion constraint is violated in interactive transaction": *"the transaction is rolled back but no JavaScript error is thrown"*; a `prisma:error transaction failed to commit` appears in the logs only; batch transactions throw. Open, `kind/bug`, `topic: interactiveTransactions`, reported on 6.2.1; this repo runs `@prisma/client ^5.22.0` (`package.json:23`) and shows the same behavior (fetched as reference data; the repro below is the evidence).
- **Reproduced here** (throwaway Postgres 16 from `schema.prisma` + the triggers of `20260226000100`, `20260226000500`, `20260227000100`), case **A**: deferred trigger, two INSERTs, unbalanced → `threw: null`, `landed: { je: 0, lines: 0 }`.

## Audit (read-only, against `origin/main` = `038ae6f7`)

**The triggers.** `prisma/migrations/20250930_double_entry_foundation/migration.sql:43-78` created `no_ledger_updates` (BEFORE UPDATE/DELETE, refuses) and `check_transaction_balance` (AFTER INSERT FOR EACH ROW, immediate — every first line of an entry was refused, hence:) → `20260226000100_reconcile_triggers_baseline:9-50` recreated both on `journal_entry_id` → `20260226000500_fix_balance_trigger_deferred:10-17` made the balance check a **`CONSTRAINT TRIGGER … DEFERRABLE INITIALLY DEFERRED`** → `20260227000100_protect_journal_entries` added `protect_journal_entry_fields` (only `status` / `reversed_by_entry_id` may change) and `no_journal_entry_deletes`. The deferred trigger is the only deferrable object in the history.

**Every `$transaction` that writes journal/ledger rows** (`grep -rn '\$transaction' src` → 50 sites; the 12 that post):

| Path | Where it wrote (main) | Now |
|---|---|---|
| `journal-entry-service.ts` `commitPlaidTransaction` | `:75` tx: JE + 2 `ledger_entries.create` + links + 2 balance updates + `transactions.update` | `postJournal`; links on `lineIds[expense side]`; same guards inside |
| `journal-entry-service.ts` `reversePlaidTransaction` | `:229` tx: reversal JE + a line per original line | `postJournal`, one `post` |
| `api/journal-entries/manual` | `:70` tx: JE + per-line create + balance | `postJournal`, one `post` |
| `api/journal-entries` POST | `:95` **nested create, no transaction, no balance move** | `postJournal`, one `post`, balances move (gate 2a) |
| `api/trading/commit-to-ledger` | `:169` tx per trade: JE + 2 lines + 2 balances | `postJournal` per trade |
| `api/investment-transactions/commit-to-ledger` | `:110` tx → `positionTrackerService.commitOptionsTrade({ tx })` | `postJournal` → `commitOptionsTrade({ tx, post })` |
| `api/stock-lots` POST | `:166` tx → `commitStockTrade({ tx })` | `postJournal` → `commitStockTrade({ tx, post })` |
| `api/stock-lots/commit` | `:118` tx: dispositions + JE + 3 lines | `postJournal`; the sale's entry through `post` |
| `api/investment-transactions/uncommit` | `:42` tx: a reversal JE + lines per original | `postJournal`; one `post` per original |
| `api/year-end-close` | `:176` tx: JE + a line per account + RE line, balance check at the end | lines built first, checked, then one `post` (gate 2b) |
| `api/admin/fix-entity-assignment` | `:91` tx per txn: reversal JE + new JE | `postJournal`; two `post`s |
| `api/chart-of-accounts/reclassify` (COA-01) | `:96` tx + its own read-back | `postJournal` (the read-back is the helper's) |
| `lib/position-tracker-service.ts` `createJournalEntry` | `:602-640` JE + per-line create + balance, called by open/close/spread/stock; `handleAssignmentExercise` (`:671`) wrote **outside any transaction** with `db: prisma` | `post` threaded through every method; the assignment handler now inside one `postJournal` |
| `lib/batch-trade-processor.ts` | `:497`, `:725`, `:1370` → tracker; `:894`, `:1214`, `:1625` write JEs directly | all six through `postJournal` / `post` |

Not posting paths (checked, untouched): `closing-periods/close` (closing_periods only), `corporate-actions`, `wash-sale-service` (lots/dispositions), `trading-journal` (`trade_journal_entries` — a different table), `src/scripts/test-commit.ts` (reads).

**How Prisma surfaces a COMMIT failure:** it does not (issue above; case A). An error raised **inside** the transaction — by a statement — is surfaced as a normal query error (`PrismaClientUnknownRequestError`, Postgres `P0001` with the trigger's text), which is what the discipline relies on (cases B and D).

## Build

`src/lib/posting/postJournal.ts` — `postJournal(client, body, options)` opens the interactive transaction, issues **`SET CONSTRAINTS ALL IMMEDIATE` as its first statement**, hands the body a `post({ entry, lines })` that writes the journal row, **every line in one `createMany`** (with client-generated ids, returned in order), and the balance increments the caller computed (`balanceDeltaOf` — the rule every writer used), records each posted id, runs the body's other writes in the same transaction, commits, then **reads every posted id back** — an absent id throws `PostingNotLandedError`. Structural refusals (fewer than two lines, a non-positive amount) are `ValidationError`s before any write; the balance itself stays the database's word.

Why `createMany`: in immediate mode a row-level constraint trigger runs at the end of the **statement** that inserted the row — probe case **B** shows two sequential INSERTs refused after the first (`debits=100 credits=0`); one statement carrying both lines is checked whole (case **C**).

`scripts/assert-tool-registry.ts` — **the posting law**: a `journal_entries` / `ledger_entries` create anywhere in `src/` but `postJournal.ts` fails the build (tests excluded; a word boundary keeps `trade_journal_entries` out); `postJournal.ts` must issue `SET CONSTRAINTS ALL IMMEDIATE`, insert lines with `createMany`, and carry `PostingNotLandedError`; at least the audited 12 files must route through it.

COA-01's reclass port (`src/lib/coa/reclassify.ts` `PostingDb`) became the one-call `postEntry` — the route passes `post` in; `prismaPostingDb` is gone (a ledger write outside the helper would fail the law); the test fake (`fakeChart.ts`, not a test) implements `postEntry`; `coa.test.ts` is untouched.

## Verify

| Check | Result |
|---|---|
| `npx tsc --noEmit` | 0 errors |
| eslint, every touched file vs its main baseline | identical counts on every file (pre-existing `any`s in the tracker, the batch processor and three routes unchanged); new files 0/0 |
| `npm test` | 195/195 (189 + 6 in `postJournal.test.ts`); **every existing posting test unchanged** (`coa.test.ts` byte-identical) |
| Build with the asserts | all prior laws ✓ · **the posting law ✓ (13 files)** · `next build` exit 0 |
| README regen | byte-stable |

**Throwaway Postgres, real triggers** (`schema.prisma` + `20260226000100` + `20260226000500` + `20260227000100`; `check_transaction_balance` verified `deferrable=t initdeferred=t`):

| Case | Mechanics | Result |
|---|---|---|
| A | deferred + two INSERTs, unbalanced (main's shape) | `threw: null`, `landed: { je: 0, lines: 0 }` — the silent failure |
| B | IMMEDIATE first + two INSERTs, **balanced** | first INSERT refused: `Transaction must be balanced: debits=100 credits=0` |
| C | IMMEDIATE first + one createMany, balanced | landed `{ je: 1, lines: 2 }` |
| D | IMMEDIATE first + one createMany, unbalanced | thrown **inside** the transaction: `debits=100 credits=90`; landed `{ 0, 0 }` |
| E | after the transaction | trigger definition unchanged (`tginitdeferred=t`) |

**Through the helper** (`postJournal` on the real binding): a balanced posting landed, balances moved (+250 / −250), the id read back and the written line ids equal the returned ones; an unbalanced posting threw inside the transaction, zero rows, zero balance change; a reversal whose follow-up write failed (`transactions.update` on a row that does not exist) left **no** reversal entry behind — the whole transaction rolled back.

**Through a route** (next dev on the throwaway DB, the real `POST /api/journal-entries/manual`, viewer holds `tab:books`): a 1-cent-unbalanced entry — it passes the route's own `> 1` guard — answered **the HYG-01 envelope** `{"ok":false,"stage":"Manual journal entry","error":"Failed to create journal entry","message":"Failed to create journal entry"}` **HTTP 500**, the server log carries the trigger's `P0001 … debits=100 credits=99`, and the ledger row count did not move; a balanced entry answered `{"success":true,"journalEntryId":…}` HTTP 200 and its two lines are in the table.

## Findings outside this PR's fence (reported, not fixed)

1. `api/journal-entries/manual/route.ts:41` accepts up to a 1-cent imbalance (`> 1`) before posting — the DB now refuses it loudly (500), but the route's own guard should be `!== 0` (a one-line follow-up).
2. `api/journal-entries/route.ts` still types its lines as `any` and lets a line with both `debit` and `credit` empty through to the helper's "positive number of cents" refusal (400) — its own validation is a separate cleanup.
3. Prisma's issue #26366 is open; when the client is upgraded, the read-back stays — it is the proof, not a workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc

---
_Generated by [Claude Code](https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc)_