### PR TITLE
TRUTH-01b: a four-beat PARTIAL's claim line says why

### DIFF
--- a/src/components/landing/Landing.tsx
+++ b/src/components/landing/Landing.tsx
@@ -184,7 +184,7 @@ import { PROVIDER_MENU, ROUTING_RULES } from '@/lib/providers';
 // TABLES-01: step 5's honest line — every table name from the kind-views census, none retyped.
 import { KIND_VIEWS_HONEST_LINE } from '@/lib/kindViews';
 // SELL-02: the offer — what is sold and what is free, from ONE source; the hero's counts from the registry.
-import { FREE_TOOLS, OFFERS, heroCountsLine, offerCard } from '@/lib/offer';
+import { OFFERS, freeSetLine, heroCountsLine, offerCard } from '@/lib/offer';
 import OfferCard from '@/components/OfferCard';
 // PR-ELEV-1: the coming-soon tiles became badged "Soon" chips INSIDE the
 // booking strip (travelStripModes) — the separate tile row is gone.
@@ -2180,7 +2180,8 @@ export default function Landing({ onRequireAuth, onRequireLogin, logoAvailabilit
             ))}
           </div>
           <p className="mt-5 text-[13px] text-text-secondary" data-free-set>
-            Free with an account, no module to buy: {FREE_TOOLS.map((t) => t.name).join(', ')} — the registry&apos;s live tools with no tab gate.
+            {/* TRUTH-01b: the sentence is freeSetLine (src/lib/offer.ts) — the noun follows FREE_TOOLS.length: "tool" for one. */}
+            {freeSetLine()}
           </p>
         </div>
       </section>

--- a/src/lib/__tests__/offer.test.ts
+++ b/src/lib/__tests__/offer.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import {
-  FREE_TOOLS, OFFERS, OfferLawError, SELLABLE_KEYS, TOOL_GATE, claimForCockpit, claimLine, heroCountsLine, keysGranting, moduleDoorPlan,
+  FREE_TOOLS, OFFERS, OfferLawError, SELLABLE_KEYS, TOOL_GATE, claimForCockpit, claimLine, freeSetLine, heroCountsLine, keysGranting, moduleDoorPlan,
   numberWord, offerAvailabilityFromEnv, offerCard, offerFor, offerFromModuleParam, offerGranting, offerLaw, priceEnvName, priceLineFor, type Offer,
 } from '../offer';
 import { TOOL_REGISTRY, type ToolEntry } from '../toolRegistry';
@@ -63,6 +63,19 @@ test('claim lines come from the registry: "built and running" for LIVE only, "pa
   assert.equal(claimLine(tool('Trade Log')), 'partial — discover · commit · record');
   assert.equal(claimLine(tool('Banking')), 'partial — discover');
   assert.throws(() => claimLine(tool('Payroll')), /Payroll is NOT_BUILT — it cannot be sold/);
+  // TRUTH-01b: a four-beat PARTIAL says why — the registry's note verbatim, never the four beats
+  for (const name of ['Calendar', 'Tasks', 'Time', 'Budget'] as const) {
+    const t = tool(name);
+    assert.equal(t.status, 'PARTIAL');
+    assert.equal(claimLine(t), `partial — ${t.why}`);
+    assert.ok(!claimLine(t).includes('discover'), `${name}: the why, not the beats`);
+  }
+  assert.equal(claimLine(tool('Calendar')), 'partial — an agenda list whose commit lands on calendar_events; the calendar grid itself lives on /runway');
+  // a four-beat PARTIAL with no why is thrown, not rendered as the beats form
+  assert.throws(() => claimLine({ ...tool('Calendar'), why: undefined }), /Calendar is PARTIAL with four beats and no why/);
+  assert.throws(() => claimLine({ ...tool('Calendar'), why: '  ' }), /Calendar is PARTIAL with four beats and no why/);
+  // fewer than four beats keeps the beats form even when a why is present
+  assert.equal(claimLine({ ...tool('Tax'), why: 'not used' }), 'partial — discover · decide');
   const card = offerCard(books(), {});
   assert.deepEqual(card.tools.map((t) => t.name), ['Banking', 'Brokerage', 'Trade Log', 'Bookkeeping', 'Tax', 'Compliance'], 'sheet order; Trade, Tax and Compliance ride inside Books');
   for (const t of card.tools) {
@@ -72,9 +85,9 @@ test('claim lines come from the registry: "built and running" for LIVE only, "pa
   assert.equal(card.includesAnswers, true);
   // the free showcases' CTAs read the registry through the cockpit key
   // TRUTH-01: Tasks and Time are four-beat PARTIALs (the job is not done for a customer), so the showcase CTAs no longer say built and running.
-  assert.equal(claimForCockpit('projects'), 'partial — discover · decide · commit · record');
-  assert.equal(claimForCockpit('content'), 'partial — discover · decide · commit · record');
-  assert.equal(claimForCockpit('calendar'), 'partial — discover · decide · commit · record'); // Budget, a four-beat PARTIAL since TRUTH-01
+  assert.equal(claimForCockpit('projects'), "partial — the founder's build pipeline — accepting a task fires a paid Claude Code build (tasks/[taskId]/route.ts:392-402); not a customer's task tool");
+  assert.equal(claimForCockpit('content'), 'partial — day blocks and a daily log inside the Narrative pipeline; no time tool');
+  assert.equal(claimForCockpit('calendar'), 'partial — actuals by entity plus recurring lines on module_expenses; no plan vs actual; no personal · trade · travel roll-up'); // Budget, a four-beat PARTIAL since TRUTH-01
   assert.throws(() => claimForCockpit('nope'), OfferLawError);
 });
 
@@ -117,6 +130,9 @@ test('the grants: Books unlocks Trade, Tax and Compliance at both gates; the bun
 test('the free set is the registry\'s LIVE tools with no gate; the gate map covers every tool', () => {
   // TRUTH-01 (census 2026-09-09): Calendar, Tasks, Time and Budget are PARTIAL — four beats cited, the job not done for a customer — so the free set is Travel alone.
   assert.deepEqual(FREE_TOOLS.map((t) => t.name), ['Travel']);
+  // TRUTH-01b: the landing's free line — singular for the one free tool, plural otherwise, the rest of the sentence unchanged
+  assert.equal(freeSetLine(), "Free with an account, no module to buy: Travel — the registry's live tool with no tab gate.");
+  assert.equal(freeSetLine([{ name: 'Travel' }, { name: 'Budget' }]), "Free with an account, no module to buy: Travel, Budget — the registry's live tools with no tab gate.");
   assert.equal(Object.keys(TOOL_GATE).length, TOOL_REGISTRY.length);
   for (const t of TOOL_REGISTRY) assert.ok(t.name in TOOL_GATE, t.name);
   assert.equal(TOOL_GATE.CRM, 'owner');

--- a/src/lib/offer.ts
+++ b/src/lib/offer.ts
@@ -162,11 +162,29 @@ export function beatsOf(b: Beats): string[] {
   return BEAT_NAMES.filter((name) => b[name]);
 }
 
-/** What a selling surface may say about a tool — from its registry status, never typed. */
-export function claimLine(tool: Pick<ToolEntry, 'name' | 'status' | 'beats'>): string {
+/**
+ * What a selling surface may say about a tool — from its registry status, never typed.
+ * TRUTH-01b: a PARTIAL with all four beats cited says WHY it is not LIVE (the registry's
+ * `why`, verbatim — "partial — <why>"); fewer than four beats keeps the beats form
+ * ("partial — discover · decide"). A four-beat PARTIAL without a why is a registry-law
+ * violation, thrown here too — never the beats form as a stand-in.
+ */
+export function claimLine(tool: Pick<ToolEntry, 'name' | 'status' | 'beats' | 'why'>): string {
   if (tool.status === 'LIVE') return 'built and running';
-  if (tool.status === 'PARTIAL') return `partial — ${beatsOf(tool.beats).join(' · ')}`;
+  if (tool.status === 'PARTIAL') {
+    const beats = beatsOf(tool.beats);
+    if (beats.length === BEAT_NAMES.length) {
+      if (!tool.why?.trim()) throw new OfferLawError(`${tool.name} is PARTIAL with four beats and no why — the registry law requires one`);
+      return `partial — ${tool.why}`;
+    }
+    return `partial — ${beats.join(' · ')}`;
+  }
   throw new OfferLawError(`${tool.name} is NOT_BUILT — it cannot be sold, so it has no claim line`);
+}
+
+/** The landing's free line — the free set's names and a count-true noun ("tool" for one, "tools" otherwise); the rest of the sentence is the one the landing carried. */
+export function freeSetLine(free: ReadonlyArray<Pick<ToolEntry, 'name'>> = FREE_TOOLS): string {
+  return `Free with an account, no module to buy: ${free.map((t) => t.name).join(', ')} — the registry's live ${free.length === 1 ? 'tool' : 'tools'} with no tab gate.`;
 }
 
 /** The claim line for a cockpit section's primary tool (COCKPIT_PRIMARY_TOOL) — the free showcases' CTAs read this. */


### PR DESCRIPTION
**Do not merge — Alex merges after Vercel Preview (SOC 2 gate).**

Branch from main `c3353be4` (#1673 merged). Commit `9fb70e54` (`git log origin/claude/truth-01b-claim-why --oneline -1`). No migration, no nav change.

## HARD GATE

| Gate | Touched | What |
|---|---|---|
| auth / migration / cost / security / user data | no | — |
| public copy | by derivation | three showcase CTA lines and the landing's free line change through `src/lib/offer.ts`; the registry's `why` is rendered verbatim, nothing typed |

## Audit (read-only)

| Where | Before this PR |
|---|---|
| `src/lib/offer.ts:166-170` `claimLine` | `PARTIAL → "partial — " + beatsOf(beats).join(' · ')` for every PARTIAL, so a four-beat PARTIAL rendered all four beat names; the `Pick` did not carry `why` |
| `offer.ts:173-178` `claimForCockpit` | `COCKPIT_PRIMARY_TOOL` → `claimLine(tool)`; readers: `ProjectsShowcaseSections.tsx:252` (`projects` → Tasks), `ContentShowcaseSections.tsx:207` (`content` → Time), `RunwayShowcaseSections.tsx:324` (`calendar` → Budget) |
| `src/lib/toolRegistry.ts:75,96,109,136` and Tasks' entry | `why` on the four four-beat PARTIALs since TRUTH-01; the registry law throws without it |
| `src/components/landing/Landing.tsx:2183` | `Free with an account, no module to buy: {FREE_TOOLS…join(', ')} — the registry's live tools with no tab gate.` — "tools" typed, one free tool since TRUTH-01 |
| `src/lib/__tests__/offer.test.ts:59-78,119` | pinned the beats form for the three cockpit claims and the free set |
| README generator | extracts no claim line; README carries none |

## Build

1. **`claimLine`** (`offer.ts:166-184`): `Pick` gains `why`; a PARTIAL with all four beats renders `partial — <why>` (verbatim); fewer than four beats keeps the beats form. A four-beat PARTIAL with no `why` **throws** `OfferLawError` ("… is PARTIAL with four beats and no why — the registry law requires one") — never the beats form as a stand-in.
2. **`freeSetLine(free = FREE_TOOLS)`** (`offer.ts:187-189`): the landing's sentence, the noun by count — "tool" for one, "tools" otherwise; the rest of the sentence is the one the landing carried. `Landing.tsx:2183` renders `{freeSetLine()}` (the `FREE_TOOLS` import goes; nothing else on the page moves).
3. **Tests** (`offer.test.ts`): each of Calendar, Tasks, Time, Budget renders `partial — ${why}` and never the word "discover"; Calendar's exact line; a four-beat PARTIAL with `why` undefined or blank throws; Tax with a stray `why` keeps the beats form; the three cockpit claims pinned to the why text; `freeSetLine()` singular for Travel alone and plural for two.

## The three CTA lines, before → after

| Reader | Before (TRUTH-01) | After |
|---|---|---|
| `ProjectsShowcaseSections.tsx:252` | Projects — partial — discover · decide · commit · record | Projects — partial — the founder's build pipeline — accepting a task fires a paid Claude Code build (tasks/[taskId]/route.ts:392-402); not a customer's task tool |
| `ContentShowcaseSections.tsx:207` | Content — partial — discover · decide · commit · record | Content — partial — day blocks and a daily log inside the Narrative pipeline; no time tool |
| `RunwayShowcaseSections.tsx:324` | Runway — partial — discover · decide · commit · record | Runway — partial — actuals by entity plus recurring lines on module_expenses; no plan vs actual; no personal · trade · travel roll-up |

The Projects label is the `label` prop ("Projects", `:344`); the other two are typed in the readers. The offer cards are untouched: no four-beat PARTIAL is sold (Banking, Brokerage, Trade Log, Tax, Compliance keep their beats form; Bookkeeping "built and running").

**The free line, before → after** (`Landing.tsx:2183`): "Free with an account, no module to buy: Travel — the registry's live **tools** with no tab gate." → "… the registry's live **tool** with no tab gate."

## Verify

| Check | Result |
|---|---|
| `npx tsc --noEmit` | exit 0 |
| `npm run lint` (whole repo) | 859 problems (580 errors, 279 warnings) before and after — zero new; `offer.ts`, `Landing.tsx`, `offer.test.ts` each 0/0 against main |
| `npm test` | **258 / 258** |
| full build with the asserts | exit 0; `counts: LIVE 2 · PARTIAL 9 · NOT_BUILT 14 (census 2/9/14)`; `✔ The offer law passed — 2 offers over 6 tools (LIVE or PARTIAL only), 1 free; … "built and running" typed nowhere but offer.ts`; the other ten laws unchanged |
| README | regenerated twice — md5 `7e0de63a10b476f45e86f5de666525a9` both runs, `git diff README.md` empty |

## Findings

1. The Projects CTA now runs to two lines of copy at the showcase's `text-base font-bold` size — honest, and long. Whether a shorter `why` belongs on that surface is a registry-text ruling, not a code one.
2. The `why` for Tasks names a route line (`tasks/[taskId]/route.ts:392-402`) on a public page — the registry's citation style, rendered verbatim as ruled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc

---
_Generated by [Claude Code](https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc)_