### PR TITLE
TRUTH-01: status means the job is done, not that code exists — 2 live · 9 partial · 14 not built

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,14 @@ prose. **Reuse over rebuild** — search for what exists before writing anything
   **cost/paid calls**, or **security**, STOP and **confirm/report before building**. Report
   the finding, then proceed only on the established plan.
 
+## The tool registry's rubric
+- **Status means the job is done, not that code exists** (`src/lib/toolRegistry.ts`, TRUTH-01):
+  **LIVE** = all four loop beats cited in code AND the tool does the job the sheet names, for a
+  customer, on production. **Four beats never imply LIVE.** A **PARTIAL** tool with four beats
+  carries a `why` note saying what is not done for a customer (the law throws without it).
+  **NOT_BUILT** ⇔ no beats. The counts are a law; bump them only with a new dated census. Every
+  count on a public or selling surface derives from the registry — never typed.
+
 ## Fail-loud / no fallback
 - **No silent fallbacks. No silent catches. No fake/placeholder data — ever.**
 - If you are about to write "fallback" logic: **STOP**, state the rationale, and ask Alex

--- a/scripts/assert-tool-registry.ts
+++ b/scripts/assert-tool-registry.ts
@@ -62,7 +62,9 @@
  * The assert:showroom pattern: a plain script wired into the `build` script so
  * it runs in CI / Vercel and fails the BUILD. It imports the registry (which
  * runs its module-scope law: sheet cells 25/25 both ways, LIVE/PARTIAL have a
- * home, NOT_BUILT have none, beats agree with status, counts 6/7/12) and adds
+ * home, NOT_BUILT have none, beats agree with status — TRUTH-01: NOT_BUILT ⇔ no
+ * beats, LIVE ⇒ four, a four-beat PARTIAL says why — counts match the dated
+ * census) and adds
  * the check only the filesystem can answer: every home and every link resolves
  * to a page file — `src/app/<route>/page.tsx`, or a single segment in the
  * `[tab]` allowlist (src/app/[tab]/page.tsx TAB_PATHS), or `/?tab=` on the root.

--- a/src/lib/__tests__/offer.test.ts
+++ b/src/lib/__tests__/offer.test.ts
@@ -34,10 +34,15 @@ test('a NOT_BUILT tool in an offer fails the law (the build); so does a free too
   const notBuilt = [{ ...b, tools: [...b.tools, 'Payroll' as const] }, OFFERS[1]];
   assert.match(offerLaw({ throwOnFail: false, offers: notBuilt }).join('\n'), /Payroll is NOT_BUILT — a tool that does not exist cannot be sold/);
   assert.throws(() => offerLaw({ offers: notBuilt }), OfferLawError);
-  const free = [{ ...b, tools: [...b.tools, 'Calendar' as const] }, OFFERS[1]];
+  // TRUTH-01: Travel is the one LIVE tool with no gate — the free tool a seller may not list.
+  const free = [{ ...b, tools: [...b.tools, 'Travel' as const] }, OFFERS[1]];
   const v = offerLaw({ throwOnFail: false, offers: free }).join('\n');
-  assert.match(v, /Calendar carries no tab gate/);
-  assert.match(v, /Calendar: free \(LIVE, no gate\) and also sold/);
+  assert.match(v, /Travel carries no tab gate/);
+  assert.match(v, /Travel: free \(LIVE, no gate\) and also sold/);
+  // a four-beat PARTIAL with no gate (Calendar since TRUTH-01) is not free and not sold: the gate line fires, the free line does not
+  const partialUngated = offerLaw({ throwOnFail: false, offers: [{ ...b, tools: [...b.tools, 'Calendar' as const] }, OFFERS[1]] }).join('\n');
+  assert.match(partialUngated, /Calendar carries no tab gate/);
+  assert.doesNotMatch(partialUngated, /Calendar: free/);
   const narrow = [{ ...b, grants: ['tab:books' as const] }, OFFERS[1]];
   assert.match(offerLaw({ throwOnFail: false, offers: narrow }).join('\n'), /Brokerage is gated by tab:trade, which this offer does not grant/);
   const smallBundle = [b, { ...OFFERS[1], grants: ['tab:books' as const] }];
@@ -66,9 +71,10 @@ test('claim lines come from the registry: "built and running" for LIVE only, "pa
   }
   assert.equal(card.includesAnswers, true);
   // the free showcases' CTAs read the registry through the cockpit key
-  assert.equal(claimForCockpit('projects'), 'built and running');
-  assert.equal(claimForCockpit('content'), 'built and running');
-  assert.equal(claimForCockpit('calendar'), 'built and running');
+  // TRUTH-01: Tasks and Time are four-beat PARTIALs (the job is not done for a customer), so the showcase CTAs no longer say built and running.
+  assert.equal(claimForCockpit('projects'), 'partial — discover · decide · commit · record');
+  assert.equal(claimForCockpit('content'), 'partial — discover · decide · commit · record');
+  assert.equal(claimForCockpit('calendar'), 'partial — discover · decide · commit · record'); // Budget, a four-beat PARTIAL since TRUTH-01
   assert.throws(() => claimForCockpit('nope'), OfferLawError);
 });
 
@@ -109,15 +115,16 @@ test('the grants: Books unlocks Trade, Tax and Compliance at both gates; the bun
 });
 
 test('the free set is the registry\'s LIVE tools with no gate; the gate map covers every tool', () => {
-  assert.deepEqual(FREE_TOOLS.map((t) => t.name), ['Calendar', 'Tasks', 'Time', 'Travel', 'Budget']);
+  // TRUTH-01 (census 2026-09-09): Calendar, Tasks, Time and Budget are PARTIAL — four beats cited, the job not done for a customer — so the free set is Travel alone.
+  assert.deepEqual(FREE_TOOLS.map((t) => t.name), ['Travel']);
   assert.equal(Object.keys(TOOL_GATE).length, TOOL_REGISTRY.length);
   for (const t of TOOL_REGISTRY) assert.ok(t.name in TOOL_GATE, t.name);
   assert.equal(TOOL_GATE.CRM, 'owner');
 });
 
 test('the hero line is the registry\'s counts in words — never typed', () => {
-  assert.equal(heroCountsLine(), 'Twenty-five tools, counted: six live, seven partial, twelve on the blueprint.');
-  assert.equal(heroCountsLine(TOOL_REGISTRY.filter((t) => t.status !== 'NOT_BUILT')), 'Thirteen tools, counted: six live, seven partial, zero on the blueprint.');
+  assert.equal(heroCountsLine(), 'Twenty-five tools, counted: two live, nine partial, fourteen on the blueprint.');
+  assert.equal(heroCountsLine(TOOL_REGISTRY.filter((t) => t.status !== 'NOT_BUILT')), 'Eleven tools, counted: two live, nine partial, zero on the blueprint.');
   assert.equal(numberWord(25), 'twenty-five');
   assert.throws(() => numberWord(26), OfferLawError);
 });

--- a/src/lib/__tests__/toolRegistry.test.ts
+++ b/src/lib/__tests__/toolRegistry.test.ts
@@ -1,0 +1,65 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { EXPECTED_STATUS_COUNTS, TOOL_REGISTRY, registryLaw, statusCounts, type ToolEntry } from '../toolRegistry';
+import { OWNER_UTILITIES } from '../shellMenu';
+import { FREE_TOOLS } from '../offer';
+
+// TRUTH-01 — status means the job is done, not that code exists. The rubric: NOT_BUILT ⇔ no
+// beats; LIVE ⇒ four beats; a PARTIAL with four beats says why it is not LIVE. Census 2026-09-09.
+
+const byName = (name: string): ToolEntry => {
+  const t = TOOL_REGISTRY.find((x) => x.name === name);
+  if (!t) throw new Error(`${name} is not in the registry`);
+  return t;
+};
+const beats = (t: ToolEntry) => [t.beats.discover, t.beats.decide, t.beats.commit, t.beats.record].filter(Boolean).length;
+const withTool = (name: string, patch: Partial<ToolEntry>): ToolEntry[] => TOOL_REGISTRY.map((t) => (t.name === name ? { ...t, ...patch } : t));
+
+test('the counts are the dated census — 2 LIVE · 9 PARTIAL · 14 NOT_BUILT — and the law holds on the real registry', () => {
+  assert.deepEqual(EXPECTED_STATUS_COUNTS, { LIVE: 2, PARTIAL: 9, NOT_BUILT: 14 });
+  assert.deepEqual(statusCounts(), { LIVE: 2, PARTIAL: 9, NOT_BUILT: 14 });
+  assert.deepEqual(registryLaw({ throwOnFail: false }), []);
+  assert.deepEqual(TOOL_REGISTRY.filter((t) => t.status === 'LIVE').map((t) => t.name), ['Travel', 'Bookkeeping']);
+});
+
+test('the four four-beat PARTIALs each carry the census note; no LIVE or NOT_BUILT tool carries one', () => {
+  const fourBeatPartials = TOOL_REGISTRY.filter((t) => t.status === 'PARTIAL' && beats(t) === 4).map((t) => t.name);
+  assert.deepEqual(fourBeatPartials, ['Calendar', 'Tasks', 'Time', 'Budget']);
+  assert.equal(byName('Calendar').why, 'an agenda list whose commit lands on calendar_events; the calendar grid itself lives on /runway');
+  assert.equal(byName('Tasks').why, "the founder's build pipeline — accepting a task fires a paid Claude Code build (tasks/[taskId]/route.ts:392-402); not a customer's task tool");
+  assert.equal(byName('Time').why, 'day blocks and a daily log inside the Narrative pipeline; no time tool');
+  assert.equal(byName('Budget').why, 'actuals by entity plus recurring lines on module_expenses; no plan vs actual; no personal · trade · travel roll-up');
+  for (const t of TOOL_REGISTRY) if (t.status !== 'PARTIAL') assert.equal(t.why, undefined, `${t.name} carries no why`);
+});
+
+test('the law rejects a four-beat PARTIAL without `why`, a `why` on a non-PARTIAL, a LIVE short of four beats, a PARTIAL or LIVE with no beats, and a NOT_BUILT with beats or a home', () => {
+  const noWhy = registryLaw({ throwOnFail: false, registry: withTool('Calendar', { why: undefined }) }).join('\n');
+  assert.match(noWhy, /Calendar: PARTIAL with four beats must say why it is not LIVE/);
+  assert.match(registryLaw({ throwOnFail: false, registry: withTool('Calendar', { why: '   ' }) }).join('\n'), /Calendar: PARTIAL with four beats must say why/);
+  assert.throws(() => registryLaw({ registry: withTool('Calendar', { why: undefined }) }), /TOOL REGISTRY LAW failed/);
+  assert.match(registryLaw({ throwOnFail: false, registry: withTool('Travel', { why: 'not needed' }) }).join('\n'), /Travel: why belongs only to a PARTIAL tool/);
+  assert.match(registryLaw({ throwOnFail: false, registry: withTool('Travel', { beats: { discover: true, decide: true, commit: true, record: false } }) }).join('\n'), /Travel: LIVE needs four beats and a home \(beats 3/);
+  assert.match(registryLaw({ throwOnFail: false, registry: withTool('Banking', { beats: { discover: false, decide: false, commit: false, record: false } }) }).join('\n'), /Banking: PARTIAL with no beats — no beats is NOT_BUILT/);
+  assert.match(registryLaw({ throwOnFail: false, registry: withTool('CRM', { beats: { discover: true, decide: false, commit: false, record: false } }) }).join('\n'), /CRM: NOT_BUILT must have no beats, no home, no links/);
+  assert.match(registryLaw({ throwOnFail: false, registry: withTool('Expenses', { home: '/budgets/trips' }) }).join('\n'), /Expenses: NOT_BUILT must have no beats, no home, no links/);
+  // a wrong count is named (Calendar back to LIVE → 3/8/14)
+  assert.match(registryLaw({ throwOnFail: false, registry: withTool('Calendar', { status: 'LIVE', why: undefined }) }).join('\n'), /LIVE count 3 ≠ census 2/);
+});
+
+test('CRM and Expenses are NOT_BUILT with the census citation, no home, no beats; their former pages keep a door — /owner in the owner utilities, /budgets/trips as Travel\'s link', () => {
+  for (const name of ['CRM', 'Expenses']) {
+    const t = byName(name);
+    assert.equal(t.status, 'NOT_BUILT');
+    assert.equal(t.home, null);
+    assert.equal(beats(t), 0);
+    assert.equal(t.links, undefined);
+  }
+  assert.match(byName('CRM').citation, /proposals inbox — no contact or deal object \(src\/app\/api\/owner\/proposals\/route\.ts\)/);
+  assert.match(byName('Expenses').citation, /trip cost split on the trip planner \(src\/app\/api\/trips\/\[id\]\/expenses\/route\.ts:70\) is Travel's/);
+  assert.ok(OWNER_UTILITIES.some((u) => u.href === '/owner'), '/owner keeps its door in the utilities menu');
+  assert.ok(byName('Travel').links?.some((l) => l.href === '/budgets/trips'), '/budgets/trips keeps its door as Travel\'s link');
+});
+
+test('derived surfaces: the free set is Travel alone', () => {
+  assert.deepEqual(FREE_TOOLS.map((t) => t.name), ['Travel']);
+});

--- a/src/lib/shellMenu.ts
+++ b/src/lib/shellMenu.ts
@@ -15,4 +15,6 @@ export interface ShellUtility {
 export const OWNER_UTILITIES: readonly ShellUtility[] = [
   { label: 'Developer console', href: '/developer', why: 'prospects + client accounts behind its own gate — src/app/developer/page.tsx:23' },
   { label: 'Data observatory', href: '/data-observatory', why: 'source health probes; the check route is requireAdmin — src/app/api/data-observatory/check/route.ts:934' },
+  // TRUTH-01: CRM is NOT_BUILT (no contact or deal object), so /owner is no tool's home — it keeps its door here.
+  { label: 'Owner · proposals inbox', href: '/owner', why: "the founder's proposals inbox behind requireAdmin — src/app/api/owner/proposals/route.ts; not a customer's CRM" },
 ];

--- a/src/lib/toolRegistry.ts
+++ b/src/lib/toolRegistry.ts
@@ -3,10 +3,19 @@
  * today, where, and in what state", keyed on the deck's PROBLEM_SHEET (the six
  * families and the 25 names are imported, never retyped).
  *
- * Every fact below is the TOOL CENSUS verbatim (session report, main
- * `cec371d6`): status LIVE = all four loop beats cited · PARTIAL = some ·
- * NOT_BUILT = no page or route implements the tool. 6 LIVE · 7 PARTIAL ·
- * 12 NOT_BUILT — the counts are a LAW below; bump them only with a new census.
+ * Every fact below is the TOOL CENSUS verbatim. THE RUBRIC (TRUTH-01,
+ * census 2026-09-09 — status means the job is done, not that code exists):
+ *   LIVE      = all four loop beats cited in code AND the tool does the job
+ *               the sheet names, for a customer, on production. Four beats
+ *               never imply LIVE.
+ *   PARTIAL   = some of the job; a PARTIAL with four beats MUST carry a `why`
+ *               note saying what is not done for a customer (the law throws
+ *               without it).
+ *   NOT_BUILT = no beats — no page or route does any of the tool's job (code
+ *               that touches the name but belongs to another tool is cited,
+ *               not counted).
+ * 2 LIVE · 9 PARTIAL · 14 NOT_BUILT — the counts are a LAW below; bump them
+ * only with a new dated census.
  *
  * `home` is an EXISTING route only — this PR links, it moves nothing. A
  * cockpit-hosted tool also carries `cockpitKey` (the ModuleLauncher section
@@ -23,8 +32,9 @@
  * home resolves to a page file):
  *   1. registry keys == PROBLEM_SHEET cells, 25/25, both directions;
  *   2. a LIVE or PARTIAL tool has a home; a NOT_BUILT tool has none;
- *   3. beats agree with status (LIVE ⇔ four; NOT_BUILT ⇔ none; PARTIAL ⇔ some);
- *   4. status counts == 6 / 7 / 12;
+ *   3. NOT_BUILT ⇔ no beats; LIVE ⇒ four beats; a PARTIAL with four beats
+ *      carries a `why` note (thrown without it) — four beats never imply LIVE;
+ *   4. status counts == the dated census (EXPECTED_STATUS_COUNTS);
  *   5. (NAV-02) every family has one page route — single-segment kebab-case,
  *      unique, never a cockpit path or a tool's home.
  */
@@ -61,6 +71,8 @@ export interface ToolFacts {
   citation: string;
   /** A census note that changes how the home should be read. */
   note?: string;
+  /** TRUTH-01: a PARTIAL tool with all four beats cited says here what is NOT done for a customer on production — the law throws without it. */
+  why?: string;
 }
 
 export interface ToolEntry extends ToolFacts {
@@ -74,31 +86,34 @@ const ALL: Beats = { discover: true, decide: true, commit: true, record: true };
 const NONE: Beats = { discover: false, decide: false, commit: false, record: false };
 const some = (b: Partial<Beats>): Beats => ({ ...NONE, ...b });
 
-export const EXPECTED_STATUS_COUNTS: Readonly<Record<ToolStatus, number>> = { LIVE: 6, PARTIAL: 7, NOT_BUILT: 12 };
+// census 2026-09-09 (TRUTH-01): door by door, the job done for a customer on production.
+export const EXPECTED_STATUS_COUNTS: Readonly<Record<ToolStatus, number>> = { LIVE: 2, PARTIAL: 9, NOT_BUILT: 14 };
 
 const FACTS: Readonly<Record<ToolName, ToolFacts>> = {
   // ── THE WORK ──
   Calendar: {
-    slug: 'calendar', status: 'LIVE', beats: ALL, home: '/agenda',
+    slug: 'calendar', status: 'PARTIAL', beats: ALL, home: '/agenda',
+    why: 'an agenda list whose commit lands on calendar_events; the calendar grid itself lives on /runway',
     links: [{ label: 'Routines · the recurring form', cockpitKey: 'routines' }],
     citation: 'src/app/api/agenda/route.ts:5 (discover) · :56 (decide, draft :86) · src/app/api/agenda/[id]/route.ts:54 (commit) · :84 (record → calendar_events)',
     note: 'Reachable from no menu until this PR; the tab keyed "calendar" is Runway.',
   },
   Tasks: {
-    slug: 'tasks', status: 'LIVE', beats: ALL, home: '/projects', cockpitKey: 'projects',
+    slug: 'tasks', status: 'PARTIAL', beats: ALL, home: '/projects', cockpitKey: 'projects',
+    why: "the founder's build pipeline — accepting a task fires a paid Claude Code build (tasks/[taskId]/route.ts:392-402); not a customer's task tool",
     links: [{ label: 'Issue log', href: '/operations/issues' }, { label: 'Audit tail', href: '/operations/audit-log' }],
     citation: 'src/app/api/operations/projects/[id]/tasks/route.ts:43 · generate-tasks/route.ts:42 · tasks/bulk-create/route.ts:117 · tasks/[taskId]/route.ts:82 → :339, :370',
   },
   Time: {
-    slug: 'time', status: 'LIVE', beats: ALL, home: '/content', cockpitKey: 'content',
+    slug: 'time', status: 'PARTIAL', beats: ALL, home: '/content', cockpitKey: 'content',
+    why: 'day blocks and a daily log inside the Narrative pipeline; no time tool',
     links: [{ label: 'Daily plan · North Star', href: '/operations' }],
     citation: 'src/app/api/operations/tasks/unscheduled/route.ts · daily-plan/items/route.ts:120 · daily-plan/items/[itemId]/blocks/route.ts:36 · daily-plan/blocks/[blockId]/route.ts:38, :163',
   },
   // ── MONEY IN ──
   CRM: {
-    slug: 'crm', status: 'PARTIAL', beats: some({ discover: true, commit: true }), home: '/owner',
-    citation: 'src/app/api/owner/proposals/route.ts:11 (discover) · src/app/api/owner/proposals/[id]/route.ts:21 (commit); no draft, no record',
-    note: 'Owner-only triage of inbound proposals; no contact or deal object.',
+    slug: 'crm', status: 'NOT_BUILT', beats: NONE, home: null,
+    citation: "/owner is the founder's proposals inbox — no contact or deal object (src/app/api/owner/proposals/route.ts)",
   },
   Contracts: { slug: 'contracts', status: 'NOT_BUILT', beats: NONE, home: null, citation: 'TOOL CENSUS row 5 — no page, route, or model' },
   Invoicing: { slug: 'invoicing', status: 'NOT_BUILT', beats: NONE, home: null, citation: 'TOOL CENSUS row 6 — no invoice model, no A/R route' },
@@ -107,9 +122,8 @@ const FACTS: Readonly<Record<ToolName, ToolFacts>> = {
   'Bill Pay': { slug: 'bill-pay', status: 'NOT_BUILT', beats: NONE, home: null, citation: 'TOOL CENSUS row 8 — operations_vendor_directory (schema:3478) is a read-only GET (vendor-directory/route.ts:12)' },
   Payroll: { slug: 'payroll', status: 'NOT_BUILT', beats: NONE, home: null, citation: 'TOOL CENSUS row 9 — no page, route, or model' },
   Expenses: {
-    slug: 'expenses', status: 'PARTIAL', beats: some({ decide: true }), home: '/budgets/trips',
-    citation: 'src/app/budgets/trips/[id]/page.tsx:406 → src/app/api/trips/[id]/expenses/route.ts:70 (create, status pending :145); no receipt, status never flips, never reaches the ledger',
-    note: 'Trip cost-splitting on the legacy trip pages, not a receipt flow.',
+    slug: 'expenses', status: 'NOT_BUILT', beats: NONE, home: null,
+    citation: "trip cost split on the trip planner (src/app/api/trips/[id]/expenses/route.ts:70) is Travel's, not an expenses tool",
   },
   Travel: {
     slug: 'travel', status: 'LIVE', beats: ALL, home: '/travel', cockpitKey: 'travel',
@@ -118,7 +132,8 @@ const FACTS: Readonly<Record<ToolName, ToolFacts>> = {
   },
   Mileage: { slug: 'mileage', status: 'NOT_BUILT', beats: NONE, home: null, citation: 'TOOL CENSUS row 12 — no miles or odometer column in prisma/schema.prisma' },
   Budget: {
-    slug: 'budget', status: 'LIVE', beats: ALL, home: '/business',
+    slug: 'budget', status: 'PARTIAL', beats: ALL, home: '/business',
+    why: 'actuals by entity plus recurring lines on module_expenses; no plan vs actual; no personal · trade · travel roll-up',
     links: [
       { label: 'Personal', href: '/personal' }, { label: 'Home', href: '/home' }, { label: 'Auto', href: '/auto' },
       { label: 'Growth', href: '/growth' }, { label: 'Health', href: '/health' },
@@ -306,30 +321,36 @@ function beatCount(b: Beats): number {
 }
 
 /** THE LAW. Throws on the first violation; returns the violations list when asked not to throw. */
-export function registryLaw(opts: { throwOnFail?: boolean; familyPages?: Readonly<Record<FamilyName, string>> } = {}): string[] {
+export function registryLaw(opts: { throwOnFail?: boolean; familyPages?: Readonly<Record<FamilyName, string>>; registry?: readonly ToolEntry[] } = {}): string[] {
   const violations: string[] = [];
+  // TRUTH-01: the per-tool rules and the counts run over an injectable registry so a test can hand in a broken one.
+  const registry = opts.registry ?? TOOL_REGISTRY;
   const cells = PROBLEM_SHEET.flatMap((f) => f.tools as readonly string[]);
   const keys = Object.keys(FACTS);
   if (cells.length !== 25) violations.push(`PROBLEM_SHEET has ${cells.length} cells, expected 25`);
   for (const c of cells) if (!(c in FACTS)) violations.push(`sheet cell "${c}" has no registry facts`);
   for (const k of keys) if (!cells.includes(k)) violations.push(`registry key "${k}" is not a sheet cell`);
   if (new Set(cells).size !== cells.length) violations.push('PROBLEM_SHEET cells are not unique');
-  if (TOOL_REGISTRY.length !== 25) violations.push(`registry has ${TOOL_REGISTRY.length} entries, expected 25`);
+  if (registry.length !== 25) violations.push(`registry has ${registry.length} entries, expected 25`);
   const slugs = new Set<string>();
-  for (const t of TOOL_REGISTRY) {
+  for (const t of registry) {
     if (slugs.has(t.slug)) violations.push(`${t.name}: duplicate slug "${t.slug}"`);
     slugs.add(t.slug);
     if (!/^[a-z][a-z0-9-]*$/.test(t.slug)) violations.push(`${t.name}: slug "${t.slug}" is not kebab-case`);
     const n = beatCount(t.beats);
+    // rule 3 (TRUTH-01): NOT_BUILT ⇔ no beats; LIVE ⇒ four beats; a four-beat PARTIAL says why it is not LIVE.
     if (t.status === 'LIVE' && (n !== 4 || t.home === null)) violations.push(`${t.name}: LIVE needs four beats and a home (beats ${n}, home ${t.home})`);
-    if (t.status === 'PARTIAL' && (n === 0 || n === 4 || t.home === null)) violations.push(`${t.name}: PARTIAL needs 1-3 beats and a home (beats ${n}, home ${t.home})`);
+    if (t.status === 'PARTIAL' && (n === 0 || t.home === null)) violations.push(`${t.name}: PARTIAL needs at least one beat and a home (beats ${n}, home ${t.home})`);
+    if (t.status === 'PARTIAL' && n === 4 && !t.why?.trim()) violations.push(`${t.name}: PARTIAL with four beats must say why it is not LIVE (why: what is not done for a customer on production)`);
+    if (t.status !== 'PARTIAL' && t.why) violations.push(`${t.name}: why belongs only to a PARTIAL tool`);
     if (t.status === 'NOT_BUILT' && (n !== 0 || t.home !== null || t.cockpitKey || (t.links && t.links.length))) violations.push(`${t.name}: NOT_BUILT must have no beats, no home, no links`);
+    if (t.status !== 'NOT_BUILT' && n === 0) violations.push(`${t.name}: ${t.status} with no beats — no beats is NOT_BUILT`);
     if (t.home !== null && !t.home.startsWith('/')) violations.push(`${t.name}: home "${t.home}" is not a route`);
     for (const l of t.links ?? []) {
       if ((l.href ? 1 : 0) + (l.cockpitKey ? 1 : 0) !== 1) violations.push(`${t.name}: link "${l.label}" must have exactly one of href / cockpitKey`);
     }
   }
-  const counts = statusCounts();
+  const counts = statusCounts(registry);
   for (const s of Object.keys(EXPECTED_STATUS_COUNTS) as ToolStatus[]) {
     if (counts[s] !== EXPECTED_STATUS_COUNTS[s]) violations.push(`${s} count ${counts[s]} ≠ census ${EXPECTED_STATUS_COUNTS[s]} (bump only with a census)`);
   }
@@ -337,7 +358,7 @@ export function registryLaw(opts: { throwOnFail?: boolean; familyPages?: Readonl
     if (!(name in FACTS)) violations.push(`COCKPIT_PRIMARY_TOOL[${key}] names unknown tool "${name}"`);
     if (!(key in COCKPIT_PATH)) violations.push(`COCKPIT_PRIMARY_TOOL key "${key}" has no COCKPIT_PATH`);
   }
-  for (const t of TOOL_REGISTRY) {
+  for (const t of registry) {
     if (t.cockpitKey && !(t.cockpitKey in COCKPIT_PATH)) violations.push(`${t.name}: cockpitKey "${t.cockpitKey}" has no COCKPIT_PATH`);
     for (const l of t.links ?? []) if (l.cockpitKey && !(l.cockpitKey in COCKPIT_PATH)) violations.push(`${t.name}: link "${l.label}" cockpit key "${l.cockpitKey}" has no COCKPIT_PATH`);
   }


### PR DESCRIPTION
**Do not merge — Alex merges after Vercel Preview (SOC 2 gate).**

Branch from main `0adb02e3`. Commit `923f7d47` (`git log origin/claude/truth-01-registry --oneline -1`). No migration, no nav/page/component change, no deck copy change.

## HARD GATE

| Gate | Touched | What |
|---|---|---|
| auth / migration / cost / user data | no | — |
| public and selling copy | by derivation only | the hero sentence, the free set (Landing, /pricing, the welcome email) and three showcase CTA claim lines change because the registry's facts changed — no typed edit anywhere |
| build law | yes | `EXPECTED_STATUS_COUNTS` 6/7/12 → 2/9/14; `registryLaw` rule 3 rewritten; the reachability page count is unchanged (67) |

## STEP 0 — audit (read-only)

| Where | What it said before this PR |
|---|---|
| `src/lib/toolRegistry.ts:6-9` | "status LIVE = all four loop beats cited · PARTIAL = some · NOT_BUILT = no page or route implements the tool. 6 LIVE · 7 PARTIAL · 12 NOT_BUILT" — a code census, not a product truth |
| `toolRegistry.ts:77` | `EXPECTED_STATUS_COUNTS = { LIVE: 6, PARTIAL: 7, NOT_BUILT: 12 }` |
| `toolRegistry.ts:309-360` rule 3 (`:324-326`) | `LIVE ⇔ four beats`, `PARTIAL ⇔ 1-3 beats`, `NOT_BUILT ⇔ none` — four beats forced LIVE |
| `toolRegistry.ts:81-96,120-131` | Calendar, Tasks, Time, Budget `status: 'LIVE', beats: ALL` |
| `toolRegistry.ts:98-102` | CRM `PARTIAL`, `home: '/owner'`, beats discover+commit, note "Owner-only triage of inbound proposals; no contact or deal object" |
| `toolRegistry.ts:109-113` | Expenses `PARTIAL`, `home: '/budgets/trips'`, beats decide, note "Trip cost-splitting on the legacy trip pages, not a receipt flow" |
| `src/lib/offer.ts:150` | `FREE_TOOLS = TOOL_REGISTRY.filter(status === 'LIVE' && TOOL_GATE === null)` → Calendar, Tasks, Time, Travel, Budget |
| `offer.ts:259-263` | `heroCountsLine()` — counts in words; rendered at `Landing.tsx:2006`, `:2176`, `src/app/pricing/page.tsx:34` |
| `offer.ts:266-325` | `offerLaw` — offers hold LIVE/PARTIAL only; the free set holds no gated tool; `:48-74` TOOL_GATE: CRM `'owner'`, Expenses `null` (neither in `BOOKS_TOOLS`, so the offers are untouched) |
| `offer.ts:166-178` | `claimLine` / `claimForCockpit` — "built and running" for LIVE, "partial — <beats>" for PARTIAL; read by `ProjectsShowcaseSections.tsx:252` (projects → Tasks), `ContentShowcaseSections.tsx:207` (content → Time), `RunwayShowcaseSections.tsx:324` (calendar → Budget) |
| `scripts/assert-tool-registry.ts:64-65,76,199-200,310-311,503` | re-runs the law; prints `counts: LIVE · PARTIAL · NOT_BUILT (census …)`; doors = family menus + family pages + `OWNER_UTILITIES` + `GUEST_ROUTES` + answers |
| `src/lib/shellMenu.ts:15-18` | `OWNER_UTILITIES`: Developer console, Data observatory — `/owner` absent (its only door was CRM's home) |
| `src/lib/answers.ts` | reads no status (grep: none) |
| CLAUDE.md | **no rubric line exists** (grep `beats|LIVE|registry|census`: none) — the ruling's "update CLAUDE.md's rubric line" is satisfied by adding one (below) |
| README generator | extracts no registry count (no FREE_TOOLS / status / hero reference); README.md carries no census line |
| deck typed counts | `Landing.tsx` + `src/components/landing/**`: no "six live", "6 LIVE", "seven partial", "twelve on the" — the matches are "ONE SYSTEM · SIX LIVES" (:2121, personas), "six families/kind tables" (:2548, :3348), "seven hops" (:1574, :4414) and `ComplianceShowcaseSections.tsx:179` "six live checks" (the citation verifier, not tool status). **No STOP** — the hero sentence is `heroCountsLine()` on every surface |
| tests pinning the old truth | `offer.test.ts:112` free set, `:119-120` hero sentences, `:37-39` a free-and-sold case using Calendar, `:74-77` showcase claim lines "built and running" |

## STEP 1 — the rubric

`toolRegistry.ts` header: **LIVE** = all four loop beats cited in code AND the tool does the job the sheet names, for a customer, on production — four beats never imply LIVE; **PARTIAL** with four beats MUST carry a `why` note (the law throws without it); **NOT_BUILT** = no beats. `ToolFacts.why?` added. `registryLaw` rule 3 (`:335-341`): `NOT_BUILT ⇔ no beats` (a PARTIAL/LIVE with zero beats fails: "no beats is NOT_BUILT"); `LIVE ⇒ four beats`; a four-beat PARTIAL without `why` → `"<tool>: PARTIAL with four beats must say why it is not LIVE"`; a `why` on a non-PARTIAL fails. The law takes `opts.registry` so a test can hand in a broken one; counts run over it. CLAUDE.md gains `## The tool registry's rubric` (before "Fail-loud") saying exactly this.

## STEP 2 — the statuses

| Tool | Before | After | Note (verbatim) |
|---|---|---|---|
| Calendar | LIVE, `/agenda` | PARTIAL, four beats | an agenda list whose commit lands on calendar_events; the calendar grid itself lives on /runway |
| Tasks | LIVE, `/projects` | PARTIAL, four beats | the founder's build pipeline — accepting a task fires a paid Claude Code build (tasks/[taskId]/route.ts:392-402); not a customer's task tool |
| Time | LIVE, `/content` | PARTIAL, four beats | day blocks and a daily log inside the Narrative pipeline; no time tool |
| Budget | LIVE, `/business` | PARTIAL, four beats | actuals by entity plus recurring lines on module_expenses; no plan vs actual; no personal · trade · travel roll-up |
| CRM | PARTIAL, `/owner` | NOT_BUILT, home null, beats NONE | citation: /owner is the founder's proposals inbox — no contact or deal object (src/app/api/owner/proposals/route.ts) |
| Expenses | PARTIAL, `/budgets/trips` | NOT_BUILT, home null, beats NONE | citation: trip cost split on the trip planner (src/app/api/trips/[id]/expenses/route.ts:70) is Travel's, not an expenses tool |

All others unchanged. `EXPECTED_STATUS_COUNTS = { LIVE: 2, PARTIAL: 9, NOT_BUILT: 14 }` with the `census 2026-09-09` comment. LIVE: Travel, Bookkeeping.

**Door check.** `OWNER_UTILITIES` gains `{ label: 'Owner · proposals inbox', href: '/owner', why: "the founder's proposals inbox behind requireAdmin — src/app/api/owner/proposals/route.ts; not a customer's CRM" }`. Travel's link `{ label: 'Trips · the legacy pages', href: '/budgets/trips' }` was already there and stays. The build's REACHABILITY listing:

```
/budgets/trips                                   family page     /money-out · Travel · "Trips · the legacy pages"
/budgets/trips/[id]                              family page     /money-out · Travel · "Trips · the legacy pages"
/budgets/trips/[id]/discover/[category]/[rank]   family page     /money-out · Travel · "Trips · the legacy pages"
/budgets/trips/new                               family page     /money-out · Travel · "Trips · the legacy pages"
/owner                                           utilities menu  Owner · proposals inbox
✔ Reachability law passed — 67 pages, every one has a door
```

## STEP 3 — derived surfaces

- `FREE_TOOLS` → `['Travel']` (asserted in two tests); `offerLaw` passes: `✔ The offer law passed — 2 offers over 6 tools (LIVE or PARTIAL only), 1 free`.
- **The hero sentence** (`Landing.tsx:2006`, `:2176`, `/pricing:34`), by derivation:
  - before: `Twenty-five tools, counted: six live, seven partial, twelve on the blueprint.`
  - after: `Twenty-five tools, counted: two live, nine partial, fourteen on the blueprint.`
- **The free line**, by derivation: Landing `:2183` "Free with an account, no module to buy: **Travel** — the registry's live tools with no tab gate." (was "Calendar, Tasks, Time, Travel, Budget"); `/pricing` free list renders one card (Travel · money out · no module to buy); the welcome email says "Free with your account: Travel." (`welcomeEmail.ts:43`, asserted by `registration.test.ts:142`).
- **Showcase CTAs**, by derivation (`claimForCockpit`): the Projects, Content and Runway showcases now read "… — partial — discover · decide · commit · record" instead of "… — built and running". See Findings.
- README: regenerated twice with the branch-matching generator — md5 `978fa81117c2e6c343ff8c05279270d6` both runs, `git diff README.md` empty (the README carries no registry count).

## Verify

| Check | Before | After |
|---|---|---|
| `npx tsc --noEmit` | — | exit 0 |
| `npm run lint` (whole repo) | 859 problems (580 errors, 279 warnings) on main | **859 (580 / 279)** — zero new; the five touched files are 0/0 against main, `toolRegistry.test.ts` new 0/0 |
| `npm test` | 245 / 245 | **250 / 250** (+5 in `toolRegistry.test.ts`; `offer.test.ts` expectations moved to the new truth) |
| the law rejects a four-beat PARTIAL without `why` | — | `Calendar: PARTIAL with four beats must say why it is not LIVE` (also for a whitespace `why`; throws with `throwOnFail` default); `why` on Travel → `why belongs only to a PARTIAL tool`; a LIVE with 3 beats, a PARTIAL with 0, a NOT_BUILT with a beat or a home, and Calendar flipped back to LIVE (`LIVE count 3 ≠ census 2`) are each named |
| full build with the asserts | — | **exit 0**; the census as the law counts it: |

```
counts: LIVE 2 · PARTIAL 9 · NOT_BUILT 14 (census 2/9/14) · sheet cells 25
01  Calendar      THE WORK      PARTIAL   discover · decide · commit · record    /agenda         src/app/agenda/page.tsx
02  Tasks         THE WORK      PARTIAL   discover · decide · commit · record    /projects       src/app/[tab]/page.tsx
03  Time          THE WORK      PARTIAL   discover · decide · commit · record    /content        src/app/[tab]/page.tsx
04  CRM           MONEY IN      NOT_BUILT — · — · — · —                          none            —
10  Expenses      MONEY OUT     NOT_BUILT — · — · — · —                          none            —
11  Travel        MONEY OUT     LIVE      discover · decide · commit · record    /travel         src/app/[tab]/page.tsx
13  Budget        MONEY OUT     PARTIAL   discover · decide · commit · record    /business       src/app/business/page.tsx
22  Bookkeeping   THE PROOF     LIVE      discover · decide · commit · record    /books          src/app/[tab]/page.tsx
✔ Tool registry law passed — 25/25 cells, homes resolve to page files, counts match the census.
✔ Reachability law passed — 67 pages, every one has a door (family menus and family pages count).
✔ The family map law passed — 6 menus, 6 family pages, every tool once in each.
✔ The offer law passed — 2 offers over 6 tools (LIVE or PARTIAL only), 1 free; the purchasable keys are the offers'; "built and running" typed nowhere but offer.ts; 4 selling surfaces render the offer.
```

(the other six laws — answers, arrivals, rule book, kind views, posting, env — passed unchanged.)

## Files touched

`src/lib/toolRegistry.ts` (rubric, `why`, six facts, counts, rule 3, injectable registry) · `src/lib/shellMenu.ts` (the `/owner` door) · `scripts/assert-tool-registry.ts` (header comment only) · `CLAUDE.md` (the rubric section) · `src/lib/__tests__/offer.test.ts` (expectations moved to the new truth) · `src/lib/__tests__/toolRegistry.test.ts` (new).

## Findings

1. **Three showcase CTAs now say "partial — discover · decide · commit · record"** (Projects, Content, Runway — `claimForCockpit`). That line is honest but reads as "all four beats, yet partial" without the `why`; surfacing `why` in `claimLine` for a four-beat PARTIAL would be a lib-level derivation change and a visible copy change on those showcases — not built under "no component change"; needs a ruling.
2. **CLAUDE.md had no rubric line** — the section was added rather than edited.
3. The Landing free line reads "…: Travel — the registry's live tools with no tab gate" (plural "tools" for one tool). Its text is typed in `Landing.tsx:2183`; left alone (no component change).
4. `FamilyPage` renders per-family status counts and `FamilyNav` renders status chips from the registry — both move by derivation (THE WORK now shows 0 live · 3 partial; MONEY IN 0 · 0 · 4; MONEY OUT 1 · 1 · 3).
5. ENV-01 (#1672) is not on this branch (branched from main `0adb02e3`); nothing here overlaps it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc

---
_Generated by [Claude Code](https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc)_