### PR TITLE
ENV-01: library-read variables join the env law; an OAuth callback test; NEXTAUTH_URL checked at boot

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,10 @@ DATABASE_URL="postgresql://user:password@host:5432/temple_stuart?sslmode=require
 # NEXTAUTH_SECRET is RETIRED: the server refuses to boot while it is set
 # (src/instrumentation.ts → src/lib/secretGuard.ts, "set JWT_SECRET instead").
 JWT_SECRET="your-jwt-secret-here"
+# ENV-01: read by next-auth (not by this code — src/lib/envLaw.ts declares it): the origin
+# of EVERY OAuth callback and redirect. In production it MUST be the https origin whose host
+# equals NEXT_PUBLIC_APP_URL's — https://www.templestuart.com, never the bare domain — or the
+# server refuses to boot (src/lib/siteUrlGuard.ts). Locally: the dev server's origin.
 NEXTAUTH_URL="http://localhost:3000"
 
 # ═══════════════════════════════════════════════════════════════

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,15 @@ prose. **Reuse over rebuild** — search for what exists before writing anything
   **cost/paid calls**, or **security**, STOP and **confirm/report before building**. Report
   the finding, then proceed only on the established plan.
 
+## Dependency upgrades
+- **Every version bump's PR body quotes the release notes' behavior changes, not only the
+  advisories.** When the notes are silent, diff the installed package against the old one
+  (`npm pack <pkg>@<old>` vs `node_modules/<pkg>`) and quote the change. ENV-01's lesson:
+  next-auth 4.24.15 changed origin detection in one line (`utils/detect-origin.js` — NEXTAUTH_URL
+  now wins over the request host on Vercel) and broke GitHub sign-in with no advisory naming it.
+- A variable a **dependency** reads (NEXTAUTH_URL, DATABASE_URL, VERCEL_*) is declared in
+  `src/lib/envLaw.ts` — the env law at build requires every one documented in the README.
+
 ## Fail-loud / no fallback
 - **No silent fallbacks. No silent catches. No fake/placeholder data — ever.**
 - If you are about to write "fallback" logic: **STOP**, state the rationale, and ask Alex

--- a/README.md
+++ b/README.md
@@ -362,11 +362,11 @@ The deck's own count: today that is 121 feeds from 20 providers — counted Augu
 
 ## Self-hosting
 
-You need Node (the code is typed against `@types/node ^20`), PostgreSQL, and a host — it is built for Vercel. Then the keys. Every name below is read by the code (`grep -rhoE "process\.env\.[A-Z0-9_]+" src`, 2026-09-02).
+You need Node (the code is typed against `@types/node ^20`), PostgreSQL, and a host — it is built for Vercel. Then the keys. Every name in the first table is read by the code (`grep -rhoE "process\.env\.[A-Z0-9_]+" src`, 2026-09-02); the second table is what a dependency reads for it, which that grep cannot see — declared in `src/lib/envLaw.ts`, and the build's env law (`scripts/assert-tool-registry.ts`) requires every name in both tables documented here and nothing documented that nothing reads.
 
 | Vendor / concern | Keys | Needed when |
 |---|---|---|
-| Core | `DATABASE_URL` (read by Prisma, `prisma/schema.prisma:7`), `JWT_SECRET` (the ONE session secret — the former NEXTAUTH_SECRET is retired: the server refuses to boot while it is set, `src/lib/secretGuard.ts`), `OWNER_EMAIL`, `ADMIN_USER_ID` (the admin's users.id; every admin gate throws when it is unset — `src/lib/admin.ts`), `NEXT_PUBLIC_OWNER_EMAIL`, `NEXT_PUBLIC_APP_URL`, `NEXT_PUBLIC_BASE_URL` | Required |
+| Core | `JWT_SECRET` (the ONE session secret — the former NEXTAUTH_SECRET is retired: the server refuses to boot while it is set, `src/lib/secretGuard.ts`), `OWNER_EMAIL`, `ADMIN_USER_ID` (the admin's users.id; every admin gate throws when it is unset — `src/lib/admin.ts`), `NEXT_PUBLIC_OWNER_EMAIL`, `NEXT_PUBLIC_APP_URL`, `NEXT_PUBLIC_BASE_URL` | Required |
 | Set by the platform | `NODE_ENV`, `NEXT_RUNTIME` (`nodejs` or `edge`, set by Next.js — the session-secret boot guard runs on the Node runtime only, `src/instrumentation.ts`), `NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA` | Provided by Vercel / Node / Next; nothing to set |
 | Plaid (bank sync) | `PLAID_CLIENT_ID`, `PLAID_SECRET`, `PLAID_REDIRECT_URI` (the OAuth return URL, `src/lib/plaid/oauth.ts`) | Required unless Books sync is disabled — no link token is created without the redirect URI |
 | Provider tokens at rest | `TOKEN_ENCRYPTION_KEY` (base64 of 32 bytes), `TOKEN_ENCRYPTION_KEY_ID` (`src/lib/secrets/tokenCipher.ts`) | Required — every Plaid and tastytrade token read or write fails loud without both |
@@ -384,6 +384,23 @@ You need Node (the code is typed against `@types/node ^20`), PostgreSQL, and a h
 | Routine and audit hooks | `CRON_SECRET`, `ROUTINE_AUDIT_TOKEN`, `ROUTINE_AUDIT_FIRE_URL`, `EXEC_ROUTINE_TOKEN`, `EXEC_ROUTINE_FIRE_URL`, `EXEC_INGEST_SECRET`, `AUDIT_INGEST_SECRET` | Required unless scheduled routines are disabled |
 | Rate limits and caps | `SEARCH_RATE_LIMIT`, `SEARCH_RATE_WINDOW`, `SCAN_RATE_LIMIT`, `SCAN_RATE_WINDOW`, `AI_RATE_LIMIT`, `AI_RATE_WINDOW`, `AI_PIPE_DAILY_CAP`, `AI_EXEC_DAILY_CAP`, `AI_ROUTINE_DAILY_CAP`, `AI_DISCOVERY_DAILY_CAP`, `TRAVEL_SEARCH_DAILY_CAP`; per provider `TRAVEL_SEARCH_DAILY_CAP_<PROVIDER>` (`src/lib/travelSearchQuota.ts:79`) | Optional; the code has defaults |
 | Misc | `YELP_API_KEY` | Required unless its feature is disabled |
+
+### Read by a library
+
+Variables no line of this code reads — a dependency does. The night next-auth 4.24.15 started building every OAuth callback from `NEXTAUTH_URL` (its `utils/detect-origin.js`), the table above could not have known the variable existed; in production the server now refuses to boot unless `NEXTAUTH_URL` is the https origin whose host equals `NEXT_PUBLIC_APP_URL`'s (`src/lib/siteUrlGuard.ts`).
+
+| Name | Read by | Where | Needed | Expected shape |
+|---|---|---|---|---|
+| `DATABASE_URL` | prisma | prisma/schema.prisma:12 `url = env("DATABASE_URL")` — the client and every migration | Required | postgresql://user:password@host:5432/db?sslmode=require (Azure Postgres requires SSL) |
+| `NEXTAUTH_URL` | next-auth | utils/detect-origin.js:9 (the origin of every OAuth callback and redirect — since 4.24.15 it wins over the request host on Vercel), jwt/index.js:65 (secure-cookie decision), react/index.js:53-54 (client base URL) | Required | the deployment's https origin with no path — its host must equal NEXT_PUBLIC_APP_URL's (https://www.templestuart.com in production; a bare templestuart.com is refused at boot by src/lib/siteUrlGuard.ts) |
+| `NEXTAUTH_URL_INTERNAL` | next-auth | react/index.js:55-56 (server-side fetch base when the public origin is not reachable from the server) | Optional | an http(s) origin; unset here |
+| `AUTH_TRUST_HOST` | next-auth | utils/detect-origin.js:10 (trust x-forwarded-host when NEXTAUTH_URL is unset) | Optional | unset — NEXTAUTH_URL rules the origin; never set this to paper over a wrong NEXTAUTH_URL |
+| `AUTH_SECRET` | next-auth | next/index.js:17,49,128 (the fallback when options.secret is unset — ours is JWT_SECRET, so this is never consulted) | Optional | unset — SECRET-01: JWT_SECRET is the one session secret |
+| `VERCEL` | next-auth | utils/detect-origin.js:10 (trust the forwarded host when NEXTAUTH_URL is unset), jwt/index.js:65 (secure cookies) | Set by the host | "1" on Vercel; set by the host |
+| `VERCEL_URL` | next-auth | react/index.js:53 (client base URL fallback when NEXTAUTH_URL is unset) | Set by the host | <deployment>.vercel.app, set by the host — never the production origin |
+| `VERCEL_ENV` | the boot check | src/lib/siteUrlGuard.ts (through the env record: production / preview / development — the NEXTAUTH_URL check runs for production only, a Preview has a per-deploy host) | Set by the host | production / preview / development; set by the host |
+| `PORT` | next | dist/server/lib/start-server.js (`next start` — self-hosting only; Vercel runs its own runtime) | Set by the host | a port number; set by the host |
+| `HOSTNAME` | next | dist/build/utils.js (`next start` bind host — self-hosting only) | Set by the host | a hostname; set by the host |
 
 Yes, that's a lot of keys. That's why the next section exists.
 

--- a/scripts/assert-tool-registry.ts
+++ b/scripts/assert-tool-registry.ts
@@ -59,6 +59,16 @@
  * side is the CREATE TABLE plus every later migration's ALTER TABLE … ADD
  * COLUMN / ALTER COLUMN … SET NOT NULL on that table, in migration order.
  *
+ * THE ENV LAW (ENV-01): every variable the app reads is documented in
+ * README.md's "## Self-hosting" section, and nothing documented there is read
+ * by nothing. Three kinds of read: a `process.env.X` literal in src (the
+ * grep), a variable a DEPENDENCY reads for us (src/lib/envLaw.ts
+ * LIBRARY_READ_ENV — name, reading package, where, need, shape; each row must
+ * appear in the README with its reader), and a computed key (DYNAMIC_READ_ENV).
+ * A name declared library-read that src also reads as a literal is a
+ * contradiction and fails. The night next-auth 4.24.15 started obeying
+ * NEXTAUTH_URL, the README could not have known the variable existed.
+ *
  * The assert:showroom pattern: a plain script wired into the `build` script so
  * it runs in CI / Vercel and fails the BUILD. It imports the registry (which
  * runs its module-scope law: sheet cells 25/25 both ways, LIVE/PARTIAL have a
@@ -80,6 +90,7 @@ import { ARRIVAL_KINDS, PROVIDERS, PROVIDER_CODES, ROUTING_RULES, RULE_BOOK, pro
 import { KIND_VIEWS_HONEST_LINE, KIND_VIEW_CENSUS, STOPPED_TABLES, VIEW_COLUMNS, kindOfTable, kindViewsLaw, latestViews, latestViewsSql, parseViews } from '../src/lib/kindViews';
 // SELL-02: the offer law — every sales claim from the registry, every price from one source.
 import { FREE_TOOLS, OFFERS, TOOL_GATE, heroCountsLine, offerCard, offerLaw, priceEnvName } from '../src/lib/offer';
+import { DYNAMIC_READ_ENV, LIBRARY_READ_ENV } from '../src/lib/envLaw';
 import { PURCHASABLE_ENTITLEMENT_KEYS } from '../src/lib/stripe';
 
 /**
@@ -495,6 +506,29 @@ if (!/ledger_entries\.createMany\(/.test(postingHome)) violations.push('posting:
 if (!/PostingNotLandedError/.test(postingHome)) violations.push('posting: postJournal.ts has no read-back failure');
 if (postingPaths.size < 12) violations.push(`posting: only ${postingPaths.size} files route through postJournal() — the audit counted 12`);
 
+// ─── THE ENV LAW (ENV-01) ────────────────────────────────────────────────────
+const readmeText = readFileSync(resolve(ROOT, 'README.md'), 'utf8');
+const selfHosting = readmeText.split(/^## /m).find((section) => section.startsWith('Self-hosting')) ?? '';
+if (!selfHosting) violations.push('env: README.md has no "## Self-hosting" section');
+const documentedEnv = new Set([...selfHosting.matchAll(/`([A-Z][A-Z0-9_]+)`/g)].map((m) => m[1]));
+const srcEnv = new Set<string>();
+for (const { src } of srcFiles) for (const m of src.matchAll(/process\.env\.([A-Z][A-Z0-9_]+)/g)) srcEnv.add(m[1]);
+const libraryEnv = new Set(LIBRARY_READ_ENV.map((e) => e.name));
+const dynamicEnv = new Set(DYNAMIC_READ_ENV.map((e) => e.name));
+for (const name of libraryEnv) if (srcEnv.has(name)) violations.push(`env: ${name} is declared library-read (src/lib/envLaw.ts) but src reads process.env.${name} as a literal — not library-read`);
+const readKind = (name: string) => (srcEnv.has(name) ? 'a src literal' : libraryEnv.has(name) ? 'a library' : 'a computed key');
+for (const name of [...new Set([...srcEnv, ...libraryEnv, ...dynamicEnv])].sort()) {
+  if (!documentedEnv.has(name)) violations.push(`env: ${name} is read (${readKind(name)}) but README.md's Self-hosting section does not document it`);
+}
+for (const name of [...documentedEnv].sort()) {
+  if (!srcEnv.has(name) && !libraryEnv.has(name) && !dynamicEnv.has(name)) violations.push(`env: README.md documents ${name} but nothing reads it`);
+}
+for (const e of LIBRARY_READ_ENV) {
+  const row = selfHosting.split('\n').find((line) => line.startsWith(`| \`${e.name}\` |`));
+  if (!row) violations.push(`env: README.md has no library row for ${e.name} (src/lib/envLaw.ts)`);
+  else if (!row.includes(e.readBy)) violations.push(`env: README.md's row for ${e.name} does not name its reader '${e.readBy}'`);
+}
+
 if (violations.length) {
   console.error('\n✖ TOOL REGISTRY LAW FAILED:');
   for (const v of violations) console.error(`  ${v}`);
@@ -534,4 +568,5 @@ console.log(`✔ The arrivals law passed — ${PROVIDERS.length} providers, enum
 console.log(`✔ The rule book law passed — ${RULE_BOOK.length} rules, ${callSites.length} landing call sites covered, enum arrival_kind === the six kinds, the migration applies ${applied.length} rules the book holds.`);
 console.log(`✔ The kind views law passed — ${ARRIVAL_KINDS.length} views over ${KIND_VIEW_CENSUS.length} feed tables, each once, the kind from the rule book; posting unions nothing; ${STOPPED_TABLES.length} tables reported, not viewed.`);
 console.log(`✔ The posting law passed — every journal and ledger row is created by postJournal.ts (SET CONSTRAINTS ALL IMMEDIATE first, one statement for the lines, read back after commit); ${postingPaths.size} files post through it.`);
+console.log(`✔ The env law passed — ${srcEnv.size} names read as src literals, ${libraryEnv.size} read by a library (src/lib/envLaw.ts), ${dynamicEnv.size} by a computed key; every one documented in README.md, nothing documented that nothing reads.`);
 console.log(`✔ The offer law passed — ${OFFERS.length} offers over ${new Set(OFFERS.flatMap((o) => o.tools)).size} tools (LIVE or PARTIAL only), ${FREE_TOOLS.length} free; the purchasable keys are the offers'; "built and running" typed nowhere but offer.ts; ${SELLING_SURFACES.length} selling surfaces render the offer.`);

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,78 +1,28 @@
 import NextAuth from 'next-auth';
-import GoogleProvider from 'next-auth/providers/google';
-import GitHubProvider from 'next-auth/providers/github';
-import { PrismaAdapter } from '@auth/prisma-adapter';
 import { PrismaClient } from '@prisma/client';
 import { cookies } from 'next/headers';
-import { signCookie } from '@/lib/cookie-auth';
+import { buildAuthOptions } from '@/lib/auth/nextAuthOptions';
+
+// ENV-01: the options live in src/lib/auth/nextAuthOptions.ts — the callback test
+// drives next-auth's core with the SAME options, so the redirect_uri host is
+// asserted against the app's host on every `npm test`. NEXTAUTH_URL (read by
+// next-auth, not by this code) is checked at boot (src/lib/siteUrlGuard.ts).
 
 const prisma = new PrismaClient();
 
-function generateId() {
-  return Math.random().toString(36).substring(2) + Date.now().toString(36);
-}
-
-const handler = NextAuth({
-  adapter: PrismaAdapter(prisma),
-  providers: [
-    GoogleProvider({
-      clientId: process.env.GOOGLE_CLIENT_ID!,
-      clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
-    }),
-    GitHubProvider({
-      clientId: process.env.GITHUB_CLIENT_ID!,
-      clientSecret: process.env.GITHUB_CLIENT_SECRET!,
-      issuer: "https://github.com/login/oauth",
-    }),
-  ],
-  callbacks: {
-    async signIn({ user }) {
-      if (user.email) {
-        const normalizedEmail = user.email.toLowerCase().trim();
-        // Check if user exists in our users table (case-insensitive)
-        const existingUser = await prisma.users.findFirst({
-          where: { email: { equals: normalizedEmail, mode: 'insensitive' } }
-        });
-        if (!existingUser) {
-          // Create user in our users table — SELL-03b: the provider verified
-          // the address, so the account is verified at creation.
-          await prisma.users.create({
-            data: {
-              id: generateId(),
-              email: normalizedEmail,
-              name: user.name || normalizedEmail.split('@')[0],
-              password: '',
-              updatedAt: new Date(),
-              email_verified_at: new Date(),
-            }
-          });
-        } else if (!existingUser.email_verified_at) {
-          // SELL-03b: an email-signup that never used its link, now signing in
-          // through a provider that verified the same address — verified.
-          await prisma.users.update({ where: { id: existingUser.id }, data: { email_verified_at: new Date() } });
-        }
-
-        // Set the userEmail cookie for API routes
-        const cookieStore = await cookies();
-        cookieStore.set('userEmail', signCookie(normalizedEmail), {
-          httpOnly: true,
-          secure: process.env.NODE_ENV === 'production',
-          sameSite: 'lax',
-          maxAge: 60 * 60 * 24 * 30, // 30 days
-        });
-      }
-      return true;
+const handler = NextAuth(
+  buildAuthOptions({
+    prisma,
+    setSessionCookie: async (value) => {
+      const cookieStore = await cookies();
+      cookieStore.set('userEmail', value, {
+        httpOnly: true,
+        secure: process.env.NODE_ENV === 'production',
+        sameSite: 'lax',
+        maxAge: 60 * 60 * 24 * 30, // 30 days
+      });
     },
-  },
-  pages: {
-    signIn: '/',
-  },
-  // LAUNCH-01 SECRET-01: ONE session secret — the same JWT_SECRET middleware's
-  // getToken and src/app/page.tsx's decode verify this token with (before this,
-  // NEXTAUTH_SECRET signed here and JWT_SECRET verified there: two names, one
-  // job, and a mismatch broke OAuth sessions silently). NEXTAUTH_SECRET is
-  // retired — the boot guard (src/instrumentation.ts) refuses to start with it set.
-  secret: process.env.JWT_SECRET,
-});
+  }),
+);
 
 export { handler as GET, handler as POST };

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -3,8 +3,14 @@
 // LAUNCH-01 SECRET-01: the session-secret guard. A deploy still carrying the
 // retired NEXTAUTH_SECRET, or missing JWT_SECRET, refuses to boot with the fix
 // named — no request is served on a misconfigured secret.
+// ENV-01: the site-URL guard. In production NEXTAUTH_URL must be an https
+// origin whose host equals NEXT_PUBLIC_APP_URL's — next-auth builds every OAuth
+// callback from it, and a bare-domain value broke GitHub sign-in silently.
 export async function register() {
   if (process.env.NEXT_RUNTIME !== 'nodejs') return;
   const { secretGuard } = await import('@/lib/secretGuard');
   secretGuard(process.env);
+  const { siteUrlGuard } = await import('@/lib/siteUrlGuard');
+  const site = siteUrlGuard(process.env);
+  console.log(site.checked ? `[boot] NEXTAUTH_URL checked — host ${site.host}` : `[boot] NEXTAUTH_URL check skipped — ${site.reason}`);
 }

--- a/src/lib/__tests__/nextAuthCallback.test.ts
+++ b/src/lib/__tests__/nextAuthCallback.test.ts
@@ -1,0 +1,95 @@
+import test, { mock } from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import { resolve } from 'node:path';
+import type { PrismaClient } from '@prisma/client';
+import { buildAuthOptions } from '../auth/nextAuthOptions';
+
+// ENV-01 — the OAuth callback test. next-auth 4.24.15 builds every authorize
+// URL's redirect_uri from NEXTAUTH_URL (utils/detect-origin.js:9 — it wins over
+// the request host on Vercel since that version). GitHub and Google accept only
+// the redirect_uri registered with them — the app's own origin — so this test
+// drives next-auth's core handler with THE configured options
+// (src/lib/auth/nextAuthOptions.ts) and asserts, for both providers, that the
+// redirect_uri host equals NEXTAUTH_URL's host AND the app's host
+// (NEXT_PUBLIC_APP_URL). Run with NEXTAUTH_URL=https://templestuart.com (the
+// bare-domain value that broke sign-in) and it fails.
+//
+// Hermetic: the only network call next-auth would make — Google's OpenID
+// discovery — is stubbed at openid-client's Issuer.discover; everything else
+// (csrf, state, pkce, the URL) is next-auth's own code.
+
+const APP_URL = process.env.NEXT_PUBLIC_APP_URL ?? 'https://www.templestuart.com';
+process.env.NEXTAUTH_URL ??= APP_URL;
+process.env.JWT_SECRET ??= 'env01-callback-test-secret';
+process.env.GOOGLE_CLIENT_ID ??= 'google-client-id.apps.googleusercontent.com';
+process.env.GOOGLE_CLIENT_SECRET ??= 'google-client-secret';
+process.env.GITHUB_CLIENT_ID ??= 'Iv1.githubclientid';
+process.env.GITHUB_CLIENT_SECRET ??= 'github-client-secret';
+
+const appHost = new URL(APP_URL).host;
+const nextauthHost = new URL(process.env.NEXTAUTH_URL!).host;
+
+// next-auth's core is not in its exports map — the route wrapper requires it by
+// path, and so does this test (an absolute require bypasses the exports map).
+const req = createRequire(resolve(process.cwd(), 'package.json'));
+const { AuthHandler } = req(resolve(process.cwd(), 'node_modules/next-auth/core/index.js')) as {
+  AuthHandler: (params: { req: Record<string, unknown>; options: unknown }) => Promise<{ status?: number; body?: unknown; redirect?: string; cookies?: Array<{ name: string; value: string }> }>;
+};
+const { Issuer } = req('openid-client') as { Issuer: { discover: (uri: string) => Promise<unknown>; new (meta: Record<string, string>): unknown } };
+
+const discovered: string[] = [];
+mock.method(Issuer, 'discover', async (uri: string) => {
+  discovered.push(uri);
+  return new Issuer({
+    issuer: 'https://accounts.google.com',
+    authorization_endpoint: 'https://accounts.google.com/o/oauth2/v2/auth',
+    token_endpoint: 'https://oauth2.googleapis.com/token',
+    userinfo_endpoint: 'https://openidconnect.googleapis.com/v1/userinfo',
+    jwks_uri: 'https://www.googleapis.com/oauth2/v3/certs',
+  });
+});
+
+const options = buildAuthOptions({
+  prisma: {} as PrismaClient, // never touched by the authorize step
+  setSessionCookie: async () => { throw new Error('the authorize step must not set a session cookie'); },
+});
+
+// The request as the route wrapper hands it to the core: the app's host, https.
+const headers = { host: appHost, 'x-forwarded-host': appHost, 'x-forwarded-proto': 'https' };
+
+async function authorizeUrl(providerId: 'github' | 'google'): Promise<URL> {
+  const csrf = await AuthHandler({ req: { method: 'GET', action: 'csrf', headers, cookies: {}, query: {} }, options });
+  const csrfToken = (csrf.body as { csrfToken: string }).csrfToken;
+  const cookie = csrf.cookies?.[0];
+  assert.ok(csrfToken && cookie, 'the csrf step returns a token and its cookie');
+  const res = await AuthHandler({
+    req: { method: 'POST', action: 'signin', providerId, headers, cookies: { [cookie.name]: cookie.value }, body: { csrfToken, callbackUrl: `${APP_URL}/` }, query: {} },
+    options,
+  });
+  assert.ok(res.redirect, `signin/${providerId} redirects to the provider (got status ${res.status ?? 'none'}: ${JSON.stringify(res.body ?? null).slice(0, 200)})`);
+  return new URL(res.redirect);
+}
+
+for (const [providerId, authorize] of [
+  ['github', 'https://github.com/login/oauth/authorize'],
+  ['google', 'https://accounts.google.com/o/oauth2/v2/auth'],
+] as const) {
+  test(`${providerId}: the authorize URL's redirect_uri is https://<NEXTAUTH_URL host>/api/auth/callback/${providerId}, and that host is the app's`, async () => {
+    const url = await authorizeUrl(providerId);
+    assert.equal(`${url.origin}${url.pathname}`, authorize, 'the provider endpoint');
+    const redirectUri = url.searchParams.get('redirect_uri');
+    assert.ok(redirectUri, 'redirect_uri is present');
+    const cb = new URL(redirectUri);
+    assert.equal(cb.protocol, 'https:');
+    assert.equal(cb.pathname, `/api/auth/callback/${providerId}`);
+    assert.equal(cb.host, nextauthHost, 'redirect_uri host === NEXTAUTH_URL host (next-auth builds it from NEXTAUTH_URL)');
+    assert.equal(cb.host, appHost, `redirect_uri host === the app's host (NEXT_PUBLIC_APP_URL) — NEXTAUTH_URL=${process.env.NEXTAUTH_URL} would send ${providerId} a callback host the provider was not registered with`);
+    assert.ok(url.searchParams.get('state'), 'the state check is armed');
+    assert.equal(url.searchParams.get('client_id'), providerId === 'github' ? process.env.GITHUB_CLIENT_ID : process.env.GOOGLE_CLIENT_ID);
+  });
+}
+
+test('the only network call — Google discovery — was stubbed, once, at its documented URL', () => {
+  assert.deepEqual(discovered, ['https://accounts.google.com/.well-known/openid-configuration']);
+});

--- a/src/lib/__tests__/siteUrlGuard.test.ts
+++ b/src/lib/__tests__/siteUrlGuard.test.ts
@@ -1,0 +1,50 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { SiteUrlConfigError, isProductionEnv, siteUrlGuard } from '../siteUrlGuard';
+
+// ENV-01 — the site-URL boot check, pure over an env record.
+
+const PROD = { VERCEL_ENV: 'production', NEXT_PUBLIC_APP_URL: 'https://www.templestuart.com' };
+
+test('production is VERCEL_ENV production, or NODE_ENV production off Vercel; a Preview and development are not', () => {
+  assert.equal(isProductionEnv({ VERCEL_ENV: 'production' }), true);
+  assert.equal(isProductionEnv({ NODE_ENV: 'production' }), true);
+  assert.equal(isProductionEnv({ VERCEL_ENV: 'preview', NODE_ENV: 'production' }), false);
+  assert.equal(isProductionEnv({ VERCEL_ENV: 'development' }), false);
+  assert.equal(isProductionEnv({ NODE_ENV: 'development' }), false);
+  assert.equal(isProductionEnv({}), false);
+});
+
+test('outside production the check is skipped and says so', () => {
+  assert.deepEqual(siteUrlGuard({ NODE_ENV: 'development', NEXTAUTH_URL: 'http://localhost:3000' }), { checked: false, reason: 'not production (VERCEL_ENV=unset, NODE_ENV=development)' });
+  assert.deepEqual(siteUrlGuard({ VERCEL_ENV: 'preview', NODE_ENV: 'production' }), { checked: false, reason: 'not production (VERCEL_ENV=preview, NODE_ENV=production)' });
+});
+
+test('the good production value passes and names the host; a trailing slash is tolerated', () => {
+  assert.deepEqual(siteUrlGuard({ ...PROD, NEXTAUTH_URL: 'https://www.templestuart.com' }), { checked: true, host: 'www.templestuart.com' });
+  assert.deepEqual(siteUrlGuard({ ...PROD, NEXTAUTH_URL: 'https://www.templestuart.com/' }), { checked: true, host: 'www.templestuart.com' });
+});
+
+const refuses = (env: Record<string, string | undefined>, re: RegExp) =>
+  assert.throws(() => siteUrlGuard(env), (e: unknown) => {
+    assert.ok(e instanceof SiteUrlConfigError, `SiteUrlConfigError, got ${String(e)}`);
+    assert.equal(e.name, 'SiteUrlConfigError');
+    assert.match(e.message, re);
+    return true;
+  });
+
+test('the bare domain that broke sign-in is refused with the fix named', () => {
+  refuses({ ...PROD, NEXTAUTH_URL: 'https://templestuart.com' }, /host 'templestuart\.com' does not match NEXT_PUBLIC_APP_URL host 'www\.templestuart\.com'.*set NEXTAUTH_URL=https:\/\/www\.templestuart\.com/);
+  refuses({ ...PROD, NEXTAUTH_URL: 'templestuart.com' }, /NEXTAUTH_URL is not a URL — got 'templestuart\.com'/);
+});
+
+test('absence, http, a path, and any other host are refused, each with a named message', () => {
+  refuses({ ...PROD }, /NEXTAUTH_URL is not set — next-auth builds every OAuth callback from it; set NEXTAUTH_URL=https:\/\/www\.templestuart\.com/);
+  refuses({ ...PROD, NEXTAUTH_URL: '' }, /NEXTAUTH_URL is not set/);
+  refuses({ ...PROD, NEXTAUTH_URL: 'http://www.templestuart.com' }, /must be an https origin — got 'http:\/\/www\.templestuart\.com'/);
+  refuses({ ...PROD, NEXTAUTH_URL: 'https://www.templestuart.com/api/auth' }, /bare origin with no path, query or hash — got 'https:\/\/www\.templestuart\.com\/api\/auth'/);
+  refuses({ ...PROD, NEXTAUTH_URL: 'https://www.templestuart.com?x=1' }, /bare origin/);
+  refuses({ ...PROD, NEXTAUTH_URL: 'https://staging.templestuart.com' }, /host 'staging\.templestuart\.com' does not match/);
+  refuses({ VERCEL_ENV: 'production', NEXTAUTH_URL: 'https://www.templestuart.com' }, /NEXT_PUBLIC_APP_URL is not set — production needs the public origin/);
+  refuses({ VERCEL_ENV: 'production', NEXT_PUBLIC_APP_URL: 'not a url', NEXTAUTH_URL: 'https://www.templestuart.com' }, /NEXT_PUBLIC_APP_URL is not a URL/);
+});

--- a/src/lib/auth/nextAuthOptions.ts
+++ b/src/lib/auth/nextAuthOptions.ts
@@ -1,0 +1,88 @@
+import type { NextAuthOptions } from 'next-auth';
+import GoogleProvider from 'next-auth/providers/google';
+import GitHubProvider from 'next-auth/providers/github';
+import { PrismaAdapter } from '@auth/prisma-adapter';
+import type { PrismaClient } from '@prisma/client';
+import { signCookie } from '@/lib/cookie-auth';
+
+/**
+ * ENV-01 — THE configured NextAuth options, as one function the route and the
+ * tests share. The route (src/app/api/auth/[...nextauth]/route.ts) passes the
+ * real PrismaClient and next/headers' cookie jar; the callback test
+ * (src/lib/__tests__/nextAuthCallback.test.ts) passes fakes and drives
+ * next-auth's own core handler with these options to build the GitHub and
+ * Google authorize URLs — so the redirect_uri host next-auth derives from
+ * NEXTAUTH_URL (utils/detect-origin.js, 4.24.15) is asserted against the app's
+ * host on every `npm test`, the way it was not the night the bare-domain value
+ * broke sign-in.
+ *
+ * Providers read their client ids at CALL time (process.env literals — the env
+ * law's grep sees them). The session secret is JWT_SECRET (SECRET-01).
+ */
+export interface AuthOptionDeps {
+  prisma: PrismaClient;
+  /** Sets the HMAC-signed userEmail cookie the API routes read — the route hands in next/headers' cookies(). */
+  setSessionCookie: (value: string) => Promise<void>;
+  newId?: () => string;
+}
+
+function generateId() {
+  return Math.random().toString(36).substring(2) + Date.now().toString(36);
+}
+
+export function buildAuthOptions({ prisma, setSessionCookie, newId = generateId }: AuthOptionDeps): NextAuthOptions {
+  return {
+    adapter: PrismaAdapter(prisma),
+    providers: [
+      GoogleProvider({
+        clientId: process.env.GOOGLE_CLIENT_ID!,
+        clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
+      }),
+      GitHubProvider({
+        clientId: process.env.GITHUB_CLIENT_ID!,
+        clientSecret: process.env.GITHUB_CLIENT_SECRET!,
+        issuer: 'https://github.com/login/oauth',
+      }),
+    ],
+    callbacks: {
+      async signIn({ user }) {
+        if (user.email) {
+          const normalizedEmail = user.email.toLowerCase().trim();
+          // Check if user exists in our users table (case-insensitive)
+          const existingUser = await prisma.users.findFirst({
+            where: { email: { equals: normalizedEmail, mode: 'insensitive' } },
+          });
+          if (!existingUser) {
+            // Create user in our users table — SELL-03b: the provider verified
+            // the address, so the account is verified at creation.
+            await prisma.users.create({
+              data: {
+                id: newId(),
+                email: normalizedEmail,
+                name: user.name || normalizedEmail.split('@')[0],
+                password: '',
+                updatedAt: new Date(),
+                email_verified_at: new Date(),
+              },
+            });
+          } else if (!existingUser.email_verified_at) {
+            // SELL-03b: an email-signup that never used its link, now signing in
+            // through a provider that verified the same address — verified.
+            await prisma.users.update({ where: { id: existingUser.id }, data: { email_verified_at: new Date() } });
+          }
+
+          // Set the userEmail cookie for API routes
+          await setSessionCookie(signCookie(normalizedEmail));
+        }
+        return true;
+      },
+    },
+    pages: {
+      signIn: '/',
+    },
+    // LAUNCH-01 SECRET-01: ONE session secret — the same JWT_SECRET middleware's
+    // getToken and src/app/page.tsx's decode verify this token with. NEXTAUTH_SECRET
+    // is retired — the boot guard (src/instrumentation.ts) refuses to start with it set.
+    secret: process.env.JWT_SECRET,
+  };
+}

--- a/src/lib/envLaw.ts
+++ b/src/lib/envLaw.ts
@@ -1,0 +1,131 @@
+// ─── THE ENV LAW — variables a DEPENDENCY reads (ENV-01) ─────────────────────
+// The README's env table derives from a grep of `process.env.<NAME>` literals in
+// src/ (scripts/assert-tool-registry.ts, the env law at build; readme-gen).
+// A variable a dependency reads for us is invisible to that grep — and it was
+// exactly such a variable that broke sign-in: next-auth 4.24.15 added one line
+// to utils/detect-origin.js (return NEXTAUTH_URL first, before the forwarded
+// host), so the OAuth callback origin stopped following the request host on
+// Vercel and started following NEXTAUTH_URL, whose
+// nine-month-old value was the bare domain. GitHub rejected the redirect_uri
+// and no test caught it.
+//
+// This const is the declared list of every such variable: who reads it, where
+// (the file in node_modules, so the claim is checkable), whether the app needs
+// it, and the shape it must have. The build's env law requires every entry to
+// be documented in README.md's Self-hosting section, and refuses a name that is
+// BOTH declared here and read as a literal in src (it would not be library-read).
+// src/lib/siteUrlGuard.ts enforces NEXTAUTH_URL's shape at boot in production.
+
+export type EnvNeed = 'required' | 'optional' | 'platform';
+
+export interface LibraryReadEnv {
+  name: string;
+  /** The package (or file) that reads it. */
+  readBy: string;
+  /** Where in that package — a path under node_modules or the repo, so the claim is checkable. */
+  where: string;
+  /** required: the app does not work without it; optional: changes behavior when set; platform: the host sets it, never by hand. */
+  need: EnvNeed;
+  /** The value's expected shape — and, for a required one, the production value's rule. */
+  shape: string;
+}
+
+export const LIBRARY_READ_ENV: readonly LibraryReadEnv[] = [
+  {
+    name: 'DATABASE_URL',
+    readBy: 'prisma',
+    where: 'prisma/schema.prisma:12 `url = env("DATABASE_URL")` — the client and every migration',
+    need: 'required',
+    shape: 'postgresql://user:password@host:5432/db?sslmode=require (Azure Postgres requires SSL)',
+  },
+  {
+    name: 'NEXTAUTH_URL',
+    readBy: 'next-auth',
+    where: 'utils/detect-origin.js:9 (the origin of every OAuth callback and redirect — since 4.24.15 it wins over the request host on Vercel), jwt/index.js:65 (secure-cookie decision), react/index.js:53-54 (client base URL)',
+    need: 'required',
+    shape: 'the deployment\'s https origin with no path — its host must equal NEXT_PUBLIC_APP_URL\'s (https://www.templestuart.com in production; a bare templestuart.com is refused at boot by src/lib/siteUrlGuard.ts)',
+  },
+  {
+    name: 'NEXTAUTH_URL_INTERNAL',
+    readBy: 'next-auth',
+    where: 'react/index.js:55-56 (server-side fetch base when the public origin is not reachable from the server)',
+    need: 'optional',
+    shape: 'an http(s) origin; unset here',
+  },
+  {
+    name: 'AUTH_TRUST_HOST',
+    readBy: 'next-auth',
+    where: 'utils/detect-origin.js:10 (trust x-forwarded-host when NEXTAUTH_URL is unset)',
+    need: 'optional',
+    shape: 'unset — NEXTAUTH_URL rules the origin; never set this to paper over a wrong NEXTAUTH_URL',
+  },
+  {
+    name: 'AUTH_SECRET',
+    readBy: 'next-auth',
+    where: 'next/index.js:17,49,128 (the fallback when options.secret is unset — ours is JWT_SECRET, so this is never consulted)',
+    need: 'optional',
+    shape: 'unset — SECRET-01: JWT_SECRET is the one session secret',
+  },
+  {
+    name: 'VERCEL',
+    readBy: 'next-auth',
+    where: 'utils/detect-origin.js:10 (trust the forwarded host when NEXTAUTH_URL is unset), jwt/index.js:65 (secure cookies)',
+    need: 'platform',
+    shape: '"1" on Vercel; set by the host',
+  },
+  {
+    name: 'VERCEL_URL',
+    readBy: 'next-auth',
+    where: 'react/index.js:53 (client base URL fallback when NEXTAUTH_URL is unset)',
+    need: 'platform',
+    shape: '<deployment>.vercel.app, set by the host — never the production origin',
+  },
+  {
+    name: 'VERCEL_ENV',
+    readBy: 'the boot check',
+    where: 'src/lib/siteUrlGuard.ts (through the env record: production / preview / development — the NEXTAUTH_URL check runs for production only, a Preview has a per-deploy host)',
+    need: 'platform',
+    shape: 'production / preview / development; set by the host',
+  },
+  {
+    name: 'PORT',
+    readBy: 'next',
+    where: 'dist/server/lib/start-server.js (`next start` — self-hosting only; Vercel runs its own runtime)',
+    need: 'platform',
+    shape: 'a port number; set by the host',
+  },
+  {
+    name: 'HOSTNAME',
+    readBy: 'next',
+    where: 'dist/build/utils.js (`next start` bind host — self-hosting only)',
+    need: 'platform',
+    shape: 'a hostname; set by the host',
+  },
+];
+
+/** Names read through a computed key, not a literal — the grep cannot see them either. */
+export const DYNAMIC_READ_ENV: ReadonlyArray<{ name: string; where: string }> = [
+  { name: 'STRIPE_BUNDLE_ALL_PRICE_ID', where: 'process.env[entitlementPriceEnvName(key)], src/lib/stripe.ts' },
+];
+
+export class EnvLawError extends Error {
+  constructor(message: string) {
+    super(`ENV LAW: ${message}`);
+    this.name = 'EnvLawError';
+  }
+}
+
+/** The const's own law — run at module scope so a malformed entry fails the import, the tests and the build alike. */
+export function envLaw(entries: readonly LibraryReadEnv[] = LIBRARY_READ_ENV): void {
+  const seen = new Set<string>();
+  for (const e of entries) {
+    if (!/^[A-Z][A-Z0-9_]+$/.test(e.name)) throw new EnvLawError(`'${e.name}' is not an env name`);
+    if (seen.has(e.name)) throw new EnvLawError(`${e.name} is declared twice`);
+    seen.add(e.name);
+    for (const field of ['readBy', 'where', 'shape'] as const) {
+      if (!e[field].trim()) throw new EnvLawError(`${e.name}: ${field} is empty`);
+    }
+    if (!['required', 'optional', 'platform'].includes(e.need)) throw new EnvLawError(`${e.name}: need '${e.need}' is not required | optional | platform`);
+  }
+}
+envLaw();

--- a/src/lib/siteUrlGuard.ts
+++ b/src/lib/siteUrlGuard.ts
@@ -1,0 +1,69 @@
+// ─── ENV-01 — the site-URL boot check (the secret-guard pattern) ─────────────
+// next-auth 4.24.15 builds every OAuth callback and redirect from NEXTAUTH_URL
+// (utils/detect-origin.js:9 — it wins over the request host on Vercel since
+// that version). GitHub and Google accept only the redirect_uri registered
+// with them — the www origin — so a NEXTAUTH_URL whose host is not the app's
+// host breaks sign-in with no error on our side. This guard runs once at boot
+// (src/instrumentation.ts, Node runtime) and refuses to serve in production
+// unless NEXTAUTH_URL is an https origin whose host equals NEXT_PUBLIC_APP_URL's.
+//
+// Pure over an env record so node:test drives it without touching process.env.
+// "Production" is VERCEL_ENV === 'production', or NODE_ENV === 'production'
+// off Vercel (a self-host `next start`). A Vercel Preview (VERCEL_ENV
+// 'preview') has a per-deploy host and is skipped — its NEXTAUTH_URL cannot be
+// pinned; development is skipped.
+
+export class SiteUrlConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SiteUrlConfigError';
+  }
+}
+
+export type SiteUrlCheck = { checked: false; reason: string } | { checked: true; host: string };
+
+export function isProductionEnv(env: Record<string, string | undefined>): boolean {
+  if (env.VERCEL_ENV !== undefined) return env.VERCEL_ENV === 'production';
+  return env.NODE_ENV === 'production';
+}
+
+const strip = (s: string) => s.replace(/\/+$/, '');
+
+function parseOrigin(name: string, value: string): URL {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new SiteUrlConfigError(`${name} is not a URL — got '${value}'; set the deployment's https origin (https://www.templestuart.com)`);
+  }
+  return url;
+}
+
+/** Pure: in production, NEXTAUTH_URL must be an https origin (no path, query or hash) whose host equals NEXT_PUBLIC_APP_URL's host; otherwise a SiteUrlConfigError naming the fix. Outside production the check is skipped, declared. */
+export function siteUrlGuard(env: Record<string, string | undefined>): SiteUrlCheck {
+  if (!isProductionEnv(env)) {
+    return { checked: false, reason: `not production (VERCEL_ENV=${env.VERCEL_ENV ?? 'unset'}, NODE_ENV=${env.NODE_ENV ?? 'unset'})` };
+  }
+  const appUrl = env.NEXT_PUBLIC_APP_URL;
+  if (!appUrl) {
+    throw new SiteUrlConfigError('NEXT_PUBLIC_APP_URL is not set — production needs the public origin (https://www.templestuart.com) to check NEXTAUTH_URL against');
+  }
+  const appHost = parseOrigin('NEXT_PUBLIC_APP_URL', appUrl).host;
+  const raw = env.NEXTAUTH_URL;
+  if (!raw) {
+    throw new SiteUrlConfigError(`NEXTAUTH_URL is not set — next-auth builds every OAuth callback from it; set NEXTAUTH_URL=https://${appHost}`);
+  }
+  const url = parseOrigin('NEXTAUTH_URL', raw);
+  if (url.protocol !== 'https:') {
+    throw new SiteUrlConfigError(`NEXTAUTH_URL must be an https origin — got '${raw}'; set NEXTAUTH_URL=https://${appHost}`);
+  }
+  if (url.origin !== strip(raw)) {
+    throw new SiteUrlConfigError(`NEXTAUTH_URL must be a bare origin with no path, query or hash — got '${raw}'; set NEXTAUTH_URL=https://${appHost}`);
+  }
+  if (url.host !== appHost) {
+    throw new SiteUrlConfigError(
+      `NEXTAUTH_URL host '${url.host}' does not match NEXT_PUBLIC_APP_URL host '${appHost}' — GitHub and Google receive redirect_uri built from NEXTAUTH_URL and reject a host they were not registered with; set NEXTAUTH_URL=https://${appHost}`,
+    );
+  }
+  return { checked: true, host: url.host };
+}


### PR DESCRIPTION
**Do not merge — Alex merges after Vercel Preview (SOC 2 gate).**

Branch from main `0adb02e3` (LAUNCH-01 merged). No migration. Commit `8eda8ee0`.

## HARD GATE

| Gate | Touched | What |
|---|---|---|
| auth | yes | the NextAuth options move to `src/lib/auth/nextAuthOptions.ts:33` (`buildAuthOptions`) — providers, callbacks, pages and `secret: process.env.JWT_SECRET` (:86) byte-equivalent to the route's; the route passes the real PrismaClient and `next/headers` cookies. A new boot guard can refuse to serve production (`src/lib/siteUrlGuard.ts`, run from `src/instrumentation.ts:14`) |
| security | yes | the guard forbids an OAuth callback host that is not the app's; the callback test pins it |
| build | yes | `scripts/assert-tool-registry.ts:509` gains THE ENV LAW — a README that misses a variable now fails the build |
| cost / migration / user data | no | — |

## Audit (read-only, before building)

**Why sign-in broke.** `npm pack next-auth@4.24.13` diffed against the installed 4.24.15: the only host-related change is one line in `utils/detect-origin.js`:

```js
function detectOrigin(forwardedHost, protocol) {
  if (process.env.NEXTAUTH_URL) return process.env.NEXTAUTH_URL;        // ← added in 4.24.15
  if (process.env.VERCEL ?? process.env.AUTH_TRUST_HOST) return `${protocol === "http" ? "http" : "https"}://${forwardedHost}`;
  return process.env.NEXTAUTH_URL;
}
```

Before: on Vercel (`VERCEL` set) the forwarded host won, so a stale `NEXTAUTH_URL` never mattered. After: `NEXTAUTH_URL` wins, and `core/init.js:32` (`parseUrl(origin)`) → `core/lib/providers.js:26,33` (`callbackUrl: \`${url}/callback/${id}\``) → `core/lib/oauth/client.js` (`redirect_uris: [provider.callbackUrl]`) → openid-client `authorizationUrl` puts that host in `redirect_uri`. With the bare domain in Vercel, GitHub received `https://templestuart.com/api/auth/callback/github` — not the registered `www` callback — and refused. No advisory named it (the 4.24.15 changelog is the security fix set; the other diff line is an email `normalize("NFKC")` in `core/routes/signin.js`). No test built an authorize URL: the suite's OAuth tests are Plaid's.

**Why the README could not know.** `readme-gen` and the build assert derive the env table from `process.env.X` literals in `src/` (`scripts/assert-tool-registry.ts:424` scans `srcFiles`; the generator's walk). A dependency's read is invisible. Enumerated by grepping the packages (`js` only): `next-auth` reads `NEXTAUTH_URL` (`utils/detect-origin.js:9,11`, `jwt/index.js:65`, `react/index.js:53-54`), `NEXTAUTH_URL_INTERNAL` (`react/index.js:55-56`), `AUTH_TRUST_HOST` and `VERCEL` (`utils/detect-origin.js:10`), `VERCEL_URL` (`react/index.js:53`), `AUTH_SECRET` (`next/index.js:17,49,128` — the fallback when `options.secret` is unset; ours is set); Prisma reads `DATABASE_URL` (`prisma/schema.prisma:12 env("DATABASE_URL")` — the generator special-cased it by hand); `next start` reads `PORT` (`dist/server/lib/start-server.js`) and `HOSTNAME` (`dist/build/utils.js`). Inngest, the Anthropic and OpenAI SDKs, Resend and Stripe are all handed their keys by src literals (`src/inngest/client.ts:30-31` etc.) — not library-read. `.env.example` vs src: `ADMIN_PASSWORD` is read by nothing; `TASTYTRADE_USERNAME/PASSWORD` are listed while src reads `TT_USERNAME/TT_PASSWORD`; `RESEND_API_KEY`, `EMAIL_FROM`, `GOOGLE_*`, `GITHUB_*` are read but not listed — findings, not touched.

**The boot pattern.** `src/instrumentation.ts` → `secretGuard(process.env)` (LAUNCH-01), pure over an env record, tested in isolation; Node runtime only. Production on Vercel: `NODE_ENV=production` on Production AND Preview; `VERCEL_ENV` distinguishes them, and a Preview's host is per-deploy, so a pinned `NEXTAUTH_URL` cannot hold there.

## Build

**`src/lib/envLaw.ts:33` — `LIBRARY_READ_ENV`**, ten entries: `{ name, readBy, where (the node_modules path, checkable), need: required | optional | platform, shape }` — `DATABASE_URL`, `NEXTAUTH_URL`, `NEXTAUTH_URL_INTERNAL`, `AUTH_TRUST_HOST`, `AUTH_SECRET`, `VERCEL`, `VERCEL_URL`, `VERCEL_ENV` (read by the boot check through the env record — declared, since the grep cannot see a record read), `PORT`, `HOSTNAME`; `DYNAMIC_READ_ENV` (:107) names the computed-key read the generator had hard-coded; `envLaw()` (:119, run at module scope :131) refuses a duplicate, a non-name, an empty field or a bad `need`.

**README** (`readme-gen`, byte-stable on the second run): the Self-hosting intro now says what each table is; a **`### Read by a library`** heading (README:388) with the table rendered from the const — Name · Read by · Where · Needed · Expected shape; `DATABASE_URL` moved out of the hand-typed Core row. The generator's assert now: every src literal documented in the first table; every library name in the second; no name in both; the computed-key set from the const; test files skipped (they SET the names they exercise).

**THE ENV LAW at build** (`scripts/assert-tool-registry.ts:509-530`, printed :571): parses README's `## Self-hosting` section; every src literal ∪ library entry ∪ computed key must be documented; nothing documented that nothing reads; every library entry must have its row with its reader; a name both declared library-read and read as a src literal fails. Wired into the existing build script — no new build step.

**`src/lib/siteUrlGuard.ts:43` — `siteUrlGuard(env)`** (the secret-guard pattern): `isProductionEnv` (:25) = `VERCEL_ENV === 'production'`, or `NODE_ENV === 'production'` when `VERCEL_ENV` is unset (a self-host `next start`). In production: `NEXT_PUBLIC_APP_URL` absent → refuse; `NEXTAUTH_URL` absent → refuse; not a URL / not https / any path, query or hash / host ≠ `NEXT_PUBLIC_APP_URL`'s host → refuse, each `SiteUrlConfigError` naming the fix (`set NEXTAUTH_URL=https://www.templestuart.com`). A Preview or development → `{ checked: false, reason }`, logged. `src/instrumentation.ts:14` runs it after the secret guard and logs `[boot] NEXTAUTH_URL checked — host …`.

**`src/lib/__tests__/nextAuthCallback.test.ts`** — the ruled test: `buildAuthOptions` with a fake Prisma and a cookie setter that throws if called; next-auth's own core (`AuthHandler`, required by path — `core` is not in the package's exports map) runs `GET csrf` then `POST signin/<provider>` with the real csrf cookie, the app's host in the headers, and `NEXTAUTH_URL` from the env (default: the app's origin); Google's OpenID discovery — the one network call — is stubbed at `openid-client`'s `Issuer.discover` (:42) with Google's documented endpoints. Asserts per provider: the provider endpoint, `redirect_uri` is https, path `/api/auth/callback/<id>`, **host === NEXTAUTH_URL's host** and **host === NEXT_PUBLIC_APP_URL's host** (:87), the `state` check is armed, `client_id` is the configured one; and that discovery was called once at its URL.

**CLAUDE.md:36 `## Dependency upgrades`**: every version bump's PR body quotes the release notes' behavior changes, not only the advisories — and diffs the installed package when the notes are silent; library-read variables are declared in `envLaw.ts`. **`.env.example:19-23`** documents `NEXTAUTH_URL`'s shape and the boot refusal.

## Verify — hermetic

| Check | Result |
|---|---|
| `npx tsc --noEmit` | exit 0 |
| eslint vs main | no changed file widens; 5 new files 0/0; `scripts/assert-tool-registry.ts` 0/0 |
| `npm test` | **253 / 253** (245 on main + `siteUrlGuard.test.ts` 5 + `nextAuthCallback.test.ts` 3) |
| **the callback test with `NEXTAUTH_URL=https://templestuart.com`** | **fails**, both providers: `redirect_uri host === the app's host … expected: 'www.templestuart.com', actual: 'templestuart.com'` (the exact break of that night); `NEXTAUTH_URL=https://staging.templestuart.com` fails the same way |
| the env law, negative | the `NEXTAUTH_URL` library row deleted from README → `npx tsx scripts/assert-tool-registry.ts` exits 1: `env: README.md has no library row for NEXTAUTH_URL (src/lib/envLaw.ts)`; restored → 10 laws pass |
| build with the asserts | exit 0 — the ten laws incl. **`✔ The env law passed — 63 names read as src literals, 10 read by a library, 1 by a computed key; every one documented in README.md, nothing documented that nothing reads`** |

## Verify — the built app (`next start`, `VERCEL_ENV=production NODE_ENV=production NEXT_PUBLIC_APP_URL=https://www.templestuart.com`)

| Boot | Result |
|---|---|
| `NEXTAUTH_URL=https://templestuart.com` (the bare domain) | **refuses**: `Failed to prepare server Error [SiteUrlConfigError]: … NEXTAUTH_URL host 'templestuart.com' does not match NEXT_PUBLIC_APP_URL host 'www.templestuart.com' — GitHub and Google receive redirect_uri built from NEXTAUTH_URL and reject a host they were not registered with; set NEXTAUTH_URL=https://www.templestuart.com`; `/pricing` never answers |
| `NEXTAUTH_URL=https://www.templestuart.com` | boots: `[boot] NEXTAUTH_URL checked — host www.templestuart.com`, `/pricing` 200 |

## Findings

1. **Vercel Preview is exempt by design** (`VERCEL_ENV=preview` → skipped, declared in the boot log): its host is per-deploy, so `NEXTAUTH_URL` cannot be pinned; on a Preview next-auth falls back to the forwarded host (`VERCEL` set, `NEXTAUTH_URL` unset — so Preview must NOT have `NEXTAUTH_URL` set to the production value, or Preview sign-in would redirect to production). Not verified what Vercel Preview currently carries.
2. `.env.example` drift, untouched: `ADMIN_PASSWORD` read by nothing; `TASTYTRADE_USERNAME/PASSWORD` listed while src reads `TT_USERNAME/TT_PASSWORD`; `RESEND_API_KEY`, `EMAIL_FROM`, `GOOGLE_CLIENT_*`, `GITHUB_CLIENT_*` read but not listed. A separate PR could make `.env.example` a third leg of the env law.
3. `NEXTAUTH_URL_INTERNAL`, `AUTH_TRUST_HOST`, `AUTH_SECRET` are declared as "unset" shapes; the guard does not refuse them if set (out of the ruling). `AUTH_TRUST_HOST` set would not change the origin while `NEXTAUTH_URL` is set (4.24.15 returns it first).
4. `next start` needed no DB to serve `/pricing`; the boot guard runs before any route, so a wrong value fails the deploy's first request, not a user's sign-in.

## Deploy facts (Alex)

- **Vercel Production: `NEXTAUTH_URL=https://www.templestuart.com`** exactly (https, `www`, no trailing path). Anything else, or its absence, and the deploy refuses to serve — the message names the fix.
- Vercel Preview: leave `NEXTAUTH_URL` unset (finding 1).
- `NEXT_PUBLIC_APP_URL=https://www.templestuart.com` must be set in Production (the LAUNCH-01/SELL-03b deploy fact) — the guard compares against it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc

---
_Generated by [Claude Code](https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc)_