### PR TITLE
SELL-03b: non-enumerating, truthful sign-up — email verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Twenty-five business tools on one data pipe that ends in one Ledger and one Calendar.
 
-Source-available (BSL 1.1) · built and operated in production by its founder as User #1 · as of 2026-09-02: 115 Prisma models, 290 API route files, 121 feeds from 20 providers (counted August 24, 2026)
+Source-available (BSL 1.1) · built and operated in production by its founder as User #1 · as of 2026-09-02: 116 Prisma models, 292 API route files, 121 feeds from 20 providers (counted August 24, 2026)
 
 ## The system
 
@@ -283,15 +283,15 @@ BLUEPRINT is the step's headline; TODAY is the deck's honest-state line, verbati
 
 | Module | What exists in code |
 |---|---|
-| Travel | stays and flights through LiteAPI, activities through Viator, visa checks through RapidAPI — public routes under src/app/api/travel (15 route files) and src/app/api/flights (3); models `trips` (schema:629) and `reservations` (schema:1385). |
-| Runway | the reservation matcher — src/app/api/runway/match/propose, queue, review (the step-9 piece alive today) — plus src/app/api/runway/route.ts; models `budgets` (schema:599) and `home_expenses` (schema:1639). |
+| Travel | stays and flights through LiteAPI, activities through Viator, visa checks through RapidAPI — public routes under src/app/api/travel (15 route files) and src/app/api/flights (3); models `trips` (schema:653) and `reservations` (schema:1409). |
+| Runway | the reservation matcher — src/app/api/runway/match/propose, queue, review (the step-9 piece alive today) — plus src/app/api/runway/route.ts; models `budgets` (schema:623) and `home_expenses` (schema:1663). |
 | Books | Plaid-synced transactions, a chart of accounts, journal and ledger entries — the one Plaid writer, src/app/api/transactions/sync-complete/route.ts, writes `transactions` (schema:460) through src/lib/arrivals/plaidTransactionsPage.ts:114; `journal_entries` (schema:186), `ledger_entries` (schema:225). |
-| Trade | tastytrade connection, quotes and backtests — src/app/api/tastytrade (13 route files); models `trade_cards` (schema:1770) and `scan_snapshots` (schema:1956). |
-| Tax | scenarios, documents and the 2025 export script (`npm run tax:export:2025`) — src/app/api/tax (7 route files); models `tax_scenarios` (schema:1559) and `tax_documents` (schema:1878). |
-| Compliance | the regulatory corpus (eCFR, US Code, Federal Register, IRS bulletins) ingested by Inngest functions with sha256 on write, citations re-verified, and the hash-chained audit log — models `regulatory_sources` (schema:2269), `citations` (schema:2333), `audit_log` (schema:2499). |
-| Routines | scheduled routines evaluated by the `routine-evaluator` Inngest function — models `operations_routines` (schema:3153) and `hub_scheduled_items` (schema:3259); the deck calls the calendar window live in the cockpit (step 12 honest line). |
-| Projects | projects and tasks; accepting a pending task fires the Execute-Task Routine (src/app/api/operations/projects/[id]/tasks/[taskId]/route.ts:395-405) — models `operations_projects` (schema:2977) and `operations_project_tasks` (schema:3022). |
-| Content | scene groups, scenes, pieces and takes — model `operations_content_pieces` (schema:3386); src/app/api/operations carries 50 route files across Routines, Projects and Content. |
+| Trade | tastytrade connection, quotes and backtests — src/app/api/tastytrade (13 route files); models `trade_cards` (schema:1794) and `scan_snapshots` (schema:1980). |
+| Tax | scenarios, documents and the 2025 export script (`npm run tax:export:2025`) — src/app/api/tax (7 route files); models `tax_scenarios` (schema:1583) and `tax_documents` (schema:1902). |
+| Compliance | the regulatory corpus (eCFR, US Code, Federal Register, IRS bulletins) ingested by Inngest functions with sha256 on write, citations re-verified, and the hash-chained audit log — models `regulatory_sources` (schema:2293), `citations` (schema:2357), `audit_log` (schema:2523). |
+| Routines | scheduled routines evaluated by the `routine-evaluator` Inngest function — models `operations_routines` (schema:3177) and `hub_scheduled_items` (schema:3283); the deck calls the calendar window live in the cockpit (step 12 honest line). |
+| Projects | projects and tasks; accepting a pending task fires the Execute-Task Routine (src/app/api/operations/projects/[id]/tasks/[taskId]/route.ts:395-405) — models `operations_projects` (schema:3001) and `operations_project_tasks` (schema:3046). |
+| Content | scene groups, scenes, pieces and takes — model `operations_content_pieces` (schema:3410); src/app/api/operations carries 50 route files across Routines, Projects and Content. |
 
 ## Architecture
 
@@ -310,7 +310,7 @@ Versions from package.json, read 2026-09-02:
 
 Observed versus authored (step 6): what the world sends is observed; what you do is authored; the blueprint keeps the two apart and matches them on one key. Today the Plaid feeds land word for word, fingerprinted — 9,092 transactions, 712 investment transactions, 247 securities, counted September 7, 2026; the other providers still land parsed — see the gap ledger, step 14.
 
-Scale, as of 2026-09-02: 115 Prisma models, 34 enums, 290 API route files, 37 runtime dependencies, 18 dev dependencies, one test file (`npm test`).
+Scale, as of 2026-09-02: 116 Prisma models, 34 enums, 292 API route files, 37 runtime dependencies, 18 dev dependencies, one test file (`npm test`).
 
 ## Engineering discipline
 
@@ -331,7 +331,7 @@ These are the written laws in `CLAUDE.md`, stated as practice:
 - Middleware: every path not in `PUBLIC_PATHS` requires the verified cookie — `src/middleware.ts:50-160, 162, 165-170`; the two Routine callbacks (`…/audit-ingest`, `…/exec-ingest`) bypass the cookie and validate a shared-secret bearer (`AUDIT_INGEST_SECRET`, `EXEC_INGEST_SECRET`) instead — `src/middleware.ts:173-187`.
 - Route gates: `getCurrentUser` (`src/lib/auth-helpers.ts:11`), `requireTier` (`:42`), `requireAdmin` (`src/lib/require-admin.ts:8`); the working law is that a paid external call is never made before the gate (CLAUDE.md, Security-first).
 - User scoping: every query is scoped to the authed user — e.g. `where: { userId: user.id }` at `src/app/api/tastytrade/connect/route.ts:54`.
-- Rate limits: a durable fixed-window limiter backed by the `rate_limit_hits` table (`src/lib/rateLimit.ts:3-15`; schema:1370), plus `src/lib/scan-rate-limit.ts` and `src/lib/ai-rate-limit.ts`; tuned by `SEARCH_/BOOK_/SCAN_/AI_RATE_LIMIT` and `_WINDOW`, with daily caps `AI_PIPE_DAILY_CAP`, `AI_EXEC_DAILY_CAP`, `AI_ROUTINE_DAILY_CAP`, `AI_DISCOVERY_DAILY_CAP` (USD, from recorded spend — `src/lib/discovery/discoveryGate.ts`), `TRAVEL_SEARCH_DAILY_CAP`, and `GOOGLE_PLACES_MONTHLY_CAP`.
+- Rate limits: a durable fixed-window limiter backed by the `rate_limit_hits` table (`src/lib/rateLimit.ts:3-15`; schema:1394), plus `src/lib/scan-rate-limit.ts` and `src/lib/ai-rate-limit.ts`; tuned by `SEARCH_/BOOK_/SCAN_/AI_RATE_LIMIT` and `_WINDOW`, with daily caps `AI_PIPE_DAILY_CAP`, `AI_EXEC_DAILY_CAP`, `AI_ROUTINE_DAILY_CAP`, `AI_DISCOVERY_DAILY_CAP` (USD, from recorded spend — `src/lib/discovery/discoveryGate.ts`), `TRAVEL_SEARCH_DAILY_CAP`, and `GOOGLE_PLACES_MONTHLY_CAP`.
 - Audit log: a hash chain — each entry stores `prev_hash` and its own sha256 `content_hash` with a `sequence_number` (`prisma/schema.prisma:2441-2443`; written at `src/lib/audit/writeAuditLog.ts:99`); `src/lib/audit/verifyAuditChain.ts:47, 80` recomputes the chain.
 - Citations: `src/lib/citations/verifyCitation.ts:97` re-fetches the source and re-hashes it against `citations.retrieved_content_hash` (`prisma/schema.prisma:2287`); the column's only writer stores an empty string today (`src/lib/discovery/materializeProposal.ts:165`), so the check is structurally dead until the arrivals rebuild lands the real hash.
 - Corpus: the four ingest persisters hash content with sha256 on write — `src/lib/corpus/ingest/ecfr-persist.ts:28`, `uscode-persist.ts:32`, `fedreg-persist.ts:31`, `irb-persist.ts:32`.

--- a/prisma/migrations/20260909000000_email_verification/migration.sql
+++ b/prisma/migrations/20260909000000_email_verification/migration.sql
@@ -1,0 +1,32 @@
+-- SELL-03b: email verification — users.email_verified_at + the verification_tokens table.
+-- DDL generated with `prisma migrate diff` from main's schema to this branch's; the backfill
+-- at the end grandfathers every account that pre-dates verification (they were created
+-- when no verification existed — locking them out would be a lie about their history).
+
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN     "email_verified_at" TIMESTAMPTZ(6);
+
+-- CreateTable
+CREATE TABLE "verification_tokens" (
+    "id" UUID NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "token_hash" VARCHAR(64) NOT NULL,
+    "expires_at" TIMESTAMPTZ(6) NOT NULL,
+    "used_at" TIMESTAMPTZ(6),
+    "created_at" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "verification_tokens_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "verification_tokens_token_hash_key" ON "verification_tokens"("token_hash");
+
+-- CreateIndex
+CREATE INDEX "verification_tokens_user_id_idx" ON "verification_tokens"("user_id");
+
+-- AddForeignKey
+ALTER TABLE "verification_tokens" ADD CONSTRAINT "verification_tokens_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+
+-- Backfill: accounts created before verification existed count as verified at creation.
+UPDATE "users" SET "email_verified_at" = "createdAt" WHERE "email_verified_at" IS NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -559,6 +559,10 @@ model users {
   stripeCustomerId        String?
   stripeSubscriptionId    String?
   bookkeeping_initialized Boolean                  @default(false)
+  // SELL-03b: set by the verification link (or by OAuth, whose provider verified
+  // the address); NULL = the account has not finished signing in. Accounts that
+  // pre-date verification were backfilled to their createdAt in the migration.
+  email_verified_at       DateTime?                @db.Timestamptz(6)
   scanner_start_date      DateTime?
   accounts                accounts[]
   plaid_items             plaid_items[]
@@ -594,6 +598,26 @@ model users {
   transaction_reservation_links transaction_reservation_links[]
   provider_responses      provider_responses[]
   arrivals                arrivals[]
+  verification_tokens     verification_tokens[]
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// SELL-03b: EMAIL VERIFICATION TOKENS — the link's random half is stored
+// HASHED (sha256 hex); the link itself is signed (HMAC over the random half,
+// src/lib/auth/verification.ts). Single-use (used_at set once, atomically
+// with users.email_verified_at), 24h (expires_at). Cascade with the user.
+// ═══════════════════════════════════════════════════════════════════
+
+model verification_tokens {
+  id         String    @id @default(uuid()) @db.Uuid
+  user_id    String
+  token_hash String    @unique @db.VarChar(64)
+  expires_at DateTime  @db.Timestamptz(6)
+  used_at    DateTime? @db.Timestamptz(6)
+  created_at DateTime  @default(now()) @db.Timestamptz(6)
+  user       users     @relation(fields: [user_id], references: [id], onDelete: Cascade)
+
+  @@index([user_id])
 }
 
 model budgets {

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -34,7 +34,8 @@ const handler = NextAuth({
           where: { email: { equals: normalizedEmail, mode: 'insensitive' } }
         });
         if (!existingUser) {
-          // Create user in our users table
+          // Create user in our users table — SELL-03b: the provider verified
+          // the address, so the account is verified at creation.
           await prisma.users.create({
             data: {
               id: generateId(),
@@ -42,8 +43,13 @@ const handler = NextAuth({
               name: user.name || normalizedEmail.split('@')[0],
               password: '',
               updatedAt: new Date(),
+              email_verified_at: new Date(),
             }
           });
+        } else if (!existingUser.email_verified_at) {
+          // SELL-03b: an email-signup that never used its link, now signing in
+          // through a provider that verified the same address — verified.
+          await prisma.users.update({ where: { id: existingUser.id }, data: { email_verified_at: new Date() } });
         }
 
         // Set the userEmail cookie for API routes

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -3,6 +3,23 @@ import bcrypt from 'bcryptjs';
 import { prisma } from '@/lib/prisma';
 import { signCookie } from '@/lib/cookie-auth';
 import { rateLimit, RateLimitError } from '@/lib/rateLimit';
+import { loginDecision, LOGIN_FAILED } from '@/lib/auth/verification';
+import { SIGNUP_LANDING } from '@/lib/auth/registration';
+
+/**
+ * POST /api/auth/login — SELL-03b: an account that never verified its email
+ * fails with the SAME line as a wrong password or no account at all
+ * (loginDecision — one frozen refusal), and bcrypt runs whether or not the
+ * account exists or is verified, so the timing does not tell either. A
+ * success names the one front door (landing: /answers).
+ */
+
+// A real bcrypt hash (cost 12) of a dummy password: compared against when no
+// account exists — or when the account carries no bcrypt hash (an OAuth
+// account stores password '', and bcryptjs answers a non-60-char hash
+// instantly) — so every refused path costs what the wrong-password path costs.
+const DUMMY_HASH = '$2a$12$uZy16vsU.8dLcGuGbFdbZedJ5NhjA/7VwAT2QYdXPogo6FTfczA82';
+const BCRYPT_HASH_LENGTH = 60;
 
 export async function POST(request: Request) {
   try {
@@ -19,7 +36,7 @@ export async function POST(request: Request) {
 
     if (!email || !password) {
       return NextResponse.json(
-        { error: 'Invalid email or password' },
+        { error: LOGIN_FAILED },
         { status: 401 }
       );
     }
@@ -32,24 +49,22 @@ export async function POST(request: Request) {
       }
     });
 
-    if (!user) {
-      return NextResponse.json(
-        { error: 'Invalid email or password' },
-        { status: 401 }
-      );
-    }
+    // The same cost on every path: compare against the account's bcrypt hash, or the dummy when
+    // there is no account or no hash (an OAuth account can never sign in with a password).
+    const storedHash = user && user.password.length === BCRYPT_HASH_LENGTH ? user.password : DUMMY_HASH;
+    const passwordOk = (await bcrypt.compare(password, storedHash)) && storedHash !== DUMMY_HASH;
+    const decision = loginDecision({ user, passwordOk });
 
-    const isValid = await bcrypt.compare(password, user.password);
-
-    if (!isValid) {
+    if (!decision.ok || !user) {
       return NextResponse.json(
-        { error: 'Invalid email or password' },
+        { error: LOGIN_FAILED },
         { status: 401 }
       );
     }
 
     const response = NextResponse.json({
       success: true,
+      landing: SIGNUP_LANDING,
       user: { email: user.email, name: user.name }
     });
 

--- a/src/app/api/auth/verify/resend/route.ts
+++ b/src/app/api/auth/verify/resend/route.ts
@@ -1,27 +1,20 @@
-import { randomUUID } from 'crypto';
 import { NextResponse } from 'next/server';
 import bcrypt from 'bcryptjs';
 import { prisma } from '@/lib/prisma';
 import { rateLimit, RateLimitError } from '@/lib/rateLimit';
 import { failClosedResponse } from '@/lib/http/failClosedResponse';
-import { mintToken, signupOutcome } from '@/lib/auth/verification';
+import { mintToken, resendOutcome } from '@/lib/auth/verification';
 import { prismaVerifyDb, verificationSecret } from '@/lib/auth/prismaVerifyDb';
 import { sendAuthMail } from '@/lib/auth/welcomeEmail';
 
 /**
- * POST /api/auth/signup — THE register route (SELL-03), NON-ENUMERATING
- * (SELL-03b): a new and a taken email get the SAME bytes back — 200
- * { message: "Check your email to finish signing in." }, no cookie, no
- * header that differs — and the same work: one bcrypt hash (a dummy on the
- * taken path), one mail. The difference is in the mail only: a verification
- * link (signed, single-use, 24h, stored hashed) for a new address; "someone
- * tried to sign up with your address" for a taken one. Nothing is signed in
- * until the link is used (GET /api/auth/verify).
- *
- * Order: per-IP rate limit (SEC-5, unchanged: 5/hour) → the input rules
- * (src/lib/auth/registration.ts — about the INPUT, so a refusal says nothing
- * about any account) → signupOutcome. A mail failure is logged, never in the
- * body. A fault is the fixed failClosed line.
+ * POST /api/auth/verify/resend { email } — SELL-03b: a fresh verification
+ * link for an account that never verified. NON-ENUMERATING: an unknown
+ * address, a verified account and an unverified one all get the same bytes
+ * back (200 { message: "If an account is waiting to be verified, a new link
+ * is on its way." }) and the same bcrypt-cost work; only the unverified path
+ * mints, stores and sends. Tighter per-IP limit than sign-up (3/hour) — the
+ * one thing this route can do is send mail.
  */
 export async function POST(request: Request) {
   try {
@@ -29,24 +22,18 @@ export async function POST(request: Request) {
       request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
       request.headers.get('x-real-ip') ||
       'unknown';
-    await rateLimit(`auth-signup:${ip}`, { limit: 5, windowSeconds: 3600 });
+    await rateLimit(`auth-resend:${ip}`, { limit: 3, windowSeconds: 3600 });
 
     const body = await request.json().catch(() => ({}));
     const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
     const secret = verificationSecret();
     const store = prismaVerifyDb(prisma);
 
-    const { response } = await signupOutcome(
+    const { response } = await resendOutcome(
       {
         findUserByEmail: (email) =>
           prisma.users.findFirst({ where: { email: { equals: email, mode: 'insensitive' } }, select: { id: true, email: true, name: true, email_verified_at: true } }),
         hashPassword: (password) => bcrypt.hash(password, 12),
-        newId: () => randomUUID(),
-        createUser: (u) =>
-          prisma.users.create({
-            data: { id: u.id, email: u.email, password: u.password, name: u.name, tier: 'free', updatedAt: new Date() },
-            select: { id: true, email: true, name: true },
-          }),
         mintToken: () => mintToken(secret),
         storeToken: (row) => store.storeToken(row),
         verifyUrl: (token) => `${baseUrl}/api/auth/verify?token=${encodeURIComponent(token)}`,
@@ -63,6 +50,6 @@ export async function POST(request: Request) {
         { status: 429, headers: { 'Retry-After': String(error.retryAfterSeconds) } }
       );
     }
-    return failClosedResponse('Signup', 'Failed to create account', error);
+    return failClosedResponse('Resend verification', 'Failed to resend the link', error);
   }
 }

--- a/src/app/api/auth/verify/route.ts
+++ b/src/app/api/auth/verify/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { signCookie } from '@/lib/cookie-auth';
+import { rateLimit, RateLimitError } from '@/lib/rateLimit';
+import { failClosedResponse } from '@/lib/http/failClosedResponse';
+import { verifyToken } from '@/lib/auth/verification';
+import { prismaVerifyDb, verificationSecret } from '@/lib/auth/prismaVerifyDb';
+import { SIGNUP_LANDING } from '@/lib/auth/registration';
+
+/**
+ * GET /api/auth/verify?token=… — SELL-03b: the verification link.
+ *
+ * A good link (our signature, a stored hash, unused, unexpired) is consumed
+ * ONCE — used_at and users.email_verified_at set in one transaction — then
+ * the HMAC userEmail cookie is set (login's flags) and the viewer lands on
+ * the one front door, /answers. An expired, used or foreign link lands on
+ * '/' with ?verify=<state>, where the deck renders the declared error and a
+ * resend form (VerifyResultBanner). Per-IP rate-limited (a 256-bit random
+ * half makes guessing hopeless; the limit keeps it cheap to refuse).
+ */
+export async function GET(request: Request) {
+  try {
+    const ip =
+      request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
+      request.headers.get('x-real-ip') ||
+      'unknown';
+    await rateLimit(`auth-verify:${ip}`, { limit: 20, windowSeconds: 300 });
+
+    const raw = new URL(request.url).searchParams.get('token');
+    const outcome = await verifyToken(prismaVerifyDb(prisma), verificationSecret(), raw);
+
+    if (!outcome.ok) {
+      return NextResponse.redirect(new URL(`/?verify=${outcome.state}`, request.url), 303);
+    }
+
+    const response = NextResponse.redirect(new URL(SIGNUP_LANDING, request.url), 303);
+    response.cookies.set('userEmail', signCookie(outcome.email), {
+      httpOnly: true,
+      secure: true,
+      sameSite: 'lax',
+      maxAge: 60 * 60 * 24 * 7, // 7 days
+      path: '/',
+    });
+    return response;
+  } catch (error) {
+    if (error instanceof RateLimitError) {
+      return NextResponse.json(
+        { error: 'Too many attempts — please try again later.' },
+        { status: 429, headers: { 'Retry-After': String(error.retryAfterSeconds) } }
+      );
+    }
+    return failClosedResponse('Verify', 'Failed to verify the link', error);
+  }
+}

--- a/src/app/developer/page.tsx
+++ b/src/app/developer/page.tsx
@@ -101,11 +101,14 @@ export default function DeveloperDashboard() {
 
       const data = await response.json();
 
-      if (response.ok) {
-        // SELL-03: the server's own line and the one front door.
+      if (response.ok && isLogin) {
+        // SELL-03: the one front door.
         const landing = typeof data?.landing === 'string' ? data.landing : ANSWERS_HOME;
-        setMessage(`${typeof data?.message === 'string' ? data.message : 'Signed in'} — opening ${landing}`);
+        setMessage(`Signed in — opening ${landing}`);
         setTimeout(() => { window.location.href = landing; }, 800);
+      } else if (response.ok) {
+        // SELL-03b: a sign-up answers the same line for every address; the link in the mail signs in.
+        setMessage(typeof data?.message === 'string' ? data.message : 'Check your email to finish signing in.');
       } else {
         setMessage(data.error || 'Something went wrong');
       }

--- a/src/components/LoginBox.tsx
+++ b/src/components/LoginBox.tsx
@@ -4,34 +4,40 @@ import { useState } from 'react';
 import { signIn } from 'next-auth/react';
 import { ANSWERS_HOME } from '@/lib/answers';
 import { PASSWORD_MIN_LENGTH } from '@/lib/auth/registration';
+import { TOKEN_TTL_HOURS } from '@/lib/auth/verification';
 
 /**
- * SELL-03 — THE sign-in / sign-up box: the deck's modal (GuestLanding), the
- * cockpit's modal (HomeClient) and the /login page all mount this one
- * component. Every completion lands on ONE front door, ANSWERS_HOME
- * (/answers): the email routes answer `landing` and the box navigates there
- * with a full page load (so the fresh cookie is honored); OAuth's callbackUrl
- * is the same door. A caller that must do something first (the purchase
- * resume — checkout for a pending module key) passes onSuccess and owns the
- * navigation; nothing else redirects anywhere else.
+ * SELL-03 / 03b — THE sign-in / sign-up box: the deck's modal (GuestLanding),
+ * the cockpit's modal (HomeClient) and the /login page all mount this one
+ * component.
+ *
+ * Sign-up is NON-ENUMERATING: the server answers the same line for every
+ * address — "Check your email to finish signing in." — and sets no cookie;
+ * the box shows that line with the address typed and stays put. The link in
+ * the mail signs in and lands on ANSWERS_HOME. "Didn't get it? Resend" posts
+ * to the resend route, whose one line is the same whatever the address.
+ *
+ * Login completions land on ONE front door, ANSWERS_HOME: the route answers
+ * `landing` and the box navigates there with a full page load (so the fresh
+ * cookie is honored); OAuth's callbackUrl is the same door. EVERY login
+ * failure shows the same line and the same resend offer — an account that
+ * never verified is refused with the wrong-password words, and the resend
+ * is the way in. A caller that must do something first (the purchase
+ * resume) passes onSuccess and owns the navigation.
  *
  * The password hint is PASSWORD_MIN_LENGTH — the number the server enforces
- * (src/lib/auth/registration.ts) — so client and server cannot disagree. A
- * refusal renders the server's own words; after sign-up the box shows the
- * server's message ("You're signed in") while the front door opens.
+ * (src/lib/auth/registration.ts) — so client and server cannot disagree.
  */
 
 export interface AuthResult {
-  mode: 'login' | 'register';
-  /** The server's own line — "You're signed in" after sign-up. */
-  message: string;
+  mode: 'login';
   /** The one front door, from the server when it names it, else ANSWERS_HOME. */
   landing: string;
 }
 
 interface LoginBoxProps {
   onClose?: () => void;
-  /** Own the completion (the purchase resume); when absent the box opens `result.landing`. */
+  /** Own a LOGIN completion (the purchase resume); when absent the box opens `result.landing`. */
   onSuccess?: (result: AuthResult) => void;
   initialMode?: 'login' | 'register';
 }
@@ -43,13 +49,16 @@ export default function LoginBox({ onClose, onSuccess, initialMode = 'login' }: 
   const [name, setName] = useState('');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
-  const [notice, setNotice] = useState('');
+  /** After a sign-up: the server's line, shown with the address; the form gives way to it. */
+  const [sentTo, setSentTo] = useState<{ email: string; message: string } | null>(null);
+  const [resendNotice, setResendNotice] = useState('');
+  const [resending, setResending] = useState(false);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setLoading(true);
     setError('');
-    setNotice('');
+    setResendNotice('');
 
     const endpoint = mode === 'login' ? '/api/auth/login' : '/api/auth/signup';
     const body = mode === 'login'
@@ -64,28 +73,57 @@ export default function LoginBox({ onClose, onSuccess, initialMode = 'login' }: 
       });
       const data = await res.json().catch(() => ({}));
 
-      if (res.ok) {
-        const result: AuthResult = {
-          mode,
-          message: typeof data?.message === 'string' ? data.message : 'Signed in',
-          landing: typeof data?.landing === 'string' && data.landing.startsWith('/') ? data.landing : ANSWERS_HOME,
-        };
-        setNotice(result.message);
-        if (onSuccess) {
-          onSuccess(result);
-        } else {
-          // A full navigation, not a client transition: the cookie the server
-          // just set must be on the request that renders the front door.
-          window.location.href = result.landing;
-        }
-        onClose?.();
-      } else {
+      if (!res.ok) {
         setError(typeof data?.error === 'string' ? data.error : `${mode === 'login' ? 'Login' : 'Registration'} failed (HTTP ${res.status})`);
         setLoading(false);
+        return;
       }
+
+      if (mode === 'register') {
+        // Nothing is signed in yet — the same line for every address; the mail carries the way in.
+        setSentTo({ email: email.trim().toLowerCase(), message: typeof data?.message === 'string' ? data.message : 'Check your email to finish signing in.' });
+        setLoading(false);
+        return;
+      }
+
+      const result: AuthResult = {
+        mode: 'login',
+        landing: typeof data?.landing === 'string' && data.landing.startsWith('/') ? data.landing : ANSWERS_HOME,
+      };
+      if (onSuccess) {
+        onSuccess(result);
+      } else {
+        // A full navigation, not a client transition: the cookie the server
+        // just set must be on the request that renders the front door.
+        window.location.href = result.landing;
+      }
+      onClose?.();
     } catch {
       setError('Something went wrong');
       setLoading(false);
+    }
+  };
+
+  /** The resend — the same request and the same one-line answer whatever the address. */
+  const resend = async (address: string) => {
+    setResending(true);
+    setResendNotice('');
+    try {
+      const res = await fetch('/api/auth/verify/resend', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: address }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setError(typeof data?.error === 'string' ? data.error : `Resend failed (HTTP ${res.status})`);
+        return;
+      }
+      setResendNotice(typeof data?.message === 'string' ? data.message : 'Sent.');
+    } catch {
+      setError('Something went wrong');
+    } finally {
+      setResending(false);
     }
   };
 
@@ -96,8 +134,49 @@ export default function LoginBox({ onClose, onSuccess, initialMode = 'login' }: 
   const switchMode = () => {
     setMode(mode === 'login' ? 'register' : 'login');
     setError('');
-    setNotice('');
+    setResendNotice('');
+    setSentTo(null);
   };
+
+  if (sentTo) {
+    return (
+      <div className="bg-white shadow-sm p-8 w-full max-w-md mx-4 border border-border" data-login-box="sent">
+        <div className="text-center mb-6">
+          <div className="flex items-center justify-center gap-2 mb-4">
+            <div className="w-8 h-8 bg-brand-purple flex items-center justify-center">
+              <span className="text-white text-xs font-bold">TS</span>
+            </div>
+            <span className="text-sm font-medium text-text-primary">Temple Stuart</span>
+          </div>
+          <h2 className="text-sm font-light text-text-primary mb-1" role="status" data-auth-notice>{sentTo.message}</h2>
+          <p className="text-text-muted text-xs">
+            We sent a link to <span className="font-mono text-text-primary" data-sent-to>{sentTo.email}</span>. It works once, for {TOKEN_TTL_HOURS} hours, and opens your answers.
+          </p>
+        </div>
+        {error && <p className="text-brand-red text-xs mb-3" role="alert" data-auth-error>{error}</p>}
+        {resendNotice && <p className="text-emerald-700 text-xs mb-3" role="status" data-resend-notice>{resendNotice}</p>}
+        <button
+          type="button"
+          disabled={resending}
+          onClick={() => resend(sentTo.email)}
+          className="w-full py-2.5 border border-border text-sm font-medium text-text-secondary hover:bg-bg-row disabled:opacity-50"
+          data-auth-resend
+        >
+          {resending ? 'Sending…' : "Didn't get it? Send a new link"}
+        </button>
+        <div className="mt-4 text-center">
+          <button type="button" onClick={() => { setSentTo(null); setMode('login'); setError(''); setResendNotice(''); }} className="text-xs text-text-muted hover:text-brand-purple transition-colors" data-auth-switch="login">
+            Already verified? Sign in
+          </button>
+        </div>
+        {onClose && (
+          <button type="button" onClick={onClose} className="mt-3 w-full text-center text-xs text-text-faint hover:text-text-secondary">
+            Close
+          </button>
+        )}
+      </div>
+    );
+  }
 
   return (
     <div className="bg-white shadow-sm p-8 w-full max-w-md mx-4 border border-border" data-login-box={mode}>
@@ -183,7 +262,7 @@ export default function LoginBox({ onClose, onSuccess, initialMode = 'login' }: 
           minLength={mode === 'register' ? PASSWORD_MIN_LENGTH : undefined}
         />
         {error && <p className="text-brand-red text-xs" role="alert" data-auth-error>{error}</p>}
-        {notice && <p className="text-emerald-700 text-xs" role="status" data-auth-notice>{notice} — opening your answers…</p>}
+        {resendNotice && <p className="text-emerald-700 text-xs" role="status" data-resend-notice>{resendNotice}</p>}
         <button
           type="submit"
           disabled={loading}
@@ -194,6 +273,18 @@ export default function LoginBox({ onClose, onSuccess, initialMode = 'login' }: 
             : (mode === 'login' ? 'Continue with Email' : 'Create Account')
           }
         </button>
+        {/* SELL-03b: on EVERY login failure, the same offer — the way in for an account that never verified. */}
+        {mode === 'login' && error && (
+          <button
+            type="button"
+            disabled={resending || !email}
+            onClick={() => resend(email.trim().toLowerCase())}
+            className="w-full py-2 text-xs text-text-muted hover:text-brand-purple disabled:opacity-50"
+            data-auth-resend
+          >
+            {resending ? 'Sending…' : "Didn't finish signing up? Send a new sign-in link"}
+          </button>
+        )}
       </form>
 
       {/* Mode Switcher — the register link on every mount, /login included */}

--- a/src/components/VerifyResultBanner.tsx
+++ b/src/components/VerifyResultBanner.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+/**
+ * SELL-03b — the verification link's DECLARED failure, on the front door.
+ * GET /api/auth/verify lands a bad link on `/?verify=expired|used|invalid`;
+ * this banner names what happened and offers the resend — a form that posts
+ * to /api/auth/verify/resend and shows that route's one line (the same words
+ * whatever the address is; the route is rate-limited and non-enumerating).
+ * useSearchParams rides inside its own <Suspense> (the Next.js requirement).
+ */
+
+import { Suspense, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+
+const LINES: Record<string, string> = {
+  expired: 'That sign-in link has expired — links last 24 hours.',
+  used: 'That sign-in link was already used — links work once.',
+  invalid: "That sign-in link isn't one we issued.",
+};
+
+function BannerInner() {
+  const params = useSearchParams();
+  const router = useRouter();
+  const state = params.get('verify');
+  const [email, setEmail] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [notice, setNotice] = useState('');
+  const [error, setError] = useState('');
+  if (!state || !LINES[state]) return null;
+
+  const dismiss = () => {
+    const next = new URLSearchParams(params.toString());
+    next.delete('verify');
+    const qs = next.toString();
+    router.replace(`${window.location.pathname}${qs ? `?${qs}` : ''}${window.location.hash}`);
+  };
+
+  const resend = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setBusy(true);
+    setNotice('');
+    setError('');
+    try {
+      const res = await fetch('/api/auth/verify/resend', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ email }) });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(typeof data?.error === 'string' ? data.error : `Resend failed (HTTP ${res.status})`);
+      setNotice(typeof data?.message === 'string' ? data.message : 'Sent.');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="mx-auto max-w-7xl px-4 pt-4 lg:px-8">
+      <div role="alert" className="rounded-lg border border-amber-300 bg-amber-50 p-3 text-xs text-amber-900" data-verify-banner={state}>
+        <div className="flex items-center justify-between gap-3">
+          <span>{LINES[state]}</span>
+          <button type="button" onClick={dismiss} aria-label="Dismiss" className="shrink-0 text-current opacity-60 hover:opacity-100">×</button>
+        </div>
+        <form onSubmit={resend} className="mt-2 flex flex-wrap items-center gap-2" data-verify-resend>
+          <label className="sr-only" htmlFor="verify-resend-email">Email address</label>
+          <input
+            id="verify-resend-email"
+            type="email"
+            required
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="Your email address"
+            className="min-w-[220px] flex-1 border border-amber-300 bg-white px-2 py-1.5 text-xs text-text-primary"
+          />
+          <button type="submit" disabled={busy} className="bg-brand-purple px-3 py-1.5 text-xs font-medium text-white hover:bg-brand-purple-hover disabled:opacity-50">
+            {busy ? 'Sending…' : 'Send a new link'}
+          </button>
+          {notice && <span role="status" className="text-emerald-800" data-verify-resend-notice>{notice}</span>}
+          {error && <span role="alert" className="text-brand-red">{error}</span>}
+        </form>
+      </div>
+    </div>
+  );
+}
+
+export default function VerifyResultBanner() {
+  return (
+    <Suspense fallback={null}>
+      <BannerInner />
+    </Suspense>
+  );
+}

--- a/src/components/landing/GuestLanding.tsx
+++ b/src/components/landing/GuestLanding.tsx
@@ -34,6 +34,7 @@
 import { useEffect, useState } from 'react';
 import Landing from './Landing';
 import CheckoutResultBanner from '@/components/CheckoutResultBanner';
+import VerifyResultBanner from '@/components/VerifyResultBanner';
 import LoginBox from '@/components/LoginBox';
 // SELL-02: the `?module=<key>` door and the one checkout call.
 import { moduleDoorPlan } from '@/lib/offer';
@@ -91,6 +92,8 @@ export default function GuestLanding({ offerAvailability, logoAvailability }: {
       {/* UNLOCK-BANNER: the checkout result card — the ?unlocked/?cancelled
           params the purchase resume returns with land here for guests. */}
       <CheckoutResultBanner />
+      {/* SELL-03b: a bad verification link lands here with ?verify=<state> — the declared error and the resend. */}
+      <VerifyResultBanner />
       <Landing
         offerAvailability={offerAvailability}
         logoAvailability={logoAvailability}

--- a/src/lib/__tests__/registration.test.ts
+++ b/src/lib/__tests__/registration.test.ts
@@ -1,44 +1,32 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { ValidationError } from '../errors/ValidationError';
-import {
-  ACCOUNT_EXISTS,
-  EMAIL_INVALID,
-  NAME_REQUIRED,
-  PASSWORD_MIN_LENGTH,
-  PASSWORD_TOO_SHORT,
-  SIGNED_IN_MESSAGE,
-  SIGNUP_LANDING,
-  parseRegistration,
-  registerAccount,
-  type RegistrationDeps,
-  type WelcomeSendResult,
-} from '../auth/registration';
-import { sendWelcomeEmail, welcomeEmail } from '../auth/welcomeEmail';
+import { EMAIL_INVALID, NAME_REQUIRED, PASSWORD_MIN_LENGTH, PASSWORD_TOO_SHORT, SIGNUP_LANDING, parseRegistration } from '../auth/registration';
+import { CHECK_EMAIL_MESSAGE, SIGNUP_RESPONSE, hashToken, mintToken, signupOutcome, type AuthMail, type MailSendResult, type SignupDeps } from '../auth/verification';
+import { renderAuthMail, sendAuthMail, takenEmail, verificationEmail } from '../auth/welcomeEmail';
 import { EmailConfigError, EmailSendError } from '../email';
 import { ANSWERS_HOME } from '../answers';
 import { FREE_TOOLS, OFFERS } from '../offer';
 
-// SELL-03 — one front door, an honest sign-up. Hermetic: the registration
-// runs over fake deps (no prisma, no bcrypt, no Resend); the welcome send
-// over a fake sender and a fake log.
+// SELL-03 / 03b — one front door, an honest, NON-ENUMERATING sign-up.
+// Hermetic: the sign-up runs over fake deps (no prisma, no bcrypt, no Resend).
 
-function fakeDeps(overrides: Partial<RegistrationDeps> & { existing?: boolean; welcome?: WelcomeSendResult | Error } = {}) {
-  const calls = { find: [] as string[], hash: [] as string[], create: [] as Array<{ id: string; email: string; password: string; name: string }>, welcome: [] as Array<{ to: string; name: string }> };
-  const deps: RegistrationDeps = {
-    findUserByEmail: async (email) => { calls.find.push(email); return overrides.existing ? { id: 'user-existing' } : null; },
-    hashPassword: async (pw) => { calls.hash.push(pw); return `hashed(${pw})`; },
+const SECRET = 'test-secret';
+
+function fakeDeps(opts: { existing?: boolean; hashDelayMs?: number; mail?: MailSendResult | Error } = {}) {
+  const calls = { find: [] as string[], hash: [] as string[], create: [] as Array<{ id: string; email: string; password: string; name: string }>, stored: [] as Array<{ userId: string; hash: string; expiresAt: Date }>, mail: [] as AuthMail[] };
+  let minted: ReturnType<typeof mintToken> | null = null;
+  const deps: SignupDeps = {
+    findUserByEmail: async (email) => { calls.find.push(email); return opts.existing ? { id: 'user-existing', email, name: 'Existing', email_verified_at: new Date('2026-01-01') } : null; },
+    hashPassword: async (pw) => { calls.hash.push(pw); if (opts.hashDelayMs) await new Promise((r) => setTimeout(r, opts.hashDelayMs)); return `hashed(${pw})`; },
     newId: () => 'user-new',
     createUser: async (u) => { calls.create.push(u); return { id: u.id, email: u.email, name: u.name }; },
-    sendWelcome: async (input) => {
-      calls.welcome.push(input);
-      const w = overrides.welcome ?? { sent: true, id: 'msg-1' };
-      if (w instanceof Error) throw w;
-      return w;
-    },
-    ...Object.fromEntries(Object.entries(overrides).filter(([k]) => !['existing', 'welcome'].includes(k))),
+    mintToken: () => { minted = mintToken(SECRET, new Date('2026-09-08T00:00:00Z'), 'random-part-for-the-test-0000000000'); return minted; },
+    storeToken: async (row) => { calls.stored.push(row); },
+    verifyUrl: (token) => `https://templestuart.com/api/auth/verify?token=${encodeURIComponent(token)}`,
+    sendMail: async (mail) => { calls.mail.push(mail); const m = opts.mail ?? { sent: true, id: 'msg-1' }; if (m instanceof Error) throw m; return m; },
   };
-  return { deps, calls };
+  return { deps, calls, minted: () => minted };
 }
 
 function refuses(fn: () => unknown, status: number, message: string, field: string) {
@@ -51,108 +39,140 @@ function refuses(fn: () => unknown, status: number, message: string, field: stri
   });
 }
 
+// ── the input rules (about the input, never about an account) ───────────────
+
 test('password shorter than the rule → 400 with the authored message; the rule is the ONE number the client hints', () => {
   assert.equal(PASSWORD_MIN_LENGTH, 8);
   assert.equal(PASSWORD_TOO_SHORT, 'Password must be at least 8 characters');
   refuses(() => parseRegistration({ email: 'a@b.co', password: 'short12', name: 'A' }), 400, PASSWORD_TOO_SHORT, 'password');
   refuses(() => parseRegistration({ email: 'a@b.co', password: '', name: 'A' }), 400, PASSWORD_TOO_SHORT, 'password');
   refuses(() => parseRegistration({ email: 'a@b.co', name: 'A' }), 400, PASSWORD_TOO_SHORT, 'password');
-  // the boundary: exactly the rule passes
   assert.equal(parseRegistration({ email: 'a@b.co', password: 'x'.repeat(PASSWORD_MIN_LENGTH), name: 'A' }).password.length, PASSWORD_MIN_LENGTH);
 });
 
 test('the email shape and the name are enforced on the server with the authored messages; the fields are normalized', () => {
   refuses(() => parseRegistration({ email: 'not-an-email', password: 'longenough', name: 'A' }), 400, EMAIL_INVALID, 'email');
   refuses(() => parseRegistration({ email: 'a@b', password: 'longenough', name: 'A' }), 400, EMAIL_INVALID, 'email');
-  refuses(() => parseRegistration({ email: 'a b@c.d', password: 'longenough', name: 'A' }), 400, EMAIL_INVALID, 'email');
-  refuses(() => parseRegistration({ email: '', password: 'longenough', name: 'A' }), 400, EMAIL_INVALID, 'email');
   refuses(() => parseRegistration({ email: 'a@b.co', password: 'longenough', name: '   ' }), 400, NAME_REQUIRED, 'name');
   refuses(() => parseRegistration(null), 400, EMAIL_INVALID, 'email');
-  const reg = parseRegistration({ email: '  Alex@Example.COM ', password: 'longenough', name: '  Alex   Stuart ' });
-  assert.deepEqual(reg, { email: 'alex@example.com', password: 'longenough', name: 'Alex Stuart' });
-});
-
-test('sign-up → /answers: the body says what happens ("You\'re signed in"), names the one front door, and the cookie email is the created user\'s', async () => {
-  const { deps, calls } = fakeDeps();
-  const out = await registerAccount(deps, { email: 'New@Example.com', password: 'longenough', name: 'New Person' });
-  assert.equal(out.body.message, SIGNED_IN_MESSAGE);
-  assert.equal(SIGNED_IN_MESSAGE, "You're signed in");
-  assert.equal(out.body.landing, '/answers');
+  assert.deepEqual(parseRegistration({ email: '  Alex@Example.COM ', password: 'longenough', name: '  Alex   Stuart ' }), { email: 'alex@example.com', password: 'longenough', name: 'Alex Stuart' });
   assert.equal(SIGNUP_LANDING, ANSWERS_HOME);
-  assert.equal(out.cookieEmail, 'new@example.com');
-  assert.deepEqual(out.body.user, { id: 'user-new', email: 'new@example.com', name: 'New Person' });
-  assert.deepEqual(calls.find, ['new@example.com']);
-  assert.deepEqual(calls.hash, ['longenough']);
-  assert.deepEqual(calls.create, [{ id: 'user-new', email: 'new@example.com', password: 'hashed(longenough)', name: 'New Person' }]);
 });
 
-test('the welcome email is attempted exactly once, after the account exists, and a send failure does not fail the sign-up', async () => {
-  const ok = fakeDeps();
-  const out = await registerAccount(ok.deps, { email: 'a@b.co', password: 'longenough', name: 'A' });
-  assert.deepEqual(ok.calls.welcome, [{ to: 'a@b.co', name: 'A' }]);
-  assert.deepEqual(out.body.welcomeEmail, { sent: true, id: 'msg-1' });
+// ── sign-up: identical for a new and a taken email ───────────────────────────
 
-  // a declared failure from the sender
-  const failing = fakeDeps({ welcome: { sent: false, error: 'EmailConfigError' } });
-  const out2 = await registerAccount(failing.deps, { email: 'a@b.co', password: 'longenough', name: 'A' });
-  assert.equal(out2.body.message, SIGNED_IN_MESSAGE, 'still signed in');
-  assert.equal(out2.cookieEmail, 'a@b.co', 'the cookie still gets set');
-  assert.deepEqual(out2.body.welcomeEmail, { sent: false, error: 'EmailConfigError' });
-  assert.equal(failing.calls.welcome.length, 1, 'attempted once, never retried');
-  assert.equal(failing.calls.create.length, 1);
-
-  // a sender that THROWS despite its contract — still declared, still signed in
-  const throwing = fakeDeps({ welcome: new EmailSendError('Resend: 500') });
-  const out3 = await registerAccount(throwing.deps, { email: 'a@b.co', password: 'longenough', name: 'A' });
-  assert.deepEqual(out3.body.welcomeEmail, { sent: false, error: 'EmailSendError' });
-  assert.equal(out3.body.landing, '/answers');
-  assert.equal(throwing.calls.welcome.length, 1);
-});
-
-test('a taken email is refused honestly (409, the authored message) — nothing created, no email attempted; a bad body never reaches the database', async () => {
+test('new vs taken email produce byte-identical responses — status, body, headers, no cookie — and each sends exactly one email of the right kind', async () => {
+  const fresh = fakeDeps();
   const taken = fakeDeps({ existing: true });
-  await assert.rejects(() => registerAccount(taken.deps, { email: 'a@b.co', password: 'longenough', name: 'A' }), (err: unknown) => err instanceof ValidationError && err.status === 409 && err.message === ACCOUNT_EXISTS && err.field === 'email');
+  const body = { email: 'Someone@Example.com', password: 'longenough', name: 'Some One' };
+  const a = await signupOutcome(fresh.deps, body);
+  const b = await signupOutcome(taken.deps, body);
+
+  assert.equal(JSON.stringify(a.response), JSON.stringify(b.response), 'the same bytes');
+  assert.equal(a.response.status, 200);
+  assert.deepEqual(a.response.body, { message: CHECK_EMAIL_MESSAGE });
+  assert.equal(CHECK_EMAIL_MESSAGE, 'Check your email to finish signing in.');
+  assert.deepEqual(Object.keys(a.response.headers), [], 'no header — and no cookie — either way');
+  assert.equal(a.response, SIGNUP_RESPONSE, 'the ONE frozen response object');
+  assert.equal(b.response, SIGNUP_RESPONSE);
+  assert.ok(Object.isFrozen(SIGNUP_RESPONSE) && Object.isFrozen(SIGNUP_RESPONSE.body));
+  assert.equal(a.path, 'new');
+  assert.equal(b.path, 'taken');
+
+  // the new path: one verify mail carrying the link, one token stored hashed, one user
+  assert.equal(fresh.calls.mail.length, 1);
+  assert.equal(fresh.calls.mail[0].kind, 'verify');
+  assert.equal(fresh.calls.mail[0].to, 'someone@example.com');
+  assert.equal(fresh.calls.mail[0].name, 'Some One');
+  const minted = fresh.minted()!;
+  assert.equal(fresh.calls.mail[0].verifyUrl, `https://templestuart.com/api/auth/verify?token=${encodeURIComponent(minted.token)}`);
+  assert.deepEqual(fresh.calls.stored, [{ userId: 'user-new', hash: hashToken('random-part-for-the-test-0000000000'), expiresAt: new Date('2026-09-09T00:00:00Z') }]);
+  assert.equal(fresh.calls.stored[0].hash, minted.hash);
+  assert.ok(!fresh.calls.stored[0].hash.includes('random-part'), 'the database never holds the link');
+  assert.equal(fresh.calls.create.length, 1);
+  assert.deepEqual(fresh.calls.hash, ['longenough']);
+
+  // the taken path: one "taken" mail, nothing created or stored, the same bcrypt cost paid on a dummy
+  assert.equal(taken.calls.mail.length, 1);
+  assert.equal(taken.calls.mail[0].kind, 'taken');
+  assert.equal(taken.calls.mail[0].to, 'someone@example.com');
+  assert.equal(taken.calls.mail[0].verifyUrl, undefined);
   assert.equal(taken.calls.create.length, 0);
-  assert.equal(taken.calls.welcome.length, 0);
-  const bad = fakeDeps();
-  await assert.rejects(() => registerAccount(bad.deps, { email: 'a@b.co', password: 'short', name: 'A' }), (err: unknown) => err instanceof ValidationError && err.status === 400);
-  assert.equal(bad.calls.find.length, 0, 'the lookup never ran');
+  assert.equal(taken.calls.stored.length, 0);
+  assert.equal(taken.calls.hash.length, 1, 'the dummy hash');
+  assert.notEqual(taken.calls.hash[0], 'longenough', 'never the real password on the taken path');
 });
 
-test('sendWelcomeEmail: one send through the given sender; a config or provider failure is logged with its class and declared, never thrown', async () => {
+test('a mail failure changes nothing in the response on either path — it is declared to the sender\'s log, not to the caller', async () => {
+  const body = { email: 'a@b.co', password: 'longenough', name: 'A' };
+  const freshFail = fakeDeps({ mail: { sent: false, error: 'EmailConfigError' } });
+  const takenFail = fakeDeps({ existing: true, mail: { sent: false, error: 'EmailConfigError' } });
+  const a = await signupOutcome(freshFail.deps, body);
+  const b = await signupOutcome(takenFail.deps, body);
+  assert.equal(JSON.stringify(a.response), JSON.stringify(b.response));
+  assert.equal(JSON.stringify(a.response), JSON.stringify(SIGNUP_RESPONSE));
+  assert.deepEqual(a.mail, { sent: false, error: 'EmailConfigError' });
+  assert.equal(freshFail.calls.create.length, 1, 'the account exists; the link can be resent');
+});
+
+test('timing: the new and the taken path take the same wall time within tolerance (both pay one hash, one send)', async () => {
+  const HASH_MS = 40;
+  const TOLERANCE_MS = 40;
+  const body = { email: 'a@b.co', password: 'longenough', name: 'A' };
+  const time = async (existing: boolean) => {
+    const { deps } = fakeDeps({ existing, hashDelayMs: HASH_MS });
+    const t0 = process.hrtime.bigint();
+    await signupOutcome(deps, body);
+    return Number(process.hrtime.bigint() - t0) / 1e6;
+  };
+  const median = (xs: number[]) => xs.slice().sort((x, y) => x - y)[Math.floor(xs.length / 2)];
+  const fresh = median([await time(false), await time(false), await time(false)]);
+  const taken = median([await time(true), await time(true), await time(true)]);
+  assert.ok(fresh >= HASH_MS && taken >= HASH_MS, `both paid the hash (${fresh.toFixed(1)}ms / ${taken.toFixed(1)}ms)`);
+  assert.ok(Math.abs(fresh - taken) <= TOLERANCE_MS, `new ${fresh.toFixed(1)}ms vs taken ${taken.toFixed(1)}ms — within ${TOLERANCE_MS}ms`);
+});
+
+// ── the mails ───────────────────────────────────────────────────────────────
+
+test('the verification email carries the link first, then what the deck says — the front door, the free set and the offers from their sources; the taken email promises no reset that does not exist', () => {
+  const v = verificationEmail({ name: 'Ada <Lovelace>', verifyUrl: 'https://templestuart.com/api/auth/verify?token=abc.def', baseUrl: 'https://templestuart.com/' });
+  assert.equal(v.subject, 'Finish signing in to Temple Stuart');
+  assert.ok(v.text.indexOf('https://templestuart.com/api/auth/verify?token=abc.def') < v.text.indexOf('https://templestuart.com/answers'), 'the link comes first');
+  assert.ok(v.text.includes('works once and for 24 hours'));
+  for (const t of FREE_TOOLS) assert.ok(v.text.includes(t.name), `free tool ${t.name} named`);
+  for (const o of OFFERS) assert.ok(v.text.includes(o.label), `offer ${o.label} named`);
+  assert.ok(v.html.includes('Ada &lt;Lovelace&gt;') && !v.html.includes('<Lovelace>'));
+  assert.ok(v.text.includes('not a CPA firm'));
+  assert.ok(v.text.includes('nothing is signed in until the link is used'));
+
+  const t = takenEmail({ baseUrl: 'https://templestuart.com' });
+  assert.equal(t.subject, 'Someone tried to sign up with your Temple Stuart address');
+  assert.ok(t.text.includes('https://templestuart.com/login'));
+  assert.ok(t.text.includes('no self-service reset yet'), 'says so — the product has none');
+  assert.ok(!/reset your password at|\/reset/.test(t.text), 'no reset link is promised');
+  assert.ok(t.text.includes('no one was signed in'));
+  assert.equal(renderAuthMail({ kind: 'taken', to: 'a@b.co' }, 'https://templestuart.com').subject, t.subject);
+  assert.throws(() => renderAuthMail({ kind: 'verify', to: 'a@b.co' }, 'https://templestuart.com'), /needs the name and the link/);
+});
+
+test('sendAuthMail: one send through the given sender; a config or provider failure is logged with its class and declared, never thrown', async () => {
   const sent: unknown[] = [];
   const logged: Array<[string, Record<string, unknown>]> = [];
   const log = (m: string, d: Record<string, unknown>) => { logged.push([m, d]); };
+  const mail: AuthMail = { kind: 'verify', to: 'a@b.co', name: 'A', verifyUrl: 'https://templestuart.com/api/auth/verify?token=x.y' };
 
-  const okResult = await sendWelcomeEmail({ to: 'a@b.co', name: 'A', baseUrl: 'https://templestuart.com/' }, async (input) => { sent.push(input); return { id: 'msg-9' }; }, log);
-  assert.deepEqual(okResult, { sent: true, id: 'msg-9' });
+  const ok = await sendAuthMail(mail, 'https://templestuart.com', async (input) => { sent.push(input); return { id: 'msg-9' }; }, log);
+  assert.deepEqual(ok, { sent: true, id: 'msg-9' });
   assert.equal(sent.length, 1);
-  const input = sent[0] as { to: string; subject: string; html: string; text: string };
-  assert.equal(input.to, 'a@b.co');
-  assert.equal(input.subject, "Welcome to Temple Stuart — you're signed in");
-  assert.match(input.text, /https:\/\/templestuart\.com\/answers/);
-  assert.match(input.html, /href="https:\/\/templestuart\.com\/answers"/);
+  assert.equal((sent[0] as { to: string }).to, 'a@b.co');
   assert.equal(logged.length, 0);
 
-  const missing = await sendWelcomeEmail({ to: 'a@b.co', name: 'A', baseUrl: 'https://templestuart.com' }, async () => { throw new EmailConfigError('RESEND_API_KEY'); }, log);
+  const missing = await sendAuthMail(mail, 'https://templestuart.com', async () => { throw new EmailConfigError('RESEND_API_KEY'); }, log);
   assert.deepEqual(missing, { sent: false, error: 'EmailConfigError' });
-  assert.equal(logged.length, 1);
-  assert.match(logged[0][0], /welcome email NOT sent/);
-  assert.deepEqual(logged[0][1], { errorClass: 'EmailConfigError', message: 'RESEND_API_KEY is not configured' });
+  assert.deepEqual(logged[0], ['[signup] verify mail NOT sent (the response is unchanged):', { errorClass: 'EmailConfigError', message: 'RESEND_API_KEY is not configured' }]);
 
-  const refused = await sendWelcomeEmail({ to: 'a@b.co', name: 'A', baseUrl: 'https://templestuart.com' }, async () => { throw new EmailSendError('validation_error: bad from'); }, log);
+  const refused = await sendAuthMail({ kind: 'taken', to: 'a@b.co' }, 'https://templestuart.com', async () => { throw new EmailSendError('validation_error: bad from'); }, log);
   assert.deepEqual(refused, { sent: false, error: 'EmailSendError' });
   assert.equal(logged.length, 2);
-});
-
-test('the welcome email says what the deck says: the front door, the free set and the offers come from their sources, never typed; the name is escaped', () => {
-  const r = welcomeEmail({ name: 'Ada <Lovelace>', baseUrl: 'https://templestuart.com' });
-  for (const t of FREE_TOOLS) { assert.ok(r.text.includes(t.name), `free tool ${t.name} named`); assert.ok(r.html.includes(t.name)); }
-  for (const o of OFFERS) { assert.ok(r.text.includes(o.label), `offer ${o.label} named`); }
-  assert.ok(r.text.includes('https://templestuart.com/answers'));
-  assert.ok(r.text.includes('https://templestuart.com/pricing'));
-  assert.ok(r.html.includes('Ada &lt;Lovelace&gt;'));
-  assert.ok(!r.html.includes('<Lovelace>'));
-  assert.ok(r.text.includes('not a CPA firm'));
-  assert.ok(!/confirm/i.test(r.text), 'no promise of a confirmation step — there is none');
+  assert.match(logged[1][0], /taken mail NOT sent/);
 });

--- a/src/lib/__tests__/verification.test.ts
+++ b/src/lib/__tests__/verification.test.ts
@@ -1,0 +1,144 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { ValidationError } from '../errors/ValidationError';
+import {
+  LOGIN_FAILED,
+  LOGIN_REFUSED,
+  RESEND_MESSAGE,
+  RESEND_RESPONSE,
+  TOKEN_TTL_HOURS,
+  hashToken,
+  loginDecision,
+  mintToken,
+  parseToken,
+  resendOutcome,
+  verifyToken,
+  type AuthMail,
+  type ResendDeps,
+  type StoredToken,
+  type VerifyDb,
+} from '../auth/verification';
+
+// SELL-03b — the verification link, the login refusal, the resend. Hermetic:
+// a fake token store with the table's own rule (used_at set once).
+
+const SECRET = 'test-secret';
+const NOW = new Date('2026-09-08T12:00:00Z');
+
+class FakeVerifyDb implements VerifyDb {
+  rows = new Map<string, StoredToken>();
+  users = new Map<string, { email: string; email_verified_at: Date | null }>();
+  consumeCalls: Array<[string, string]> = [];
+  add(hash: string, row: Omit<StoredToken, 'user'>, user: { email: string; email_verified_at: Date | null }) {
+    this.users.set(row.user_id, user);
+    this.rows.set(hash, { ...row, user });
+  }
+  async findToken(hash: string) { const r = this.rows.get(hash); return r ? { ...r, user: { ...this.users.get(r.user_id)! } } : null; }
+  async consume(tokenId: string, userId: string, now: Date) {
+    this.consumeCalls.push([tokenId, userId]);
+    const row = [...this.rows.values()].find((r) => r.id === tokenId);
+    if (!row || row.used_at) return false;      // the database's rule: used_at is set once
+    row.used_at = now;
+    const u = this.users.get(userId)!;
+    if (!u.email_verified_at) u.email_verified_at = now;
+    return true;
+  }
+}
+
+test('the link: 32 random bytes signed with the secret; the database holds only the hash; a tampered or foreign link is refused before any lookup', () => {
+  const m = mintToken(SECRET, NOW);
+  const [random, sig] = m.token.split('.');
+  assert.ok(random.length >= 40 && /^[A-Za-z0-9_-]+$/.test(random), 'base64url random half');
+  assert.ok(sig.length > 20);
+  assert.equal(m.hash, hashToken(random));
+  assert.equal(m.hash.length, 64, 'sha256 hex');
+  assert.notEqual(m.hash, random);
+  assert.equal(m.expiresAt.getTime(), NOW.getTime() + TOKEN_TTL_HOURS * 3600 * 1000);
+  assert.equal(TOKEN_TTL_HOURS, 24);
+
+  assert.equal(parseToken(m.token, SECRET), m.hash, 'our link parses to its hash');
+  assert.equal(parseToken(m.token, 'another-secret'), null, 'a different secret does not sign it');
+  assert.equal(parseToken(`${random}.${sig.slice(0, -1)}x`, SECRET), null, 'a tampered signature');
+  assert.equal(parseToken(`${random}x.${sig}`, SECRET), null, 'a tampered random half');
+  assert.equal(parseToken(random, SECRET), null, 'no signature at all');
+  assert.equal(parseToken('', SECRET), null);
+  assert.equal(parseToken(undefined, SECRET), null);
+  assert.notEqual(mintToken(SECRET, NOW).token, mintToken(SECRET, NOW).token, 'every mint is fresh');
+});
+
+test('a valid token verifies once and never twice; expired and foreign links are declared by state; verifying sets the user\'s email_verified_at', async () => {
+  const db = new FakeVerifyDb();
+  const m = mintToken(SECRET, NOW);
+  db.add(m.hash, { id: 'tok-1', user_id: 'user-1', expires_at: m.expiresAt, used_at: null }, { email: 'a@b.co', email_verified_at: null });
+
+  const first = await verifyToken(db, SECRET, m.token, new Date(NOW.getTime() + 1000));
+  assert.deepEqual(first, { ok: true, email: 'a@b.co' });
+  assert.deepEqual(db.consumeCalls, [['tok-1', 'user-1']]);
+  assert.ok(db.users.get('user-1')!.email_verified_at instanceof Date, 'verified');
+  assert.ok(db.rows.get(m.hash)!.used_at instanceof Date, 'used once');
+
+  const second = await verifyToken(db, SECRET, m.token, new Date(NOW.getTime() + 2000));
+  assert.deepEqual(second, { ok: false, state: 'used' }, 'never twice');
+  assert.equal(db.consumeCalls.length, 1, 'the second use never reached consume — used_at was already set');
+
+  // a token that expires
+  const old = mintToken(SECRET, NOW);
+  db.add(old.hash, { id: 'tok-2', user_id: 'user-2', expires_at: old.expiresAt, used_at: null }, { email: 'c@d.co', email_verified_at: null });
+  assert.deepEqual(await verifyToken(db, SECRET, old.token, new Date(old.expiresAt.getTime())), { ok: false, state: 'expired' });
+  assert.deepEqual(await verifyToken(db, SECRET, old.token, new Date(old.expiresAt.getTime() - 1)), { ok: true, email: 'c@d.co' }, 'one millisecond before expiry it works');
+
+  // a foreign link, a well-formed link we never issued
+  assert.deepEqual(await verifyToken(db, SECRET, 'garbage', NOW), { ok: false, state: 'invalid' });
+  const never = mintToken(SECRET, NOW);
+  assert.deepEqual(await verifyToken(db, SECRET, never.token, NOW), { ok: false, state: 'invalid' }, 'signed by us but not stored');
+
+  // a race: two consumers, one row — the database's used_at rule decides
+  const r = mintToken(SECRET, NOW);
+  db.add(r.hash, { id: 'tok-3', user_id: 'user-3', expires_at: r.expiresAt, used_at: null }, { email: 'e@f.co', email_verified_at: null });
+  const [x, y] = await Promise.all([verifyToken(db, SECRET, r.token, NOW), verifyToken(db, SECRET, r.token, NOW)]);
+  assert.deepEqual([x.ok, y.ok].sort(), [false, true], 'exactly one wins');
+});
+
+test('login for an unverified account fails with the SAME object as a wrong password and as no account', () => {
+  const unverified = loginDecision({ user: { email_verified_at: null }, passwordOk: true });
+  const wrongPassword = loginDecision({ user: { email_verified_at: new Date() }, passwordOk: false });
+  const noAccount = loginDecision({ user: null, passwordOk: false });
+  assert.deepEqual(unverified, wrongPassword);
+  assert.deepEqual(unverified, noAccount);
+  assert.equal(unverified, LOGIN_REFUSED, 'the one frozen refusal');
+  assert.equal(JSON.stringify(unverified), JSON.stringify({ ok: false, status: 401, error: LOGIN_FAILED }));
+  assert.equal(LOGIN_FAILED, 'Invalid email or password');
+  assert.deepEqual(loginDecision({ user: { email_verified_at: new Date() }, passwordOk: true }), { ok: true });
+  assert.ok(Object.isFrozen(LOGIN_REFUSED));
+});
+
+test('resend answers the same bytes for an unknown address, a verified account and an unverified one; only the unverified one gets a fresh link', async () => {
+  const make = (user: { id: string; email: string; name: string; email_verified_at: Date | null } | null) => {
+    const calls = { hash: 0, stored: [] as unknown[], mail: [] as AuthMail[] };
+    const deps: ResendDeps = {
+      findUserByEmail: async () => user,
+      hashPassword: async () => { calls.hash += 1; return 'h'; },
+      mintToken: () => mintToken(SECRET, NOW),
+      storeToken: async (row) => { calls.stored.push(row); },
+      verifyUrl: (token) => `https://templestuart.com/api/auth/verify?token=${encodeURIComponent(token)}`,
+      sendMail: async (mail) => { calls.mail.push(mail); return { sent: true, id: 'm' }; },
+    };
+    return { deps, calls };
+  };
+  const unknown = make(null);
+  const verified = make({ id: 'u1', email: 'a@b.co', name: 'A', email_verified_at: NOW });
+  const waiting = make({ id: 'u2', email: 'w@b.co', name: 'W', email_verified_at: null });
+  const [a, b, c] = await Promise.all([resendOutcome(unknown.deps, { email: 'x@y.co' }), resendOutcome(verified.deps, { email: 'a@b.co' }), resendOutcome(waiting.deps, { email: 'W@B.co' })]);
+  assert.equal(JSON.stringify(a.response), JSON.stringify(b.response));
+  assert.equal(JSON.stringify(b.response), JSON.stringify(c.response));
+  assert.equal(a.response, RESEND_RESPONSE);
+  assert.deepEqual(a.response.body, { message: RESEND_MESSAGE });
+  assert.deepEqual([a.path, b.path, c.path], ['unknown', 'verified', 'sent']);
+  assert.deepEqual([unknown.calls.hash, verified.calls.hash, waiting.calls.hash], [1, 1, 1], 'the same work on every path');
+  assert.equal(unknown.calls.mail.length + verified.calls.mail.length, 0, 'nothing sent where nothing waits');
+  assert.equal(waiting.calls.mail.length, 1);
+  assert.equal(waiting.calls.mail[0].kind, 'verify');
+  assert.equal(waiting.calls.mail[0].to, 'w@b.co');
+  assert.equal(waiting.calls.stored.length, 1);
+  await assert.rejects(() => resendOutcome(unknown.deps, { email: 'nope' }), (e: unknown) => e instanceof ValidationError && e.status === 400);
+});

--- a/src/lib/auth/prismaVerifyDb.ts
+++ b/src/lib/auth/prismaVerifyDb.ts
@@ -1,0 +1,45 @@
+import type { PrismaClient } from '@prisma/client';
+import type { VerifyDb } from './verification';
+
+/**
+ * SELL-03b — the Prisma binding of the verify port (src/lib/auth/verification.ts).
+ * consume() is ONE transaction: the token's used_at is set only where it is
+ * still NULL (a second use finds no row and returns false — single use by
+ * the database's own word), and the user's email_verified_at is set where
+ * NULL in the same transaction.
+ */
+
+type Client = Pick<PrismaClient, 'verification_tokens' | 'users' | '$transaction'>;
+
+export interface TokenStore extends VerifyDb {
+  storeToken(row: { userId: string; hash: string; expiresAt: Date }): Promise<void>;
+}
+
+export function prismaVerifyDb(client: Client): TokenStore {
+  return {
+    async findToken(hash) {
+      return client.verification_tokens.findUnique({
+        where: { token_hash: hash },
+        select: { id: true, user_id: true, expires_at: true, used_at: true, user: { select: { email: true, email_verified_at: true } } },
+      });
+    },
+    async consume(tokenId, userId, now) {
+      return client.$transaction(async (tx) => {
+        const used = await tx.verification_tokens.updateMany({ where: { id: tokenId, used_at: null }, data: { used_at: now } });
+        if (used.count !== 1) return false;
+        await tx.users.updateMany({ where: { id: userId, email_verified_at: null }, data: { email_verified_at: now } });
+        return true;
+      });
+    },
+    async storeToken({ userId, hash, expiresAt }) {
+      await client.verification_tokens.create({ data: { user_id: userId, token_hash: hash, expires_at: expiresAt } });
+    },
+  };
+}
+
+/** The signing secret for the link — the app's cookie secret; missing = fail loud, never a default. */
+export function verificationSecret(): string {
+  const secret = process.env.JWT_SECRET;
+  if (!secret) throw new Error('JWT_SECRET environment variable is required to sign verification links');
+  return secret;
+}

--- a/src/lib/auth/registration.ts
+++ b/src/lib/auth/registration.ts
@@ -8,14 +8,12 @@ import { ANSWERS_HOME } from '@/lib/answers';
  * (LoginBox, the developer page) reads PASSWORD_MIN_LENGTH for its own hint
  * and the server enforces the same number through parseRegistration — the
  * two can no longer disagree. Every refusal is a ValidationError with the
- * authored message, answered verbatim at 400 (409 for an account that
- * already exists). Every completion lands on ANSWERS_HOME.
+ * authored message, answered verbatim at 400. These rules are about the
+ * INPUT, so a refusal says nothing about any account (SELL-03b: the sign-up
+ * itself is non-enumerating — src/lib/auth/verification.ts).
  *
- * registerAccount is the whole sign-up over a small port (RegistrationDeps)
- * so it runs hermetically in node:test: parse → refuse a taken email → hash →
- * create → ONE welcome-email attempt whose failure is declared in the body
- * and never blocks the sign-in → the cookie email for the route to sign.
- * Pure of prisma, bcrypt and Resend.
+ * Every completion — the verification link, a login, OAuth — lands on
+ * SIGNUP_LANDING, the one front door.
  */
 
 export const PASSWORD_MIN_LENGTH = 8;
@@ -23,9 +21,6 @@ export const NAME_MAX_LENGTH = 100;
 export const PASSWORD_TOO_SHORT = `Password must be at least ${PASSWORD_MIN_LENGTH} characters`;
 export const EMAIL_INVALID = 'Enter a valid email address';
 export const NAME_REQUIRED = 'Name is required';
-export const ACCOUNT_EXISTS = 'There is already an account for this email — sign in instead';
-/** What the sign-up answers, because it is what happens: the cookie is set and the front door opens. */
-export const SIGNED_IN_MESSAGE = "You're signed in";
 /** Where every completion lands — the one front door (NAV-01c). */
 export const SIGNUP_LANDING = ANSWERS_HOME;
 
@@ -55,52 +50,4 @@ export function parseRegistration(body: unknown): Registration {
     throw new ValidationError(`Name is longer than ${NAME_MAX_LENGTH} characters`, { status: 400, field: 'name' });
   }
   return { email, password, name };
-}
-
-export type WelcomeSendResult = { sent: true; id: string } | { sent: false; error: string };
-
-export interface RegistrationDeps {
-  findUserByEmail(email: string): Promise<{ id: string } | null>;
-  hashPassword(password: string): Promise<string>;
-  newId(): string;
-  createUser(user: { id: string; email: string; password: string; name: string }): Promise<{ id: string; email: string; name: string }>;
-  /** ONE attempt; a failure is a declared result, never a throw that blocks the sign-in (sendWelcomeEmail keeps that contract). */
-  sendWelcome(input: { to: string; name: string }): Promise<WelcomeSendResult>;
-}
-
-export interface RegistrationBody {
-  message: typeof SIGNED_IN_MESSAGE;
-  landing: typeof SIGNUP_LANDING;
-  user: { id: string; email: string; name: string };
-  welcomeEmail: WelcomeSendResult;
-}
-
-export interface RegistrationOutcome {
-  body: RegistrationBody;
-  /** The email the route signs into the userEmail cookie. */
-  cookieEmail: string;
-}
-
-export async function registerAccount(deps: RegistrationDeps, body: unknown): Promise<RegistrationOutcome> {
-  const reg = parseRegistration(body);
-  const existing = await deps.findUserByEmail(reg.email);
-  if (existing) {
-    throw new ValidationError(ACCOUNT_EXISTS, { status: 409, field: 'email' });
-  }
-  const password = await deps.hashPassword(reg.password);
-  const user = await deps.createUser({ id: deps.newId(), email: reg.email, password, name: reg.name });
-
-  // The welcome email: attempted ONCE, after the account exists; its failure
-  // is a fact in the body, never a reason the sign-in fails.
-  let welcomeEmail: WelcomeSendResult;
-  try {
-    welcomeEmail = await deps.sendWelcome({ to: user.email, name: user.name });
-  } catch (err) {
-    welcomeEmail = { sent: false, error: err instanceof Error ? err.name : 'UnknownError' };
-  }
-
-  return {
-    body: { message: SIGNED_IN_MESSAGE, landing: SIGNUP_LANDING, user: { id: user.id, email: user.email, name: user.name }, welcomeEmail },
-    cookieEmail: user.email,
-  };
 }

--- a/src/lib/auth/verification.ts
+++ b/src/lib/auth/verification.ts
@@ -1,0 +1,227 @@
+import { createHash, createHmac, randomBytes, timingSafeEqual } from 'crypto';
+import { ValidationError } from '@/lib/errors/ValidationError';
+import { EMAIL_INVALID, parseRegistration, type Registration } from './registration';
+
+/**
+ * SELL-03b — NON-ENUMERATING, TRUTHFUL SIGN-UP.
+ *
+ * Sign-up answers IDENTICALLY for a new and a taken email — status, body,
+ * headers, no cookie either way — and the difference lives only in the
+ * mail: a NEW address gets a verification link (signed, single-use, 24h,
+ * its random half stored hashed); a TAKEN address gets "someone tried to
+ * sign up with your address". Both paths do the same work: one bcrypt hash
+ * (a dummy on the taken path), one email send. Nothing in the response, its
+ * timing or its headers says which path ran.
+ *
+ * The link: `<random>.<hmac>` — 32 random bytes (base64url) signed with the
+ * app secret, so a tampered link is refused before any lookup; the database
+ * holds only sha256(random). Verifying is atomic and single-use: used_at is
+ * set once (a second use is 'used'), users.email_verified_at with it.
+ *
+ * Login for an account that never verified answers the SAME line as a wrong
+ * password (loginDecision) — and every login failure offers the resend.
+ * Everything here is pure or over a small port (VerifyDb / SignupDeps), so
+ * the tests prove byte-identical responses, one email of the right kind per
+ * path, single use, the equal messages, and the timing — hermetically.
+ */
+
+export const TOKEN_TTL_HOURS = 24;
+export const CHECK_EMAIL_MESSAGE = 'Check your email to finish signing in.';
+export const RESEND_MESSAGE = 'If an account is waiting to be verified, a new link is on its way.';
+export const LOGIN_FAILED = 'Invalid email or password';
+
+// ── the token ─────────────────────────────────────────────────────────────
+
+export interface MintedToken {
+  /** What the link carries: `<random>.<hmac>`. */
+  token: string;
+  /** What the database stores: sha256(random), hex. */
+  hash: string;
+  expiresAt: Date;
+}
+
+function sign(secret: string, random: string): string {
+  return createHmac('sha256', secret).update(random).digest('base64url');
+}
+
+export function hashToken(random: string): string {
+  return createHash('sha256').update(random).digest('hex');
+}
+
+export function mintToken(secret: string, now: Date = new Date(), random: string = randomBytes(32).toString('base64url')): MintedToken {
+  return {
+    token: `${random}.${sign(secret, random)}`,
+    hash: hashToken(random),
+    expiresAt: new Date(now.getTime() + TOKEN_TTL_HOURS * 3600 * 1000),
+  };
+}
+
+/** The hash to look up, or null for a link whose signature is not ours (timing-safe). */
+export function parseToken(raw: unknown, secret: string): string | null {
+  if (typeof raw !== 'string') return null;
+  const dot = raw.indexOf('.');
+  if (dot <= 0 || dot === raw.length - 1) return null;
+  const random = raw.slice(0, dot);
+  const sig = raw.slice(dot + 1);
+  if (!/^[A-Za-z0-9_-]{20,}$/.test(random)) return null;
+  const expected = sign(secret, random);
+  const a = Buffer.from(sig, 'utf8');
+  const b = Buffer.from(expected, 'utf8');
+  if (a.length !== b.length || !timingSafeEqual(a, b)) return null;
+  return hashToken(random);
+}
+
+// ── the verify port ───────────────────────────────────────────────────────
+
+export interface StoredToken {
+  id: string;
+  user_id: string;
+  expires_at: Date;
+  used_at: Date | null;
+  user: { email: string; email_verified_at: Date | null };
+}
+
+export interface VerifyDb {
+  findToken(hash: string): Promise<StoredToken | null>;
+  /** Atomically: used_at = now where it is NULL, and the user's email_verified_at = now where NULL. False when the token was already used. */
+  consume(tokenId: string, userId: string, now: Date): Promise<boolean>;
+}
+
+export type VerifyOutcome = { ok: true; email: string } | { ok: false; state: 'invalid' | 'expired' | 'used' };
+
+export async function verifyToken(db: VerifyDb, secret: string, raw: unknown, now: Date = new Date()): Promise<VerifyOutcome> {
+  const hash = parseToken(raw, secret);
+  if (!hash) return { ok: false, state: 'invalid' };
+  const row = await db.findToken(hash);
+  if (!row) return { ok: false, state: 'invalid' };
+  if (row.used_at) return { ok: false, state: 'used' };
+  if (row.expires_at.getTime() <= now.getTime()) return { ok: false, state: 'expired' };
+  const consumed = await db.consume(row.id, row.user_id, now);
+  if (!consumed) return { ok: false, state: 'used' };
+  return { ok: true, email: row.user.email };
+}
+
+// ── sign-up: identical outcomes ───────────────────────────────────────────
+
+export type AuthMailKind = 'verify' | 'taken';
+
+export interface AuthMail {
+  kind: AuthMailKind;
+  to: string;
+  /** The recipient's name (verify only). */
+  name?: string;
+  /** The verification link (verify only). */
+  verifyUrl?: string;
+}
+
+export type MailSendResult = { sent: true; id: string } | { sent: false; error: string };
+
+export interface SignupDeps {
+  findUserByEmail(email: string): Promise<{ id: string; email: string; name: string; email_verified_at: Date | null } | null>;
+  /** The real bcrypt cost — run on BOTH paths (a dummy password on the taken one) so they take the same time. */
+  hashPassword(password: string): Promise<string>;
+  newId(): string;
+  createUser(user: { id: string; email: string; password: string; name: string }): Promise<{ id: string; email: string; name: string }>;
+  mintToken(): MintedToken;
+  storeToken(row: { userId: string; hash: string; expiresAt: Date }): Promise<void>;
+  /** The link for a minted token — `${baseUrl}/api/auth/verify?token=…`. */
+  verifyUrl(token: string): string;
+  /** ONE send per sign-up; the result is logged by the sender, never surfaced in the response. */
+  sendMail(mail: AuthMail): Promise<MailSendResult>;
+}
+
+/** The ONE response every sign-up gets — new or taken, the same bytes, no cookie. */
+export interface SignupResponse {
+  status: 200;
+  body: { message: typeof CHECK_EMAIL_MESSAGE };
+  headers: Record<string, string>;
+}
+
+export const SIGNUP_RESPONSE: SignupResponse = Object.freeze({
+  status: 200,
+  body: Object.freeze({ message: CHECK_EMAIL_MESSAGE }),
+  headers: Object.freeze({}),
+}) as SignupResponse;
+
+/** A dummy password of the same shape as a real one, hashed on the taken path so both paths pay bcrypt once. */
+const DUMMY_PASSWORD = 'not-a-real-password-just-the-same-cost';
+
+/**
+ * Sign up. Input refusals (a bad email shape, a short password, no name) are
+ * ValidationErrors — they are about the INPUT and say nothing about any
+ * account. Past them, both paths return SIGNUP_RESPONSE.
+ */
+export async function signupOutcome(deps: SignupDeps, body: unknown): Promise<{ response: SignupResponse; mail: MailSendResult; path: 'new' | 'taken' }> {
+  const reg: Registration = parseRegistration(body);
+  const existing = await deps.findUserByEmail(reg.email);
+
+  if (existing) {
+    // The taken path: the same bcrypt cost, the same single send.
+    await deps.hashPassword(DUMMY_PASSWORD);
+    const mail = await deps.sendMail({ kind: 'taken', to: existing.email });
+    return { response: SIGNUP_RESPONSE, mail, path: 'taken' };
+  }
+
+  const password = await deps.hashPassword(reg.password);
+  const user = await deps.createUser({ id: deps.newId(), email: reg.email, password, name: reg.name });
+  const minted = deps.mintToken();
+  await deps.storeToken({ userId: user.id, hash: minted.hash, expiresAt: minted.expiresAt });
+  const mail = await deps.sendMail({ kind: 'verify', to: user.email, name: user.name, verifyUrl: deps.verifyUrl(minted.token) });
+  return { response: SIGNUP_RESPONSE, mail, path: 'new' };
+}
+
+// ── resend: identical outcomes ────────────────────────────────────────────
+
+export interface ResendResponse {
+  status: 200;
+  body: { message: typeof RESEND_MESSAGE };
+  headers: Record<string, string>;
+}
+
+export const RESEND_RESPONSE: ResendResponse = Object.freeze({
+  status: 200,
+  body: Object.freeze({ message: RESEND_MESSAGE }),
+  headers: Object.freeze({}),
+}) as ResendResponse;
+
+export type ResendDeps = Pick<SignupDeps, 'findUserByEmail' | 'hashPassword' | 'mintToken' | 'storeToken' | 'verifyUrl' | 'sendMail'>;
+
+/**
+ * Resend the verification link. The only path that sends is an account that
+ * exists and never verified; an unknown address and a verified account get
+ * the same dummy work and the same response. The email shape is checked
+ * (a ValidationError about the input, not about any account).
+ */
+export async function resendOutcome(deps: ResendDeps, body: unknown): Promise<{ response: ResendResponse; mail: MailSendResult | null; path: 'sent' | 'unknown' | 'verified' }> {
+  const b = (body && typeof body === 'object' ? body : {}) as Record<string, unknown>;
+  const email = typeof b.email === 'string' ? b.email.trim().toLowerCase() : '';
+  if (!email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) throw new ValidationError(EMAIL_INVALID, { status: 400, field: 'email' });
+  const user = await deps.findUserByEmail(email);
+  if (!user || user.email_verified_at) {
+    await deps.hashPassword(DUMMY_PASSWORD);
+    return { response: RESEND_RESPONSE, mail: null, path: user ? 'verified' : 'unknown' };
+  }
+  await deps.hashPassword(DUMMY_PASSWORD);
+  const minted = deps.mintToken();
+  await deps.storeToken({ userId: user.id, hash: minted.hash, expiresAt: minted.expiresAt });
+  const mail = await deps.sendMail({ kind: 'verify', to: user.email, name: user.name, verifyUrl: deps.verifyUrl(minted.token) });
+  return { response: RESEND_RESPONSE, mail, path: 'sent' };
+}
+
+// ── login: one failure line ───────────────────────────────────────────────
+
+export type LoginDecision = { ok: true } | { ok: false; status: 401; error: typeof LOGIN_FAILED };
+
+export const LOGIN_REFUSED: LoginDecision = Object.freeze({ ok: false, status: 401, error: LOGIN_FAILED }) as LoginDecision;
+
+/**
+ * No account, a wrong password, an account that never verified: the SAME
+ * object. The route runs bcrypt.compare whenever an account exists — verified
+ * or not — so the timing does not tell either.
+ */
+export function loginDecision(input: { user: { email_verified_at: Date | null } | null; passwordOk: boolean }): LoginDecision {
+  if (!input.user) return LOGIN_REFUSED;
+  if (!input.passwordOk) return LOGIN_REFUSED;
+  if (!input.user.email_verified_at) return LOGIN_REFUSED;
+  return { ok: true };
+}

--- a/src/lib/auth/welcomeEmail.ts
+++ b/src/lib/auth/welcomeEmail.ts
@@ -1,27 +1,25 @@
 import { sendTransactionalEmail, type TransactionalEmailInput } from '@/lib/email';
 import { FREE_TOOLS, OFFERS } from '@/lib/offer';
 import { ANSWERS_HOME } from '@/lib/answers';
-import type { WelcomeSendResult } from './registration';
+import { TOKEN_TTL_HOURS, type AuthMail, type MailSendResult } from './verification';
 
 /**
- * SELL-03 — the welcome email, a real one through Resend (src/lib/email.ts).
+ * SELL-03 / 03b — the sign-up mail, a real one through Resend (src/lib/email.ts).
  *
- * The words come from the same sources the deck sells from: the front door
- * (ANSWERS_HOME), the free set and the offers (src/lib/offer.ts) — never
- * typed here, so the email cannot outrun the registry. Plain HTML + text.
+ * Two kinds, one sender:
+ *   verify — the welcome email that carries the verification link (the
+ *            link first, then what the deck says: the front door, the free
+ *            set and the offers from their sources, never typed);
+ *   taken  — "someone tried to sign up with your address": sign in with the
+ *            password you have. There is no self-service password reset in
+ *            the product today, so the mail does not promise one — it says
+ *            to reply and Alex will help.
  *
- * sendWelcomeEmail attempts the send ONCE. A failure (missing RESEND_API_KEY
- * / EMAIL_FROM, a provider refusal, no message id) is DECLARED — logged with
- * the error class and Resend's own message, returned as { sent: false } to
- * the caller's body — and never thrown: the sign-in is not the email's to
- * block (the LiteAPI booking precedent, api/travel/liteapi/book/route.ts).
+ * sendAuthMail attempts the send ONCE. A failure (missing RESEND_API_KEY /
+ * EMAIL_FROM, a provider refusal, no message id) is DECLARED — logged with
+ * the error class and Resend's own message, returned as { sent: false } —
+ * and never thrown: the sign-up's response is the same bytes either way.
  */
-
-export interface WelcomeEmailInput {
-  name: string;
-  /** The site's absolute origin for the links (NEXT_PUBLIC_APP_URL). */
-  baseUrl: string;
-}
 
 export interface RenderedEmail {
   subject: string;
@@ -30,31 +28,65 @@ export interface RenderedEmail {
 }
 
 const esc = (s: string) => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+const DISCLAIMER = 'Temple Stuart is not a CPA firm, tax preparer, or licensed financial advisor. Figures the platform produces are estimates to verify with a qualified professional before filing.';
+const WRAP_OPEN = '<div style="font-family:-apple-system,Segoe UI,Helvetica,Arial,sans-serif;font-size:14px;line-height:1.5;color:#1f1b2e;max-width:560px">';
+const SMALL = 'style="color:#6b6480;font-size:12px"';
 
-export function welcomeEmail({ name, baseUrl }: WelcomeEmailInput): RenderedEmail {
-  const origin = baseUrl.replace(/\/+$/, '');
-  const answers = `${origin}${ANSWERS_HOME}`;
-  const pricing = `${origin}/pricing`;
+function origin(baseUrl: string): string {
+  return baseUrl.replace(/\/+$/, '');
+}
+
+export function verificationEmail({ name, verifyUrl, baseUrl }: { name: string; verifyUrl: string; baseUrl: string }): RenderedEmail {
+  const o = origin(baseUrl);
+  const answers = `${o}${ANSWERS_HOME}`;
+  const pricing = `${o}/pricing`;
   const free = FREE_TOOLS.map((t) => t.name);
-  const sold = OFFERS.map((o) => o.label);
-  const subject = "Welcome to Temple Stuart — you're signed in";
-  const lines = [
+  const sold = OFFERS.map((o2) => o2.label);
+  const subject = 'Finish signing in to Temple Stuart';
+  const text = [
     `Hi ${name},`,
-    `Your account is open and you are signed in. Your front door is ${answers} — the four answers (tax, runway, trading, business) on your own numbers.`,
+    `Finish signing in with this link — it works once and for ${TOKEN_TTL_HOURS} hours:`,
+    verifyUrl,
+    `It opens your front door, ${answers} — the four answers (tax, runway, trading, business) on your own numbers.`,
     `Free with your account: ${free.join(', ')}.`,
     `For sale: ${sold.join(' and ')} — what each includes, and the price when one is set, is at ${pricing}.`,
-    'Temple Stuart is not a CPA firm, tax preparer, or licensed financial advisor. Figures the platform produces are estimates to verify with a qualified professional before filing.',
-    'You are receiving this because an account was created with this address.',
-  ];
-  const text = lines.join('\n\n');
+    DISCLAIMER,
+    'If you did not create this account, ignore this message — nothing is signed in until the link is used.',
+  ].join('\n\n');
   const html = [
-    '<div style="font-family:-apple-system,Segoe UI,Helvetica,Arial,sans-serif;font-size:14px;line-height:1.5;color:#1f1b2e;max-width:560px">',
+    WRAP_OPEN,
     `<p>Hi ${esc(name)},</p>`,
-    `<p>Your account is open and you are signed in. Your front door is <a href="${esc(answers)}">${esc(answers)}</a> — the four answers (tax, runway, trading, business) on your own numbers.</p>`,
+    `<p>Finish signing in with this link — it works once and for ${TOKEN_TTL_HOURS} hours:</p>`,
+    `<p><a href="${esc(verifyUrl)}" style="display:inline-block;padding:10px 16px;background:#3b2a6b;color:#fff;text-decoration:none;font-weight:600">Finish signing in</a></p>`,
+    `<p ${SMALL}>Or paste it: ${esc(verifyUrl)}</p>`,
+    `<p>It opens your front door, <a href="${esc(answers)}">${esc(answers)}</a> — the four answers (tax, runway, trading, business) on your own numbers.</p>`,
     `<p>Free with your account: ${esc(free.join(', '))}.</p>`,
     `<p>For sale: ${esc(sold.join(' and '))} — what each includes, and the price when one is set, is at <a href="${esc(pricing)}">${esc(pricing)}</a>.</p>`,
-    '<p style="color:#6b6480;font-size:12px">Temple Stuart is not a CPA firm, tax preparer, or licensed financial advisor. Figures the platform produces are estimates to verify with a qualified professional before filing.</p>',
-    '<p style="color:#6b6480;font-size:12px">You are receiving this because an account was created with this address.</p>',
+    `<p ${SMALL}>${esc(DISCLAIMER)}</p>`,
+    `<p ${SMALL}>If you did not create this account, ignore this message — nothing is signed in until the link is used.</p>`,
+    '</div>',
+  ].join('');
+  return { subject, html, text };
+}
+
+export function takenEmail({ baseUrl }: { baseUrl: string }): RenderedEmail {
+  const o = origin(baseUrl);
+  const login = `${o}/login`;
+  const subject = 'Someone tried to sign up with your Temple Stuart address';
+  const text = [
+    'Someone just tried to create a Temple Stuart account with this email address — and there already is one.',
+    `If that was you, sign in with the password you have: ${login}`,
+    'Forgot the password? There is no self-service reset yet — reply to this message and Alex will help.',
+    'If it was not you, nothing has changed: no one was signed in, and no account was created.',
+    DISCLAIMER,
+  ].join('\n\n');
+  const html = [
+    WRAP_OPEN,
+    '<p>Someone just tried to create a Temple Stuart account with this email address — and there already is one.</p>',
+    `<p>If that was you, sign in with the password you have: <a href="${esc(login)}">${esc(login)}</a></p>`,
+    '<p>Forgot the password? There is no self-service reset yet — reply to this message and Alex will help.</p>',
+    '<p>If it was not you, nothing has changed: no one was signed in, and no account was created.</p>',
+    `<p ${SMALL}>${esc(DISCLAIMER)}</p>`,
     '</div>',
   ].join('');
   return { subject, html, text };
@@ -62,20 +94,29 @@ export function welcomeEmail({ name, baseUrl }: WelcomeEmailInput): RenderedEmai
 
 export type Sender = (input: TransactionalEmailInput) => Promise<{ id: string }>;
 
-export async function sendWelcomeEmail(
-  input: { to: string; name: string; baseUrl: string },
+export function renderAuthMail(mail: AuthMail, baseUrl: string): RenderedEmail {
+  if (mail.kind === 'verify') {
+    if (!mail.verifyUrl || !mail.name) throw new Error('a verify mail needs the name and the link');
+    return verificationEmail({ name: mail.name, verifyUrl: mail.verifyUrl, baseUrl });
+  }
+  return takenEmail({ baseUrl });
+}
+
+export async function sendAuthMail(
+  mail: AuthMail,
+  baseUrl: string,
   send: Sender = sendTransactionalEmail,
   log: (message: string, detail: Record<string, unknown>) => void = console.error,
-): Promise<WelcomeSendResult> {
-  const rendered = welcomeEmail({ name: input.name, baseUrl: input.baseUrl });
+): Promise<MailSendResult> {
+  const rendered = renderAuthMail(mail, baseUrl);
   try {
-    const { id } = await send({ to: input.to, subject: rendered.subject, html: rendered.html, text: rendered.text });
+    const { id } = await send({ to: mail.to, subject: rendered.subject, html: rendered.html, text: rendered.text, ...(mail.kind === 'taken' && process.env.OWNER_EMAIL ? { replyTo: process.env.OWNER_EMAIL } : {}) });
     return { sent: true, id };
   } catch (err) {
     const errorClass = err instanceof Error ? err.name : 'UnknownError';
     const message = err instanceof Error ? err.message : String(err);
-    // Declared, not swallowed: the class and Resend's own words reach the log; the caller's body says sent: false.
-    log('[signup] welcome email NOT sent (the account and the sign-in stand):', { errorClass, message });
+    // Declared, not swallowed: the class and Resend's own words reach the log; the response is the same bytes either way.
+    log(`[signup] ${mail.kind} mail NOT sent (the response is unchanged):`, { errorClass, message });
     return { sent: false, error: errorClass };
   }
 }


### PR DESCRIPTION
**Do not merge — Alex merges after Vercel Preview (SOC 2 gate).**

**Why this is a new PR:** the ruling said "on claude/sell-03-front-door … update the PR body", but #1666 was merged at 13:41 UTC (`cf432284`) before this landed. A merged PR cannot track new work, so SELL-03b is its own PR on the same branch. The branch now sits on main's tip by a merge commit (`a9b0a446`, content-empty — a force push of a rebased branch was not available to this session); the whole diff is the one commit `69c8ca2d`.

## HARD GATE items (read first)

| # | What | Where | Why it needs Alex's eyes |
|---|---|---|---|
| 1 | **Auth surface: sign-up no longer signs in.** A new and a taken email get the SAME bytes — `200 {"message":"Check your email to finish signing in."}`, no cookie, no header that differs — and the same work (one bcrypt-12 hash, a dummy on the taken path; one mail). The 409 of SELL-03 is gone (it let anyone probe which emails have accounts). | `src/lib/auth/verification.ts:140-172`, `src/app/api/auth/signup/route.ts:32-59` | The cookie is set only by `GET /api/auth/verify` after a link is used (`verify/route.ts:36-43`, login's flags: `Secure; HttpOnly; SameSite=Lax; Path=/; 7d`). Sign-up rate limit unchanged (5/hour/IP, `signup/route.ts:32`). |
| 2 | **Migration + a backfill of `users` rows.** `users.email_verified_at timestamptz NULL` and `verification_tokens` (uuid id, user_id → users cascade, `token_hash varchar(64) unique`, expires_at, used_at, created_at). Then `UPDATE "users" SET "email_verified_at" = "createdAt" WHERE "email_verified_at" IS NULL` — every account that pre-dates verification is grandfathered as verified; without it, **every existing account would be locked out at deploy** (item 4). Applied at deploy after merge — Claude cannot touch Azure. | `prisma/migrations/20260909000000_email_verification/migration.sql`, `prisma/schema.prisma:565,601,611-621` | Not financial data, but a write to user rows by migration — flagged per the constitution. Schema ↔ SQL lockstep proven: `prisma migrate diff --from-url <main's schema applied> --to-schema-datamodel prisma/schema.prisma --script` → "This is an empty migration" after the file is applied. `npx prisma generate` run. |
| 3 | **Paid calls: one Resend send per sign-up (both paths) and per resend of an unverified account.** Kind by path: new → the verification email (subject "Finish signing in to Temple Stuart"); taken → "Someone tried to sign up with your Temple Stuart address" (reply-to `OWNER_EMAIL` when set — the mail says "reply to this message and Alex will help" because **there is no self-service password reset** and the mail promises none). A send failure is logged with its class and declared to the log only — the response is unchanged either way (that is the non-enumeration). Resend: 3/hour/IP, identical bytes for unknown / verified / unverified; only the unverified path mints and sends. | `src/lib/auth/welcomeEmail.ts:39-118`, `src/app/api/auth/verify/resend/route.ts:25-46` | Bounded per IP; nothing in the body says whether a mail went out. The link's base is `NEXT_PUBLIC_APP_URL \|\| 'http://localhost:3000'` — the convention of `api/stripe/checkout/route.ts:41` and `api/trips/[id]/participants/route.ts:57`; **whether the Vercel env sets it is not verified** — if unset, the mailed link points at localhost. |
| 4 | **Login now refuses an unverified account** with the same frozen line as a wrong password or no account (`{"error":"Invalid email or password"}` 401) and offers the resend on every failure. Also closes a timing gap the probe found: OAuth accounts store `password: ''` and bcryptjs answers a non-60-char hash instantly (`node_modules/bcryptjs/dist/bcrypt.js:289`), so a login attempt against an OAuth address was ~0 ms vs ~400 ms for a real wrong password — the route now compares against a dummy cost-12 hash whenever there is no account or no bcrypt hash. | `src/app/api/auth/login/route.ts:21-22,54-56`, `verification.ts:213-227` | With item 2's backfill, no existing account is refused. OAuth accounts are verified at creation, and an email sign-up that never used its link is verified when the same address signs in through Google/GitHub (`[...nextauth]/route.ts:46-53`). |
| 5 | **Middleware and PUBLIC_PATHS untouched.** `/api/auth` is already public (`src/middleware.ts:55`), so `/api/auth/verify` and `/api/auth/verify/resend` need no change; a bad link lands on `/?verify=<state>` (public) rather than `/login` (still not public — the SELL-03 finding stands). | — | — |

## Audit (read-only, against `origin/main` = `cf432284`, i.e. SELL-03)

| What main had | Where | What SELL-03b does with it |
|---|---|---|
| `registerAccount` → 409 `ACCOUNT_EXISTS` for a taken email; 200 `"You're signed in"` + cookie for a new one; one welcome mail declared in the body as `welcomeEmail: { sent, error }` | `src/lib/auth/registration.ts` (SELL-03) | `registerAccount`, `ACCOUNT_EXISTS`, `SIGNED_IN_MESSAGE`, `WelcomeSendResult` removed; the file keeps only the input rules (`PASSWORD_MIN_LENGTH`, `EMAIL_INVALID`, `NAME_REQUIRED`, `parseRegistration`, `SIGNUP_LANDING`). Input refusals stay 400 with the authored line — they are about the INPUT and say nothing about any account (identical for a new and a taken address, probed). |
| `welcomeEmail()` / `sendWelcomeEmail()` — "you're signed in" | `src/lib/auth/welcomeEmail.ts` | Becomes `verificationEmail()` (the link first, then the front door, `FREE_TOOLS`, `OFFERS`, `/pricing`, the disclaimer — from their sources, never typed; "nothing is signed in until the link is used"), `takenEmail()`, `renderAuthMail()`, `sendAuthMail()` (one send; failure logged `[signup] <kind> mail NOT sent (the response is unchanged): { errorClass, message }`, never thrown). |
| `users` model: no verified column | `prisma/schema.prisma` | `email_verified_at`, the `verification_tokens` model, the relation. |
| `LoginBox` register success → navigate to `result.landing` | `src/components/LoginBox.tsx` | Register success → the `sent` state (`:143-176`: the server's line, the address, "works once, for 24 hours", a resend button → `POST /api/auth/verify/resend` → its line); every login failure shows the line and a "Didn't finish signing up? Send a new sign-in link" button (`:283`). OAuth `callbackUrl` stays `ANSWERS_HOME` (`:131`). |
| `GuestLanding` mounts `CheckoutResultBanner` | `src/components/landing/GuestLanding.tsx:92-96` | Also mounts `VerifyResultBanner` (new, `src/components/VerifyResultBanner.tsx`): reads `?verify=expired\|used\|invalid`, one declared line each, a resend form, dismiss drops the param. |
| developer page: `setMessage(data.message)` + navigate on any 200 | `src/app/developer/page.tsx:104-112` | Navigates only for login; a sign-up shows the server's line. |
| NextAuth callback creates `users` with `password: ''` | `[...nextauth]/route.ts:36-53` | `email_verified_at: new Date()` at creation; an existing unverified row is verified on OAuth sign-in. (Its cookie stays 30d / `secure` prod-only — untouched, finding 3 of #1666.) |

**New, small, hermetic:** `src/lib/auth/verification.ts` — `mintToken` (32 random bytes base64url, HMAC-SHA256 with `JWT_SECRET`; the DB holds `sha256(random)`), `parseToken` (timing-safe; a tampered or foreign link is refused before any lookup), `verifyToken` over a `VerifyDb` port (`invalid` / `expired` / `used` / ok), `signupOutcome`, `resendOutcome`, `loginDecision` + the frozen `LOGIN_REFUSED`; `src/lib/auth/prismaVerifyDb.ts` — `consume` is one `$transaction`: `updateMany used_at where used_at IS NULL` must count 1, then `users.updateMany email_verified_at where NULL` (`:27-32`); `verificationSecret()` throws when `JWT_SECRET` is unset (fail-loud).

## Verify

| Check | Result |
|---|---|
| `npx tsc --noEmit` | 0 errors |
| eslint, every touched file vs its main baseline | no widening: `signup/route.ts` 2 → 0; `login/route.ts` 1 → 1 (the pre-existing `prefer-const`); `developer/page.tsx` 3/1 → 3/1 (pre-existing); every new file 0/0 |
| `npm test` | **206/206** (202 − 7 old registration tests + 7 rewritten + 4 in `verification.test.ts`) |
| `npx prisma validate` · `prisma generate` · lockstep | valid · generated · `migrate diff` after applying the SQL to main's schema → "This is an empty migration." |
| Build with the asserts | showroom ✓ · tool registry 25/25 ✓ · reachability ✓ 67 pages (`/login`, `/answers` doors intact) · family map 6/6 ✓ · answers 4/4 ✓ · arrivals 28 ✓ · rule book 24/8 ✓ · kind views ✓ · posting law ✓ (13 files) · offer law ✓ · `next build` exit 0; `/api/auth/verify` and `/api/auth/verify/resend` listed |
| README regen | 290 → 292 route files, 115 → 116 models; byte-stable on the second run; committed |

Ruled tests → where they live:

| Ruled test | Hermetic (`registration.test.ts`, `verification.test.ts`) | The real routes (next dev on a throwaway Postgres 16 with the migration applied, no `RESEND_API_KEY`; `x-forwarded-for` varied so no limit interferes) |
|---|---|---|
| new vs taken email produce byte-identical responses and both send one email of the right kind | `registration.test.ts:64` — `JSON.stringify` of status/body/headers equal, the same frozen `SIGNUP_RESPONSE` object, no cookie field; exactly one `sendMail` each: `verify` (with the link, to the new address) / `taken`; the token stored is `sha256(random)`, 24h | `curl -i` new vs taken: bodies `cmp` identical, headers identical with `Date` stripped, `Set-Cookie` lines 0/0; the server log shows `[signup] verify mail NOT sent` on the new path and `[signup] taken mail NOT sent` on the taken one (`EmailConfigError: RESEND_API_KEY is not configured` — the response unchanged, as designed); the browser's sent state is the same text for both |
| a valid token verifies once and never twice | `verification.test.ts:69` — first use ok + `email_verified_at` set + `used_at` set; second use `{ ok:false, state:'used' }` without reaching `consume`; expired at `expires_at` exactly, ok 1 ms before; a signed-but-unstored link and garbage → `invalid`; a race of two consumers → exactly one wins | link minted with the app's lib, hash inserted for the user: 1st `GET /api/auth/verify?token=` → **303 `/answers`** + `userEmail` cookie (`Secure; HttpOnly; SameSite=Lax; Path=/; Max-Age=604800`), `/answers` with that cookie → 200; 2nd → 303 `/?verify=used`, no cookie; expired → `/?verify=expired`; garbage / tampered signature / no token → `/?verify=invalid`; the row shows `email_verified_at` set and one token used |
| the login message for unverified equals the wrong-password message | `verification.test.ts:102` — unverified (right password), wrong password, no account → the same frozen `LOGIN_REFUSED` object | `POST /api/auth/login` unverified / wrong password / no account → 401, bodies `cmp` identical, headers identical; wall time 0.42 / 0.42 / 0.40 s (the dummy-hash compare); in the browser both show "Invalid email or password" with the resend button; after the link, the same account signs in (200, `landing: /answers`, cookie) |
| timing test within tolerance | `registration.test.ts:118` — medians of the new and taken paths with a 40 ms hash, tolerance 40 ms | 8 pairs through the route: new 0.37–0.56 s vs taken 0.41–0.45 s (medians 0.43 / 0.42); resend warm: unverified / verified / unknown 0.39 / 0.39 / 0.39 s |
| resend is rate-limited and non-enumerating | `verification.test.ts:115` — unknown / verified / unverified: the same frozen `RESEND_RESPONSE`, one dummy hash each, a fresh link only for the unverified account | bodies and headers identical across the three; the unverified account gains a second stored token; a bad shape → 400 `field: email`; 3/hour/IP |
| the verification email's words | `registration.test.ts:137` — the link first, then `ANSWERS_HOME`, every `FREE_TOOLS` name, every `OFFERS` label, `/pricing`, the disclaimer; the taken email names `/login` and promises no reset | — |
| a mail failure changes nothing | `registration.test.ts:106,158` — a declared failure and a THROWING sender leave both responses byte-identical; logged once with `{ errorClass, message }` | see row 1 |

Screenshots (the sent state for a new and for a taken email, its resend notice, the login line for an unverified account and for a wrong password, the expired-link banner with its resend, `/answers` after the link, the second use declared as used) are in the session chat — not committed, the repo is public.

## Findings outside this PR's fence (reported, not fixed)

1. **`/login` is still not in PUBLIC_PATHS** (finding 1 of #1666) — a guest is bounced to `/` before the page renders. This PR routes a bad link's error to `/` for that reason.
2. **No self-service password reset exists.** The ruling's taken-address mail says "sign in or reset your password"; the mail here says sign in, and to reply for help — writing "reset your password" would promise a flow that does not exist. A reset route is its own PR (the token table here would carry it).
3. **Old `users` rows carry `createdAt` as their verification time** by the backfill — honest about their history, but any account created between the merge and the migration's apply at deploy (the same deploy) is not a window that exists on Vercel; if the migration is applied by hand later than the deploy, sign-ups in the gap are refused at login until their link is used or they are backfilled again.
4. The NextAuth callback's cookie is still 30 days / `secure` prod-only (finding 3 of #1666); the OAuth buttons still render whether or not the providers are configured.
5. `/api/auth/me` and the header show the address for a verified viewer — unchanged; a viewer whose link was never used has no cookie and sees nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc

---
_Generated by [Claude Code](https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc)_