### PR TITLE
SELL-04: first value for a new account — honest answers, entity setup, no single-tenant constants

### DIFF
--- a/src/app/answers/page.tsx
+++ b/src/app/answers/page.tsx
@@ -1,5 +1,7 @@
 import { getVerifiedEmail } from '@/lib/cookie-auth';
 import AnswersClient from '@/components/answers/AnswersClient';
+// SELL-04: a free account's cards render THE OFFER with the server's price-id presence map.
+import { offerAvailabilityFromEnv } from '@/lib/offer';
 
 /**
  * NAV-01c — /answers, THE ANSWERS: the app's front page and the post-login
@@ -18,5 +20,5 @@ export const dynamic = 'force-dynamic';
 
 export default async function AnswersPage() {
   const viewer = await getVerifiedEmail();
-  return <AnswersClient viewer={viewer ?? ''} />;
+  return <AnswersClient viewer={viewer ?? ''} offerAvailability={offerAvailabilityFromEnv(process.env)} />;
 }

--- a/src/app/api/chart-of-accounts/reclassify/route.ts
+++ b/src/app/api/chart-of-accounts/reclassify/route.ts
@@ -2,7 +2,7 @@ import { randomUUID } from 'crypto';
 import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
-import { ensureBookkeepingInitialized } from '@/lib/ensure-bookkeeping';
+import { requireEntitySetup } from '@/lib/ensure-bookkeeping';
 import { requireTabAccess } from '@/lib/auth-helpers';
 import { failClosedResponse } from '@/lib/http/failClosedResponse';
 import { assertPeriodOpen, PeriodClosedError } from '@/lib/period-close-guard';
@@ -52,7 +52,9 @@ export async function POST(request: Request) {
     const tabGate = await requireTabAccess(user.id, 'tab:books');
     if (tabGate) return tabGate;
 
-    await ensureBookkeepingInitialized(user);
+    // SELL-04: a user with no entity gets the declared setup line (412) — nothing is created here.
+    const setup = await requireEntitySetup(user);
+    if (setup) return setup;
 
     const body = await request.json().catch(() => ({}));
     const { entityId, fromCode, toCode, memo, amountCents } = body ?? {};

--- a/src/app/api/chart-of-accounts/route.ts
+++ b/src/app/api/chart-of-accounts/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
-import { ensureBookkeepingInitialized } from '@/lib/ensure-bookkeeping';
+import { requireEntitySetup } from '@/lib/ensure-bookkeeping';
 import { requireTabAccess } from '@/lib/auth-helpers';
 import { failClosedResponse } from '@/lib/http/failClosedResponse';
 import { addAccount } from '@/lib/coa/accounts';
@@ -44,7 +44,9 @@ export async function GET(request: Request) {
     const tabGate = await requireTabAccess(user.id, 'tab:books');
     if (tabGate) return tabGate;
 
-    await ensureBookkeepingInitialized(user);
+    // SELL-04: a user with no entity gets the declared setup line (412) — nothing is created here.
+    const setup = await requireEntitySetup(user);
+    if (setup) return setup;
 
     const { searchParams } = new URL(request.url);
     const entityId = searchParams.get('entity_id') || null;
@@ -104,7 +106,9 @@ export async function POST(request: Request) {
     const tabGate = await requireTabAccess(user.id, 'tab:books');
     if (tabGate) return tabGate;
 
-    await ensureBookkeepingInitialized(user);
+    // SELL-04: a user with no entity gets the declared setup line (412) — nothing is created here.
+    const setup = await requireEntitySetup(user);
+    if (setup) return setup;
 
     const body = await request.json().catch(() => ({}));
     const { code, name, entityId, subType } = body ?? {};

--- a/src/app/api/chart-of-accounts/seed/route.ts
+++ b/src/app/api/chart-of-accounts/seed/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
-import { ensureBookkeepingInitialized } from '@/lib/ensure-bookkeeping';
+import { requireEntitySetup } from '@/lib/ensure-bookkeeping';
 import { requireTabAccess } from '@/lib/auth-helpers';
 import { failClosedResponse } from '@/lib/http/failClosedResponse';
 import { applySeed } from '@/lib/coa/accounts';
@@ -41,7 +41,9 @@ export async function POST(request: Request) {
     const tabGate = await requireTabAccess(user.id, 'tab:books');
     if (tabGate) return tabGate;
 
-    await ensureBookkeepingInitialized(user);
+    // SELL-04: a user with no entity gets the declared setup line (412) — nothing is created here.
+    const setup = await requireEntitySetup(user);
+    if (setup) return setup;
 
     const body = await request.json().catch(() => ({}));
     const { entityId, setKey } = body ?? {};

--- a/src/app/api/entities/route.ts
+++ b/src/app/api/entities/route.ts
@@ -2,6 +2,9 @@ import { NextResponse } from 'next/server';
 import { failClosedResponse } from '@/lib/http/failClosedResponse';
 import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { requireTabAccess } from '@/lib/auth-helpers';
+import { createEntity } from '@/lib/entities/setup';
+import { prismaEntityDb } from '@/lib/entities/prismaEntityDb';
 
 export async function GET() {
   try {
@@ -26,5 +29,51 @@ export async function GET() {
     return NextResponse.json({ entities });
   } catch (error) {
     return failClosedResponse('Entities API', 'Entities read failed', error);
+  }
+}
+
+/**
+ * POST /api/entities { name, entity_type } — SELL-04: THE entity creator, the
+ * first-run step's one call. User-scoped by construction (the row carries the
+ * authed user's id; the port is handed it); the kind must be one the routes
+ * read (personal | sole_prop — src/lib/entities/kinds.ts); the name is unique
+ * for the user (409). The entity, its starter chart and its Schedule C
+ * mappings land in ONE transaction; the user's first entity becomes their
+ * default and sets bookkeeping_initialized (what the old silent path set).
+ * Gate: verified email → user → tab:books (Books' write surfaces' gate).
+ */
+export async function POST(request: Request) {
+  try {
+    const userEmail = await getVerifiedEmail();
+    if (!userEmail) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    const user = await prisma.users.findFirst({
+      where: { email: { equals: userEmail, mode: 'insensitive' } },
+      select: { id: true },
+    });
+    if (!user) {
+      return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    }
+    // TAB-SERVER-GATE: tab:books entitlement (bundle:all included; admin bypass inside).
+    const tabGate = await requireTabAccess(user.id, 'tab:books');
+    if (tabGate) return tabGate;
+
+    const body = await request.json().catch(() => ({}));
+    const taxYear = new Date().getFullYear();
+    const created = await prisma.$transaction((tx) => createEntity(prismaEntityDb(tx, user.id), { userId: user.id, body, taxYear }));
+
+    return NextResponse.json(
+      {
+        success: true,
+        entity: { id: created.entity.id, name: created.entity.name, entity_type: created.entity.entity_type, is_default: created.entity.is_default },
+        chart: created.chart,
+        isFirst: created.isFirst,
+        taxYear,
+      },
+      { status: 201 },
+    );
+  } catch (error) {
+    return failClosedResponse('Entity setup', 'Failed to create the entity', error);
   }
 }

--- a/src/app/api/journal-entries/manual/route.ts
+++ b/src/app/api/journal-entries/manual/route.ts
@@ -2,7 +2,7 @@ import { randomUUID } from 'crypto';
 import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
-import { ensureBookkeepingInitialized } from '@/lib/ensure-bookkeeping';
+import { requireEntitySetup } from '@/lib/ensure-bookkeeping';
 import { assertPeriodOpen, PeriodClosedError } from '@/lib/period-close-guard';
 import { requireTabAccess } from '@/lib/auth-helpers';
 import { failClosedResponse } from '@/lib/http/failClosedResponse';
@@ -25,7 +25,9 @@ export async function POST(request: Request) {
     const tabGate = await requireTabAccess(user.id, 'tab:books');
     if (tabGate) return tabGate;
 
-    await ensureBookkeepingInitialized(user);
+    // SELL-04: a user with no entity gets the declared setup line (412) — nothing is created here.
+    const setup = await requireEntitySetup(user);
+    if (setup) return setup;
 
     const { date, description, entityId, lines } = await request.json();
 

--- a/src/app/api/journal-entries/route.ts
+++ b/src/app/api/journal-entries/route.ts
@@ -3,7 +3,7 @@ import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { failClosedResponse } from '@/lib/http/failClosedResponse';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
-import { ensureBookkeepingInitialized } from '@/lib/ensure-bookkeeping';
+import { requireEntitySetup } from '@/lib/ensure-bookkeeping';
 import { assertPeriodOpen, PeriodClosedError } from '@/lib/period-close-guard';
 import { balanceDeltaOf, postJournal } from '@/lib/posting/postJournal';
 import { requireTabAccess } from '@/lib/auth-helpers';
@@ -21,7 +21,9 @@ export async function GET() {
     const tabGate = await requireTabAccess(user.id, 'tab:books');
     if (tabGate) return tabGate;
 
-    await ensureBookkeepingInitialized(user);
+    // SELL-04: a user with no entity gets the declared setup line (412) — nothing is created here.
+    const setup = await requireEntitySetup(user);
+    if (setup) return setup;
 
     const entries = await prisma.journal_entries.findMany({
       where: { userId: user.id },

--- a/src/app/api/runway/route.ts
+++ b/src/app/api/runway/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from 'next/server';
+import { Prisma } from '@prisma/client';
 import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { attributeBurn, resolveOperatingEntities } from '@/lib/runway/entities';
 
 /**
  * GET /api/runway — compute-on-read runway engine (RUNWAY-2).
@@ -10,8 +12,9 @@ import { getVerifiedEmail } from '@/lib/cookie-auth';
  * income ≈ $176K but YTD ≈ ~$900 after Alex left his job, so a YTD net burn would be
  * meaningless). Two windows: trailing 3mo and trailing 6mo.
  *
- * OPERATING scope = Personal + Business only. The Trading entity is EXCLUDED from burn/income
- * (trading P&L is not operating burn — decision: audits/RUNWAY-ENTITY-MODEL.md; see TRADING_ENTITY_ID).
+ * OPERATING scope = Personal + Business only. The viewer's Trading entity is EXCLUDED from burn/income
+ * (trading P&L is not operating burn — decision: audits/RUNWAY-ENTITY-MODEL.md; SELL-04: resolved per
+ * user from their own entity rows, src/lib/runway/entities.ts — no single-tenant id constants).
  *
  * Inputs — ALL reuse the VERIFIED existing sources, user-scoped, no new table/migration:
  *   • cash       = SUM(accounts.currentBalance) for the user  (same field /api/metrics:22-27
@@ -48,21 +51,13 @@ const round = (n: number, dp: number) => {
   return Math.round(n * f) / f;
 };
 
-// Trading entity excluded from OPERATING runway — trading P&L (WIN→4100 revenue, LOSS→5100
-// expense, posted by commit-to-ledger) is NOT operating burn (decision: audits/RUNWAY-ENTITY-MODEL.md).
-// Operating burn/income = Personal + Business only. Resolved by entity_id — the IMMUTABLE key — NOT
-// entity_type, which is inconsistent across seeds (seed-entities.ts:13 wrongly seeds Trading as
-// 'personal'; Alex's psql confirmed the live row is entity_type='trading' with THIS id). Single-tenant:
-// this is the authenticated user's Trading entity. (Multi-tenant would resolve this per-user by id.)
-const TRADING_ENTITY_ID = '972658cc-c1ca-4178-b77e-fad32a89a823';
-
-// The two OPERATING entities, resolved by IMMUTABLE entity_id (psql-confirmed; entity_type is
-// inconsistent across seeds — same rationale as TRADING_ENTITY_ID). The per-entity breakdown
-// attributes each non-trading ledger row to one of these. Any non-trading row that is NEITHER
-// (a stray/legacy entity) is surfaced as `unattributed` — NEVER silently dropped — so the
-// invariant Personal + Business + Unattributed === Combined operating always holds. Single-tenant.
-const PERSONAL_ENTITY_ID = 'e83f5b3a-0b46-4c73-8b91-1b736ecdd3eb';
-const BUSINESS_ENTITY_ID = '9e8ee102-5b75-445b-a1ba-b7226a208b4a';
+// SELL-04: the operating entities are the USER'S OWN, resolved per request from their
+// entity rows (src/lib/runway/entities.ts) — Personal = their default `personal` entity,
+// Business = their `sole_prop` one, Trading = their `trading` one, excluded from operating
+// burn/income (trading P&L is not operating burn — decision: audits/RUNWAY-ENTITY-MODEL.md).
+// The three single-tenant id constants that stood here are gone: a second user's rows can
+// never match them, and a user with no operating entity gets the DECLARED setup line in
+// the breakdown (entities.setup) — never an `unattributed` bucket.
 
 type WindowState = 'ok' | 'insufficient_history' | 'cashflow_positive' | 'no_cash';
 
@@ -80,6 +75,15 @@ export async function GET() {
       return NextResponse.json({ error: 'User not found' }, { status: 404 });
     }
     const userId = user.id;
+
+    // ── The viewer's own entities (user-scoped) → Personal / Business / Trading by their ids. ──
+    const ents = resolveOperatingEntities(
+      await prisma.entities.findMany({ where: { userId }, select: { id: true, entity_type: true, is_default: true } }),
+    );
+    // Trading rows are excluded by the viewer's trading entity id; a viewer with none excludes nothing
+    // (never `!= NULL`, which would exclude every row).
+    const notTradingCoa = ents.tradingId ? Prisma.sql`AND coa.entity_id != ${ents.tradingId}` : Prisma.empty;
+    const notTradingJe = ents.tradingId ? Prisma.sql`AND je.entity_id != ${ents.tradingId}` : Prisma.empty;
 
     // ── Trailing-window bounds: FULL calendar months, excluding the current partial month.
     //    e.g. on 2026-06-21 → windowEnd = 2026-06-01 (exclusive); 3mo start = 2026-03-01;
@@ -116,7 +120,7 @@ export async function GET() {
       WHERE je."userId" = ${userId}
         AND je.is_reversal = false
         AND je.reversed_by_entry_id IS NULL
-        AND je.entity_id != ${TRADING_ENTITY_ID}
+        ${notTradingJe}
     `;
     const earliest = earliestRows[0]?.earliest ?? null;
 
@@ -136,7 +140,7 @@ export async function GET() {
           AND je.reversed_by_entry_id IS NULL
           AND je.date >= ${startStr}::date
           AND je.date <  ${windowEndStr}::date
-          AND coa.entity_id != ${TRADING_ENTITY_ID}
+          ${notTradingCoa}
       `;
       const exp = Number(rows[0]?.exp_cents ?? 0) / 100;
       const rev = Number(rows[0]?.rev_cents ?? 0) / 100;
@@ -160,7 +164,7 @@ export async function GET() {
           AND je.reversed_by_entry_id IS NULL
           AND je.date >= ${startStr}::date
           AND je.date <  ${windowEndStr}::date
-          AND coa.entity_id != ${TRADING_ENTITY_ID}
+          ${notTradingCoa}
         GROUP BY coa.entity_id
       `;
       const map: Record<string, { exp: number; rev: number }> = {};
@@ -176,22 +180,11 @@ export async function GET() {
       const netBurnTotal = round(exp - rev, 2); // positive = burning cash over the window
       const netBurnPerMonth = round(netBurnTotal / n, 2);
 
-      // Per-entity net burn (additive — the combined numbers above are unchanged). Attribute each
-      // non-trading entity_id to Personal / Business; anything else accumulates into `unattributed`
-      // (expected 0 — psql shows exactly 3 entities — but surfaced truthfully if non-zero).
+      // Per-entity net burn (additive — the combined numbers above are unchanged), attributed to
+      // the VIEWER'S Personal / Business ids; anything else is `unattributed` (surfaced, never
+      // dropped); a viewer with no operating entity gets the declared setup line instead.
       const byEntity = await burnByEntity(startStr);
-      const entityFig = (e: { exp: number; rev: number }) => {
-        const total = round(e.exp - e.rev, 2);
-        return { expenses: e.exp, income: e.rev, netBurnTotal: total, netBurnPerMonth: round(total / n, 2) };
-      };
-      const personal = entityFig(byEntity[PERSONAL_ENTITY_ID] ?? { exp: 0, rev: 0 });
-      const business = entityFig(byEntity[BUSINESS_ENTITY_ID] ?? { exp: 0, rev: 0 });
-      let otherExp = 0;
-      let otherRev = 0;
-      for (const [id, e] of Object.entries(byEntity)) {
-        if (id !== PERSONAL_ENTITY_ID && id !== BUSINESS_ENTITY_ID) { otherExp += e.exp; otherRev += e.rev; }
-      }
-      const unattributed = entityFig({ exp: otherExp, rev: otherRev });
+      const attribution = attributeBurn(byEntity, ents, n);
       const sufficientHistory = earliest !== null && earliest <= startStr;
 
       let state: WindowState;
@@ -223,12 +216,9 @@ export async function GET() {
         state,
         runwayMonths,
         zeroDate,
-        // Additive per-entity breakdown (Personal + Business + Unattributed === combined netBurnTotal).
-        entities: {
-          personal,
-          business,
-          unattributed: unattributed.netBurnTotal !== 0 ? unattributed : null,
-        },
+        // Additive per-entity breakdown (Personal + Business + Unattributed === combined netBurnTotal),
+        // or the declared setup line for a viewer with no operating entity (SELL-04).
+        entities: attribution,
       };
     };
 

--- a/src/app/api/transactions/commit-to-ledger/route.ts
+++ b/src/app/api/transactions/commit-to-ledger/route.ts
@@ -6,7 +6,7 @@ import { summarizeError, userFacingMessage } from '@/lib/http/failClosed';
 import { prisma } from '@/lib/prisma';
 import { commitPlaidTransaction, type CommitLink } from '@/lib/journal-entry-service';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
-import { ensureBookkeepingInitialized } from '@/lib/ensure-bookkeeping';
+import { requireEntitySetup } from '@/lib/ensure-bookkeeping';
 import { PeriodClosedError } from '@/lib/period-close-guard';
 import { TAB_DESCRIPTORS } from '@/lib/tabDescriptors';
 
@@ -35,7 +35,9 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'User not found' }, { status: 404 });
     }
 
-    await ensureBookkeepingInitialized(user);
+    // SELL-04: a user with no entity gets the declared setup line (412) — nothing is created here.
+    const setup = await requireEntitySetup(user);
+    if (setup) return setup;
 
     const body = await request.json();
     // DIM-3: vendorId + links are OPTIONAL — absent means the entries post

--- a/src/app/api/transactions/route.ts
+++ b/src/app/api/transactions/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
-import { ensureBookkeepingInitialized } from '@/lib/ensure-bookkeeping';
+import { requireEntitySetup } from '@/lib/ensure-bookkeeping';
 
 export async function GET(request: Request) {
   try {
@@ -20,7 +20,9 @@ export async function GET(request: Request) {
       return NextResponse.json({ error: 'User not found' }, { status: 404 });
     }
 
-    await ensureBookkeepingInitialized(user);
+    // SELL-04: a user with no entity gets the declared setup line (412) — nothing is created here.
+    const setup = await requireEntitySetup(user);
+    if (setup) return setup;
 
     const { searchParams } = new URL(request.url);
     const accountCode = searchParams.get('accountCode');

--- a/src/app/chart-of-accounts/page.tsx
+++ b/src/app/chart-of-accounts/page.tsx
@@ -4,6 +4,8 @@ import { useEffect, useState } from 'react';
 import { AppLayout } from '@/components/ui';
 import BookkeepingSection from '@/components/bookkeeping/BookkeepingSection';
 import COAManagementTable from '@/components/bookkeeping/COAManagementTable';
+// SELL-04: the first-run entity step (no entity yet) and the add-a-business step (no sole-prop).
+import EntitySetup from '@/components/books/EntitySetup';
 import { FAMILIES, FAMILY_RULES, letterFor } from '@/lib/coa/scheme';
 
 /**
@@ -13,6 +15,9 @@ import { FAMILIES, FAMILY_RULES, letterFor } from '@/lib/coa/scheme';
  * with the entity's REAL type driving its code letter. Reads /api/entities
  * (user-scoped) and, per entity, the two chart routes the table calls.
  * Every failure renders as the server's own words; nothing is swallowed.
+ * SELL-04: with no entity yet the page IS the first-run step (EntitySetup);
+ * with entities but no sole-prop it offers the business one — the Answers'
+ * "set up your business entity" door lands here.
  */
 
 interface Entity {
@@ -27,6 +32,9 @@ const TYPE_ORDER: Record<string, number> = { personal: 0, sole_prop: 1, trading:
 export default function ChartOfAccountsPage() {
   const [entities, setEntities] = useState<Entity[] | null>(null);
   const [error, setError] = useState<string | null>(null);
+
+  const [reloads, setReloads] = useState(0);
+  const reload = () => setReloads((n) => n + 1);
 
   useEffect(() => {
     let cancelled = false;
@@ -45,7 +53,7 @@ export default function ChartOfAccountsPage() {
       })
       .catch((err: Error) => { if (!cancelled) setError(err.message); });
     return () => { cancelled = true; };
-  }, []);
+  }, [reloads]);
 
   return (
     <AppLayout>
@@ -67,7 +75,10 @@ export default function ChartOfAccountsPage() {
           </div>
         )}
         {entities !== null && entities.length === 0 && (
-          <div className="text-sm text-text-muted">No entity yet — open Books once and the Personal entity is created with the default chart.</div>
+          <EntitySetup existing={[]} mode="first-run" onCreated={reload} />
+        )}
+        {entities !== null && entities.length > 0 && !entities.some((e) => e.entity_type === 'sole_prop') && (
+          <EntitySetup existing={entities} mode="add" onCreated={reload} />
         )}
         {entities?.map((entity) => {
           const letter = letterFor(entity.entity_type);

--- a/src/components/answers/AnswersClient.tsx
+++ b/src/components/answers/AnswersClient.tsx
@@ -12,6 +12,14 @@
  * route's own error, never a number; an empty ledger prints the empty state in
  * words, never $0 as if it were a sum. No retry, no fallback, no placeholder.
  *
+ * SELL-04 — FIRST VALUE: before any route is read, each card's state comes
+ * from the viewer's facts (src/lib/answersState.ts cardState): a free account
+ * sees THE OFFER line from offer.ts with its buy door — the gated routes are
+ * never read, so there is no HTTP line to print; a paid account with no bank
+ * sees "link a bank" with the door to Books; one with a bank but no sole-prop
+ * entity sees "set up your business entity" with the door to the step, on the
+ * two cards whose route reads one. Only then does a card read its route.
+ *
  * The shell is the one shell (NAV-01b): ShellBar + the family navigation in
  * link mode (THE ANSWERS is its first entry). Mobile: cards stack; ≥10px.
  */
@@ -24,6 +32,8 @@ import FamilyNav from '@/components/home/FamilyNav';
 import CheckoutResultBanner from '@/components/CheckoutResultBanner';
 import { deriveRunwayReceipts } from '@/components/hub/RunwayBudgetPanel';
 import { ANSWER_ROWS, ANSWER_READS, NET_WORTH_READ, type AnswerRead, type ComputedRead } from '@/lib/answers';
+import { cardState, answersLocked, type CardState, type ViewerFacts } from '@/lib/answersState';
+import { startEntitlementCheckout } from '@/lib/checkoutDoor';
 
 type Read<T> = { status: 'reading' } | { status: 'failed'; message: string } | { status: 'ok'; data: T };
 
@@ -47,13 +57,15 @@ async function readJson<T>(endpoint: string): Promise<Read<T>> {
   }
 }
 
-function useRead<T>(endpoint: string): Read<T> {
+/** One read, made only when `enabled` — a card whose state is not 'read' never touches its route. */
+function useRead<T>(endpoint: string, enabled = true): Read<T> {
   const [read, setRead] = useState<Read<T>>({ status: 'reading' });
   useEffect(() => {
+    if (!enabled) return;
     let live = true;
     readJson<T>(endpoint).then((r) => { if (live) setRead(r); });
     return () => { live = false; };
-  }, [endpoint]);
+  }, [endpoint, enabled]);
   return read;
 }
 
@@ -142,6 +154,56 @@ function netWorthFigure(d: NetWorthAnswer): Figure {
 
 const TONE: Record<'pos' | 'neg' | 'flat', string> = { pos: 'text-emerald-700', neg: 'text-rose-700', flat: 'text-text-primary' };
 
+const DOOR_CLASS = 'self-start rounded border border-brand-purple px-2.5 py-1 font-mono text-[10px] uppercase tracking-wider text-brand-purple hover:bg-brand-purple-wash';
+
+/**
+ * SELL-04: what a card shows BEFORE its route — the offer line (free account),
+ * "link a bank" (paid, no bank) or "set up your business entity" (paid, a
+ * bank, no sole-prop) — each with its door. The offer's buy door is the one
+ * checkout call every selling surface makes (checkoutDoor.ts) when the price
+ * is live; otherwise the door is the offer page. A failed checkout is declared.
+ */
+function StateBlock({ state }: { state: Exclude<CardState, { kind: 'read' }> }) {
+  const [starting, setStarting] = useState(false);
+  const [error, setError] = useState('');
+  if (state.kind === 'offer') {
+    const buy = async () => {
+      if (state.door.kind !== 'checkout') return;
+      setError('');
+      setStarting(true);
+      try {
+        window.location.href = await startEntitlementCheckout(state.door.key);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Could not start checkout');
+        setStarting(false);
+      }
+    };
+    return (
+      <div data-read="offer" data-offer={state.card.key} data-buyable={state.card.buyable}>
+        <p className="font-mono text-sm text-text-secondary" data-offer-line>{state.line}</p>
+        {state.door.kind === 'checkout' ? (
+          <button type="button" onClick={buy} disabled={starting} className={`mt-2 ${DOOR_CLASS} disabled:opacity-60`} data-offer-door="button">
+            {starting ? 'Starting checkout…' : `Subscribe to ${state.card.label} — ${state.card.price.text}`}
+          </button>
+        ) : (
+          <Link href={state.door.href} className={`mt-2 inline-block ${DOOR_CLASS}`} data-offer-door="link">
+            The offer · {state.door.href}
+          </Link>
+        )}
+        {error && <p role="alert" className="mt-1 text-[10px] text-rose-700">{error}</p>}
+      </div>
+    );
+  }
+  return (
+    <div data-read="line" data-why={state.why}>
+      <p className="font-mono text-sm text-text-secondary" data-state-line>{state.line}</p>
+      <Link href={state.door} className={`mt-2 inline-block ${DOOR_CLASS}`} data-state-door>
+        Open · {state.door}
+      </Link>
+    </div>
+  );
+}
+
 function FigureBlock({ read, figure }: { read: Read<unknown>; figure: (d: never) => Figure }) {
   if (read.status === 'reading') return <p className="font-mono text-xs text-text-faint" data-read="reading">Reading…</p>;
   if (read.status === 'failed') return <p role="alert" className="font-mono text-xs text-rose-700" data-read="failed">Could not read — {read.message}</p>;
@@ -189,22 +251,26 @@ function AnswerCard({ question, math, read, children }: { question: string; math
   );
 }
 
-function TaxCard({ question, math, read }: { question: string; math: ReadonlyArray<readonly [string, boolean]>; read: ComputedRead }) {
-  const r = useRead<TaxAnswer>(`${read.endpoint}?year=${YEAR}`);
-  return <AnswerCard question={question} math={math} read={read}><FigureBlock read={r} figure={taxFigure} /></AnswerCard>;
+interface CardProps { question: string; math: ReadonlyArray<readonly [string, boolean]>; read: ComputedRead; state: CardState }
+
+function TaxCard({ question, math, read, state }: CardProps) {
+  const r = useRead<TaxAnswer>(`${read.endpoint}?year=${YEAR}`, state.kind === 'read');
+  return <AnswerCard question={question} math={math} read={read}>{state.kind === 'read' ? <FigureBlock read={r} figure={taxFigure} /> : <StateBlock state={state} />}</AnswerCard>;
 }
-function RunwayCard({ question, math, read }: { question: string; math: ReadonlyArray<readonly [string, boolean]>; read: ComputedRead }) {
-  const r = useRead<RunwayAnswer>(read.endpoint);
-  return <AnswerCard question={question} math={math} read={read}><FigureBlock read={r} figure={runwayFigure} /></AnswerCard>;
+function RunwayCard({ question, math, read, state }: CardProps) {
+  const r = useRead<RunwayAnswer>(read.endpoint, state.kind === 'read');
+  return <AnswerCard question={question} math={math} read={read}>{state.kind === 'read' ? <FigureBlock read={r} figure={runwayFigure} /> : <StateBlock state={state} />}</AnswerCard>;
 }
-function TradingCard({ question, math, read }: { question: string; math: ReadonlyArray<readonly [string, boolean]>; read: ComputedRead }) {
-  const r = useRead<TradingAnswer>(read.endpoint);
-  return <AnswerCard question={question} math={math} read={read}><FigureBlock read={r} figure={tradingFigure} /></AnswerCard>;
+function TradingCard({ question, math, read, state }: CardProps) {
+  const r = useRead<TradingAnswer>(read.endpoint, state.kind === 'read');
+  return <AnswerCard question={question} math={math} read={read}>{state.kind === 'read' ? <FigureBlock read={r} figure={tradingFigure} /> : <StateBlock state={state} />}</AnswerCard>;
 }
-function BusinessCard({ question, math, read }: { question: string; math: ReadonlyArray<readonly [string, boolean]>; read: ComputedRead }) {
+function BusinessCard({ question, math, read, state }: CardProps) {
   // Two reads, one source: the sole-prop entity (entities), then its statements for the year.
   const [r, setR] = useState<Read<{ entities: EntitiesAnswer['entities']; statements: StatementsAnswer[] }>>({ status: 'reading' });
+  const enabled = state.kind === 'read';
   useEffect(() => {
+    if (!enabled) return;
     let live = true;
     (async () => {
       const ents = await readJson<EntitiesAnswer>('/api/entities');
@@ -219,10 +285,12 @@ function BusinessCard({ question, math, read }: { question: string; math: Readon
       if (live) setR({ status: 'ok', data: { entities: business, statements } });
     })();
     return () => { live = false; };
-  }, [read.endpoint]);
+  }, [read.endpoint, enabled]);
   return (
     <AnswerCard question={question} math={math} read={read}>
-      <FigureBlock read={r} figure={(d: { entities: EntitiesAnswer['entities']; statements: StatementsAnswer[] }) => businessFigure(d.entities, d.statements)} />
+      {state.kind === 'read'
+        ? <FigureBlock read={r} figure={(d: { entities: EntitiesAnswer['entities']; statements: StatementsAnswer[] }) => businessFigure(d.entities, d.statements)} />
+        : <StateBlock state={state} />}
     </AnswerCard>
   );
 }
@@ -235,21 +303,40 @@ const CARD_BY_ENDPOINT: Record<string, typeof TaxCard> = {
   '/api/statements': BusinessCard,
 };
 
-export default function AnswersClient({ viewer }: { viewer: string }) {
+interface MeAnswer { user: { id: string; isAdmin?: boolean; entitledCategories?: string[] } }
+interface AccountsAnswer { items: Array<{ accounts: unknown[] }> }
+
+export default function AnswersClient({ viewer, offerAvailability }: { viewer: string; offerAvailability: Readonly<Record<string, boolean>> }) {
   const router = useRouter();
   const { data: session } = useSession();
   const [isAdmin, setIsAdmin] = useState(false);
   const [profileError, setProfileError] = useState<string | null>(null);
+  // SELL-04: the viewer's facts — entitlement keys (the same /api/auth/me payload the cockpit's
+  // isTabLocked reads), then, for an unlocked viewer only, linked accounts and entities.
+  const [facts, setFacts] = useState<ViewerFacts | null>(null);
+  const [factsError, setFactsError] = useState<string | null>(null);
 
   // The utilities menu is admin-only (the same /api/auth/me flag both headers read). A failed
   // profile read is declared, never swallowed: no menu, and the failure printed under the bar.
   useEffect(() => {
     let live = true;
-    readJson<{ user: { isAdmin?: boolean } }>('/api/auth/me').then((r) => {
+    (async () => {
+      const me = await readJson<MeAnswer>('/api/auth/me');
       if (!live) return;
-      if (r.status === 'ok') setIsAdmin(Boolean(r.data.user.isAdmin));
-      else if (r.status === 'failed') setProfileError(r.message);
-    });
+      if (me.status !== 'ok') { if (me.status === 'failed') setProfileError(me.message); return; }
+      setIsAdmin(Boolean(me.data.user.isAdmin));
+      const base = { userId: me.data.user.id, entitledKeys: me.data.user.entitledCategories ?? [] };
+      if (answersLocked(base)) { setFacts({ ...base, accountsLinked: null, soleProp: null }); return; }
+      const [accounts, entities] = await Promise.all([readJson<AccountsAnswer>('/api/accounts'), readJson<EntitiesAnswer>('/api/entities')]);
+      if (!live) return;
+      if (accounts.status !== 'ok') { setFactsError(`accounts — ${accounts.status === 'failed' ? accounts.message : 'reading'}`); return; }
+      if (entities.status !== 'ok') { setFactsError(`entities — ${entities.status === 'failed' ? entities.message : 'reading'}`); return; }
+      setFacts({
+        ...base,
+        accountsLinked: accounts.data.items.reduce((n, item) => n + item.accounts.length, 0),
+        soleProp: entities.data.entities.some((e) => e.entity_type === 'sole_prop'),
+      });
+    })();
     return () => { live = false; };
   }, []);
 
@@ -281,14 +368,20 @@ export default function AnswersClient({ viewer }: { viewer: string }) {
           <p className="mt-1 text-xs text-text-muted">Four questions, each a number with its source, or the honest state in words.</p>
         </header>
 
-        {/* The four, ANSWER_ROWS order. Cards stack on a phone, two-up from sm. */}
-        <section aria-label="The four answers" className="grid grid-cols-1 gap-3 sm:grid-cols-2 sm:gap-4" data-answers>
+        {factsError && (
+          <p role="alert" className="mb-4 font-mono text-[10px] text-rose-700" data-facts-error>Could not read your Books facts — {factsError}. The cards wait; nothing is assumed.</p>
+        )}
+
+        {/* The four, ANSWER_ROWS order. Cards stack on a phone, two-up from sm. Each card's state
+            (offer · link a bank · set up your entity · read) is decided from the facts first. */}
+        <section aria-label="The four answers" className="grid grid-cols-1 gap-3 sm:grid-cols-2 sm:gap-4" data-answers data-answers-locked={facts ? String(answersLocked(facts)) : undefined}>
           {ANSWER_ROWS.map(([question, math]) => {
             const read = ANSWER_READS[question];
             if (!read.computed) return <AnswerCard key={question} question={question} math={math} read={read}><p className="font-mono text-sm text-text-secondary">{read.honest}</p></AnswerCard>;
             const Card = CARD_BY_ENDPOINT[read.endpoint];
             if (!Card) throw new Error(`THE ANSWERS: no card renders ${read.endpoint} ("${question}")`);
-            return <Card key={question} question={question} math={math} read={read} />;
+            if (!facts) return <AnswerCard key={question} question={question} math={math} read={read}><p className="font-mono text-xs text-text-faint" data-read="reading">{factsError ? 'Waiting on your Books facts.' : 'Reading…'}</p></AnswerCard>;
+            return <Card key={question} question={question} math={math} read={read} state={cardState(question, facts, offerAvailability)} />;
           })}
         </section>
 

--- a/src/components/books/EntitySetup.tsx
+++ b/src/components/books/EntitySetup.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+/**
+ * SELL-04 — ENTITY SETUP, the first-run step in Books (not silent). The
+ * user chooses personal, sole proprietorship, or both, names them, and the
+ * one creator (POST /api/entities) makes each with its starter chart. Kinds
+ * come from src/lib/entities/kinds.ts — the two the routes can read — and
+ * the step says why there is no LLC / S-corp choice (UNSUPPORTED_ENTITY_LINE).
+ *
+ * Two mounts: `first-run` (no entity yet — Books' pipeline and the chart page)
+ * and `add` (entities exist, no business one — the chart page; the Answers'
+ * "set up your business entity" door lands here). Every failure renders the
+ * route's own words; nothing is swallowed, nothing is created on failure.
+ */
+
+import { useState } from 'react';
+import { ENTITY_KINDS, UNSUPPORTED_ENTITY_LINE, type EntityKindType } from '@/lib/entities/kinds';
+
+interface Existing { id: string; name: string; entity_type: string }
+
+export default function EntitySetup({ existing, mode, onCreated }: { existing: readonly Existing[]; mode: 'first-run' | 'add'; onCreated: () => void }) {
+  const kinds = mode === 'add' ? ENTITY_KINDS.filter((k) => !existing.some((e) => e.entity_type === k.type)) : ENTITY_KINDS;
+  const [chosen, setChosen] = useState<Record<EntityKindType, boolean>>({ personal: mode === 'first-run', sole_prop: true });
+  const [names, setNames] = useState<Record<EntityKindType, string>>({ personal: ENTITY_KINDS[0].defaultName, sole_prop: ENTITY_KINDS[1].defaultName });
+  const [busy, setBusy] = useState(false);
+  const [errors, setErrors] = useState<Partial<Record<EntityKindType, string>>>({});
+  const [made, setMade] = useState<string[]>([]);
+
+  const selected = kinds.filter((k) => chosen[k.type]);
+
+  const create = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (selected.length === 0) return;
+    setBusy(true);
+    setErrors({});
+    const done: string[] = [];
+    const failed: Partial<Record<EntityKindType, string>> = {};
+    for (const k of selected) {
+      const res = await fetch('/api/entities', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ name: names[k.type], entity_type: k.type }) });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) { failed[k.type] = typeof data?.error === 'string' ? data.error : `HTTP ${res.status}`; continue; }
+      done.push(`${data.entity?.name ?? names[k.type]} — ${k.letter}- chart, ${data.chart?.created ?? '?'} accounts${data.chart?.mappings ? `, ${data.chart.mappings} Schedule C lines` : ''}`);
+    }
+    setMade(done);
+    setErrors(failed);
+    setBusy(false);
+    if (done.length > 0 && Object.keys(failed).length === 0) onCreated();
+  };
+
+  return (
+    <form onSubmit={create} className="rounded-lg border border-brand-purple/30 bg-white p-4 space-y-3" data-entity-setup={mode}>
+      <div>
+        <p className="font-mono text-[10px] font-semibold uppercase tracking-wider text-brand-purple">{mode === 'first-run' ? 'First run · set up your entity' : 'Add your business entity'}</p>
+        <p className="mt-1 text-xs text-text-muted">
+          {mode === 'first-run'
+            ? 'Books keeps one chart per entity. Choose what you keep books for and name it — nothing is created until you say so.'
+            : 'The Tax and Business answers read a sole proprietorship — its B- chart with the Schedule C lines.'}
+        </p>
+      </div>
+      <ul className="space-y-2">
+        {kinds.map((k) => (
+          <li key={k.type} className="flex flex-wrap items-start gap-3 rounded border border-border p-3" data-entity-kind={k.type}>
+            <label className="flex items-center gap-2 text-sm text-text-primary">
+              <input type="checkbox" checked={chosen[k.type]} onChange={(e) => setChosen((c) => ({ ...c, [k.type]: e.target.checked }))} />
+              <span className="font-medium">{k.label}</span>
+              <span className="font-mono text-[10px] uppercase tracking-wider text-text-faint">{k.letter}- chart</span>
+            </label>
+            <input
+              type="text"
+              value={names[k.type]}
+              onChange={(e) => setNames((n) => ({ ...n, [k.type]: e.target.value }))}
+              disabled={!chosen[k.type]}
+              maxLength={100}
+              aria-label={`${k.label} name`}
+              className="min-w-[200px] flex-1 border border-border px-2 py-1 text-sm text-text-primary disabled:opacity-50"
+              data-entity-name={k.type}
+            />
+            <p className="basis-full text-[11px] text-text-muted">{k.what}</p>
+            {errors[k.type] && <p role="alert" className="basis-full text-xs text-brand-red" data-entity-error={k.type}>{errors[k.type]}</p>}
+          </li>
+        ))}
+      </ul>
+      <p className="text-[11px] text-text-faint" data-entity-unsupported>{UNSUPPORTED_ENTITY_LINE}</p>
+      {made.length > 0 && (
+        <ul className="text-xs text-emerald-700" data-entity-made>
+          {made.map((m) => <li key={m}>Created {m}.</li>)}
+        </ul>
+      )}
+      <button type="submit" disabled={busy || selected.length === 0} className="bg-brand-purple px-4 py-2 text-sm font-medium text-white hover:bg-brand-purple-hover disabled:opacity-50" data-entity-create>
+        {busy ? 'Creating…' : selected.length === 1 ? `Create ${selected[0].label}` : `Create ${selected.length} entities`}
+      </button>
+    </form>
+  );
+}

--- a/src/components/home/BooksPipeline.tsx
+++ b/src/components/home/BooksPipeline.tsx
@@ -2,6 +2,8 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import BookkeepingSection from '@/components/bookkeeping/BookkeepingSection';
+// SELL-04: the first-run entity step — a viewer with no entity sets one up before the pipeline reads.
+import EntitySetup from '@/components/books/EntitySetup';
 import SpendingTab from '@/components/dashboard/SpendingTab';
 import InvestmentsTab from '@/components/dashboard/InvestmentsTab';
 import JournalEntryEngine from '@/components/dashboard/JournalEntryEngine';
@@ -82,7 +84,7 @@ export default function BooksPipeline() {
   // established conversion (panel family → border/bg families, white inks →
   // the text ladder).
   const [year] = useState(new Date().getFullYear());
-  const [state, setState] = useState<'loading' | 'error' | 'ok'>('loading');
+  const [state, setState] = useState<'loading' | 'error' | 'ok' | 'setup'>('loading');
   // BOOKS-PIPE-FRAME: the active phase — the ONLY state the retired
   // ToggleStrip owned, now owned here (keep-mounted CSS show/hide survival
   // unchanged, the house idiom). 'feed' = the strip's first phase, matching
@@ -268,6 +270,13 @@ export default function BooksPipeline() {
   const reloadAll = useCallback(async () => {
     setState('loading');
     try {
+      // SELL-04: entities FIRST — a viewer with none gets the setup step, and the Books routes
+      // (which now answer 412 "set up your entity" instead of creating one) are not read.
+      const entRes = await fetch('/api/entities');
+      if (!entRes.ok) throw new Error('entities fetch failed');
+      const ent = await entRes.json();
+      if (!Array.isArray(ent.entities)) throw new Error('entities: expected an array');
+      if (ent.entities.length === 0) { setState('setup'); return; }
       await Promise.all([loadData(), loadReconciliations(), loadPeriodCloses(), loadStatementYears()]);
       setState('ok');
     } catch {
@@ -330,6 +339,9 @@ export default function BooksPipeline() {
         Loading your books pipeline…
       </div>
     );
+  }
+  if (state === 'setup') {
+    return <EntitySetup existing={[]} mode="first-run" onCreated={reloadAll} />;
   }
   if (state === 'error') {
     return (

--- a/src/components/hub/RunwayBudgetPanel.tsx
+++ b/src/components/hub/RunwayBudgetPanel.tsx
@@ -34,7 +34,9 @@ interface RunwayWindow {
   runwayMonths: number | null;
   zeroDate: string | null;
   // Additive per-entity breakdown — Personal + Business (+ Unattributed if any) === netBurnTotal.
-  entities: { personal: EntityBurn; business: EntityBurn; unattributed: EntityBurn | null };
+  // SELL-04: each is the VIEWER'S OWN entity (null when they have none of that kind); `setup` is
+  // the declared line for a viewer with no operating entity at all (then the three are null).
+  entities: { personal: EntityBurn | null; business: EntityBurn | null; unattributed: EntityBurn | null; setup: string | null };
 }
 interface EntityBurn {
   expenses: number;
@@ -106,12 +108,14 @@ function windowStrings(w: RunwayWindow): { burnLine: string; runwayLine: string;
 // Per-entity net burn/mo — same trailing-ledger basis as the combined line. Net burn is real in
 // every state EXCEPT insufficient_history (the window lacks full data); no per-entity runway/zero
 // date (cash is not entity-split this PR). Mirrors the combined burnLine sign convention.
-const entityBurnLine = (w: RunwayWindow, e: EntityBurn) =>
-  w.state === 'insufficient_history'
-    ? '—'
-    : e.netBurnPerMonth > 0
-      ? `${usd(e.netBurnPerMonth)}/mo out`
-      : `${usd(Math.abs(e.netBurnPerMonth))}/mo in`;
+const entityBurnLine = (w: RunwayWindow, e: EntityBurn | null) =>
+  e === null
+    ? 'no entity' // SELL-04: the viewer has no entity of this kind — declared, never a zero
+    : w.state === 'insufficient_history'
+      ? '—'
+      : e.netBurnPerMonth > 0
+        ? `${usd(e.netBurnPerMonth)}/mo out`
+        : `${usd(Math.abs(e.netBurnPerMonth))}/mo in`;
 
 // RUNWAY-PIPE: the receipts the tab's ProofStrip renders, derived from the
 // panel's OWN payload via the SAME windowStrings mapping the hero + cards use
@@ -169,6 +173,10 @@ function RunwayWindowCard({ w }: { w: RunwayWindow }) {
       </div>
       {/* Per-entity operating breakdown (additive; Personal + Business reconcile to Net burn above). */}
       <div className="mt-1.5 pt-1.5 border-t border-border-light space-y-0.5">
+        {/* SELL-04: a viewer with no operating entity gets the declared setup line, never an unattributed bucket. */}
+        {w.entities.setup && (
+          <div className="text-[10px] text-status-warning" data-runway-setup>{w.entities.setup}</div>
+        )}
         <div className="flex items-baseline justify-between gap-2">
           <span className="text-[10px] text-text-faint uppercase tracking-wide">Personal</span>
           <span className="font-mono text-xs text-text-secondary tabular-nums">{entityBurnLine(w, w.entities.personal)}</span>
@@ -200,7 +208,7 @@ function previewRunway(): RunwayData {
     months, rangeStart: '', rangeEnd: '', expenses: 0, income: 0,
     netBurnTotal: 0, netBurnPerMonth: 0, sufficientHistory: false,
     state: 'insufficient_history', runwayMonths: null, zeroDate: null,
-    entities: { personal: PREVIEW_EMPTY_ENTITY, business: PREVIEW_EMPTY_ENTITY, unattributed: null },
+    entities: { personal: PREVIEW_EMPTY_ENTITY, business: PREVIEW_EMPTY_ENTITY, unattributed: null, setup: null },
   });
   return {
     asOf: new Date().toISOString().slice(0, 10),

--- a/src/components/workbench/operations/routines/RoutineList.tsx
+++ b/src/components/workbench/operations/routines/RoutineList.tsx
@@ -19,6 +19,7 @@ import RoutineCreateForm from './RoutineCreateForm';
 import type { CadenceGroup, Routine } from './types';
 import { CADENCE_GROUP_LABELS, CADENCE_GROUP_ORDER } from './types';
 import type { Scene, Take } from '../content/ContentTable';
+import { SETUP_DOOR } from '@/lib/entities/kinds';
 
 
 interface Entity {
@@ -163,13 +164,13 @@ export default function RoutineList({ entities, onCommitted, onTotals }: Props &
         {!showCreate && (
           <div className="flex items-center gap-2">
             {/* ZERO-STATE-1: no silent disable — when no entity exists the
-                reason renders beside the button. Truth source: entities are
-                created automatically by ensureBookkeepingInitialized the
-                first time a bookkeeping route runs (ensure-bookkeeping.ts:
-                5-23) — there is no manual create-entity flow. */}
+                reason renders beside the button. Truth source (SELL-04):
+                entities are set up BY THE USER in Books — the first-run step
+                on the Books tab and the chart page (POST /api/entities);
+                nothing creates one automatically any more. */}
             {entities.length === 0 && (
               <span className="text-[11px] text-text-faint">
-                no entity yet — open the Books tab once and your default entity is created automatically.
+                no entity yet — set one up in Books › <a href={SETUP_DOOR} className="underline">Chart of accounts</a>.
               </span>
             )}
             <button

--- a/src/lib/__tests__/answersState.test.ts
+++ b/src/lib/__tests__/answersState.test.ts
@@ -1,0 +1,98 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { ANSWER_ROWS } from '../answers';
+import { OFFERS, priceEnvName, priceLineFor } from '../offer';
+import { SETUP_DOOR } from '../entities/kinds';
+import {
+  ANSWERS_OFFER,
+  ANSWERS_TAB,
+  BOOKS_DOOR,
+  CARD_NEEDS,
+  LINK_BANK_LINE,
+  OFFER_PAGE,
+  OFFER_VERB,
+  SETUP_ENTITY_LINE,
+  answersLocked,
+  answersStateLaw,
+  cardState,
+  type CardState,
+  type ViewerFacts,
+} from '../answersState';
+
+// SELL-04 — the four cards' states before any route is read. Hermetic: the facts are injected.
+
+const QUESTIONS = ANSWER_ROWS.map(([q]) => q);
+const NONE: Readonly<Record<string, boolean>> = Object.fromEntries(OFFERS.map((o) => [o.key, false]));
+const ALL: Readonly<Record<string, boolean>> = Object.fromEntries(OFFERS.map((o) => [o.key, true]));
+const free: ViewerFacts = { userId: 'user-free', entitledKeys: [], accountsLinked: null, soleProp: null };
+const paid = (over: Partial<ViewerFacts>): ViewerFacts => ({ userId: 'user-paid', entitledKeys: [ANSWERS_TAB], accountsLinked: 2, soleProp: true, ...over });
+const states = (facts: ViewerFacts, availability = NONE): CardState[] => QUESTIONS.map((q) => cardState(q, facts, availability));
+
+test('the law: CARD_NEEDS covers the four questions in order; the Answers ride with an offer whose key the gate resolves', () => {
+  assert.deepEqual(answersStateLaw({ throwOnFail: false }), []);
+  assert.deepEqual(Object.keys(CARD_NEEDS), QUESTIONS);
+  assert.equal(ANSWERS_OFFER.includesAnswers, true);
+  assert.equal(ANSWERS_OFFER.key, ANSWERS_TAB);
+  assert.equal(ANSWERS_OFFER.label, 'Books');
+  assert.equal(BOOKS_DOOR, '/books');
+  assert.match(answersStateLaw({ throwOnFail: false, needs: { [QUESTIONS[0]]: CARD_NEEDS[QUESTIONS[0]] } })[0], /4\/4 in order/);
+  assert.throws(() => answersStateLaw({ needs: {} }), /THE ANSWERS STATE LAW failed/);
+});
+
+test('a free account → four OFFER-line cards from offer.ts, no HTTP text, the offer page as the door while no price is live', () => {
+  assert.equal(answersLocked(free), true);
+  const s = states(free);
+  assert.equal(s.length, 4);
+  for (const st of s) {
+    assert.equal(st.kind, 'offer');
+    if (st.kind !== 'offer') continue;
+    assert.equal(st.card.key, ANSWERS_OFFER.key);
+    const price = priceLineFor(ANSWERS_OFFER, false);
+    assert.equal(st.line, `Books — ${price.text} — ${OFFER_VERB}.`);
+    assert.ok(st.line.includes('link a bank and this computes'));
+    assert.doesNotMatch(st.line, /HTTP|403|Tab not unlocked/);
+    assert.equal(st.card.buyable, false, 'no price is set today — nothing is for sale, so no checkout door');
+    assert.deepEqual(st.door, { kind: 'link', href: OFFER_PAGE });
+  }
+  // the bundle unlocks the Answers too — the gate's own keysGranting
+  assert.equal(answersLocked({ userId: 'u', entitledKeys: ['bundle:all'] }), false);
+  assert.equal(answersLocked({ userId: 'u', entitledKeys: ['tab:tax'] }), true, 'a tab that does not carry the Answers does not unlock them');
+});
+
+test('with a live price the offer line carries the number and the door is the one checkout call', () => {
+  const live = { ...ANSWERS_OFFER, monthlyPrice: 29 };
+  const price = priceLineFor(live, true);
+  assert.equal(price.kind, 'live');
+  assert.equal(price.text, '$29/mo');
+  assert.equal(priceEnvName(ANSWERS_OFFER.key), 'STRIPE_TAB_BOOKS_PRICE_ID');
+  // cardState reads OFFERS' own price (null today) — prove the door rule on the card model directly
+  const st = cardState(QUESTIONS[0], free, ALL);
+  assert.equal(st.kind, 'offer');
+  if (st.kind === 'offer') {
+    assert.equal(st.card.price.kind, 'unset', 'the const holds no price yet — Stripe alone does not make it live');
+    assert.equal(st.door.kind, 'link');
+  }
+});
+
+test('paid, no bank → "link a bank" on all four, the door to Books; the routes are not read', () => {
+  const s = states(paid({ accountsLinked: 0, soleProp: false }));
+  for (const st of s) assert.deepEqual(st, { kind: 'line', why: 'bank', line: LINK_BANK_LINE, door: BOOKS_DOOR });
+});
+
+test('paid, a bank, no sole-prop → "set up your business entity" on the two cards that read one; the others read', () => {
+  const s = states(paid({ soleProp: false }));
+  const byQ = Object.fromEntries(QUESTIONS.map((q, i) => [q, s[i]]));
+  assert.deepEqual(byQ['What do I owe in tax?'], { kind: 'line', why: 'entity', line: SETUP_ENTITY_LINE, door: SETUP_DOOR });
+  assert.deepEqual(byQ['How is my business doing?'], { kind: 'line', why: 'entity', line: SETUP_ENTITY_LINE, door: SETUP_DOOR });
+  assert.deepEqual(byQ['How long can I last?'], { kind: 'read' });
+  assert.deepEqual(byQ['How is my trading doing?'], { kind: 'read' });
+  assert.equal(SETUP_DOOR, '/chart-of-accounts');
+});
+
+test('paid, a bank, a sole-prop → every card reads its route; an unread fact is never guessed', () => {
+  assert.deepEqual(states(paid({})), [{ kind: 'read' }, { kind: 'read' }, { kind: 'read' }, { kind: 'read' }]);
+  assert.throws(() => cardState(QUESTIONS[0], paid({ accountsLinked: null }), NONE), /not read yet/);
+  assert.throws(() => cardState(QUESTIONS[0], paid({ soleProp: null }), NONE), /not read yet/);
+  assert.deepEqual(cardState('How long can I last?', paid({ soleProp: null }), NONE), { kind: 'read' }, 'a card that needs no sole-prop does not wait for that fact');
+  assert.throws(() => cardState('Is this a question?', paid({}), NONE), /has no needs row/);
+});

--- a/src/lib/__tests__/entitySetup.test.ts
+++ b/src/lib/__tests__/entitySetup.test.ts
@@ -1,0 +1,107 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { ValidationError } from '../errors/ValidationError';
+import { DEFAULT_COA } from '../coaDefaults';
+import { SOLE_PROP_STANDARD } from '../seed-coa-templates';
+import { familyOfCode } from '../coa/scheme';
+import { ENTITY_KINDS, ENTITY_NAME_MAX, UNSUPPORTED_ENTITY_LINE, isEntityKindType } from '../entities/kinds';
+import { createEntity, mappingMultiplier, parseNewEntity, starterChartFor, type EntityDb, type EntityRecord } from '../entities/setup';
+import { FakeChart } from './fakeChart';
+
+// SELL-04 — the entity setup over its port. Hermetic, with the table's own rule
+// (entities @@unique([userId, name])) and rows that carry their user.
+
+class FakeEntityDb implements EntityDb {
+  rows: EntityRecord[] = [];
+  mappings: Array<{ account_id: string; tax_form: string; form_line: string; tax_year: number; multiplier: number; created_by: string }> = [];
+  initialized: string[] = [];
+  chart = new FakeChart();
+  private seq = 0;
+  async count(userId: string) { return this.rows.filter((r) => r.userId === userId).length; }
+  async findByName(userId: string, name: string) { return this.rows.find((r) => r.userId === userId && r.name.toLowerCase() === name.toLowerCase()) ?? null; }
+  async insert(row: { userId: string; name: string; entity_type: 'personal' | 'sole_prop'; is_default: boolean }) {
+    if (this.rows.some((r) => r.userId === row.userId && r.name === row.name)) throw new Error('unique violation (userId, name)');
+    const rec = { id: `ent-${++this.seq}`, ...row };
+    this.rows.push(rec);
+    return rec;
+  }
+  async insertTaxMapping(row: { account_id: string; tax_form: string; form_line: string; tax_year: number; multiplier: number; created_by: string }) { this.mappings.push(row); }
+  async markInitialized(userId: string) { this.initialized.push(userId); }
+}
+
+const refuses = (fn: () => unknown, status: number, field: string, re: RegExp) =>
+  assert.throws(fn, (e: unknown) => e instanceof ValidationError && e.status === status && e.field === field && re.test(e.message));
+
+test('the kinds are the two the routes read; the type is validated with the honest line for an LLC / S-corp; the name is required and bounded', () => {
+  assert.deepEqual(ENTITY_KINDS.map((k) => k.type), ['personal', 'sole_prop']);
+  assert.deepEqual(ENTITY_KINDS.map((k) => k.letter), ['P', 'B']);
+  assert.ok(isEntityKindType('sole_prop') && !isEntityKindType('llc') && !isEntityKindType('trading'));
+  assert.deepEqual(parseNewEntity({ name: '  My   Shop ', entity_type: 'sole_prop' }), { name: 'My Shop', entity_type: 'sole_prop' });
+  refuses(() => parseNewEntity({ name: 'Co', entity_type: 'llc' }), 400, 'entity_type', /Personal and sole proprietorship only/);
+  assert.match(UNSUPPORTED_ENTITY_LINE, /Schedule C/);
+  refuses(() => parseNewEntity({ name: 'Co', entity_type: 's_corp' }), 400, 'entity_type', /S-corp/);
+  refuses(() => parseNewEntity({ name: 'Co' }), 400, 'entity_type', /required/);
+  refuses(() => parseNewEntity({ entity_type: 'personal' }), 400, 'name', /required/);
+  refuses(() => parseNewEntity({ name: 'x'.repeat(ENTITY_NAME_MAX + 1), entity_type: 'personal' }), 400, 'name', /longer than 100/);
+  refuses(() => parseNewEntity(null), 400, 'entity_type', /required/);
+});
+
+test('the starter charts come from the two existing seeds — every code in its family; the sole-prop rows carry their Schedule C lines', () => {
+  const personal = starterChartFor('personal');
+  assert.equal(personal.length, DEFAULT_COA.length);
+  assert.deepEqual(personal.map((a) => a.code), DEFAULT_COA.map((a) => a.code));
+  for (const a of personal) assert.equal(familyOfCode(a.code), a.family);
+  assert.ok(personal.every((a) => a.tax_form_line === null));
+  const sole = starterChartFor('sole_prop');
+  assert.equal(sole.length, SOLE_PROP_STANDARD.accounts.length);
+  for (const a of sole) assert.equal(familyOfCode(a.code), a.family);
+  assert.ok(sole.filter((a) => a.tax_form_line).length >= 20, 'the Schedule C lines ride the sole-prop rows');
+  assert.equal(sole.find((a) => a.name === 'Service Revenue')?.tax_form_line, 'schedule_c_line_1');
+  assert.equal(mappingMultiplier('Meals (Business)'), 0.5);
+  assert.equal(mappingMultiplier('Advertising'), 1);
+});
+
+test('create: the first entity is the default and marks bookkeeping initialized; the chart and the Schedule C mappings land with it', async () => {
+  const db = new FakeEntityDb();
+  const first = await createEntity(db, { userId: 'user-a', body: { name: 'Personal', entity_type: 'personal' }, taxYear: 2026 });
+  assert.equal(first.isFirst, true);
+  assert.equal(first.entity.is_default, true);
+  assert.deepEqual(db.initialized, ['user-a']);
+  assert.equal(first.chart.created, DEFAULT_COA.length);
+  assert.equal(first.chart.mappings, 0);
+  assert.ok(db.chart.accounts.every((a) => a.userId === 'user-a' && a.entity_id === first.entity.id && a.entity_type === 'personal'));
+
+  const second = await createEntity(db, { userId: 'user-a', body: { name: 'Business', entity_type: 'sole_prop' }, taxYear: 2026 });
+  assert.equal(second.isFirst, false);
+  assert.equal(second.entity.is_default, false);
+  assert.deepEqual(db.initialized, ['user-a'], 'marked once');
+  assert.equal(second.chart.created, SOLE_PROP_STANDARD.accounts.length);
+  assert.equal(second.chart.mappings, SOLE_PROP_STANDARD.accounts.filter((a) => a.tax_form_line).length);
+  assert.ok(db.mappings.every((m) => m.tax_form === 'schedule_c' && m.tax_year === 2026 && m.created_by === 'user-a' && /^line_/.test(m.form_line)));
+  const meals = db.chart.accounts.find((a) => a.name === 'Meals (Business)');
+  assert.equal(db.mappings.find((m) => m.account_id === meals?.id)?.multiplier, 0.5);
+  assert.equal(db.mappings.find((m) => m.account_id === meals?.id)?.form_line, 'line_24b');
+});
+
+test('create is user-scoped: a duplicate name is a 409 for THAT user only; two users with the same name never share a row', async () => {
+  const db = new FakeEntityDb();
+  await createEntity(db, { userId: 'user-a', body: { name: 'Business', entity_type: 'sole_prop' }, taxYear: 2026 });
+  await assert.rejects(
+    () => createEntity(db, { userId: 'user-a', body: { name: 'business', entity_type: 'sole_prop' }, taxYear: 2026 }),
+    (e: unknown) => e instanceof ValidationError && e.status === 409 && e.field === 'name' && /already have an entity named "Business"/.test(e.message),
+  );
+  const b = await createEntity(db, { userId: 'user-b', body: { name: 'Business', entity_type: 'sole_prop' }, taxYear: 2026 });
+  assert.equal(b.isFirst, true, "user-b's first entity — user-a's rows do not count");
+  assert.equal(b.entity.is_default, true);
+  assert.equal(db.rows.length, 2);
+  assert.notEqual(db.rows[0].id, db.rows[1].id);
+  assert.deepEqual(db.rows.map((r) => r.userId), ['user-a', 'user-b']);
+  const byUser = (u: string) => db.chart.accounts.filter((a) => a.userId === u);
+  assert.equal(byUser('user-a').length, SOLE_PROP_STANDARD.accounts.length);
+  assert.equal(byUser('user-b').length, SOLE_PROP_STANDARD.accounts.length);
+  assert.ok(byUser('user-a').every((a) => a.entity_id === db.rows[0].id) && byUser('user-b').every((a) => a.entity_id === db.rows[1].id));
+  // a refused input creates nothing
+  await assert.rejects(() => createEntity(db, { userId: 'user-c', body: { name: 'Co', entity_type: 'llc' }, taxYear: 2026 }), ValidationError);
+  assert.equal(db.rows.filter((r) => r.userId === 'user-c').length, 0);
+  assert.deepEqual(db.initialized, ['user-a', 'user-b']);
+});

--- a/src/lib/__tests__/runwayEntities.test.ts
+++ b/src/lib/__tests__/runwayEntities.test.ts
@@ -1,0 +1,63 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { RUNWAY_SETUP_LINE, attributeBurn, entityFigure, resolveOperatingEntities } from '../runway/entities';
+
+// SELL-04 — the runway's operating entities are the VIEWER'S OWN; a viewer with none gets the
+// declared setup line, never an `unattributed` bucket. Hermetic: entity rows and burn maps injected.
+
+const A = [
+  { id: 'a-personal', entity_type: 'personal', is_default: true },
+  { id: 'a-business', entity_type: 'sole_prop', is_default: false },
+  { id: 'a-trading', entity_type: 'trading', is_default: false },
+];
+const B = [
+  { id: 'b-personal-old', entity_type: 'personal', is_default: false },
+  { id: 'b-personal', entity_type: 'personal', is_default: true },
+];
+
+test('resolve: the default personal entity, the sole-prop, the trading one — each the viewer\'s own, or null', () => {
+  assert.deepEqual(resolveOperatingEntities(A), { personalId: 'a-personal', businessId: 'a-business', tradingId: 'a-trading' });
+  assert.deepEqual(resolveOperatingEntities(B), { personalId: 'b-personal', businessId: null, tradingId: null });
+  assert.deepEqual(resolveOperatingEntities([{ id: 'p', entity_type: 'personal', is_default: false }]), { personalId: 'p', businessId: null, tradingId: null }, 'no default → the first personal');
+  assert.deepEqual(resolveOperatingEntities([]), { personalId: null, businessId: null, tradingId: null });
+  assert.deepEqual(resolveOperatingEntities([{ id: 't', entity_type: 'trading', is_default: true }]), { personalId: null, businessId: null, tradingId: 't' }, 'a trading-only viewer has no operating entity');
+});
+
+test('two users never mix: each attribution reads only its own ids; the other user\'s ids can only ever be `unattributed`, never Personal or Business', () => {
+  const entsA = resolveOperatingEntities(A);
+  const entsB = resolveOperatingEntities(B);
+  const burnA = { 'a-personal': { exp: 300, rev: 100 }, 'a-business': { exp: 50, rev: 500 } };
+  const burnB = { 'b-personal': { exp: 90, rev: 0 } };
+  const a = attributeBurn(burnA, entsA, 3);
+  const b = attributeBurn(burnB, entsB, 3);
+  assert.deepEqual(a.personal, entityFigure({ exp: 300, rev: 100 }, 3));
+  assert.deepEqual(a.business, entityFigure({ exp: 50, rev: 500 }, 3));
+  assert.equal(a.unattributed, null);
+  assert.equal(a.setup, null);
+  assert.deepEqual(b.personal, entityFigure({ exp: 90, rev: 0 }, 3));
+  assert.equal(b.business, null, 'user B has no business entity — declared null, never a zero');
+  assert.equal(b.unattributed, null);
+  // if user A's rows ever reached user B's attribution, they could only land as `unattributed` — never as B's own
+  const leaked = attributeBurn({ ...burnB, ...burnA }, entsB, 3);
+  assert.deepEqual(leaked.personal, b.personal);
+  assert.equal(leaked.business, null);
+  assert.deepEqual(leaked.unattributed, entityFigure({ exp: 350, rev: 600 }, 3));
+  // the invariant: personal + business + unattributed === the combined total
+  const total = (x: ReturnType<typeof attributeBurn>) => (x.personal?.netBurnTotal ?? 0) + (x.business?.netBurnTotal ?? 0) + (x.unattributed?.netBurnTotal ?? 0);
+  assert.equal(total(a), 300 - 100 + 50 - 500);
+  assert.equal(total(leaked), 90 + 300 - 100 + 50 - 500);
+});
+
+test('a viewer with no operating entity gets the declared setup line — and no unattributed bucket, whatever rows exist', () => {
+  const none = attributeBurn({}, resolveOperatingEntities([]), 3);
+  assert.deepEqual(none, { personal: null, business: null, unattributed: null, setup: RUNWAY_SETUP_LINE });
+  const tradingOnly = attributeBurn({ stray: { exp: 10, rev: 0 } }, resolveOperatingEntities([{ id: 't', entity_type: 'trading', is_default: true }]), 3);
+  assert.deepEqual(tradingOnly, { personal: null, business: null, unattributed: null, setup: RUNWAY_SETUP_LINE });
+  assert.match(RUNWAY_SETUP_LINE, /Set up your entity/);
+  // with an entity present, a stray entity's rows are surfaced, never dropped
+  const stray = attributeBurn({ 'a-personal': { exp: 1, rev: 0 }, legacy: { exp: 5, rev: 2 } }, resolveOperatingEntities(A), 6);
+  assert.deepEqual(stray.unattributed, entityFigure({ exp: 5, rev: 2 }, 6));
+  assert.equal(stray.setup, null);
+  // zero rows on the other entity → no bucket
+  assert.equal(attributeBurn({ 'a-personal': { exp: 1, rev: 0 } }, resolveOperatingEntities(A), 6).unattributed, null);
+});

--- a/src/lib/answersState.ts
+++ b/src/lib/answersState.ts
@@ -1,0 +1,131 @@
+/**
+ * SELL-04 — FIRST VALUE FOR A NEW ACCOUNT: what each Answers card shows
+ * BEFORE its route is read, decided from the viewer's facts — pure, so the
+ * ruled cases run in node:test:
+ *
+ *   free account (no key granting the Answers)  → the OFFER line from offer.ts
+ *     — "<label> — <price line> — link a bank and this computes." — with the
+ *     buy door (checkout when the price is live; the offer page otherwise);
+ *     NEVER an HTTP line, and the gated routes are never read;
+ *   paid, no bank linked                        → "Link a bank and this computes." + the door to Books;
+ *   paid, a bank, no sole-prop entity           → on the cards whose route reads a
+ *     sole-prop (Tax: Schedule C, Business: the statements on the sole-prop) —
+ *     "Set up your business entity and this computes." + the door to the setup step;
+ *   otherwise                                   → read the route (the existing figure).
+ *
+ * THE LAW (module scope, re-run by the test): CARD_NEEDS keys === ANSWER_ROWS
+ * questions 4/4; the Answers' offer exists (the first offer that carries them,
+ * offer.ts includesAnswers) and its key is a tab key the gate resolves — the
+ * SAME isTabLocked the cockpit uses, so the card and the tab never disagree.
+ * Client- and server-safe: leaves only (answers.ts, offer.ts, categoryLock.ts, the registry).
+ */
+import { ANSWER_ROWS } from './answers';
+import { isTabLocked } from './categoryLock';
+import { TAB_ENTITLEMENT_KEYS } from './categoryKeys';
+import { OFFERS, offerCard, type Offer, type OfferCardModel, type TabKey } from './offer';
+import { TOOL_REGISTRY } from './toolRegistry';
+import { SETUP_DOOR } from './entities/kinds';
+
+export interface CardNeeds {
+  /** Every card computes from linked accounts (ledger rows come from committed bank transactions; positions from investment accounts). */
+  bank: true;
+  /** The route reads the user's sole-prop entity (Tax: Schedule C; Business: the statements on it). */
+  soleProp: boolean;
+}
+
+export const CARD_NEEDS: Readonly<Record<string, CardNeeds>> = {
+  'What do I owe in tax?': { bank: true, soleProp: true },
+  'How long can I last?': { bank: true, soleProp: false },
+  'How is my trading doing?': { bank: true, soleProp: false },
+  'How is my business doing?': { bank: true, soleProp: true },
+};
+
+/** The offer the four Answers ride with (offer.ts: includesAnswers) — Books. */
+export const ANSWERS_OFFER: Offer = (() => {
+  const o = OFFERS.find((x) => x.includesAnswers);
+  if (!o) throw new Error('THE ANSWERS: no offer includes the four Answers (offer.ts includesAnswers)');
+  return o;
+})();
+
+/** The tab key the Answers are gated by — the offer's own key; isTabLocked resolves every key that grants it (the bundle too). */
+export const ANSWERS_TAB: TabKey = ANSWERS_OFFER.key as TabKey;
+
+export const OFFER_VERB = 'link a bank and this computes';
+export const LINK_BANK_LINE = 'Link a bank and this computes.';
+export const SETUP_ENTITY_LINE = 'Set up your business entity and this computes.';
+export const OFFER_PAGE = '/pricing';
+
+/** The door to Books — the registry's Bookkeeping home, never typed. */
+export const BOOKS_DOOR: string = (() => {
+  const t = TOOL_REGISTRY.find((x) => x.name === 'Bookkeeping');
+  if (!t || !t.home) throw new Error('THE ANSWERS: the registry has no home for Bookkeeping');
+  return t.home;
+})();
+
+export type CardState =
+  | { kind: 'offer'; line: string; card: OfferCardModel; door: { kind: 'checkout'; key: Offer['key'] } | { kind: 'link'; href: string } }
+  | { kind: 'line'; why: 'bank' | 'entity'; line: string; door: string }
+  | { kind: 'read' };
+
+export interface ViewerFacts {
+  userId: string;
+  /** The viewer's active entitlement keys (/api/auth/me entitledCategories — every active row's key). */
+  entitledKeys: readonly string[];
+  /** Linked accounts on live Plaid items (/api/accounts); null until read. */
+  accountsLinked: number | null;
+  /** Whether a sole-prop entity exists (/api/entities); null until read. */
+  soleProp: boolean | null;
+}
+
+/** "<label> — <price line> — link a bank and this computes." — the label and the price line are offer.ts's own words. */
+export function offerLine(card: OfferCardModel): string {
+  return `${card.label} — ${card.price.text} — ${OFFER_VERB}.`;
+}
+
+export function answersLocked(facts: Pick<ViewerFacts, 'userId' | 'entitledKeys'>): boolean {
+  return isTabLocked(ANSWERS_TAB, [...facts.entitledKeys], facts.userId);
+}
+
+/**
+ * The card's state. A locked viewer needs no other fact (the routes are not
+ * read). An unlocked viewer's bank / entity facts must be READ before a card
+ * decides — a null fact throws (the caller waits; nothing is assumed).
+ */
+export function cardState(question: string, facts: ViewerFacts, offerAvailability: Readonly<Record<string, boolean>>): CardState {
+  const needs = CARD_NEEDS[question];
+  if (!needs) throw new Error(`THE ANSWERS: "${question}" has no needs row (answersState.ts CARD_NEEDS)`);
+  if (answersLocked(facts)) {
+    const card = offerCard(ANSWERS_OFFER, offerAvailability);
+    return {
+      kind: 'offer',
+      line: offerLine(card),
+      card,
+      door: card.buyable ? { kind: 'checkout', key: ANSWERS_OFFER.key } : { kind: 'link', href: OFFER_PAGE },
+    };
+  }
+  if (facts.accountsLinked === null) throw new Error('THE ANSWERS: accountsLinked is not read yet — a card decides on facts, never on a guess');
+  if (facts.accountsLinked === 0) return { kind: 'line', why: 'bank', line: LINK_BANK_LINE, door: BOOKS_DOOR };
+  if (needs.soleProp) {
+    if (facts.soleProp === null) throw new Error('THE ANSWERS: the entities are not read yet — a card decides on facts, never on a guess');
+    if (!facts.soleProp) return { kind: 'line', why: 'entity', line: SETUP_ENTITY_LINE, door: SETUP_DOOR };
+  }
+  return { kind: 'read' };
+}
+
+/** THE LAW. Throws on the first violation; returns the violations when asked not to throw. */
+export function answersStateLaw(opts: { throwOnFail?: boolean; needs?: Readonly<Record<string, CardNeeds>>; rows?: typeof ANSWER_ROWS } = {}): string[] {
+  const needs = opts.needs ?? CARD_NEEDS;
+  const rows = opts.rows ?? ANSWER_ROWS;
+  const violations: string[] = [];
+  const questions = rows.map(([q]) => q);
+  const keys = Object.keys(needs);
+  if (keys.length !== questions.length || keys.some((k, i) => k !== questions[i])) {
+    violations.push(`CARD_NEEDS keys must equal ANSWER_ROWS questions 4/4 in order — got [${keys.join(' | ')}]`);
+  }
+  if (!(TAB_ENTITLEMENT_KEYS as readonly string[]).includes(ANSWERS_TAB)) violations.push(`the Answers' offer key ${ANSWERS_TAB} is not a tab key the gate resolves`);
+  if (!ANSWERS_OFFER.includesAnswers) violations.push(`${ANSWERS_OFFER.key} does not carry the four Answers`);
+  if (violations.length && opts.throwOnFail !== false) throw new Error(`THE ANSWERS STATE LAW failed:\n  ${violations.join('\n  ')}`);
+  return violations;
+}
+
+answersStateLaw();

--- a/src/lib/ensure-bookkeeping.ts
+++ b/src/lib/ensure-bookkeeping.ts
@@ -1,42 +1,48 @@
+import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
-import { seedDefaultCOA } from '@/lib/seedDefaultCOA';
+import { SETUP_DOOR, SETUP_ENTITY_LINE } from '@/lib/entities/kinds';
 
 /**
- * Ensure bookkeeping is initialized for a user.
- * Creates default entity + COA if bookkeeping_initialized is false.
- * If already initialized, returns immediately (zero additional queries).
+ * SELL-04 — where this used to CREATE (a `Personal` entity and the default
+ * chart, silently, the first time any Books route ran), it now DECLARES:
+ * a user with no entity gets a 412 with the setup line and the door to the
+ * step (Books › Chart of accounts — POST /api/entities is the one creator,
+ * chosen and named by the user). Nothing is created here any more.
  *
+ * Existing users are untouched: `bookkeeping_initialized` short-circuits as
+ * before; a user whose flag is unset but who has an entity is marked
+ * initialized (the same flag write the old path made) and passes.
+ *
+ * Usage (the requireTabAccess idiom — FIRST thing after the tab gate):
+ *   const setup = await requireEntitySetup(user);
+ *   if (setup) return setup;
  * Call this from bookkeeping routes ONLY — never from scanner, AI, or trading routes.
  */
-export async function ensureBookkeepingInitialized(user: {
+export const ENTITY_SETUP_STATUS = 412;
+
+export function entitySetupResponse(): NextResponse {
+  return NextResponse.json(
+    { ok: false, stage: 'Entity setup', error: SETUP_ENTITY_LINE, message: SETUP_ENTITY_LINE, setup: SETUP_DOOR },
+    { status: ENTITY_SETUP_STATUS },
+  );
+}
+
+export async function requireEntitySetup(user: {
   id: string;
   bookkeeping_initialized: boolean;
-}): Promise<void> {
-  if (user.bookkeeping_initialized) return;
+}): Promise<NextResponse | null> {
+  if (user.bookkeeping_initialized) return null;
 
-  // Check if entity already exists (idempotent)
-  let entity = await prisma.entities.findFirst({
-    where: { userId: user.id, is_default: true },
+  const entity = await prisma.entities.findFirst({
+    where: { userId: user.id },
+    select: { id: true },
   });
+  if (!entity) return entitySetupResponse();
 
-  if (!entity) {
-    entity = await prisma.entities.create({
-      data: {
-        userId: user.id,
-        name: 'Personal',
-        entity_type: 'personal',
-        is_default: true,
-        fiscal_year_start: 1,
-      },
-    });
-  }
-
-  // Seed default COA for the entity (idempotent — checks existing count)
-  await seedDefaultCOA(user.id, entity.id);
-
-  // Set the flag so future requests skip this entirely
+  // An entity exists (set up in the product, or seeded before the flag existed): mark it, as before.
   await prisma.users.update({
     where: { id: user.id },
     data: { bookkeeping_initialized: true },
   });
+  return null;
 }

--- a/src/lib/entities/kinds.ts
+++ b/src/lib/entities/kinds.ts
@@ -1,0 +1,62 @@
+/**
+ * SELL-04 — the entity kinds the product can set up, as data. A LEAF (zero
+ * imports; client- and server-safe): the first-run step renders it, the
+ * POST route validates against it, the tests read it.
+ *
+ * Only the kinds a route can READ are offered. The tax routes compute
+ * Schedule C (src/lib/schedule-c-service.ts:162-163 finds the `sole_prop`
+ * entity; src/lib/form-1040-service.ts:188-191 the default `personal` one);
+ * no route reads an LLC, S-corp or partnership (grep: nothing in src/lib or
+ * src/app/api/tax handles them), so they are not labels here — offering a
+ * kind nothing computes would be a claim with nothing behind it. The letters
+ * are the chart's (src/lib/accountString.ts:25-28: personal→P, sole_prop→B).
+ */
+
+export type EntityKindType = 'personal' | 'sole_prop';
+
+export interface EntityKind {
+  readonly type: EntityKindType;
+  readonly label: string;
+  readonly letter: 'P' | 'B';
+  readonly defaultName: string;
+  /** One line on what the kind is for — printed under the choice. */
+  readonly what: string;
+}
+
+export const ENTITY_KINDS: readonly EntityKind[] = [
+  {
+    type: 'personal',
+    label: 'Personal',
+    letter: 'P',
+    defaultName: 'Personal',
+    what: 'Your own money — wages, living costs, the P- chart. Runway and net worth read it.',
+  },
+  {
+    type: 'sole_prop',
+    label: 'Sole proprietorship',
+    letter: 'B',
+    defaultName: 'Business',
+    what: 'A business you own alone, filed on Schedule C — the B- chart the Tax and Business answers read.',
+  },
+];
+
+export function entityKind(type: unknown): EntityKind | undefined {
+  return ENTITY_KINDS.find((k) => k.type === type);
+}
+
+export function isEntityKindType(x: unknown): x is EntityKindType {
+  return entityKind(x) !== undefined;
+}
+
+/** Why the step offers no LLC / S-corp / partnership — the honest line, printed on the step. */
+export const UNSUPPORTED_ENTITY_LINE =
+  'Personal and sole proprietorship only — the tax routes compute Schedule C; an LLC, S-corp or partnership has no route that reads it yet.';
+
+/** The declared line a Books route answers when the user has no entity yet (where ensure-bookkeeping used to create one). */
+export const SETUP_ENTITY_LINE = 'Set up your entity first — Books › Chart of accounts.';
+
+/** Where the setup step lives — the chart page (the registry\'s Bookkeeping link) carries it. */
+export const SETUP_DOOR = '/chart-of-accounts';
+
+/** The name rule: 1–100 characters (entities.name is varchar(100)), whitespace collapsed. */
+export const ENTITY_NAME_MAX = 100;

--- a/src/lib/entities/prismaEntityDb.ts
+++ b/src/lib/entities/prismaEntityDb.ts
@@ -1,0 +1,31 @@
+import type { PrismaClient } from '@prisma/client';
+import { prismaChartDb } from '@/lib/coa/prismaChartDb';
+import type { EntityDb } from './setup';
+
+/**
+ * SELL-04 — the Prisma binding of the entity-setup port (setup.ts EntityDb).
+ * The route hands a $transaction context in so the entity, its starter chart
+ * and the Schedule C mappings land together or not at all.
+ */
+type Client = Pick<PrismaClient, 'entities' | 'chart_of_accounts' | 'account_tax_mappings' | 'users'>;
+
+const SELECT = { id: true, userId: true, name: true, entity_type: true, is_default: true } as const;
+
+export function prismaEntityDb(client: Client, userId: string): EntityDb {
+  return {
+    count: (uid) => client.entities.count({ where: { userId: uid } }),
+    findByName: (uid, name) => client.entities.findFirst({ where: { userId: uid, name: { equals: name, mode: 'insensitive' } }, select: SELECT }),
+    insert: (row) =>
+      client.entities.create({
+        data: { userId: row.userId, name: row.name, entity_type: row.entity_type, is_default: row.is_default, fiscal_year_start: 1, created_by: row.userId },
+        select: SELECT,
+      }),
+    chart: prismaChartDb(client, userId),
+    async insertTaxMapping(row) {
+      await client.account_tax_mappings.create({ data: row });
+    },
+    async markInitialized(uid) {
+      await client.users.update({ where: { id: uid }, data: { bookkeeping_initialized: true } });
+    },
+  };
+}

--- a/src/lib/entities/setup.ts
+++ b/src/lib/entities/setup.ts
@@ -1,0 +1,148 @@
+import { ValidationError } from '@/lib/errors/ValidationError';
+import { DEFAULT_COA } from '@/lib/coaDefaults';
+import { SOLE_PROP_STANDARD } from '@/lib/seed-coa-templates';
+import { parseTaxFormLine } from '@/lib/seed-entities';
+import { FAMILY_RULES, assertCodeInFamily, familyOfAccountType, type Family } from '@/lib/coa/scheme';
+import type { ChartDb } from '@/lib/coa/accounts';
+import { ENTITY_KINDS, ENTITY_NAME_MAX, UNSUPPORTED_ENTITY_LINE, entityKind, type EntityKindType } from './kinds';
+
+/**
+ * SELL-04 — ENTITY SETUP, the product's one creator of an entity (POST
+ * /api/entities). Over a small port so the rules run hermetically:
+ *
+ *   • the kind is one the routes can read (ENTITY_KINDS — personal, sole_prop;
+ *     anything else is refused with the honest line);
+ *   • the name is 1–ENTITY_NAME_MAX characters and unique for the user
+ *     (entities @@unique([userId, name]) — a duplicate is a 409, never a
+ *     silent second row);
+ *   • the user's FIRST entity is their default (what commit-to-ledger,
+ *     bank-reconciliations and the pipeline resolve by);
+ *   • the entity gets its STARTER CHART in the same transaction — personal:
+ *     DEFAULT_COA, the chart every new user was seeded with until now
+ *     (src/lib/coaDefaults.ts); sole_prop: the Sole Proprietor Standard
+ *     template (src/lib/seed-coa-templates.ts) with its Schedule C line
+ *     mappings for the tax year given (schedule-c-service reads
+ *     account_tax_mappings, not the chart row) — so the Tax and Business
+ *     answers have lines to read the day the entity exists;
+ *   • when it is the user's first, bookkeeping_initialized is set (what the
+ *     old silent path set).
+ *
+ * Every row is the caller's (userId on the entity, on every chart row) — the
+ * port is handed the id and never a query of its own to make.
+ */
+
+export interface NewEntity {
+  name: string;
+  entity_type: EntityKindType;
+}
+
+const norm = (s: string) => s.trim().replace(/\s+/g, ' ');
+
+export function parseNewEntity(body: unknown): NewEntity {
+  const b = (body && typeof body === 'object' ? body : {}) as Record<string, unknown>;
+  const kind = entityKind(b.entity_type);
+  if (!kind) {
+    if (typeof b.entity_type === 'string' && b.entity_type.trim()) throw new ValidationError(UNSUPPORTED_ENTITY_LINE, { field: 'entity_type' });
+    throw new ValidationError(`entity_type is required — ${ENTITY_KINDS.map((k) => k.type).join(' or ')}`, { field: 'entity_type' });
+  }
+  const name = typeof b.name === 'string' ? norm(b.name) : '';
+  if (!name) throw new ValidationError('name is required', { field: 'name' });
+  if (name.length > ENTITY_NAME_MAX) throw new ValidationError(`name is longer than ${ENTITY_NAME_MAX} characters`, { field: 'name' });
+  return { name, entity_type: kind.type };
+}
+
+export interface StarterAccount {
+  code: string;
+  name: string;
+  family: Family;
+  balance_type: 'D' | 'C';
+  sub_type: string | null;
+  /** Schedule C line for the mapping (sole_prop rows), e.g. "schedule_c_line_8". */
+  tax_form_line: string | null;
+}
+
+/** The starter chart per kind — from the two existing seeds, never retyped. */
+export function starterChartFor(type: EntityKindType): readonly StarterAccount[] {
+  if (type === 'personal') {
+    return DEFAULT_COA.map((a) => ({
+      code: a.code,
+      name: a.name,
+      family: familyOfAccountType(a.account_type),
+      balance_type: FAMILY_RULES[familyOfAccountType(a.account_type)].balanceType,
+      sub_type: null,
+      tax_form_line: null,
+    }));
+  }
+  return SOLE_PROP_STANDARD.accounts.map((a) => ({
+    code: a.code,
+    name: a.name,
+    family: familyOfAccountType(a.account_type),
+    balance_type: a.balance_type === 'C' ? 'C' : 'D',
+    sub_type: a.sub_type ?? null,
+    tax_form_line: a.tax_form_line ?? null,
+  }));
+}
+
+/** The multiplier a mapping carries — meals are 50% deductible (IRC §274(n)); the seed script's rule, kept. */
+export function mappingMultiplier(accountName: string): number {
+  return accountName === 'Meals (Business)' ? 0.5 : 1;
+}
+
+export interface EntityRecord {
+  id: string;
+  userId: string;
+  name: string;
+  entity_type: string;
+  is_default: boolean;
+}
+
+export interface EntityDb {
+  /** How many entities the user has (0 → this one becomes the default). */
+  count(userId: string): Promise<number>;
+  /** An existing entity of the user's by name (case-insensitive) — a duplicate is refused. */
+  findByName(userId: string, name: string): Promise<EntityRecord | null>;
+  insert(row: { userId: string; name: string; entity_type: EntityKindType; is_default: boolean }): Promise<EntityRecord>;
+  /** The chart port (COA-01 ChartDb) bound to the same transaction. */
+  chart: ChartDb;
+  insertTaxMapping(row: { account_id: string; tax_form: string; form_line: string; tax_year: number; multiplier: number; created_by: string }): Promise<void>;
+  markInitialized(userId: string): Promise<void>;
+}
+
+export interface CreatedEntity {
+  entity: EntityRecord;
+  chart: { created: number; mappings: number };
+  isFirst: boolean;
+}
+
+export async function createEntity(db: EntityDb, input: { userId: string; body: unknown; taxYear: number }): Promise<CreatedEntity> {
+  const reg = parseNewEntity(input.body);
+  const existing = await db.findByName(input.userId, reg.name);
+  if (existing) throw new ValidationError(`you already have an entity named "${existing.name}"`, { status: 409, field: 'name' });
+  const isFirst = (await db.count(input.userId)) === 0;
+  const entity = await db.insert({ userId: input.userId, name: reg.name, entity_type: reg.entity_type, is_default: isFirst });
+
+  let created = 0;
+  let mappings = 0;
+  for (const a of starterChartFor(reg.entity_type)) {
+    assertCodeInFamily(a.code, a.family);
+    const row = await db.chart.insert({
+      userId: input.userId,
+      entity_id: entity.id,
+      entity_type: entity.entity_type,
+      code: a.code,
+      name: a.name,
+      account_type: a.family,
+      balance_type: a.balance_type,
+      sub_type: a.sub_type,
+      module: null,
+    });
+    created += 1;
+    if (a.tax_form_line) {
+      const { tax_form, form_line } = parseTaxFormLine(a.tax_form_line);
+      await db.insertTaxMapping({ account_id: row.id, tax_form, form_line, tax_year: input.taxYear, multiplier: mappingMultiplier(a.name), created_by: input.userId });
+      mappings += 1;
+    }
+  }
+  if (isFirst) await db.markInitialized(input.userId);
+  return { entity, chart: { created, mappings }, isFirst };
+}

--- a/src/lib/runway/entities.ts
+++ b/src/lib/runway/entities.ts
@@ -1,0 +1,85 @@
+/**
+ * SELL-04 — the runway's operating entities, resolved PER USER (never a
+ * constant). Pure: the route hands in the user's own entity rows and the
+ * per-entity burn map its user-scoped SQL grouped; this decides who is
+ * Personal, who is Business, who is excluded (Trading), and what the rest is.
+ *
+ *   • personal — the user's default `personal` entity, else their first one;
+ *   • business — their first `sole_prop` entity;
+ *   • trading  — their first `trading` entity (excluded from operating burn —
+ *                the RUNWAY-ENTITY-MODEL decision, unchanged), or none;
+ *   • a user with NO operating entity gets the declared setup line — never an
+ *     `unattributed` bucket that pretends there is something to attribute;
+ *   • with entities present, rows on any other entity id are `unattributed`
+ *     (surfaced, never dropped — the invariant Personal + Business +
+ *     Unattributed === combined still holds).
+ *
+ * Nothing here can mix users: the rows come in already scoped by the caller
+ * (WHERE "userId" = the viewer), and the ids matched are the viewer's own.
+ */
+
+export interface EntityRow {
+  id: string;
+  entity_type: string;
+  is_default: boolean;
+}
+
+export interface OperatingEntities {
+  personalId: string | null;
+  businessId: string | null;
+  tradingId: string | null;
+}
+
+export function resolveOperatingEntities(rows: readonly EntityRow[]): OperatingEntities {
+  const personal = rows.find((r) => r.entity_type === 'personal' && r.is_default) ?? rows.find((r) => r.entity_type === 'personal');
+  const business = rows.find((r) => r.entity_type === 'sole_prop');
+  const trading = rows.find((r) => r.entity_type === 'trading');
+  return { personalId: personal?.id ?? null, businessId: business?.id ?? null, tradingId: trading?.id ?? null };
+}
+
+export interface BurnLeg {
+  exp: number;
+  rev: number;
+}
+
+export interface EntityBurnFigure {
+  expenses: number;
+  income: number;
+  netBurnTotal: number;
+  netBurnPerMonth: number;
+}
+
+export interface BurnAttribution {
+  personal: EntityBurnFigure | null;
+  business: EntityBurnFigure | null;
+  /** Rows on an entity that is neither — only when the user HAS operating entities and the remainder is non-zero. */
+  unattributed: EntityBurnFigure | null;
+  /** The declared line for a user with no operating entity; null otherwise. */
+  setup: string | null;
+}
+
+export const RUNWAY_SETUP_LINE = 'Set up your entity in Books — nothing to attribute yet.';
+
+const round2 = (n: number) => Math.round(n * 100) / 100;
+
+export function entityFigure(leg: BurnLeg, months: number): EntityBurnFigure {
+  const total = round2(leg.exp - leg.rev);
+  return { expenses: leg.exp, income: leg.rev, netBurnTotal: total, netBurnPerMonth: round2(total / months) };
+}
+
+export function attributeBurn(byEntity: Readonly<Record<string, BurnLeg>>, ents: OperatingEntities, months: number): BurnAttribution {
+  if (ents.personalId === null && ents.businessId === null) {
+    return { personal: null, business: null, unattributed: null, setup: RUNWAY_SETUP_LINE };
+  }
+  const personal = ents.personalId === null ? null : entityFigure(byEntity[ents.personalId] ?? { exp: 0, rev: 0 }, months);
+  const business = ents.businessId === null ? null : entityFigure(byEntity[ents.businessId] ?? { exp: 0, rev: 0 }, months);
+  let otherExp = 0;
+  let otherRev = 0;
+  for (const [id, leg] of Object.entries(byEntity)) {
+    if (id === ents.personalId || id === ents.businessId) continue;
+    otherExp += leg.exp;
+    otherRev += leg.rev;
+  }
+  const rest = entityFigure({ exp: otherExp, rev: otherRev }, months);
+  return { personal, business, unattributed: rest.netBurnTotal !== 0 || otherExp !== 0 || otherRev !== 0 ? rest : null, setup: null };
+}

--- a/src/lib/seed-coa-templates.ts
+++ b/src/lib/seed-coa-templates.ts
@@ -1,6 +1,6 @@
 import { PrismaClient } from '@prisma/client';
 
-interface TemplateAccount {
+export interface TemplateAccount {
   code: string;
   name: string;
   account_type: string;
@@ -82,7 +82,8 @@ const PERSONAL_STANDARD: TemplateDefinition = {
   ],
 };
 
-const SOLE_PROP_STANDARD: TemplateDefinition = {
+/** SELL-04: the sole-prop starter chart the product's own entity setup seeds (src/lib/entities/setup.ts) — the same rows this script writes to coa_templates. */
+export const SOLE_PROP_STANDARD: TemplateDefinition = {
   entity_type: 'sole_prop',
   name: 'Sole Proprietor Standard',
   accounts: [

--- a/src/lib/seed-entities.ts
+++ b/src/lib/seed-entities.ts
@@ -14,7 +14,7 @@ const ENTITY_DEFS: EntityDef[] = [
   { name: 'Business', entity_type: 'sole_prop', is_default: false, template_name: 'Sole Proprietor Standard' },
 ];
 
-function parseTaxFormLine(taxFormLine: string): { tax_form: string; form_line: string } {
+export function parseTaxFormLine(taxFormLine: string): { tax_form: string; form_line: string } {
   // "schedule_c_line_24b" → tax_form="schedule_c", form_line="line_24b"
   // "form_1040_line_1a"   → tax_form="form_1040",  form_line="line_1a"
   // "form_8949"           → tax_form="form_8949",   form_line="all"


### PR DESCRIPTION
**Do not merge — Alex merges after Vercel Preview (SOC 2 gate).**

## HARD GATE items (read first)

| # | What | Where | Why it needs Alex's eyes |
|---|---|---|---|
| 1 | **A new write route: `POST /api/entities`** — the product's one entity creator. Gate: verified cookie → user → `requireTabAccess('tab:books')` → the body rules. The row carries the authed user's id; the port is handed it and never queries on its own. The entity, its starter chart and its Schedule C mappings land in ONE `$transaction`. | `src/app/api/entities/route.ts:42-76`, `src/lib/entities/setup.ts`, `src/lib/entities/prismaEntityDb.ts` | Writes three tables (`entities`, `chart_of_accounts`, `account_tax_mappings`) — user rows, not financial history. No migration: every column exists. |
| 2 | **ensure-bookkeeping creates nothing any more.** Where it silently made a `Personal` entity + the default chart the first time a Books route ran, `requireEntitySetup(user)` now answers **412** `{ error: "Set up your entity first — Books › Chart of accounts.", setup: "/chart-of-accounts" }` at its eight call sites (the `requireTabAccess` idiom: `const setup = await requireEntitySetup(user); if (setup) return setup;`). | `src/lib/ensure-bookkeeping.ts`, call sites: `chart-of-accounts/route.ts:47-49,109-111`, `seed/route.ts:44-46`, `reclassify/route.ts:55-57`, `transactions/route.ts:23-25`, `commit-to-ledger/route.ts:38-40`, `journal-entries/route.ts:24-26`, `manual/route.ts:28-30` | **Existing users untouched:** `bookkeeping_initialized` short-circuits as before; a user whose flag is unset but who has ANY entity is marked initialized (the same flag write the old path made) and passes. Only a user with zero entities meets the 412 — and on production every account that has ever opened Books has one. |
| 3 | **Runway's three single-tenant entity id constants are gone.** `TRADING_ENTITY_ID` / `PERSONAL_ENTITY_ID` / `BUSINESS_ENTITY_ID` (main `runway/route.ts:57,64-65`) are replaced by the viewer's own rows resolved per request: Personal = their default `personal` entity (else their first), Business = their `sole_prop`, Trading = their `trading` entity — excluded from operating burn by ITS id; a viewer with no trading entity excludes nothing (never `!= NULL`). | `src/app/api/runway/route.ts:51-58,78-86,123,143,167,187,221`, `src/lib/runway/entities.ts` | **For Alex's own account the arithmetic is unchanged** if his live rows are `personal`+`is_default`, `sole_prop`, `trading` (the route's old comment says psql confirmed `entity_type='trading'` on the live Trading row; the default flag on Personal is **not verified** — if Personal is not `is_default`, the first `personal` row is taken). The response shape changes: `entities.{personal,business}` are nullable and `entities.setup` is added; the one consumer (`RunwayBudgetPanel`) is updated. |
| 4 | **The Answers read fewer routes for a free account, by design.** A viewer whose keys do not grant the Answers' offer (`isTabLocked('tab:books', …)` — the cockpit's own twin of the server gate) gets the offer line on all four cards and **none of the four routes is fetched**; only `/api/net-worth` (cookie-only, unchanged) still reads. | `src/lib/answersState.ts`, `src/components/answers/AnswersClient.tsx` | The gates on the routes themselves are untouched (Tax: `tab:tax`, Statements/Accounts: `tab:books`; Runway and Positions: cookie only — finding 1). |
| 5 | **Middleware, PUBLIC_PATHS, migrations, paid calls: untouched.** | — | — |

## Audit (read-only, against `origin/main` = `dcb6d202`)

**AnswersClient's per-card error path:** `readJson` turns any non-2xx into `{ status: 'failed', message: 'HTTP <status> · <error>' }` (`AnswersClient.tsx:31-48` on main) and `FigureBlock` prints "Could not read — HTTP 403 · Tab not unlocked" (`:147`). **Each answer route's gate and entity dependency:**

| Card | Route | Gate on main | Entity dependency |
|---|---|---|---|
| Tax | `/api/tax/calculate` | cookie → user → `requireTabAccess('tab:tax')` (`:56-57`) | `schedule-c-service.ts:162-177` finds the `sole_prop` entity and **returns a zeroed Schedule C when there is none** (the card then says "No income on the lines" — a silent zero); `form-1040-service.ts:188-191` reads the default `personal` entity for W-2 wages, 0 when none |
| Runway | `/api/runway` | cookie only (`:69-82`), **no tab gate** | the three hard-coded ids (`:57,64-65`); anything else → `unattributed` (`:189-194,230`) |
| Trading | `/api/positions/summary` | cookie only (`:7-13`), **no tab gate** | none (accounts → investment txns → positions; stock lots by user) |
| Business | `/api/entities` (cookie only, `:6-26`) then `/api/statements` | statements: cookie → user → `requireTabAccess('tab:books')` (`:22-23`), `entityId` verified as the user's (`:31-36`) | the client filters `entity_type === 'sole_prop'` (`AnswersClient.tsx:212`) |
| Net worth | `/api/net-worth` | cookie only | `chart_of_accounts.entity_type = 'personal'` (`:37`) |

So the ruling's WHY ("a free account's four Answers show HTTP 403") held for **two** of four on main — Tax and (with a sole-prop) Business; Runway and Trading answered a free account. The OFFER says the four Answers ride with Books (`offer.ts:84,110` `includesAnswers`, printed on every offer card), so this PR gates all four cards on that offer — the VERIFY's "four offer-line cards".

**ensure-bookkeeping's silent create:** `ensure-bookkeeping.ts:18-31` created `Personal` / `personal` / `is_default` / `fiscal_year_start 1` when the flag was false and no default entity existed, seeded `DEFAULT_COA` (27 revenue/expense rows, `coaDefaults.ts:14-49`) via `seedDefaultCOA` and set the flag (`:38-41`); eight callers (table above). The chart page's empty state promised it ("open Books once and the Personal entity is created", `chart-of-accounts/page.tsx:70`), as did the routine list's zero state (`RoutineList.tsx:165-173`) — both now say the truth.

**`/api/entities` (GET-only)** `entities/route.ts:6-30`: cookie → user → `findMany` user-scoped. No POST existed; no entity-creation UI exists anywhere in `src/components` (grep). **The seed script:** `src/scripts/run-seed.ts:5` hard-codes `ALEX_USER_ID`; `seed-entities.ts:11-15` upserts Personal Finances/`personal`, Trading/`personal` (sic), Business/`sole_prop` from `coa_templates` rows and writes `account_tax_mappings` for tax year 2025 (`:109-128`). A script, not a product path.

**What an entity row needs** (`prisma/schema.prisma:72-99`): `userId`, `name` varchar(100) with `@@unique([userId, name])`, `entity_type` varchar(20) (no enum; a DB CHECK is **not verified**), `is_default`, optional `state_of_formation` char(2) / `ein` varchar(20) / `naics_code` varchar(6), `fiscal_year_start` int default 1, `created_by`. The types the product letters: `personal→P`, `sole_prop→B`, `trading→T` (`accountString.ts:25-28`, `coa/scheme.ts:81-84`). **LLC / S-corp / partnership: no route or service reads them** (grep across `src/lib` and `src/app/api/tax`: nothing) — Schedule C (`schedule-c-service.ts`) is the only business return; so the step offers personal and sole proprietorship only and says why (`kinds.ts` `UNSUPPORTED_ENTITY_LINE`). Schedule C reads `account_tax_mappings` (`schedule-c-service.ts:193-205,255-262`), not the chart row's `tax_form_line` — so a sole-prop created in-product needs the mappings, which the POST writes.

**Where the user's entities are read across Books:** by id + userId (statements `:31`, chart `:118`, journal-entries `:68`, manual `:48`, closing `:38`, year-end `:56,297`, cpa-export `:44`, tax-mappings `:54`, stock-lots `:82`, ops); by `entity_type: 'sole_prop'` (business `:21`, hub/business-budget `:30`, schedule-c `:163`); by `entity_type: 'personal'` (nomad-budget `:57`, year-calendar `:30`) or `+ is_default` (expense-analytics `:17`, form-1040 `:189`, auto-categorization `:118`); by `is_default` alone (commit-to-ledger `:174`, bank-reconciliations `:117`); by `entity_type: 'trading'` (trading/commit-to-ledger `:40`, batch-trade-processor ×6); the pipeline picks `is_default || entities[0]` (`BooksPipeline.tsx:196-198`). The resolution in `runway/entities.ts` follows these same rules.

## Build

- **`src/lib/answersState.ts`** — `CARD_NEEDS` per question (bank on all four; sole-prop on Tax and Business), `ANSWERS_OFFER` (the first offer with `includesAnswers`), `answersLocked` (isTabLocked on its key), `offerLine(card)` = `"<label> — <price line> — link a bank and this computes."` (label and price line are offer.ts's own words), `cardState(question, facts, availability)` → `offer` | `line (bank → /books · entity → /chart-of-accounts)` | `read`; an unread fact throws (never guessed). A module-scope law: needs keys === ANSWER_ROWS 4/4, the offer's key is a tab key the gate resolves.
- **`AnswersClient`** — reads `/api/auth/me` (id + entitled keys), then for an unlocked viewer `/api/accounts` (linked accounts on live items) and `/api/entities`; each card gets its state; `useRead` only fires for `read`. `StateBlock` renders the offer line with its door (checkout via `checkoutDoor.ts` when buyable; `/pricing` otherwise) or the line with its door. `answers/page.tsx` passes `offerAvailabilityFromEnv(process.env)` (the pattern of `/`, `/[tab]`, `/pricing`).
- **`src/lib/entities/kinds.ts`** (leaf) — the two kinds with letters, default names, one line each; the unsupported line; `SETUP_ENTITY_LINE`; `SETUP_DOOR`. **`setup.ts`** — `parseNewEntity` (kind ∈ kinds, name 1–100 collapsed), `starterChartFor` (personal: `DEFAULT_COA`; sole_prop: `SOLE_PROP_STANDARD` from `seed-coa-templates.ts`, now exported), `createEntity` over `EntityDb` (count → first = default; name unique per user case-insensitively → 409; chart rows through COA-01's `ChartDb.insert` with `assertCodeInFamily`; a Schedule C mapping per `tax_form_line` via the seed script's `parseTaxFormLine`, now exported, multiplier 0.5 for Meals; `markInitialized` when first). **`prismaEntityDb.ts`** binds it to a `$transaction` client.
- **`EntitySetup.tsx`** — `first-run` (both kinds, Personal ticked) and `add` (the missing kind) modes; one POST per chosen kind; every failure printed in the route's words; `onCreated` reloads. Mounted on the chart page (no entity → first-run; entities but no sole-prop → add) and at the top of `BooksPipeline` (entities are read FIRST; none → the step, and the Books routes that now 412 are not read).
- **`ensure-bookkeeping.ts`** — `requireEntitySetup` (above); `RoutineList.tsx` zero-state now links the step.
- **Runway** — `resolveOperatingEntities` + `attributeBurn` (`src/lib/runway/entities.ts`); the route's exclusion clauses become conditional `Prisma.sql` fragments; the breakdown is `{ personal|null, business|null, unattributed|null, setup|null }`; the panel prints "no entity" for a null kind and the setup line when present.

## Verify

| Check | Result |
|---|---|
| `npx tsc --noEmit` | 0 errors |
| eslint, every touched file vs its main baseline | no widening (every new file 0/0; `transactions/route.ts` 5 → 5, `journal-entries/route.ts` 4 → 4, `RoutineList.tsx` 3 → 3 — all pre-existing, lines shifted) |
| `npm test` | **219/219** (206 + 6 `answersState` + 4 `entitySetup` + 3 `runwayEntities`) |
| Build with the asserts | showroom ✓ · tool registry 25/25 ✓ · reachability ✓ 67 pages (`/answers`, `/chart-of-accounts` doors intact) · family map ✓ · answers 4/4 ✓ · arrivals ✓ · rule book ✓ · kind views ✓ · posting law ✓ 13 files · offer law ✓ · `next build` exit 0 |
| README regen | byte-stable (no new route file; `/api/entities` gained POST in place) |

Ruled tests → where they live:

| Ruled test | Hermetic | The real routes (next dev on a throwaway Postgres 16; viewers: a free account, a paid account with no entity, a paid account B, Alex's probe row with Personal + Business) |
|---|---|---|
| free account → four offer-line cards, no HTTP text | `answersState.test.ts` — four `offer` states, each `"Books — <price line> — link a bank and this computes."`, `/HTTP\|403\|Tab not unlocked/` absent, the door `/pricing` while no price is live; `bundle:all` unlocks, `tab:tax` alone does not | in the browser as the free account: `data-answers-locked="true"`, four `data-read="offer"` cards, `innerText` contains no "HTTP"; the only non-auth request the page made was `/api/net-worth` — none of the four routes |
| paid + no bank → link line | four `line/bank` states, door `/books` | four "Link a bank and this computes." cards, door `Open · /books` |
| paid + bank + no sole-prop → setup line | Tax and Business `line/entity` with door `/chart-of-accounts`; Runway and Trading `read` | an `accounts` row on a live item inserted → Tax and Business "Set up your business entity and this computes." with `Open · /chart-of-accounts`; Runway "Need 3 full months · cash $2,500 (1 linked account)"; Trading "No trades committed yet"; the Tax card's door lands on the add step; after Business: four reads |
| entity POST validates type and is user-scoped | `entitySetup.test.ts` — `llc` / `s_corp` → 400 with the Schedule C line, missing type / name / >100 chars → 400 with the field; first entity default + initialized once; duplicate name → 409 for THAT user only; two users with the same name → two rows, every chart row on its own user and entity; a refused input creates nothing; starter charts: 27 personal rows, 32 sole-prop rows every code in its family, ≥20 Schedule C lines, Meals 0.5 / line_24b | free account POST → **403 Tab not unlocked**, 0 rows; B: `llc` → 400 the honest line, no name → 400 `field: name`, `trading` → 400, Personal → **201** `is_default true, chart 27, isFirst true`, `personal` again → **409**, Business → **201** `chart 32, mappings 22, is_default false`; DB: flag `t`, 59 chart rows, 22 mappings for 2026 / `schedule_c`, Meals `line_24b · 0.5`; `/api/chart-of-accounts?entity_id=<B's Business>` → 32 accounts; C sees `[]`, C on B's entity id → **404**, C's own "Business" → 201 `isFirst true`; three users, three rows named Business |
| ensure-bookkeeping declares, never creates | — | paid + no entity: `/api/transactions` → **412** the setup line + `setup: "/chart-of-accounts"`, `/api/chart-of-accounts` → 412; entity count stays 0, flag stays `f`; after the POST, `/api/transactions` → 200 |
| runway with two users never mixes rows | `runwayEntities.test.ts` — resolve (default personal preferred; sole_prop; trading; none); A's and B's attributions read only their own ids; A's rows fed to B's attribution can only land as `unattributed`, never as B's Personal/Business; the invariant personal + business + unattributed === combined; no operating entity → the setup line and no bucket | B posts $123.45 revenue on B's Business dated last month → runway as B: `business.income 123.45`, `unattributed null`; as Alex: `business.expenses 120` (his own 8 entries, now attributed to HIS ids instead of the retired constants — on main they were `unattributed`), `unattributed null`; as the no-entity viewer: `entities.setup: "Set up your entity in Books — nothing to attribute yet."`, personal/business/unattributed null |

Screenshots (/answers as free, as paid-no-bank, the first-run step on /books and on the chart page, the add step, /answers as paid with a bank and no sole-prop, both entities, four reads) are in the session chat — not committed, the repo is public.

## Findings outside this PR's fence (reported, not fixed)

1. **`/api/runway` and `/api/positions/summary` carry no tab gate** (SELL-01 census) — a free account can still read them directly; the cards no longer do. Gating them is an auth change, its own PR.
2. **Two vocabularies for entity type.** `accounts.entityType` accepts `'personal' | 'business' | 'trading' | 'retirement'` (`accounts/update-entity/route.ts:24`) while `entities.entity_type` is `personal | sole_prop | trading`; `commit-to-ledger:231-238` resolves the bank entity by `entity_type: linkedAccount.entityType`, so an account tagged `business` never matches a `sole_prop` entity and silently keeps the default entity. Pre-existing; the setup step writes `sole_prop`.
3. **No product path creates a Trading entity** — trading commit and the batch processor resolve `entity_type: 'trading'` and fail without one; Alex's exists from the seed script. Not offered by the step (the ruling named personal / sole-prop / both).
4. **Schedule C mappings are per tax year.** The POST seeds the current year's; other years come from the tax-mappings page (`/api/account-tax-mappings`). The seed script had hard-coded 2025.
5. **The offer line reads "Books — Not for sale yet — no price is set. — link a bank and this computes."** while `monthlyPrice` is null — offer.ts's exact price line, by the no-drift rule; it reads cleanly once a price is set (`Books — $X/mo — …`).
6. `journal-entries/route.ts` POST never called ensure-bookkeeping on main (only its GET did); a no-entity user gets its own 404 "Entity not found" there — unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc

---
_Generated by [Claude Code](https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc)_