### PR TITLE
SELL-05: the dead gates — category search on a signed-in user and the caps, Time's AI actions under the daily cap, tab:operations gone

### DIFF
--- a/src/app/api/operations/content/enrich-routine/route.ts
+++ b/src/app/api/operations/content/enrich-routine/route.ts
@@ -14,18 +14,20 @@
  * Fail-loud: a routine with no active steps returns a clear 400 listing what's
  * needed — the AI is NEVER asked to fabricate steps or activities.
  *
- * PAID API — auth+tier mirror the src/app/api/ai/* reference routes
- * (e.g. market-brief / spending-insights): getVerifiedEmail → users lookup →
- * requireTier(user.tier, 'ai', user.id). (The sibling operations/ai/* routes
- * predate requireTier and omit it; this paid route adds the gate per the
- * src/app/api/ai/* pattern + the CE-3 "no shortcuts" mandate.)
+ * PAID API — SELL-05: getVerifiedEmail → users lookup → input + ownership →
+ * the AI DAILY CAP (AI_ROUTINE_DAILY_CAP, reserved through requireRoutineBudget
+ * and declared as a 429 when hit — src/lib/ai/dailyCap.ts) → the paid call.
+ * The 'ai' tier gate that stood here gated on a plan nothing sells; the cap
+ * is the cost control, reserved only once the request is valid and the
+ * routine is the caller's.
  */
 
 import { NextRequest, NextResponse } from 'next/server';
 import { failClosedResponse } from '@/lib/http/failClosedResponse';
 import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
-import { requireTier } from '@/lib/auth-helpers';
+import { requireRoutineBudget } from '@/lib/routineFireBudget';
+import { withDailyCap } from '@/lib/ai/dailyCap';
 import { isValidUuid } from '@/lib/operations/parseUuid';
 import { enrichRoutineScenes } from '@/lib/ai/enrichRoutineScenes';
 
@@ -38,10 +40,6 @@ export async function POST(request: NextRequest) {
       where: { email: { equals: userEmail, mode: 'insensitive' } },
     });
     if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
-
-    // Tier gate (paid AI feature) — mirrors src/app/api/ai/* routes.
-    const tierGate = requireTier(user.tier, 'ai', user.id);
-    if (tierGate) return tierGate;
 
     const body = (await request.json()) as Record<string, unknown>;
     if (typeof body.routine_id !== 'string' || !isValidUuid(body.routine_id)) {
@@ -83,6 +81,13 @@ export async function POST(request: NextRequest) {
       where: { user_id: user.id, is_active: true },
       orderBy: [{ sort_order: 'asc' }, { created_at: 'asc' }],
     });
+
+    // SELL-05: the AI daily cap — reserved now that the input is valid and the routine is the caller's; declared when hit.
+
+    const capped = await withDailyCap(requireRoutineBudget, user.id);
+
+    if (capped) return NextResponse.json(capped.body, { status: capped.status });
+
 
     const result = await enrichRoutineScenes({
       userId: user.id,

--- a/src/app/api/operations/content/generate-script/route.ts
+++ b/src/app/api/operations/content/generate-script/route.ts
@@ -15,15 +15,17 @@
  * script + usage_id; the immutable reasoning is the operations_ai_usage row recordUsage
  * wrote.
  *
- * PAID API — auth + tier mirror the enrich route: getVerifiedEmail → users lookup →
- * requireTier(user.tier, 'ai', user.id).
+ * PAID API — SELL-05, as the enrich route: getVerifiedEmail → users lookup → input +
+ * ownership → the AI DAILY CAP (AI_ROUTINE_DAILY_CAP via requireRoutineBudget, declared as
+ * a 429 when hit — src/lib/ai/dailyCap.ts) → the paid call. No tier.
  */
 
 import { NextRequest, NextResponse } from 'next/server';
 import { failClosedResponse } from '@/lib/http/failClosedResponse';
 import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
-import { requireTier } from '@/lib/auth-helpers';
+import { requireRoutineBudget } from '@/lib/routineFireBudget';
+import { withDailyCap } from '@/lib/ai/dailyCap';
 import { isValidUuid } from '@/lib/operations/parseUuid';
 import {
   compareDayOrder,
@@ -50,9 +52,6 @@ export async function POST(request: NextRequest) {
       where: { email: { equals: userEmail, mode: 'insensitive' } },
     });
     if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
-
-    const tierGate = requireTier(user.tier, 'ai', user.id);
-    if (tierGate) return tierGate;
 
     const body = (await request.json()) as Record<string, unknown>;
     if (typeof body.piece_id !== 'string' || !isValidUuid(body.piece_id)) {
@@ -171,6 +170,13 @@ export async function POST(request: NextRequest) {
     }
     taskRows.sort((a, b) => a.minute - b.minute);
     const tasks = taskRows.map((t) => t.row);
+
+    // SELL-05: the AI daily cap — reserved now that the input is valid and the piece is the caller's; declared when hit.
+
+    const capped = await withDailyCap(requireRoutineBudget, user.id);
+
+    if (capped) return NextResponse.json(capped.body, { status: capped.status });
+
 
     const result = await generateReelScript({
       userId: user.id,

--- a/src/app/api/places/category-search/route.ts
+++ b/src/app/api/places/category-search/route.ts
@@ -2,177 +2,59 @@ import { NextRequest, NextResponse } from 'next/server';
 import { failClosedResponse } from '@/lib/http/failClosedResponse';
 import { prisma } from '@/lib/prisma';
 import { getVerifiedEmail } from '@/lib/cookie-auth';
-import { requireTier } from '@/lib/auth-helpers';
-import { rateLimit, RateLimitError } from '@/lib/rateLimit';
+import { rateLimit } from '@/lib/rateLimit';
 import { searchPlacesMultiQuery } from '@/lib/placesSearch';
-import { isCacheFresh, getCachedPlaces, cachePlaces, type CachedPlace } from '@/lib/placesCache';
-import { getEntitledCategories } from '@/lib/entitlements';
-import { GOOGLE_CATEGORY_KEYS } from '@/lib/categoryKeys';
+import { isCacheFresh, getCachedPlaces, cachePlaces } from '@/lib/placesCache';
+import { reserveTravelSearch } from '@/lib/travelSearchQuota';
 import { getCOAScanQueries } from '@/lib/travelCOA';
+import { CATEGORY_SEARCH_PROVIDER, MAX_RESULTS, categorySearch } from '@/lib/places/categorySearch';
 
-// ─── PAID + CACHED category search (Google Places, trip-scan engine) ─────────
+// ─── CACHED category search (Google Places, trip-scan engine) — SELL-05 ──────
 // Fires N proven category queries via searchPlacesMultiQuery (the SAME engine + mappings the
-// trip-page scan uses, from TRAVEL_COA / getCOAScanQueries). No invented queries — mappings
-// come from TRAVEL_COA. Minimal fields mapped for card only.
+// trip-page scan uses, from TRAVEL_COA / getCOAScanQueries). No invented queries. Minimal
+// fields mapped for the card only. The decision lives in src/lib/places/categorySearch.ts.
+//
+// Gate: a SIGNED-IN USER. No tier (the 'placesSearch' tier gated on a plan nothing sells —
+// every customer was 403 forever) and no per-category key (nothing sells those either).
 //
 // Cost control by construction (bounds the N calls):
-//   - PAID WALL: requireTier(user.tier, 'placesSearch') — free tier → 403, no bypass.
-//   - PER-CATEGORY ENTITLEMENT GATE: a paying user only reaches Google for categories they've
-//     unlocked (admin → all 9). Sits BEFORE any Google/cache call.
+//   - RATE-LIMIT: per-IP burst defense (429 on exceed) — unchanged.
 //   - CACHE-FIRST: a fresh (city, country, category) bucket in places_cache returns with
-//     ZERO Google calls (reuses the existing scan's cache table + helpers, no schema change).
-//   - MONTHLY BILL-CAP: every searchPlaces under searchPlacesMultiQuery routes through
-//     googleFetch → durable monthly cap (googlePlacesQuota.ts:45-66).
-//   - RATE-LIMIT: per-IP burst defense (429 on exceed).
-//   - NO Place Details / Photos fan-out here — those are details-on-tap (a later PR). This
-//     route never calls getPlaceDetails/enrichPlaceDetails.
-//   - NO fallback: on any Google/cache error we surface the REAL error (fail-loud), never
-//     placeholder/empty data.
-
-// The 9 canonical category keys — SINGLE SOURCE OF TRUTH (categoryKeys.ts). No parallel list.
-const ALLOWED_CATEGORIES: readonly string[] = GOOGLE_CATEGORY_KEYS;
-
-// Top-N after dedup/sort — same arg the trip scan passes to searchPlacesMultiQuery (ai-assistant:446).
-const MAX_RESULTS = 60;
-
-// Minimal card — name / place_id / location / rating / price_level / business_status only.
-// website/photos/hours are intentionally dropped (details-on-tap, a later PR).
-interface CategoryCard {
-  placeId: string;
-  name: string;
-  address: string;
-  rating: number | null;
-  reviewCount: number | null;
-  priceLevel: number | null;
-  priceLevelDisplay: string | null;
-  // 'OPERATIONAL' from a fresh result (PlaceResult.isOpen); null from the cache, which does not
-  // persist business_status (including it would need a schema change — out of scope).
-  businessStatus: string | null;
-  // PlaceResult does not expose geometry (placesSearch.ts:158-171 omits lat/lng), and the cache
-  // only has lat/lng when present. Null where unavailable; never fabricated. (Threading geometry
-  // through would require a placesSearch.ts change — out of scope for this PR.)
-  location: { lat: number; lng: number } | null;
-}
-
-function cachedToCard(p: CachedPlace): CategoryCard {
-  return {
-    placeId: p.placeId,
-    name: p.name,
-    address: p.address,
-    rating: p.rating,
-    reviewCount: p.reviewCount,
-    priceLevel: p.priceLevel,
-    priceLevelDisplay: p.priceLevelDisplay,
-    businessStatus: null,
-    location: p.latitude != null && p.longitude != null ? { lat: p.latitude, lng: p.longitude } : null,
-  };
-}
-
-// PlaceResult (searchPlaces output) → minimal card. No website/photos.
-function freshToCard(p: {
-  placeId: string; name: string; address: string; rating: number; reviewCount: number;
-  priceLevel?: number; priceLevelDisplay: string | null; isOpen: boolean;
-}): CategoryCard {
-  return {
-    placeId: p.placeId,
-    name: p.name,
-    address: p.address,
-    rating: p.rating ?? null,
-    reviewCount: p.reviewCount ?? null,
-    priceLevel: p.priceLevel ?? null,
-    priceLevelDisplay: p.priceLevelDisplay ?? null,
-    businessStatus: p.isOpen ? 'OPERATIONAL' : null,
-    location: null,
-  };
-}
+//     ZERO Google calls and reserves nothing (PLACES_CACHE_TTL_DAYS).
+//   - DAILY CAP: one reservation per uncached search against the travel-search daily cap
+//     (TRAVEL_SEARCH_DAILY_CAP, provider 'googleplaces' — TRAVEL_SEARCH_DAILY_CAP_GOOGLEPLACES
+//     overrides), declared as a 429 when hit.
+//   - MONTHLY BILL-CAP: every Google call under searchPlacesMultiQuery routes through
+//     googleFetch → GOOGLE_PLACES_MONTHLY_CAP, declared as a 429 when hit (it was a 500).
+//   - NO Place Details / Photos fan-out here — those are details-on-tap.
+//   - NO fallback: any other Google/cache error is the fixed fail-closed line (logged).
 
 export async function POST(request: NextRequest) {
-  // ── 1 · AUTH — verified cookie or 401 ──
-  const userEmail = await getVerifiedEmail();
-  if (!userEmail) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-
-  // ── 2 · USER LOOKUP — pattern from ai-assistant/route.ts:128,133 ──
-  const user = await prisma.users.findFirst({
-    where: { email: { equals: userEmail, mode: 'insensitive' } },
-  });
-  if (!user) return NextResponse.json({ error: 'User not found' }, { status: 404 });
-
-  // ── 3 · PAID WALL — requireTier('placesSearch') → clean 403 (auth-helpers.ts:41-49). No bypass. ──
-  const gate = requireTier(user.tier, 'placesSearch', user.id);
-  if (gate) return gate;
-
-  // Client IP for the rate-limit key (mirror activities/search/route.ts:37-40).
   const ip =
     request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
     request.headers.get('x-real-ip') ||
     'unknown';
-
   try {
-    // ── 4 · RATE LIMIT — per-IP burst defense (429 on exceed) ──
-    await rateLimit(`places-category:${ip}`, {
-      limit: Number(process.env.SEARCH_RATE_LIMIT) || 10,
-      windowSeconds: Number(process.env.SEARCH_RATE_WINDOW) || 60,
-    });
-
-    // ── 5 · VALIDATE INPUT ──
-    const body = await request.json().catch(() => ({}));
-    const category = body?.category;
-    const city = typeof body?.city === 'string' ? body.city.trim() : '';
-    const country = typeof body?.country === 'string' ? body.country.trim() : '';
-    // radius is RESERVED: searchPlaces() uses a fixed 20km radius (placesSearch.ts:107) and takes
-    // no radius param; threading it would require editing placesSearch.ts (out of scope). Validated
-    // for the forward contract but not yet applied to the Google call. NOT part of the cache key.
-    const radius = body?.radius;
-
-    if (!ALLOWED_CATEGORIES.includes(category)) {
-      return NextResponse.json(
-        { error: `Invalid category. Allowed: ${ALLOWED_CATEGORIES.join(', ')}` },
-        { status: 400 }
-      );
-    }
-    if (!city || !country) {
-      return NextResponse.json({ error: 'Missing required params: city, country' }, { status: 400 });
-    }
-    if (radius !== undefined && (typeof radius !== 'number' || !Number.isFinite(radius) || radius <= 0)) {
-      return NextResponse.json({ error: 'radius must be a positive number' }, { status: 400 });
-    }
-
-    // ── 5b · PER-CATEGORY ENTITLEMENT GATE — the real per-category lock, AFTER category is
-    //        validated and BEFORE any paid Google / cache call. Mirrors the proven scan gate
-    //        (ai-assistant/route.ts). Admin passes (getEntitledCategories returns all 9 keys for
-    //        ADMIN_USER_ID). FAIL-CLOSED: if getEntitledCategories throws, it propagates to the
-    //        outer catch → 500, never an open scan. The requireTier('placesSearch') paid wall
-    //        above stays (defense in depth). ──
-    if ((GOOGLE_CATEGORY_KEYS as readonly string[]).includes(category)) {
-      const entitled = await getEntitledCategories(user.id);
-      if (!entitled.includes(category)) {
-        return NextResponse.json({ error: 'Category not unlocked', category }, { status: 403 });
-      }
-    }
-
-    // ── 6 · CACHE-FIRST — fresh (city, country, category) bucket → ZERO Google calls ──
-    if (await isCacheFresh(city, country, category)) {
-      const cached = await getCachedPlaces(city, country, category);
-      return NextResponse.json({ results: cached.map(cachedToCard), count: cached.length, cached: true });
-    }
-
-    // ── 7 · MISS → fire the proven category queries via searchPlacesMultiQuery — the exact
-    //        engine + mappings the trip-page scan uses (getCOAScanQueries / TRAVEL_COA). No
-    //        interests on a public destination search → []. Same args as the trip scan
-    //        (ai-assistant:446): 60 results, no type filter. Each underlying searchPlaces routes
-    //        through googleFetch → monthly cap. NO Place Details. Cache, then minimal cards. ──
-    const queries = getCOAScanQueries(category, []);
-    const results = await searchPlacesMultiQuery(queries, city, country, MAX_RESULTS, undefined);
-    await cachePlaces(results, city, country, category);
-    return NextResponse.json({ results: results.map(freshToCard), count: results.length, cached: false });
+    const out = await categorySearch(
+      {
+        findUser: (email) => prisma.users.findFirst({ where: { email: { equals: email, mode: 'insensitive' } }, select: { id: true } }),
+        burst: (key) =>
+          rateLimit(`places-category:${key}`, {
+            limit: Number(process.env.SEARCH_RATE_LIMIT) || 10,
+            windowSeconds: Number(process.env.SEARCH_RATE_WINDOW) || 60,
+          }),
+        cacheFresh: isCacheFresh,
+        cached: getCachedPlaces,
+        reserveDaily: () => reserveTravelSearch(CATEGORY_SEARCH_PROVIDER),
+        queriesFor: (category) => getCOAScanQueries(category, []),
+        search: (queries, city, country) => searchPlacesMultiQuery(queries, city, country, MAX_RESULTS, undefined),
+        store: cachePlaces,
+      },
+      { viewer: await getVerifiedEmail(), ip, body: await request.json().catch(() => ({})) },
+    );
+    return NextResponse.json(out.body, { status: out.status, headers: out.headers });
   } catch (error) {
-    if (error instanceof RateLimitError) {
-      return NextResponse.json(
-        { error: 'Too many searches — please slow down and try again shortly.' },
-        { status: 429, headers: { 'Retry-After': String(error.retryAfterSeconds) } }
-      );
-    }
-    // FAIL LOUD — surface the real Google/cache/quota error; never substitute placeholder/empty data.
+    // FAIL LOUD — the real Google/cache error is logged server-side; the client gets the fixed line, never placeholder data.
     return failClosedResponse('Category search', 'Category search failed', error);
   }
 }

--- a/src/components/home/ModuleLauncher.tsx
+++ b/src/components/home/ModuleLauncher.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import Script from 'next/script';
 import {
-  Calendar, Plane, Repeat, FolderKanban, TrendingUp, BookOpen, Receipt, ShieldCheck, Clapperboard, Lock,
+  Calendar, Plane, Repeat, FolderKanban, TrendingUp, BookOpen, Receipt, ShieldCheck, Clapperboard, MapPin,
   type LucideIcon,
 } from 'lucide-react';
 import { SECTION_HEADER, STATE } from '@/lib/ds';
@@ -22,7 +22,7 @@ import MatchReviewSection from '@/components/hub/MatchReviewSection';
 import { travelStripModes } from '@/components/trips/travelStripModes';
 import PublicCategorySearch from '@/components/trips/PublicCategorySearch';
 import { TRAVEL_INPUT_CLASS, TRAVEL_BUTTON_CLASS } from '@/components/trips/travelSection';
-import { HOMEPAGE_PAID_CATEGORIES } from '@/lib/categoryKeys';
+import { HOMEPAGE_CATEGORIES } from '@/lib/categoryKeys';
 // DS-1: the travel tab is rebuilt from the design system — the SAME ToggleStrip
 // primitive the landing consumes (one strip, chip-selected panels, all mounted).
 import ToggleStrip, { type ToggleMode } from '@/components/ui/ToggleStrip';
@@ -877,27 +877,23 @@ export default function ModuleLauncher({ onRequireAuth, onTabChange, offerAvaila
                   currentTrip,
                   onCommitted: () => setTripsRefresh((n) => n + 1),
                 }),
-                // PREMIUM (honest label): the paid Google-Places categories. Gate =
-                // isCategoryLocked(catKey, entitledCategories, currentUserId)
-                // (PublicCategorySearch.tsx:65). Locked → each card renders the
-                // EXISTING upgrade path (LockedCategoryCard "Subscribe to unlock" →
-                // the real checkout-entitlement flow); entitled/admin → the live
-                // search. Copy is the existing PR-2c divider copy, not invented.
-                // PR-STRIP-DESIGN-1: the Premium chip joins the icon-tab row
-                // (Lock = the paid-gate vocabulary, LockedTabCard precedent);
-                // its old in-panel intro line moved UP verbatim as the mode
-                // explainer — the Kayak line the shared strip renders.
-                { key: 'premium', label: 'Premium',
-                  icon: <Lock className="h-5 w-5" strokeWidth={1.75} aria-hidden="true" />,
-                  headline: 'Unlock local picks.',
-                  explainer: 'Subscription — unlock local picks with ratings and prices to access.',
+                // LOCAL PICKS (SELL-05, honest label): the Google-Places category
+                // search is free with an account — the route gates on a signed-in
+                // user and the daily/monthly caps; no tier, no per-category key
+                // (nothing sold either). A guest gets the sign-in card per category
+                // (PublicCategorySearch.tsx); a signed-in viewer the live search.
+                // The old "Premium — Subscription" chip named a purchase that did
+                // not exist; the chip now says what the section is.
+                { key: 'premium', label: 'Local picks',
+                  icon: <MapPin className="h-5 w-5" strokeWidth={1.75} aria-hidden="true" />,
+                  headline: 'Local picks by category.',
+                  explainer: 'Free with an account — real local picks with ratings and prices, by category.',
                   panel: (
                   <div className="space-y-3">
-                    {HOMEPAGE_PAID_CATEGORIES.map((catKey) => (
+                    {HOMEPAGE_CATEGORIES.map((catKey) => (
                       <PublicCategorySearch
                         key={catKey}
                         catKey={catKey}
-                        entitledCategories={entitledCategories}
                         currentUserId={currentUserId}
                         onRequireAuth={onRequireAuth}
                       />

--- a/src/components/home/RoutinesShowcaseSections.tsx
+++ b/src/components/home/RoutinesShowcaseSections.tsx
@@ -47,8 +47,8 @@
  *                                          RRULEBuilder.tsx:150
  *
  * ── CTA RULING (inventory §12, pre-verified) ────────────────────────────────
- * No tab:routines entitlement exists (categoryKeys.ts:23-28); tab:operations is
- * defined but checked nowhere; the tab mount carries no lock
+ * No tab:routines entitlement exists (categoryKeys.ts TAB_ENTITLEMENT_KEYS); the
+ * old tab:operations key gated nothing and left the vocabulary (SELL-05); the tab mount carries no lock
  * (ModuleLauncher.tsx:513-531). Auth-only tab → honest "Make my free account".
  * NO subscribe card.
  *

--- a/src/components/trips/PublicCategorySearch.tsx
+++ b/src/components/trips/PublicCategorySearch.tsx
@@ -2,36 +2,33 @@
 
 /**
  * PublicCategorySearch — ONE reusable homepage Travel-tab section for a single Google
- * category (one of the 9 GOOGLE_CATEGORY_KEYS), rendered 9× over the canonical key list.
+ * category (one of the 9 GOOGLE_CATEGORY_KEYS), rendered over the homepage key list.
  *
- * LOCKED vs UNLOCKED (per-category entitlement):
- *   - locked  → render a 🔒 card with a "Subscribe to unlock" button. The search form +
- *     fetch DO NOT MOUNT → zero Google spend for a category the user hasn't paid for.
- *   - unlocked (entitled, or admin) → mirror PublicActivitySearch: city+country form → POST
- *     /api/places/category-search → render discovery cards. The server route ALSO gates
- *     per-category (403 'Category not unlocked'); this client lock is UX, that gate is the
- *     real lock (defense in depth).
+ * SELL-05: the route gates on a SIGNED-IN USER and the caps — no tier, no per-category
+ * key (nothing sold either; the old "Subscribe to unlock" card started a checkout for a
+ * key the store refuses). So this section mirrors that gate exactly:
+ *   - a guest  → the sign-in card (the form + fetch do not mount — zero Google spend, and
+ *     the route would answer 401 anyway);
+ *   - signed in → city+country form → POST /api/places/category-search → discovery cards;
+ *     a cap the route declares (429) prints as its own line.
  *
  * No fallback data: a non-OK fetch throws the route's real error (fail-loud). The grid
  * renders exactly what the route returns. Label comes from TRAVEL_COA[catKey].label.
  */
 
 import { useState, useEffect } from 'react';
-import { Lock } from 'lucide-react';
-import { isCategoryLocked } from '@/lib/categoryLock';
+import { LogIn } from 'lucide-react';
 import { TRAVEL_COA } from '@/lib/travelCOA';
 import TravelSectionShell, { TRAVEL_INPUT_CLASS, TRAVEL_BUTTON_CLASS } from './travelSection';
 
 interface Props {
   /** One of the 9 GOOGLE_CATEGORY_KEYS. */
   catKey: string;
-  /** Google category keys this user has unlocked (from /api/auth/me). */
-  entitledCategories: string[];
-  /** This user's id (admin bypass inside isCategoryLocked). Empty when logged out. */
+  /** This user's id from /api/auth/me. Empty when logged out — the one gate (SELL-05). */
   currentUserId: string;
-  /** Opens the existing home register/login modal (unlocking requires sign-in). */
+  /** Opens the existing home register/login modal (searching requires sign-in). */
   onRequireAuth: () => void;
-  /** PR-3: unified-bar fan-out. Only consumed when UNLOCKED — a locked section returns
+  /** PR-3: unified-bar fan-out. Only consumed when signed in — a guest section returns
    *  before mounting the search child, so fan-out can never fire a Google call for it. */
   sharedCity?: string;
   sharedCountry?: string;
@@ -53,7 +50,6 @@ interface CategoryCard {
 
 export default function PublicCategorySearch({
   catKey,
-  entitledCategories,
   currentUserId,
   onRequireAuth,
   sharedCity,
@@ -62,21 +58,13 @@ export default function PublicCategorySearch({
 }: Props) {
   // Section title is the EXPENSE-CATEGORY label (TRAVEL_COA covers all 9 Google keys).
   const label = TRAVEL_COA[catKey]?.label || catKey;
-  const locked = isCategoryLocked(catKey, entitledCategories, currentUserId);
 
-  // ── LOCKED: no form, no fetch (zero Google spend). 🔒 card + subscribe CTA. ──
-  if (locked) {
-    return (
-      <LockedCategoryCard
-        catKey={catKey}
-        label={label}
-        currentUserId={currentUserId}
-        onRequireAuth={onRequireAuth}
-      />
-    );
+  // ── GUEST: no form, no fetch (zero Google spend). The sign-in card — the route's own gate. ──
+  if (!currentUserId) {
+    return <SignInCategoryCard label={label} onRequireAuth={onRequireAuth} />;
   }
 
-  // ── UNLOCKED: city+country form → POST category-search → discovery cards. ──
+  // ── SIGNED IN: city+country form → POST category-search → discovery cards. ──
   return (
     <UnlockedCategorySearch
       catKey={catKey}
@@ -88,74 +76,32 @@ export default function PublicCategorySearch({
   );
 }
 
-/** ENTITLEMENT-WRITER: the locked 🔒 card. "Subscribe to unlock" now starts a REAL
- *  Stripe Checkout for this category key (POST /api/stripe/checkout-entitlement — the
- *  webhook writes the entitlement row after signature verification). Logged-out →
- *  the sign-up modal first (checkout is auth-gated). Fail-loud: a checkout error
- *  renders under the button — never a silent unlock, never fake success. */
-function LockedCategoryCard({
-  catKey,
-  label,
-  currentUserId,
-  onRequireAuth,
-}: {
-  catKey: string;
-  label: string;
-  currentUserId: string;
-  onRequireAuth: () => void;
-}) {
-  const [starting, setStarting] = useState(false);
-  const [error, setError] = useState('');
-
-  const onRequestUnlock = async () => {
-    // Logged out (no user id from /api/auth/me) → create an account first.
-    if (!currentUserId) {
-      onRequireAuth();
-      return;
-    }
-    setError('');
-    setStarting(true);
-    try {
-      const res = await fetch('/api/stripe/checkout-entitlement', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ key: catKey }),
-      });
-      const data = await res.json().catch(() => ({}));
-      if (!res.ok || !data.url) {
-        throw new Error(data.error || 'Could not start checkout');
-      }
-      window.location.href = data.url;
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Could not start checkout');
-      setStarting(false);
-    }
-  };
-
+/** SELL-05: the guest card — the search is free with an account; the door is the sign-in
+ *  modal (the route answers a guest with 401, so nothing here starts a checkout). */
+function SignInCategoryCard({ label, onRequireAuth }: { label: string; onRequireAuth: () => void }) {
   return (
     <TravelSectionShell
       title={label}
-      explainer="Unlock this category to see real local picks with ratings and prices."
+      explainer="Sign in to see real local picks with ratings and prices."
     >
-      <div className="flex flex-col items-center justify-center gap-4 rounded-lg border border-brand-purple/15 bg-bg-row px-6 py-10 text-center">
+      <div className="flex flex-col items-center justify-center gap-4 rounded-lg border border-brand-purple/15 bg-bg-row px-6 py-10 text-center" data-category-guest={label}>
         <div className="flex h-12 w-12 items-center justify-center rounded-full bg-brand-purple/10 text-brand-purple">
-          <Lock className="h-6 w-6" strokeWidth={2} aria-hidden="true" />
+          <LogIn className="h-6 w-6" strokeWidth={2} aria-hidden="true" />
         </div>
         <div className="space-y-1">
           <p className="text-base font-bold text-text-primary">{label}</p>
-          <p className="text-sm text-text-muted">Subscribe to see top-rated {label.toLowerCase()} with prices.</p>
+          <p className="text-sm text-text-muted">Free with an account — top-rated {label.toLowerCase()} with prices.</p>
         </div>
-        <button type="button" onClick={onRequestUnlock} disabled={starting} className={TRAVEL_BUTTON_CLASS}>
-          {starting ? 'Starting checkout…' : 'Subscribe to unlock'}
+        <button type="button" onClick={onRequireAuth} className={TRAVEL_BUTTON_CLASS}>
+          Sign in to search
         </button>
-        {error && <p className="text-sm text-brand-red">{error}</p>}
       </div>
     </TravelSectionShell>
   );
 }
 
-/** The mounted search UI — only rendered when unlocked, so its fetch can never fire for a
- *  locked category. Split out so the form/state hooks don't mount on a locked section. */
+/** The mounted search UI — only rendered for a signed-in viewer, so its fetch can never fire
+ *  for a guest. Split out so the form/state hooks don't mount on a guest section. */
 function UnlockedCategorySearch({
   catKey,
   label,
@@ -176,8 +122,8 @@ function UnlockedCategorySearch({
   const [error, setError] = useState('');
   const [searched, setSearched] = useState(false);
 
-  // The paid POST to category-search. Reused by both the form submit and the PR-3
-  // unified-bar fan-out (same fetch, same route, same per-category server gate).
+  // The POST to category-search. Reused by both the form submit and the PR-3
+  // unified-bar fan-out (same fetch, same route, same signed-in gate and caps).
   const runSearch = async (cityVal: string, countryVal: string) => {
     if (!cityVal.trim() || !countryVal.trim()) {
       setError('Enter a city and country.');
@@ -195,11 +141,7 @@ function UnlockedCategorySearch({
       });
       if (!res.ok) {
         const data = await res.json().catch(() => ({}));
-        // Defensive: an unlocked section shouldn't hit the per-category 403, but if the
-        // server gate disagrees with the client lock, surface it plainly (no fake data).
-        if (res.status === 403 && data?.error === 'Category not unlocked') {
-          throw new Error('This category is locked — subscribe to unlock.');
-        }
+        // A cap the route declared (429: burst, the daily cap, the monthly cap) prints as its own line.
         throw new Error(data.error || 'Failed to search this category');
       }
       const data = await res.json();
@@ -216,9 +158,9 @@ function UnlockedCategorySearch({
     runSearch(city, country);
   };
 
-  // PR-3: fan-out — fire this (UNLOCKED) category for the unified bar's destination when its
-  // nonce changes. This effect lives in the unlocked child, so a LOCKED category (which never
-  // mounts this child) can NEVER be fired by fan-out → zero Google spend for locked.
+  // PR-3: fan-out — fire this category for the unified bar's destination when its nonce
+  // changes. This effect lives in the signed-in child, so a guest section (which never
+  // mounts this child) can NEVER be fired by fan-out → zero Google spend for guests.
   useEffect(() => {
     if (!searchNonce) return;
     if (!sharedCity?.trim() || !sharedCountry?.trim()) return;

--- a/src/lib/__tests__/aiDailyCap.test.ts
+++ b/src/lib/__tests__/aiDailyCap.test.ts
@@ -1,0 +1,33 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { RoutineBudgetError } from '../routineFireBudget';
+import { withDailyCap } from '../ai/dailyCap';
+
+// SELL-05 — Time's two AI actions gate on the AI daily cap (AI_ROUTINE_DAILY_CAP), not a tier.
+// Hermetic: a fake meter with the real error class.
+
+function meter(cap: number) {
+  const counts = new Map<string, number>();
+  return {
+    counts,
+    reserve: async (userId: string) => {
+      const n = (counts.get(userId) ?? 0) + 1;
+      counts.set(userId, n);
+      if (n > cap) throw new RoutineBudgetError(userId, n, cap);
+    },
+  };
+}
+
+test('under the cap the action proceeds; at the cap it is refused with the declared 429 — per user', async () => {
+  const m = meter(2);
+  assert.equal(await withDailyCap(m.reserve, 'user-a'), null);
+  assert.equal(await withDailyCap(m.reserve, 'user-a'), null);
+  const refused = await withDailyCap(m.reserve, 'user-a');
+  assert.deepEqual(refused, { status: 429, body: { error: 'Routine daily limit reached — 3/2 runs used today', kind: 'daily_cap', used: 3, cap: 2 } });
+  assert.equal(await withDailyCap(m.reserve, 'user-b'), null, "another user's day is their own");
+  assert.deepEqual([...m.counts.entries()], [['user-a', 3], ['user-b', 1]]);
+});
+
+test('a fault in the meter is not a refusal — it is rethrown', async () => {
+  await assert.rejects(() => withDailyCap(async () => { throw new Error('db down'); }, 'u'), /db down/);
+});

--- a/src/lib/__tests__/categorySearch.test.ts
+++ b/src/lib/__tests__/categorySearch.test.ts
@@ -1,0 +1,81 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { GOOGLE_CATEGORY_KEYS } from '../categoryKeys';
+import { BURST_LINE, CATEGORY_SEARCH_PROVIDER, capRefusal, categorySearch, type CategorySearchDeps } from '../places/categorySearch';
+
+// SELL-05 — category search over its port: a signed-in user + the caps, no tier, no category key.
+// Hermetic; the cap errors carry the real classes' names and fields.
+
+const named = (name: string, message: string, extra: Record<string, unknown> = {}) => Object.assign(new Error(message), { name, ...extra });
+
+function harness(over: Partial<CategorySearchDeps> & { fresh?: boolean; cap?: 'daily' | 'monthly' | 'burst' } = {}) {
+  const calls = { user: 0, burst: 0, cacheFresh: 0, cached: 0, reserve: 0, search: 0, store: 0 };
+  const deps: CategorySearchDeps = {
+    findUser: async (email) => { calls.user += 1; return email === 'nobody@x.co' ? null : { id: `id-${email}` }; },
+    burst: async () => { calls.burst += 1; if (over.cap === 'burst') throw named('RateLimitError', 'burst', { retryAfterSeconds: 42 }); },
+    cacheFresh: async () => { calls.cacheFresh += 1; return over.fresh === true; },
+    cached: async () => { calls.cached += 1; return [{ placeId: 'c1', name: 'Café', address: 'Rua 1', rating: 4.5, reviewCount: 120, priceLevel: 2, priceLevelDisplay: '$$', latitude: 38.7, longitude: -9.1 }]; },
+    reserveDaily: async () => { calls.reserve += 1; if (over.cap === 'daily') throw named('TravelSearchQuotaError', 'Travel search daily quota exceeded for googleplaces — bill protection active', { provider: 'googleplaces', callCount: 1001, cap: 1000 }); },
+    queriesFor: (category) => [`${category} q1`, `${category} q2`],
+    search: async () => { calls.search += 1; if (over.cap === 'monthly') throw named('GooglePlacesQuotaError', 'Google Places monthly quota exceeded — bill protection active', { callCount: 5001, cap: 5000 }); return [{ placeId: 'f1', name: 'Bar', address: 'Rua 2', rating: 4.1, reviewCount: 30, priceLevel: 1, priceLevelDisplay: '$', isOpen: true }]; },
+    store: async () => { calls.store += 1; },
+    ...over,
+  };
+  return { deps, calls };
+}
+const body = { category: 'dinner', city: ' Lisbon ', country: 'Portugal' };
+
+test('a guest → 401 and nothing else runs; a signed-in user with no tier and no category key under the caps → 200', async () => {
+  const guest = harness();
+  assert.deepEqual(await categorySearch(guest.deps, { viewer: null, ip: '1.1.1.1', body }), { status: 401, body: { error: 'Unauthorized' } });
+  assert.deepEqual(guest.calls, { user: 0, burst: 0, cacheFresh: 0, cached: 0, reserve: 0, search: 0, store: 0 });
+
+  const h = harness();
+  const out = await categorySearch(h.deps, { viewer: 'free@x.co', ip: '1.1.1.1', body });
+  assert.equal(out.status, 200);
+  assert.deepEqual(out.body, { results: [{ placeId: 'f1', name: 'Bar', address: 'Rua 2', rating: 4.1, reviewCount: 30, priceLevel: 1, priceLevelDisplay: '$', businessStatus: 'OPERATIONAL', location: null }], count: 1, cached: false });
+  assert.deepEqual(h.calls, { user: 1, burst: 1, cacheFresh: 1, cached: 0, reserve: 1, search: 1, store: 1 }, 'one daily reservation per uncached search');
+  assert.equal(CATEGORY_SEARCH_PROVIDER, 'googleplaces');
+  assert.deepEqual(await categorySearch(h.deps, { viewer: 'nobody@x.co', ip: '1.1.1.1', body }), { status: 404, body: { error: 'User not found' } });
+});
+
+test('a fresh cache bucket answers with zero Google calls and no reservation', async () => {
+  const h = harness({ fresh: true });
+  const out = await categorySearch(h.deps, { viewer: 'u@x.co', ip: '1.1.1.1', body });
+  assert.equal(out.status, 200);
+  assert.deepEqual(out.body, { results: [{ placeId: 'c1', name: 'Café', address: 'Rua 1', rating: 4.5, reviewCount: 120, priceLevel: 2, priceLevelDisplay: '$$', businessStatus: null, location: { lat: 38.7, lng: -9.1 } }], count: 1, cached: true });
+  assert.deepEqual(h.calls, { user: 1, burst: 1, cacheFresh: 1, cached: 1, reserve: 0, search: 0, store: 0 });
+});
+
+test('over the daily cap → a declared 429 with the cap\'s own line, nothing searched; over the monthly cap → a declared 429, nothing stored; the burst → 429 with Retry-After', async () => {
+  const daily = harness({ cap: 'daily' });
+  const d = await categorySearch(daily.deps, { viewer: 'u@x.co', ip: '1.1.1.1', body });
+  assert.deepEqual(d, { status: 429, body: { error: 'Travel search daily quota exceeded for googleplaces — bill protection active', source: 'google', kind: 'daily_cap', provider: 'googleplaces', used: 1001, cap: 1000 } });
+  assert.equal(daily.calls.search, 0);
+
+  const monthly = harness({ cap: 'monthly' });
+  const m = await categorySearch(monthly.deps, { viewer: 'u@x.co', ip: '1.1.1.1', body });
+  assert.deepEqual(m, { status: 429, body: { error: 'Google Places monthly quota exceeded — bill protection active', source: 'google', kind: 'quota_exceeded', used: 5001, cap: 5000 } });
+  assert.equal(monthly.calls.store, 0);
+
+  const burst = harness({ cap: 'burst' });
+  const r = await categorySearch(burst.deps, { viewer: 'u@x.co', ip: '1.1.1.1', body });
+  assert.deepEqual(r, { status: 429, body: { error: BURST_LINE, kind: 'burst' }, headers: { 'Retry-After': '42' } });
+  assert.equal(burst.calls.cacheFresh, 0);
+
+  // a fault is not a refusal — rethrown for the route's fail-closed line
+  assert.equal(capRefusal(new Error('boom')), null);
+  await assert.rejects(() => categorySearch(harness({ search: async () => { throw new Error('REQUEST_DENIED'); } }).deps, { viewer: 'u@x.co', ip: '1', body }), /REQUEST_DENIED/);
+});
+
+test('the input rules: the nine keys only; city and country; radius positive — and they say nothing about any account', async () => {
+  const h = harness();
+  const at = (b: unknown) => categorySearch(h.deps, { viewer: 'u@x.co', ip: '1', body: b });
+  assert.equal((await at({ ...body, category: 'casinos' })).status, 400);
+  assert.match(String((await at({ ...body, category: 'casinos' })).body.error), new RegExp(GOOGLE_CATEGORY_KEYS.join(', ')));
+  assert.equal((await at({ category: 'dinner', city: 'Lisbon' })).status, 400);
+  assert.equal((await at({ ...body, radius: -1 })).status, 400);
+  assert.equal((await at(null)).status, 400);
+  assert.equal(h.calls.reserve, 0, 'a refused input reserves nothing');
+  for (const k of GOOGLE_CATEGORY_KEYS) assert.equal((await at({ ...body, category: k })).status, 200, k);
+});

--- a/src/lib/__tests__/offer.test.ts
+++ b/src/lib/__tests__/offer.test.ts
@@ -5,7 +5,7 @@ import {
   numberWord, offerAvailabilityFromEnv, offerCard, offerFor, offerFromModuleParam, offerGranting, offerLaw, priceEnvName, priceLineFor, type Offer,
 } from '../offer';
 import { TOOL_REGISTRY, type ToolEntry } from '../toolRegistry';
-import { GOOGLE_CATEGORY_KEYS } from '../categoryKeys';
+import { GOOGLE_CATEGORY_KEYS, TAB_ENTITLEMENT_KEYS } from '../categoryKeys';
 import { isTabLocked } from '../categoryLock';
 import { startEntitlementCheckout } from '../checkoutDoor';
 
@@ -18,13 +18,13 @@ const tool = (name: string): ToolEntry => {
 };
 const books = (): Offer => offerFor('tab:books') as Offer;
 
-test('the law passes on the real offer; the purchasable keys are exactly the offers\' (stripe.ts reads them); tab:operations and the nine category keys are out', () => {
+test('the law passes on the real offer; the purchasable keys are exactly the offers\' (stripe.ts reads them); tab:operations is no key at all and the nine category keys are out', () => {
   assert.deepEqual(offerLaw({ throwOnFail: false }), []);
   assert.deepEqual([...SELLABLE_KEYS], ['tab:books', 'bundle:all']);
-  assert.ok(!SELLABLE_KEYS.includes('tab:operations'));
+  assert.ok(!(TAB_ENTITLEMENT_KEYS as readonly string[]).includes('tab:operations'), 'SELL-05: gone from the vocabulary');
   for (const k of GOOGLE_CATEGORY_KEYS) assert.ok(!SELLABLE_KEYS.includes(k), k);
-  // the purchasable set handed in must equal the offers
-  assert.match(offerLaw({ throwOnFail: false, purchasable: ['tab:books', 'bundle:all', 'tab:operations'] }).join('\n'), /tab:operations is not for sale/);
+  // the purchasable set handed in must equal the offers; a key outside the vocabulary is named
+  assert.match(offerLaw({ throwOnFail: false, purchasable: ['tab:books', 'bundle:all', 'tab:operations'] }).join('\n'), /tab:operations: not an entitlement key the store knows/);
   assert.match(offerLaw({ throwOnFail: false, purchasable: ['tab:books', 'bundle:all', 'brunch_coffee'] }).join('\n'), /brunch_coffee: a Google category key is not for sale/);
   assert.match(offerLaw({ throwOnFail: false, purchasable: ['tab:books'] }).join('\n'), /purchasable keys \[tab:books\] ≠ the offers/);
 });
@@ -42,7 +42,7 @@ test('a NOT_BUILT tool in an offer fails the law (the build); so does a free too
   assert.match(offerLaw({ throwOnFail: false, offers: narrow }).join('\n'), /Brokerage is gated by tab:trade, which this offer does not grant/);
   const smallBundle = [b, { ...OFFERS[1], grants: ['tab:books' as const] }];
   assert.match(offerLaw({ throwOnFail: false, offers: smallBundle }).join('\n'), /bundle:all does not grant tab:trade/);
-  const nobodySellsTax = [{ ...b, tools: b.tools.filter((t) => t !== 'Tax'), grants: ['tab:books', 'tab:trade', 'tab:compliance'] as const }, { ...OFFERS[1], grants: ['tab:books', 'tab:trade', 'tab:compliance', 'tab:travel', 'tab:operations'] as const }];
+  const nobodySellsTax = [{ ...b, tools: b.tools.filter((t) => t !== 'Tax'), grants: ['tab:books', 'tab:trade', 'tab:compliance'] as const }, { ...OFFERS[1], grants: ['tab:books', 'tab:trade', 'tab:compliance', 'tab:travel'] as const }];
   const v2 = offerLaw({ throwOnFail: false, offers: nobodySellsTax }).join('\n');
   assert.match(v2, /Tax: gated by tab:tax, which no offer grants — sold nowhere/);
   // a key outside the store's vocabulary, a price that is not a positive number

--- a/src/lib/ai/dailyCap.ts
+++ b/src/lib/ai/dailyCap.ts
@@ -1,0 +1,30 @@
+/**
+ * SELL-05 — the AI daily cap as a route gate. Time's two AI actions
+ * (enrich-routine, generate-script) used to gate on a tier nothing sells
+ * (requireTier('ai') → pro_plus only); they now gate on the per-user daily
+ * cap already in use — AI_ROUTINE_DAILY_CAP, reserved through
+ * requireRoutineBudget (src/lib/routineFireBudget.ts) — and the cap is
+ * DECLARED when hit: a 429 carrying the budget's own line, used and cap.
+ *
+ * Pure: the reservation is injected, so the gate runs in node:test with a
+ * fake meter. Any error that is not the budget's is rethrown (a fault, not a
+ * refusal). Call it AFTER input validation and ownership (a refused input
+ * must not spend the day's budget) and BEFORE the paid call.
+ */
+export interface DailyCapRefusal {
+  status: 429;
+  body: { error: string; kind: 'daily_cap'; used: number; cap: number };
+}
+
+export async function withDailyCap(reserve: (userId: string) => Promise<void>, userId: string): Promise<DailyCapRefusal | null> {
+  try {
+    await reserve(userId);
+    return null;
+  } catch (err) {
+    if (err instanceof Error && err.name === 'RoutineBudgetError') {
+      const e = err as Error & { callCount?: number; cap?: number };
+      return { status: 429, body: { error: err.message, kind: 'daily_cap', used: e.callCount ?? 0, cap: e.cap ?? 0 } };
+    }
+    throw err;
+  }
+}

--- a/src/lib/categoryKeys.ts
+++ b/src/lib/categoryKeys.ts
@@ -19,12 +19,14 @@ export const GOOGLE_CATEGORY_KEYS = [
 // Google category keys — plain strings stored in UserCategoryEntitlement.categoryKey (the
 // column is a generic String; TAB-PAYWALL-AUDIT §2b confirmed no schema change needed).
 // PRISMA-FREE and client-safe, like everything in this module.
+// SELL-05: tab:operations is gone from the vocabulary — no route ever gated on it and
+// nothing sells it (the offer law kept it out since SELL-02). A row a user still holds for
+// it is inert: no reader asks for that key.
 export const TAB_ENTITLEMENT_KEYS = [
   'tab:travel',
   'tab:trade',
   'tab:books',
   'tab:tax',
-  'tab:operations',
   'tab:compliance',
 ] as const;
 
@@ -33,12 +35,12 @@ export const TAB_ENTITLEMENT_KEYS = [
 // resolved at read time, never fanned out into per-tab rows at write time.
 export const BUNDLE_ALL_KEY = 'bundle:all';
 
-// The paid Google categories surfaced on the homepage Travel tab. Subset of
-// GOOGLE_CATEGORY_KEYS (the full system key set). Nightlife/shopping/festivals intentionally
-// excluded. This is "what we sell on the homepage" — a separate concept from "every key the
-// system knows" — so it is NOT a parallel list. Every key here MUST exist in
-// GOOGLE_CATEGORY_KEYS so the per-category entitlement gate still covers them.
-export const HOMEPAGE_PAID_CATEGORIES = [
+// The Google categories surfaced on the homepage Travel tab. Subset of GOOGLE_CATEGORY_KEYS
+// (the full system key set). Nightlife/shopping/festivals intentionally excluded. This is
+// "what the homepage shows" — a separate concept from "every key the system knows" — so it is
+// NOT a parallel list. Every key here MUST exist in GOOGLE_CATEGORY_KEYS (the route's allowed
+// set). SELL-05: the search is free with an account — no key is sold, so the old PAID name went.
+export const HOMEPAGE_CATEGORIES = [
   'brunch_coffee',
   'dinner',
   'gyms',

--- a/src/lib/offer.ts
+++ b/src/lib/offer.ts
@@ -27,9 +27,9 @@
  * PARTIAL (a NOT_BUILT tool in an offer fails the build); an offer never lists a
  * tool its grants do not unlock; every gated tool is sold by some offer; the
  * bundle grants everything any offer grants; the purchasable keys are exactly
- * the offer keys — tab:operations and the nine Google category keys are not
- * for sale; every price env name follows the naming rule; the free set holds no
- * gated tool.
+ * the offer keys — the nine Google category keys are not for sale (and
+ * tab:operations left the vocabulary in SELL-05); every price env name follows
+ * the naming rule; the free set holds no gated tool.
  *
  * Client- and server-safe: imports the registry (a leaf) and the key vocabulary.
  */
@@ -313,8 +313,8 @@ export function offerLaw(opts: {
   const sold = [...purchasable].sort();
   if (offerKeys.join(',') !== sold.join(',')) violations.push(`purchasable keys [${sold.join(', ')}] ≠ the offers [${offerKeys.join(', ')}]`);
   for (const k of purchasable) {
-    if (k === 'tab:operations') violations.push('tab:operations is not for sale — no route gates on it');
-    if ((GOOGLE_CATEGORY_KEYS as readonly string[]).includes(k)) violations.push(`${k}: a Google category key is not for sale — its route gates on an unsold tier`);
+    if (!vocabulary.has(k)) violations.push(`${k}: not an entitlement key the store knows — not for sale`);
+    if ((GOOGLE_CATEGORY_KEYS as readonly string[]).includes(k)) violations.push(`${k}: a Google category key is not for sale — no route gates on it`);
   }
   // the free set holds no gated tool
   for (const t of registry) {

--- a/src/lib/places/categorySearch.ts
+++ b/src/lib/places/categorySearch.ts
@@ -1,0 +1,191 @@
+/**
+ * SELL-05 — THE DEAD GATES: category search, gated on a SIGNED-IN USER and
+ * the existing caps — no tier, no per-category key. Pure, over a small port,
+ * so the ruled cases run in node:test:
+ *
+ *   guest                         → 401, nothing else runs;
+ *   per-IP burst (SEARCH_RATE_*)  → 429 with the limiter's Retry-After (unchanged);
+ *   bad input                     → 400 (category ∉ the nine keys; city/country);
+ *   a fresh places_cache bucket   → 200 with ZERO Google calls and NO cap reservation;
+ *   a cache miss                  → ONE reservation against the travel-search
+ *                                   daily cap (TRAVEL_SEARCH_DAILY_CAP, provider
+ *                                   'googleplaces'), then the query set through
+ *                                   the monthly-capped googleFetch; over either
+ *                                   cap → a DECLARED 429 carrying the cap's own
+ *                                   line and kind, never a 500.
+ *
+ * What stood here and is gone (the audit): requireTier('placesSearch') — a
+ * tier nothing sells, so every customer was 403 forever — and the per-category
+ * entitlement gate, whose keys nothing sells either since SELL-02 (the offer
+ * law keeps the nine Google keys out of the purchasable set). The caps are
+ * the cost control: cache-first, one daily reservation per uncached search,
+ * every Google call counted against the monthly cap.
+ *
+ * The cap errors are matched by NAME (RateLimitError, TravelSearchQuotaError,
+ * GooglePlacesQuotaError all set it) — their modules import prisma, and this
+ * one imports nothing that does.
+ */
+import { GOOGLE_CATEGORY_KEYS } from '@/lib/categoryKeys';
+
+/** The provider bucket the daily cap meters this search under (TRAVEL_SEARCH_DAILY_CAP_GOOGLEPLACES overrides the global cap). */
+export const CATEGORY_SEARCH_PROVIDER = 'googleplaces';
+
+/** Top-N after dedup/sort — the same arg the trip scan passes to searchPlacesMultiQuery. */
+export const MAX_RESULTS = 60;
+
+export const BURST_LINE = 'Too many searches — please slow down and try again shortly.';
+
+export interface CategoryCard {
+  placeId: string;
+  name: string;
+  address: string;
+  rating: number | null;
+  reviewCount: number | null;
+  priceLevel: number | null;
+  priceLevelDisplay: string | null;
+  /** 'OPERATIONAL' from a fresh result; null from the cache, which does not persist business_status. */
+  businessStatus: string | null;
+  /** From the cache when it holds lat/lng; a fresh result carries no geometry. Never fabricated. */
+  location: { lat: number; lng: number } | null;
+}
+
+/** The cache row shape this reads (placesCache.ts CachedPlace, the fields the card needs). */
+export interface CachedPlaceRow {
+  placeId: string;
+  name: string;
+  address: string;
+  rating: number | null;
+  reviewCount: number | null;
+  priceLevel: number | null;
+  priceLevelDisplay: string | null;
+  latitude: number | null;
+  longitude: number | null;
+}
+
+/** The fresh result shape this reads (placesSearch.ts PlaceResult, the fields the card needs). */
+export interface FreshPlace {
+  placeId: string;
+  name: string;
+  address: string;
+  rating: number;
+  reviewCount: number;
+  priceLevel?: number;
+  priceLevelDisplay: string | null;
+  isOpen: boolean;
+}
+
+export function cachedToCard(p: CachedPlaceRow): CategoryCard {
+  return {
+    placeId: p.placeId,
+    name: p.name,
+    address: p.address,
+    rating: p.rating,
+    reviewCount: p.reviewCount,
+    priceLevel: p.priceLevel,
+    priceLevelDisplay: p.priceLevelDisplay,
+    businessStatus: null,
+    location: p.latitude != null && p.longitude != null ? { lat: p.latitude, lng: p.longitude } : null,
+  };
+}
+
+export function freshToCard(p: FreshPlace): CategoryCard {
+  return {
+    placeId: p.placeId,
+    name: p.name,
+    address: p.address,
+    rating: p.rating ?? null,
+    reviewCount: p.reviewCount ?? null,
+    priceLevel: p.priceLevel ?? null,
+    priceLevelDisplay: p.priceLevelDisplay ?? null,
+    businessStatus: p.isOpen ? 'OPERATIONAL' : null,
+    location: null,
+  };
+}
+
+export interface CategorySearchDeps<C extends CachedPlaceRow = CachedPlaceRow, F extends FreshPlace = FreshPlace> {
+  findUser(email: string): Promise<{ id: string } | null>;
+  /** Per-IP burst limiter (rateLimit.ts) — throws RateLimitError. */
+  burst(ip: string): Promise<void>;
+  cacheFresh(city: string, country: string, category: string): Promise<boolean>;
+  cached(city: string, country: string, category: string): Promise<C[]>;
+  /** One reservation against the travel-search daily cap for CATEGORY_SEARCH_PROVIDER — throws TravelSearchQuotaError. */
+  reserveDaily(): Promise<void>;
+  /** The category's proven query set (travelCOA getCOAScanQueries). */
+  queriesFor(category: string): string[];
+  /** The engine (searchPlacesMultiQuery) — every underlying Google call is monthly-capped; throws GooglePlacesQuotaError. */
+  search(queries: string[], city: string, country: string): Promise<F[]>;
+  store(results: F[], city: string, country: string, category: string): Promise<void>;
+}
+
+export interface CategorySearchInput {
+  /** The verified cookie's email, or null for a guest. */
+  viewer: string | null;
+  ip: string;
+  body: unknown;
+}
+
+export interface Outcome {
+  status: number;
+  body: Record<string, unknown>;
+  headers?: Record<string, string>;
+}
+
+type CapError = Error & { callCount?: number; cap?: number; retryAfterSeconds?: number; provider?: string };
+
+/** The declared 429 for a cap that was hit — the cap's own line, the kind, the count. */
+export function capRefusal(err: unknown): Outcome | null {
+  if (!(err instanceof Error)) return null;
+  const e = err as CapError;
+  if (e.name === 'RateLimitError') {
+    return { status: 429, body: { error: BURST_LINE, kind: 'burst' }, headers: { 'Retry-After': String(e.retryAfterSeconds ?? 0) } };
+  }
+  if (e.name === 'TravelSearchQuotaError') {
+    return { status: 429, body: { error: e.message, source: 'google', kind: 'daily_cap', provider: e.provider ?? CATEGORY_SEARCH_PROVIDER, used: e.callCount ?? 0, cap: e.cap ?? 0 } };
+  }
+  if (e.name === 'GooglePlacesQuotaError') {
+    return { status: 429, body: { error: e.message, source: 'google', kind: 'quota_exceeded', used: e.callCount ?? 0, cap: e.cap ?? 0 } };
+  }
+  return null;
+}
+
+export async function categorySearch<C extends CachedPlaceRow, F extends FreshPlace>(deps: CategorySearchDeps<C, F>, input: CategorySearchInput): Promise<Outcome> {
+  // 1 · a signed-in user — the one gate.
+  if (!input.viewer) return { status: 401, body: { error: 'Unauthorized' } };
+  const user = await deps.findUser(input.viewer);
+  if (!user) return { status: 404, body: { error: 'User not found' } };
+
+  try {
+    // 2 · per-IP burst defense (unchanged).
+    await deps.burst(input.ip);
+
+    // 3 · the input.
+    const b = (input.body && typeof input.body === 'object' ? input.body : {}) as Record<string, unknown>;
+    const category = b.category;
+    const city = typeof b.city === 'string' ? b.city.trim() : '';
+    const country = typeof b.country === 'string' ? b.country.trim() : '';
+    const radius = b.radius;
+    if (typeof category !== 'string' || !(GOOGLE_CATEGORY_KEYS as readonly string[]).includes(category)) {
+      return { status: 400, body: { error: `Invalid category. Allowed: ${GOOGLE_CATEGORY_KEYS.join(', ')}` } };
+    }
+    if (!city || !country) return { status: 400, body: { error: 'Missing required params: city, country' } };
+    if (radius !== undefined && (typeof radius !== 'number' || !Number.isFinite(radius) || radius <= 0)) {
+      return { status: 400, body: { error: 'radius must be a positive number' } };
+    }
+
+    // 4 · cache-first — a fresh bucket costs nothing and reserves nothing.
+    if (await deps.cacheFresh(city, country, category)) {
+      const rows = await deps.cached(city, country, category);
+      return { status: 200, body: { results: rows.map(cachedToCard), count: rows.length, cached: true } };
+    }
+
+    // 5 · a miss: one daily reservation, then the query set (monthly-capped inside).
+    await deps.reserveDaily();
+    const results = await deps.search(deps.queriesFor(category), city, country);
+    await deps.store(results, city, country, category);
+    return { status: 200, body: { results: results.map(freshToCard), count: results.length, cached: false } };
+  } catch (err) {
+    const refused = capRefusal(err);
+    if (refused) return refused;
+    throw err;
+  }
+}

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -32,7 +32,7 @@ export function getPriceIdFromTier(tier: string): string | null {
 // ═══ ENTITLEMENT-WRITER: per-key price mapping ═══
 // SELL-02: the purchasable entitlement vocabulary is THE OFFER's keys
 // (src/lib/offer.ts OFFERS — Books and the all-modules bundle; the offer law
-// keeps tab:operations and the nine Google category keys out of it). Each
+// keeps the nine Google category keys out of it). Each
 // key's Stripe price ID lives in an env var named by the offer's rule
 // (priceEnvName). Alex creates the Stripe products and sets the env vars; a
 // key with NO env var set is simply NOT purchasable (checkout 400s with a
@@ -42,8 +42,9 @@ export function getPriceIdFromTier(tier: string): string | null {
 //   'tab:books'  → STRIPE_TAB_BOOKS_PRICE_ID
 //   'bundle:all' → STRIPE_BUNDLE_ALL_PRICE_ID
 //
-// Rows already held for keys no longer sold (a Google category, tab:operations)
-// keep their gate semantics (getEntitledCategories reads every active row); a
+// Rows already held for keys no longer sold (a Google category; the retired
+// tab:operations, which no reader asks for) keep whatever gate semantics a
+// reader gives them (getEntitledCategories reads every active row); a
 // Stripe event for such a subscription maps to no purchasable key and the
 // webhook declares "NO change" — nothing is granted or revoked silently.
 

--- a/src/lib/tiers.ts
+++ b/src/lib/tiers.ts
@@ -6,17 +6,19 @@
  * selling surfaces (SELL-02); both render src/lib/offer.ts (pricingModel.ts
  * died with it), and the Pro/Pro+ cards are gone. No surface names a tier price.
  * This file survives ONLY because live gates still read it (requireTier call
- * sites: ai/meal-plan, ai/cart-plan, ai/meal-planner, places/category-search,
- * trips/[id]/ai-assistant) and existing subscriptions resolve through it
- * (webhook getTierFromPriceId). Retiring it fully = migrating those gates to
- * module entitlements — its own ruled PR, not a copy change.
+ * sites: ai/meal-plan, ai/cart-plan, ai/meal-planner, trips/[id]/ai-assistant;
+ * the shopping page's canAccess twin) and existing subscriptions resolve
+ * through it (webhook getTierFromPriceId). Retiring it fully = migrating those
+ * gates to module entitlements or caps — its own ruled PR (SELL-05 reported the
+ * readers and stopped), not a copy change.
  *
- * TRUTH-LABELS: what tiers ACTUALLY gate today (post TAB-SERVER-GATE):
- *   'ai'           → lifestyle/ops AI: meal-plan, cart-plan, meal-planner,
- *                    operations content (enrich-routine, generate-script)
- *   'placesSearch' → travel premium category search (dual-gated with
- *                    per-category entitlements)
+ * TRUTH-LABELS: what tiers ACTUALLY gate today (post TAB-SERVER-GATE, SELL-05):
+ *   'ai'           → lifestyle AI: meal-plan, cart-plan, meal-planner
+ *                    (Time's enrich-routine and generate-script moved under the
+ *                    AI daily cap in SELL-05)
  *   'tripAI'       → trip AI recommendations
+ *   'placesSearch' was RETIRED by SELL-05: places/category-search gates on a
+ *                    signed-in user and the daily/monthly caps — zero readers.
  * The MODULES (Trade/Books/Tax/Compliance incl. Plaid sync, trading analytics,
  * wash sales, reconciliation, spending insights) are NOT tier features anymore —
  * they are per-tab entitlements (hasTabAccess, src/lib/entitlements.ts).
@@ -41,7 +43,6 @@ export interface TierConfig {
   manualEntry: boolean;
   tripPlanning: boolean;
   tripAI: boolean;
-  placesSearch: boolean;
   maxLinkedAccounts: number;
 }
 
@@ -52,7 +53,6 @@ const TIER_MAP: Record<Tier, TierConfig> = {
     manualEntry: true,
     tripPlanning: true,
     tripAI: false,
-    placesSearch: false,
     maxLinkedAccounts: 0,
   },
   pro: {
@@ -61,7 +61,6 @@ const TIER_MAP: Record<Tier, TierConfig> = {
     manualEntry: true,
     tripPlanning: true,
     tripAI: false,
-    placesSearch: true,
     maxLinkedAccounts: 10,
   },
   pro_plus: {
@@ -70,7 +69,6 @@ const TIER_MAP: Record<Tier, TierConfig> = {
     manualEntry: true,
     tripPlanning: true,
     tripAI: true,
-    placesSearch: true,
     maxLinkedAccounts: 25,
   },
 };


### PR DESCRIPTION
**Do not merge — Alex merges after Vercel Preview (SOC 2 gate).**

## HARD GATE items (read first)

| # | What | Where | Why it needs Alex's eyes |
|---|---|---|---|
| 1 | **Category search opens to every signed-in user, under the caps.** Two gates left the route: `requireTier('placesSearch')` (pro / pro_plus — a tier nothing sells, so every customer was 403 forever) **and the per-category entitlement gate** (`getEntitledCategories` → 403 "Category not unlocked"), whose keys nothing sells either — the offer law has kept the nine Google keys out of the purchasable set since SELL-02, so `checkout-entitlement` refuses them. Removing the tier alone would have left every customer at the second 403; the ruling's gate list is "a signed-in user + the existing daily/monthly caps", which is what stands now. | `src/app/api/places/category-search/route.ts`, `src/lib/places/categorySearch.ts` | The client mirrors the gate: a guest gets a sign-in card per category (no fetch); a signed-in viewer gets the search. The old "Subscribe to unlock" card started a checkout the store refuses — gone. The Travel tab's chip "Premium — Subscription — unlock local picks…" named a purchase that did not exist; it now reads "Local picks — Free with an account…" (`ModuleLauncher.tsx`). If the per-category lock is wanted back, it is the one block at the old `:140-151` — but nothing sells a key for it. |
| 2 | **A new cost meter on the route.** A cache miss now makes ONE reservation against the travel-search daily cap under provider `googleplaces` (`TRAVEL_SEARCH_DAILY_CAP`, default 1000/day; `TRAVEL_SEARCH_DAILY_CAP_GOOGLEPLACES` overrides — the same env rule every provider follows). The monthly cap (`GOOGLE_PLACES_MONTHLY_CAP`, inside `googleFetch`) is unchanged but is now **declared as a 429** where it was a fail-closed 500. | `route.ts:41-52`, `categorySearch.ts:capRefusal` | Both caps answer the cap's own line and `kind` (`daily_cap` / `quota_exceeded`) with used/cap. No new env var read by literal — the README env assert is unchanged (README byte-stable). |
| 3 | **Time's two AI actions gate on the AI daily cap instead of a tier.** `requireTier('ai')` (pro_plus only) is replaced by a reservation against `AI_ROUTINE_DAILY_CAP` through the existing `requireRoutineBudget` — the meter the Claude Code Routine fires use (`routineFireBudget.ts`, default 10/day/user). Reserved AFTER input validation and ownership (a refused input spends nothing) and BEFORE the paid call; over the cap → a declared 429. | `enrich-routine/route.ts:87-89`, `generate-script/route.ts:176-178`, `src/lib/ai/dailyCap.ts` | The ruling named this meter. Note it is SHARED with Routine fires (one per-user counter): a day of content actions counts against the same 10 as the auto-audit fires. If Alex wants a separate meter, it is a second counter row, its own PR. |
| 4 | **The tier system stays — reported for a ruling (below).** The `placesSearch` flag, left with zero readers, is retired from `TierConfig`; nothing else in `tiers.ts` moves. | `src/lib/tiers.ts` | — |
| 5 | **`tab:operations` leaves the vocabulary.** `TAB_ENTITLEMENT_KEYS`, the offer law's special case, the stripe/showcase comments, the offer test. The bundle's grants shrink to the five tabs (the build's offer law prints them). A `user_category_entitlements` row still holding the key (Alex's own, if any — **not verified**) is inert: no reader asks for it. | `categoryKeys.ts`, `offer.ts:316`, `stripe.ts`, `RoutinesShowcaseSections.tsx`, `offer.test.ts` | Middleware, PUBLIC_PATHS, migrations: untouched. |

## The tier system — report and stop

The ruling: "if the audit finds no seller and no other reader, delete tiers.ts, requireTier, the tier checkout route and their env rows … If any tier reader has a live purpose, report and stop for a ruling." The audit finds **no seller** (`/api/stripe/checkout` — the tier checkout — has **no caller**: `grep -rn "api/stripe/checkout[^-]" src` → nothing; only `checkout-entitlement` is called) but **readers beyond the three the ruling named**:

| Reader | Where | What it gates / does |
|---|---|---|
| `requireTier(user.tier, 'ai')` | `api/ai/meal-plan/route.ts:56`, `api/ai/cart-plan/route.ts:90`, `api/ai/meal-planner/route.ts:86` | three paid OpenAI routes — pro_plus only; nothing sells pro_plus, so 403 for everyone but admin (the same dead-gate shape as items 11/12) |
| `requireTier(user.tier, 'tripAI')` | `api/trips/[id]/ai-assistant/route.ts:139` | the trip scan (Google + AI) — pro_plus only, same shape; it also keeps its own per-category gate (`:201-203`) |
| `canAccess(userTier, 'ai')` | `app/shopping/page.tsx:253,281` | the client twin of the three `ai/*` gates |
| `userTier === 'free' \|\| 'pro'` | `app/budgets/trips/[id]/page.tsx:778` | mounts the trip-scan provider only for pro_plus/admin |
| `getTierFromPriceId` / `getPriceIdFromTier` | `lib/stripe.ts:20-30`; webhook `route.ts:216,242-257,304-334,375-400` | the webhook resolves `users.tier` from `STRIPE_PRO_PRICE_ID` / `STRIPE_PRO_PLUS_PRICE_ID` on checkout / subscription events and audit-logs the change — an existing tier subscription (**whether any exists is not verified** — a data question) would still resolve through it |
| `users.tier` | `schema.prisma:558`; `api/auth/me/route.ts:28`, `api/owner/accounts/route.ts:24,67`, `app/owner/page.tsx:175,302`, signup writes `'free'` | the column, shown on the owner page |
| `ADMIN_USER_ID` / `isAdminUser` | `lib/entitlements.ts:2,23,52`, `lib/categoryLock.ts:2,16,32`, `api/auth/me/route.ts:4,48`, `api/admin/fix-entity-assignment/route.ts:8,42`, trip page `:778` | the admin bypass — lives in `tiers.ts` but is not a tier; would need a new leaf before the file could go |

So the deletion stops here. What a ruling would decide: the three lifestyle-AI routes and the trip AI (move under a cap like Time's actions, or under a tab key), the shopping/trip-page client twins, the webhook's tier branch and the two `STRIPE_PRO*` env rows, and a home for `ADMIN_USER_ID`. Zero readers of `requireTier` remain in `places/`, `operations/`.

## Audit (read-only, against `origin/main` = `1f09b1d2`)

**Every `requireTier` call and the tiers table** — `lib/tiers.ts:36-76`: three tiers (free / pro / pro_plus) × flags `ai`, `manualEntry`, `tripPlanning`, `tripAI`, `placesSearch`, `maxLinkedAccounts`; `canAccess` (`:83-88`, admin bypass) → `requireTier` (`auth-helpers.ts:42-50`, 403 "Upgrade required"). Call sites on main: the three `ai/*` routes, `trips/[id]/ai-assistant:139` (`tripAI`), `places/category-search:101` (`placesSearch`), `operations/content/enrich-routine:43` and `generate-script:54` (`ai`). `realized-pnl` names it in a comment but gates on `requireTabAccess('tab:trade')` (`:35`). Flags with readers after this PR: `ai` (3 routes + the shopping page), `tripAI` (1); `placesSearch` had one reader — this route — and is retired; `manualEntry` / `tripPlanning` / `maxLinkedAccounts` had none before (the file's own note).

**Every caller of `/api/stripe/checkout`** — none (above). The route (`checkout/route.ts:6-62`) reads `{ tier }`, maps it through `getPriceIdFromTier`, and lands on `/dashboard?upgraded=true`. Untouched (the tier system stays).

**The places category-search route's cost per call and the caps it honors** (main `:89-178`): auth → user → the tier wall (`:101`) → per-IP burst `places-category:<ip>` at `SEARCH_RATE_LIMIT`/`SEARCH_RATE_WINDOW` (10/60s, `:112-115`) → input → the per-category gate (`:146-151`) → cache-first (`:154-157`; `places_cache`, TTL `PLACES_CACHE_TTL_DAYS` default 7 — `placesCache.ts:137-152`) → on a miss `getCOAScanQueries(category, [])` = the category's proven query set (`travelCOA.ts:331-357`: brunch 5, dinner 5, nightlife 3, coworking 3, gyms 4, groceries 4, shopping 4, sports 15, festivals 0 → 1 fallback) run in parallel by `searchPlacesMultiQuery` (`placesSearch.ts:374-415`); **each query = 1 geocode + up to 3 text-search pages, every call through `googleFetch`** (`placesSearch.ts:86,118`) → the monthly counter (`googlePlacesQuota.ts:45-66`, `GOOGLE_PLACES_MONTHLY_CAP` default 5000). So a miss costs up to 4×N Google calls — brunch/dinner ≤20, sports ≤60. **`TRAVEL_SEARCH_DAILY_CAP` was NOT honored by this route** — `reserveTravelSearch` (`travelSearchQuota.ts:105-119`) had no Google provider; the trip scan does not reserve it either. The monthly cap error surfaced as a fail-closed 500 here (the trip scan declares it as a 429, `ai-assistant/route.ts:490-494`). The one client: `PublicCategorySearch.tsx` (locked/unlocked by `isCategoryLocked`, the locked card's "Subscribe to unlock" → `checkout-entitlement` with the category key), mounted 6× by `ModuleLauncher.tsx:896` over `HOMEPAGE_PAID_CATEGORIES`.

**The two "AI" tier gates on Time's actions** — `enrich-routine/route.ts:43` and `generate-script/route.ts:54`: `requireTier(user.tier, 'ai', user.id)` right after the user lookup, before input validation; both then call Anthropic (Sonnet 4 via `recordUsage`, `enrichRoutineScenes.ts:181`, `generateReelScript.ts:160`) — paid, with no volume cap of their own (`requireAiRateLimit` in `ai-rate-limit.ts` is wired to `/api/ai/*` only). `AI_ROUTINE_DAILY_CAP` (`routineFireBudget.ts:37-73`): a durable per-(UTC day, user) counter in `operations_routine_usage`, reserve-then-check, `RoutineBudgetError` over the cap; callers on main: `fireAuditRoutine.ts:60`.

**`tab:operations` — every reference** (`grep -rn tab:operations src scripts prisma README.md docs`): `categoryKeys.ts:27` (the vocabulary), `offer.ts:30,316` (the law's special case), `stripe.ts:35,45` (comments), `offer.test.ts:21,24,27,128`, `RoutinesShowcaseSections.tsx:50` (a comment). No route gates on it; no selling surface names it; the README does not carry it.

## Build

- **`src/lib/places/categorySearch.ts`** — the route's decision over a port (`findUser`, `burst`, `cacheFresh`, `cached`, `reserveDaily`, `queriesFor`, `search`, `store`): guest → 401; burst → 429 with Retry-After; input → 400; a fresh bucket → 200 `cached: true` with zero Google calls and no reservation; a miss → one daily reservation, the query set, store, 200 `cached: false`; `capRefusal` turns the three cap errors (matched by their `name` — their modules import prisma) into declared 429s; anything else rethrows to the route's fail-closed line. The card mappers moved here unchanged.
- **The route** binds prisma / `rateLimit` / `placesCache` / `reserveTravelSearch('googleplaces')` / `getCOAScanQueries` / `searchPlacesMultiQuery` / `cachePlaces` to the port. 60 lines where 178 stood.
- **`src/lib/ai/dailyCap.ts`** — `withDailyCap(reserve, userId)` → null or `{ 429, { error, kind: 'daily_cap', used, cap } }`; the two routes call it with `requireRoutineBudget` after their 400/404 checks and before the model.
- **Client** — `PublicCategorySearch`: `SignInCategoryCard` for a guest (the sign-in modal), the search for a signed-in viewer; the 403 branch and the checkout are gone; a declared 429 prints as its own line. `ModuleLauncher`: the chip; `HOMEPAGE_PAID_CATEGORIES` → `HOMEPAGE_CATEGORIES` (its comment claimed "what we sell").
- **`tiers.ts`** — `placesSearch` retired; the truth labels name the readers that remain.

## Verify

| Check | Result |
|---|---|
| `npx tsc --noEmit` | 0 errors |
| eslint, every touched file vs its main baseline | no widening (every new file 0/0; `ModuleLauncher.tsx` 0/2 → 0/2, pre-existing) |
| `npm test` | **225/225** (219 + 4 `categorySearch.test.ts` + 2 `aiDailyCap.test.ts`; `offer.test.ts` updated) |
| Build with the asserts | showroom ✓ · tool registry 25/25 ✓ · reachability ✓ 67 · family map ✓ · answers ✓ · arrivals ✓ · rule book ✓ · kind views ✓ · posting law ✓ · offer law ✓ — the bundle now prints `grants tab:travel, tab:trade, tab:books, tab:tax, tab:compliance`; `tab:operations` appears nowhere in the build output · `next build` exit 0 |
| README regen | byte-stable (no env literal added; the env assert equals the grep) |

Ruled tests → where they live:

| Ruled test | Hermetic | The real routes (next dev on the throwaway Postgres with `TRAVEL_SEARCH_DAILY_CAP_GOOGLEPLACES=2`, `GOOGLE_PLACES_MONTHLY_CAP=3` with the month pre-seeded at 3/3, `AI_ROUTINE_DAILY_CAP=1`, a dummy Google key so a miss reaches the monthly guard and never Google, no Anthropic key) |
|---|---|---|
| a signed-in user's category search under cap → 200 | `categorySearch.test.ts` — a free viewer with no category rows: cached → 200 `cached:true`, zero search calls, zero reservations; a miss → 200 `cached:false`, exactly one reservation, one search, one store; every one of the nine keys → 200 | `curl-probe` (tier `free`, 0 category rows) → **200** `{"results":[{"placeId":"place-1","name":"Cervejaria Probe",…,"location":{"lat":38.71,"lng":-9.14}}],"count":1,"cached":true}`; `travel_search_usage` googleplaces stays 0 |
| over cap → declared 429 | daily → `{ 429, kind: 'daily_cap', provider googleplaces, used, cap }` and nothing searched; monthly → `{ 429, kind: 'quota_exceeded', used, cap }` and nothing stored; burst → 429 + Retry-After; a fault (REQUEST_DENIED) rethrows | miss 1 → **429** `Google Places monthly quota exceeded — bill protection active · quota_exceeded`; miss 2 → 429 the same; miss 3 → **429** `Travel search daily quota exceeded for googleplaces — bill protection active · daily_cap · used 3 cap 2`; the input refusals (400 ×2) reserve nothing; 11 cached calls from one IP → the 11th **429** `Too many searches…` `Retry-After: 40` |
| a guest → 401 | the port answers 401 with no other call made | at the HTTP edge the **middleware answers first — 307 to `/`** (the route is not in PUBLIC_PATHS; the same wall every non-public API path has); the route's own 401 is its first line and the hermetic proof |
| the AI actions gate on the cap | `aiDailyCap.test.ts` — with the real `RoutineBudgetError`: two under the cap pass, the third is the declared 429 with the budget's line, per user; a meter fault rethrows | guest → 307 (middleware); a bad id → 400 and a foreign id → 404 with `operations_routine_usage` empty; a real routine with one step: call 1 reserves the day (1/1) and reaches the model — no key, so the fixed fail-closed line; call 2 → **429** `Routine daily limit reached — 2/1 runs used today · daily_cap`; the usage row reads 2 |

Screenshots (the Travel tab's local-picks panel as a guest — the sign-in card per category, no fetch — and as a signed-in free account, the search answering from the cache) are in the session chat — not committed, the repo is public.

## Findings outside this PR's fence (reported, not fixed)

1. **The trip scan (`trips/[id]/ai-assistant`) keeps both dead gates** — `tripAI` (pro_plus only) and its per-category entitlement gate — so the trip page's category locks (`TripPlannerAI.tsx:349,852`, `budgets/trips/[id]/page.tsx:778`) still show a lock nobody can buy. Same shape as item 11; it is in the tier ruling above.
2. **`googlePlacesQuota` and `travelSearchQuota` count refused reservations** (reserve-then-check): the probe's monthly counter rose 4 → 9 → 13 across three refused misses (5 parallel queries each) though no Google call was made. Pre-existing; "used" over-reports at the cap.
3. **`getCachedPlaces` swallows a parse error into an empty list** (`placesCache.ts:57-60`: `JSON.parse` of `types`/`photos` → catch → `[]` with a console line) — a silent fallback; my first probe seed hit it. Pre-existing.
4. **The non-public API paths answer a guest with the middleware's 307 to `/`**, not a JSON 401 — every gated route, not only these.
5. **`/api/stripe/checkout` (the tier checkout) has no caller** and lands on `/dashboard?upgraded=true`; it stays only because the tier system stays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc

---
_Generated by [Claude Code](https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc)_