### PR TITLE
ACCOUNTS-01: step 1 is a real screen — connected accounts leave Books, and the rail stays on every page

### DIFF
--- a/scripts/assert-tool-registry.ts
+++ b/scripts/assert-tool-registry.ts
@@ -15,9 +15,11 @@
  * exactly one step; every step in one family, holding that family's jobs; the
  * families in flow order; steps 1..12 with no gaps; a roomless step holds
  * nothing LIVE), plus what only the filesystem can answer: every step's screen
- * resolves to a page file, the roomless steps' one page exists
- * (src/app/step/[slug]/page.tsx), and the rail and the sheet render FROM
- * steps.ts — never a retyped list.
+ * resolves to a page file THAT MOUNTS THE APP SHELL (ACCOUNTS-01: the rail is on
+ * every step's screen — the page file, or a layout above it, renders ShellFrame /
+ * AppLayout / the cockpit; a step whose room drops the navigation fails the
+ * build), the roomless steps' one page exists (src/app/step/[slug]/page.tsx), and
+ * the rail and the sheet render FROM steps.ts — never a retyped list.
  *
  * THE ANSWERS LAW (NAV-01c): the module-scope law of src/lib/answers.ts re-run
  * here (ANSWER_READS keys === ANSWER_ROWS questions 4/4 in order; a computed
@@ -256,6 +258,21 @@ for (const d of doors) {
 }
 console.log(`pages: ${pages.length} · doors: ${doors.length}`);
 
+// ACCOUNTS-01: does this page wear the app shell — in its own file, or in any layout
+// above it? The shells that carry the rail: ShellFrame, AppLayout, and the cockpit
+// (HomeClient / AnswersClient / ModulePageClient, which mount it themselves).
+const SHELLS = ['ShellFrame', 'AppLayout', 'HomeClient', 'AnswersClient', 'ModulePageClient'];
+function mountsShell(pageFile: string): boolean {
+  const read = (f: string) => (existsSync(resolve(ROOT, f)) ? readFileSync(resolve(ROOT, f), 'utf8') : '');
+  if (SHELLS.some((shell) => read(pageFile).includes(shell))) return true;
+  let dir = pageFile.slice(0, pageFile.lastIndexOf('/'));
+  while (dir.startsWith('src/app')) {
+    if (SHELLS.some((shell) => read(`${dir}/layout.tsx`).includes(shell))) return true;
+    dir = dir.slice(0, dir.lastIndexOf('/'));
+  }
+  return false;
+}
+
 // ── THE STEPS LAW (SHELL-01) ────────────────────────────────────────────────
 violations.push(...stepsLaw({ throwOnFail: false }));
 console.log('THE STEPS — the rail walks the sheet in flow order');
@@ -265,7 +282,12 @@ for (const step of STEPS) {
   console.log(
     `${String(step.number).padStart(2, '0')}  ${step.name.padEnd(11)} ${step.family.padEnd(13)} ${stepStatus(step, tools).padEnd(9)} ${stepHref(step).padEnd(16)} ${tools.map((t) => t.name).join(' · ').padEnd(46)} ${rooms.join(' ')}`,
   );
-  if (step.screen !== null && !pageFor(step.screen, tabs)) violations.push(`${step.name}: screen ${step.screen} has no page file`);
+  if (step.screen !== null) {
+    const file = pageFor(step.screen, tabs);
+    if (!file) violations.push(`${step.name}: screen ${step.screen} has no page file`);
+    // ACCOUNTS-01: and that page wears the shell, so the rail is present in the room.
+    else if (!mountsShell(file)) violations.push(`${step.name}: ${step.screen} (${file}) mounts no shell — the rail must be on every step's screen (ShellFrame, AppLayout, or the cockpit, in the page or a layout above it)`);
+  }
 }
 // A step with no room opens ONE page — the honest one that states its jobs.
 const STEP_PAGE = 'src/app/step/[slug]/page.tsx';
@@ -531,7 +553,7 @@ if (violations.length) {
 }
 console.log('✔ Tool registry law passed — 25/25 cells, homes resolve to page files, counts match the census.');
 console.log(`✔ Reachability law passed — ${pages.length} pages, every one has a door (the rail, the sheet, the utilities menu, a listed route, or a redirect to one).`);
-console.log(`✔ The steps law passed — ${STEPS.length} steps over ${FLOW_ORDER.length} families in flow order, every one of ${TOOL_REGISTRY.length} jobs walked once, every screen a page file; the rail and the sheet render from steps.ts.`);
+console.log(`✔ The steps law passed — ${STEPS.length} steps over ${FLOW_ORDER.length} families in flow order, every one of ${TOOL_REGISTRY.length} jobs walked once, every screen a page file that wears the shell; the rail and the sheet render from steps.ts.`);
 console.log(`✔ The answers law passed — ${ANSWER_ROWS.length}/4 questions on ${ANSWERS_HOME}, every number sourced.`);
 // ── THE KIND-VIEWS LAW (TABLES-01) ──────────────────────────────────────────
 const viewsMigration = ALL_MIGRATIONS.find((m) => m.dir.endsWith('_kind_views'));

--- a/src/app/accounts/page.tsx
+++ b/src/app/accounts/page.tsx
@@ -1,169 +1,24 @@
-'use client';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
+import ShellFrame from '@/components/ui/ShellFrame';
+import AccountsClient from '@/components/accounts/AccountsClient';
 
-import React, { useState, useEffect } from 'react';
-import { useRouter } from 'next/navigation';
-interface Account {
-id: string;
-name: string;
-institution: string;
-type: string;
-subtype: string;
-balance: number;
-lastSync: string;
-entityType?: string;
-}
-interface Transaction {
-id: string;
-date: string;
-description: string;
-amount: number;
-category: string;
-accountId: string;
-}
-export default function AccountsPage() {
-const [accounts, setAccounts] = useState<Account[]>([]);
-const [transactions, setTransactions] = useState<Transaction[]>([]);
-const [loading, setLoading] = useState(true);
-const [error, setError] = useState('');
-const router = useRouter();
-useEffect(() => {
-fetchAccountsAndTransactions();
-}, []);
-const fetchAccountsAndTransactions = async () => {
-try {
-const accountsRes = await fetch('/api/accounts');
-if (!accountsRes.ok) {
-if (accountsRes.status === 401) {
-router.push('/login');
-return;
-}
-throw new Error('Failed to fetch accounts');
-}
-const accountsData = await accountsRes.json();
-  let allAccounts: Account[] = [];
-  
-  if (Array.isArray(accountsData)) {
-    allAccounts = accountsData.map((account: any) => ({
-      id: account.id,
-      name: account.name,
-      institution: account.plaidItem?.institutionName || 'Bank',
-      type: account.type,
-      subtype: account.subtype,
-      balance: account.currentBalance || account.balance || 0,
-      lastSync: new Date().toISOString(),
-      entityType: account.entityType
-    }));
-  } else if (accountsData.items) {
-    allAccounts = accountsData.items.flatMap((item: any) => 
-      item.accounts?.map((account: any) => ({
-        id: account.id,
-        name: account.name,
-        institution: item.institutionName,
-        type: account.type,
-        subtype: account.subtype,
-        balance: account.balance,
-        lastSync: new Date().toISOString(),
-        entityType: account.entityType
-      })) || []
-    );
-  }
-  
-  setAccounts(allAccounts);
+/**
+ * ACCOUNTS-01 — /accounts, THE RAIL'S STEP 1 SCREEN. The shell (and with it the
+ * rail) is mounted here, the way /step/[slug] does it: this page reads the
+ * verified cookie for the shell bar's viewer and nothing else — every account
+ * read happens in the client component, against the already-authed,
+ * user-scoped /api/accounts.
+ *
+ * Auth: a protected path — middleware bounces an unverified visitor to '/'
+ * before this renders.
+ */
+export const dynamic = 'force-dynamic';
 
-  const transactionsRes = await fetch('/api/transactions');
-  if (transactionsRes.ok) {
-    const transactionsData = await transactionsRes.json();
-    setTransactions(transactionsData);
-  }
-} catch (err) {
-  setError('Failed to load data');
-  console.error(err);
-} finally {
-  setLoading(false);
-}
-};
-const updateEntityType = async (accountId: string, entityType: string) => {
-try {
-const res = await fetch('/api/accounts/update-entity', {
-method: 'POST',
-headers: { 'Content-Type': 'application/json' },
-body: JSON.stringify({ accountId, entityType })
-});
-  if (res.ok) {
-    setAccounts(accounts.map(acc => 
-      acc.id === accountId ? { ...acc, entityType } : acc
-    ));
-  }
-} catch (err) {
-  console.error('Failed to update entity type:', err);
-}
-};
-return (
-<div className="min-h-screen bg-bg-row">
-<div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-<h1 className="text-3xl font-bold text-text-primary mb-8">Accounts</h1>
-    {loading && <div>Loading...</div>}
-    {error && <div className="text-brand-red">{error}</div>}
-    
-    {!loading && !error && (
-      <>
-        <div className="grid gap-6 mb-8">
-          {accounts.map(account => (
-            <div key={account.id} className="bg-white p-6 rounded shadow">
-              <div className="flex justify-between">
-                <div className="flex-1">
-                  <h3 className="text-terminal-lg font-medium">{account.name}</h3>
-                  <p className="text-sm text-text-muted">{account.institution}</p>
-                  <div className="mt-2">
-                    <label className="text-xs text-text-muted block mb-1">Entity Type:</label>
-                    <select
-                      value={account.entityType || ''}
-                      onChange={(e) => updateEntityType(account.id, e.target.value)}
-                      className="border rounded px-3 py-1 text-sm"
-                    >
-                      <option value="">Not Set</option>
-                      <option value="personal">Personal</option>
-                      <option value="business">Business</option>
-                      <option value="trading">Trading</option>
-                      <option value="retirement">Retirement</option>
-                    </select>
-                  </div>
-                </div>
-                <div className="text-right">
-                  <p className="text-sm font-bold">${account.balance.toFixed(2)}</p>
-                  <p className="text-sm text-text-muted">{account.type}</p>
-                </div>
-              </div>
-            </div>
-          ))}
-        </div>
-        
-        <div className="bg-white shadow rounded">
-          <div className="px-6 py-4 border-b">
-            <h2 className="text-sm font-semibold">Recent Transactions</h2>
-          </div>
-          <div className="divide-y">
-            {transactions.slice(0, 10).map((transaction: any) => (
-              <div key={transaction.id} className="px-6 py-4">
-                <div className="flex justify-between">
-                  <div>
-                    <p className="font-medium">{transaction.name || transaction.description}</p>
-                    <p className="text-sm text-text-muted">{transaction.category}</p>
-                  </div>
-                  <div className="text-right">
-                    <p className={`font-medium ${transaction.amount < 0 ? 'text-brand-red' : 'text-brand-green'}`}>
-                      ${Math.abs(transaction.amount).toFixed(2)}
-                    </p>
-                    <p className="text-sm text-text-muted">{new Date(transaction.date).toLocaleDateString()}</p>
-                  </div>
-                </div>
-              </div>
-            ))}
-          </div>
-        </div>
-      </>
-    )}
-  </div>
-</div>
-);
+export default async function AccountsPage() {
+  const viewer = await getVerifiedEmail();
+  return (
+    <ShellFrame viewer={viewer ?? ''}>
+      <AccountsClient />
+    </ShellFrame>
+  );
 }

--- a/src/app/api/accounts/route.ts
+++ b/src/app/api/accounts/route.ts
@@ -36,14 +36,20 @@ export async function GET(request: NextRequest) {
       // BANK-01: the item's last Plaid ITEM_ERROR, so the Books page can offer Reconnect.
       lastErrorCode: item.last_error_code,
       lastErrorAt: item.last_error_at,
+      // ACCOUNTS-01: currentBalance is Float? — nullable. It is sent AS IT IS; the screen
+      // renders a missing balance as "—" (src/lib/accountsView.ts money()). The old `|| 0`
+      // turned "the institution reported nothing" into "zero dollars".
       accounts: item.accounts.map(account => ({
         id: account.id,
         name: account.name,
         type: account.type,
         subtype: account.subtype,
         mask: account.mask,
-        balance: account.currentBalance || 0,
+        balance: account.currentBalance,
         entityType: account.entityType || null,
+        // ACCOUNTS-01: the row's last write — a sync, or an entity assignment. NOT a sync
+        // timestamp: the product records none per account, and the screen says so.
+        updatedAt: account.updatedAt,
       }))
     }));
 

--- a/src/app/auto/page.tsx
+++ b/src/app/auto/page.tsx
@@ -1,5 +1,13 @@
+import AppLayout from '@/components/ui/AppLayout';
 import BudgetingPage from '@/components/dashboard/BudgetingPage';
 
+// ACCOUNTS-01: a signed-in room mounts the app shell, so THE RAIL is here too. AppLayout
+// is the shell most rooms already use — it authenticates itself (/api/auth/me), bounces a
+// guest, and carries the rail beside the page. The room's own body is unchanged.
 export default function AutoPage() {
-  return <BudgetingPage category="Auto" emoji="🚗" apiPath="/api/auto" />;
+  return (
+    <AppLayout>
+      <BudgetingPage category="Auto" emoji="🚗" apiPath="/api/auto" />
+    </AppLayout>
+  );
 }

--- a/src/app/business/page.tsx
+++ b/src/app/business/page.tsx
@@ -1,5 +1,13 @@
+import AppLayout from '@/components/ui/AppLayout';
 import BudgetingPage from '@/components/dashboard/BudgetingPage';
 
+// ACCOUNTS-01: a signed-in room mounts the app shell, so THE RAIL is here too. AppLayout
+// is the shell most rooms already use — it authenticates itself (/api/auth/me), bounces a
+// guest, and carries the rail beside the page. The room's own body is unchanged.
 export default function BusinessPage() {
-  return <BudgetingPage category="Business" emoji="💼" apiPath="/api/business" />;
+  return (
+    <AppLayout>
+      <BudgetingPage category="Business" emoji="💼" apiPath="/api/business" />
+    </AppLayout>
+  );
 }

--- a/src/app/growth/page.tsx
+++ b/src/app/growth/page.tsx
@@ -1,5 +1,13 @@
+import AppLayout from '@/components/ui/AppLayout';
 import BudgetingPage from '@/components/dashboard/BudgetingPage';
 
+// ACCOUNTS-01: a signed-in room mounts the app shell, so THE RAIL is here too. AppLayout
+// is the shell most rooms already use — it authenticates itself (/api/auth/me), bounces a
+// guest, and carries the rail beside the page. The room's own body is unchanged.
 export default function GrowthPage() {
-  return <BudgetingPage category="Growth" emoji="📈" apiPath="/api/growth" />;
+  return (
+    <AppLayout>
+      <BudgetingPage category="Growth" emoji="📈" apiPath="/api/growth" />
+    </AppLayout>
+  );
 }

--- a/src/app/health/page.tsx
+++ b/src/app/health/page.tsx
@@ -1,5 +1,13 @@
+import AppLayout from '@/components/ui/AppLayout';
 import BudgetingPage from '@/components/dashboard/BudgetingPage';
 
+// ACCOUNTS-01: a signed-in room mounts the app shell, so THE RAIL is here too. AppLayout
+// is the shell most rooms already use — it authenticates itself (/api/auth/me), bounces a
+// guest, and carries the rail beside the page. The room's own body is unchanged.
 export default function HealthPage() {
-  return <BudgetingPage category="Health" emoji="🏥" apiPath="/api/health" />;
+  return (
+    <AppLayout>
+      <BudgetingPage category="Health" emoji="🏥" apiPath="/api/health" />
+    </AppLayout>
+  );
 }

--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -1,5 +1,13 @@
+import AppLayout from '@/components/ui/AppLayout';
 import BudgetingPage from '@/components/dashboard/BudgetingPage';
 
+// ACCOUNTS-01: a signed-in room mounts the app shell, so THE RAIL is here too. AppLayout
+// is the shell most rooms already use — it authenticates itself (/api/auth/me), bounces a
+// guest, and carries the rail beside the page. The room's own body is unchanged.
 export default function HomePage() {
-  return <BudgetingPage category="Home" emoji="🏠" apiPath="/api/home" />;
+  return (
+    <AppLayout>
+      <BudgetingPage category="Home" emoji="🏠" apiPath="/api/home" />
+    </AppLayout>
+  );
 }

--- a/src/app/personal/page.tsx
+++ b/src/app/personal/page.tsx
@@ -1,5 +1,13 @@
+import AppLayout from '@/components/ui/AppLayout';
 import BudgetingPage from '@/components/dashboard/BudgetingPage';
 
+// ACCOUNTS-01: a signed-in room mounts the app shell, so THE RAIL is here too. AppLayout
+// is the shell most rooms already use — it authenticates itself (/api/auth/me), bounces a
+// guest, and carries the rail beside the page. The room's own body is unchanged.
 export default function PersonalPage() {
-  return <BudgetingPage category="Personal" emoji="👤" apiPath="/api/personal" />;
+  return (
+    <AppLayout>
+      <BudgetingPage category="Personal" emoji="👤" apiPath="/api/personal" />
+    </AppLayout>
+  );
 }

--- a/src/components/Providers.tsx
+++ b/src/components/Providers.tsx
@@ -1,7 +1,14 @@
 'use client';
 
 import { SessionProvider } from 'next-auth/react';
+// ACCOUNTS-01: the rail's open/collapsed state lives above the pages, so walking the
+// steps never resets it. React state only — no browser storage.
+import { RailStateProvider } from '@/components/shell/RailState';
 
 export default function Providers({ children }: { children: React.ReactNode }) {
-  return <SessionProvider>{children}</SessionProvider>;
+  return (
+    <SessionProvider>
+      <RailStateProvider>{children}</RailStateProvider>
+    </SessionProvider>
+  );
 }

--- a/src/components/accounts/AccountsClient.tsx
+++ b/src/components/accounts/AccountsClient.tsx
@@ -1,0 +1,257 @@
+'use client';
+
+/**
+ * ACCOUNTS-01 — STEP 1's screen: every connected account, grouped by what it IS.
+ *
+ * It replaces a legacy page that threw on production. Two habits it does not
+ * inherit: it never renders a number the data did not carry (a null balance is
+ * "—", never NaN and never $0), and it never invents a word (a missing type or
+ * subtype says "unknown — reported by the institution"). The grouping, the money
+ * and the words are all src/lib/accountsView.ts, which the tests pin.
+ *
+ * Connect · Sync · Reconnect are the SHARED hook (useBankConnection) — the same
+ * link token, the same Plaid Link, the same exchange-token / sync-complete /
+ * reconnect-complete routes the cockpit bar and Books' Source Accounts drive. No
+ * new Plaid code, no new route.
+ *
+ * Fail-loud: the read prints its HTTP status and the route's own error (a locked
+ * tab prints the gate's own message, including the lapse line); a sync prints the
+ * declared outcome; an entity change that fails reverts to the TRUE prior value.
+ * Nothing here retries, defaults, or shows a figure it could not read.
+ */
+import { useCallback, useEffect, useState } from 'react';
+import Script from 'next/script';
+import { useBankConnection } from '@/components/bank/useBankConnection';
+import {
+  ACCOUNT_GROUPS, groupAccounts, isReported, money, rowsOf, describeWord, when,
+  type AccountRow, type ApiItem,
+} from '@/lib/accountsView';
+
+/** The entity words /api/accounts/update-entity accepts (its own validTypes list). */
+const ENTITY_OPTIONS: readonly string[] = ['personal', 'business', 'trading', 'retirement'];
+
+const CARD = 'rounded-lg border border-border bg-white';
+const TH = 'px-3 py-2 text-left font-medium';
+
+export default function AccountsClient() {
+  const [state, setState] = useState<'loading' | 'error' | 'ok'>('loading');
+  const [failure, setFailure] = useState<string | null>(null);
+  const [items, setItems] = useState<ApiItem[]>([]);
+  const [entityBusy, setEntityBusy] = useState<string | null>(null);
+  const [entityError, setEntityError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setState('loading');
+    try {
+      const res = await fetch('/api/accounts', { cache: 'no-store' });
+      if (!res.ok) {
+        // The route's own words — a 403 from the tab gate carries its message (and, since
+        // LAUNCH-01, the lapse line). Never rewritten, never reduced to "failed".
+        let detail = '';
+        try {
+          const body = (await res.json()) as { error?: unknown; message?: unknown };
+          detail = [body.message, body.error].filter((v): v is string => typeof v === 'string')[0] ?? '';
+        } catch {
+          detail = 'no error body';
+        }
+        setFailure(`HTTP ${res.status}${detail ? ` · ${detail}` : ''}`);
+        setState('error');
+        return;
+      }
+      const body = (await res.json()) as { items?: ApiItem[] };
+      if (!Array.isArray(body.items)) {
+        setFailure('the accounts read answered without an items list — nothing is assumed');
+        setState('error');
+        return;
+      }
+      setItems(body.items);
+      setState('ok');
+    } catch (e) {
+      setFailure(`network — ${e instanceof Error ? e.message : String(e)}`);
+      setState('error');
+    }
+  }, []);
+
+  useEffect(() => { load(); }, [load]);
+
+  const bank = useBankConnection({ onChanged: load });
+
+  // Optimistic entity assignment with revert-on-failure — the revert restores the TRUE
+  // prior value (Books' own pattern), never a fabricated default.
+  const setEntity = async (row: AccountRow, entityType: string) => {
+    const previous = row.entityType;
+    setEntityBusy(row.id);
+    setEntityError(null);
+    setItems((prev) => prev.map((it) => ({ ...it, accounts: it.accounts.map((a) => (a.id === row.id ? { ...a, entityType } : a)) })));
+    try {
+      const res = await fetch('/api/accounts/update-entity', {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ accountId: row.id, entityType }),
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    } catch (e) {
+      setItems((prev) => prev.map((it) => ({ ...it, accounts: it.accounts.map((a) => (a.id === row.id ? { ...a, entityType: previous } : a)) })));
+      setEntityError(`${row.name}: the entity change did not save (${e instanceof Error ? e.message : String(e)}) — it is back to what it was.`);
+    } finally {
+      setEntityBusy(null);
+    }
+  };
+
+  const rows = state === 'ok' ? rowsOf(items) : [];
+  const groups = groupAccounts(rows);
+  const connected = rows.length;
+
+  return (
+    <div data-accounts>
+      {/* Plaid Link — the same CDN script the cockpit loads for the same flow. */}
+      <Script src="https://cdn.plaid.com/link/v2/stable/link-initialize.js" strategy="lazyOnload" />
+
+      <header className="mb-5">
+        <p className="font-mono text-[10px] sm:text-xs uppercase tracking-[0.2em] text-text-faint">Step 1 <span className="text-brand-gold">·</span> What you own</p>
+        <h1 className="mt-1 text-xl sm:text-2xl font-semibold tracking-tight text-text-primary">Accounts</h1>
+        <p className="mt-1 text-xs text-text-muted">
+          Every account you have connected, grouped by what it is. {state === 'ok' ? `${connected} connected.` : ''}
+        </p>
+        <div className="mt-3 flex flex-wrap items-center gap-2">
+          <button
+            type="button"
+            onClick={bank.linkAccount}
+            disabled={!bank.ready}
+            data-connect
+            className="rounded border border-brand-purple px-3 py-1.5 font-mono text-[10px] uppercase tracking-wider text-brand-purple hover:bg-brand-purple-wash disabled:opacity-50"
+          >
+            {bank.ready ? '+ Connect an account' : 'Connect — loading Plaid…'}
+          </button>
+          <button
+            type="button"
+            onClick={bank.syncAccounts}
+            disabled={bank.syncing}
+            data-sync
+            className="rounded border border-border px-3 py-1.5 font-mono text-[10px] uppercase tracking-wider text-text-secondary hover:bg-bg-row disabled:opacity-50"
+          >
+            {bank.syncing ? 'Syncing…' : 'Sync'}
+          </button>
+        </div>
+        {bank.message && (
+          <div
+            role={bank.message.tone === 'ok' ? 'status' : 'alert'}
+            data-sync-line
+            className={`mt-2 rounded border p-2 text-xs ${bank.message.tone === 'ok' ? 'border-border bg-bg-row text-text-secondary' : 'border-brand-red/40 bg-brand-red/5 text-brand-red'}`}
+          >
+            {/* One line per failed bank above one line for what succeeded — one dead bank never reads as "sync failed". */}
+            {bank.message.lines.map((line, i) => <div key={i}>{line}</div>)}
+          </div>
+        )}
+        {entityError && <p role="alert" className="mt-2 text-xs text-brand-red" data-entity-error>{entityError}</p>}
+      </header>
+
+      {state === 'loading' && <p className="font-mono text-xs text-text-faint" data-read="loading">Reading your accounts…</p>}
+
+      {state === 'error' && (
+        <div role="alert" className={`${CARD} border-brand-red/40 p-4`} data-read="failed">
+          <p className="text-sm font-semibold text-brand-red">Your accounts could not be read.</p>
+          <p className="mt-1 font-mono text-xs text-text-secondary">{failure}</p>
+          <p className="mt-2 text-xs text-text-muted">Nothing is assumed — no list is shown rather than a wrong one.</p>
+          <button type="button" onClick={load} className="mt-3 rounded border border-border px-3 py-1.5 font-mono text-[10px] uppercase tracking-wider text-text-secondary hover:bg-bg-row">Try again</button>
+        </div>
+      )}
+
+      {state === 'ok' && (
+        <div className="space-y-4">
+          {groups.map((group) => (
+            <section key={group.key} className={`${CARD} p-3`} data-group={group.key} data-group-count={group.rows.length}>
+              <div className="mb-2 flex flex-wrap items-baseline justify-between gap-2">
+                <h2 className="font-mono text-[10px] uppercase tracking-wider text-brand-purple">{group.label}</h2>
+                <p className="font-mono text-[10px] text-text-faint">
+                  {group.rows.length} {group.rows.length === 1 ? 'account' : 'accounts'}
+                  {group.rows.length > 0 && <> <span className="text-text-muted">·</span> <span data-group-total>{money(group.total)}</span></>}
+                </p>
+              </div>
+
+              {group.noFeed ? (
+                <p className="text-xs text-text-muted" data-no-feed>{group.noFeed}</p>
+              ) : group.rows.length === 0 ? (
+                <p className="text-xs text-text-muted" data-empty>{group.empty}</p>
+              ) : (
+                <div className="overflow-x-auto">
+                  <table className="w-full text-xs">
+                    <thead className="bg-bg-row text-text-secondary">
+                      <tr>
+                        <th className={TH}>Institution</th>
+                        <th className={TH}>Account</th>
+                        <th className={TH}>Type</th>
+                        <th className={TH}>Entity</th>
+                        <th className={`${TH} text-right`}>Balance</th>
+                        <th className={`${TH} text-right`}>Last updated</th>
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-border">
+                      {group.rows.map((row) => (
+                        <tr key={row.id} data-account={row.id} data-item-error={row.lastErrorCode ?? undefined}>
+                          <td className="px-3 py-2 font-medium text-text-primary">
+                            {row.institutionName ?? <span className="text-text-muted">{describeWord(null)}</span>}
+                            {(row.lastErrorCode || bank.reconnectNote?.itemId === row.itemId) && (
+                              <div className="mt-1 flex flex-wrap items-center gap-2">
+                                {row.lastErrorCode && (
+                                  <>
+                                    <span className="font-mono text-[10px] uppercase tracking-wider text-rose-700">needs reconnecting · {row.lastErrorCode}</span>
+                                    <button
+                                      type="button"
+                                      data-reconnect={row.itemId}
+                                      onClick={() => bank.reconnect(row.itemId, row.institutionName ?? '')}
+                                      disabled={bank.reconnecting === row.itemId}
+                                      className="rounded border border-brand-purple px-2 py-0.5 font-mono text-[10px] uppercase tracking-wider text-brand-purple hover:bg-brand-purple-wash disabled:opacity-60"
+                                    >
+                                      {bank.reconnecting === row.itemId ? 'Opening…' : 'Reconnect'}
+                                    </button>
+                                  </>
+                                )}
+                                {bank.reconnectNote?.itemId === row.itemId && (
+                                  <span role={bank.reconnectNote.tone === 'error' ? 'alert' : 'status'} className={`text-[10px] ${bank.reconnectNote.tone === 'ok' ? 'text-emerald-700' : bank.reconnectNote.tone === 'error' ? 'text-rose-700' : 'text-text-secondary'}`}>
+                                    {bank.reconnectNote.text}
+                                  </span>
+                                )}
+                              </div>
+                            )}
+                          </td>
+                          <td className="px-3 py-2 text-text-secondary">
+                            {row.name}
+                            <span className="ml-2 font-mono text-text-faint">•••• {row.mask ?? '----'}</span>
+                          </td>
+                          <td className="px-3 py-2">
+                            <span className={isReported(row.type) ? 'text-text-secondary' : 'text-text-muted italic'}>{describeWord(row.type)}</span>
+                            <span className="text-text-faint"> · </span>
+                            <span className={isReported(row.subtype) ? 'text-text-secondary' : 'text-text-muted italic'}>{describeWord(row.subtype)}</span>
+                          </td>
+                          <td className="px-3 py-2">
+                            <select
+                              value={row.entityType ?? ''}
+                              disabled={entityBusy === row.id}
+                              onChange={(e) => setEntity(row, e.target.value)}
+                              data-entity={row.entityType ?? ''}
+                              className="rounded border border-border px-2 py-0.5 text-[10px] uppercase disabled:opacity-50"
+                            >
+                              {!row.entityType && <option value="" disabled>unassigned</option>}
+                              {ENTITY_OPTIONS.map((o) => <option key={o} value={o}>{o}</option>)}
+                            </select>
+                          </td>
+                          <td className="px-3 py-2 text-right font-mono font-semibold text-text-primary" data-balance>{money(row.balance)}</td>
+                          <td className="px-3 py-2 text-right font-mono text-text-muted">{when(row.updatedAt)}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </section>
+          ))}
+          <p className="font-mono text-[10px] leading-relaxed text-text-faint">
+            Balance is what the institution last reported; “—” means it reported none. “Last updated” is when the
+            row last changed — a sync, or an entity assignment. The product records no per-account sync time, so
+            none is shown. Groups come from the account’s own type and subtype ({ACCOUNT_GROUPS.map((g) => g.label).join(' · ')}).
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/bank/useBankConnection.ts
+++ b/src/components/bank/useBankConnection.ts
@@ -1,0 +1,219 @@
+'use client';
+
+/**
+ * ACCOUNTS-01 — the ONE bank-connection glue: link a new account, sync, and
+ * reconnect an item Plaid has flagged. Extracted VERBATIM from the two places
+ * that owned it — the cockpit bar (ModuleLauncher: the link token, Plaid Link,
+ * exchange-token, sync-complete) and Books' Source Accounts (BooksPipeline:
+ * update-mode Link, reconnect-complete) — so step 1's screen, the cockpit bar
+ * and Books' phase all drive the SAME code against the SAME routes.
+ *
+ * NO new Plaid code and NO new route: every call here already existed
+ * (/api/plaid/link-token · /api/plaid/exchange-token · /api/plaid/reconnect-complete ·
+ * /api/plaid/link-exit · /api/transactions/sync-complete), and every envelope is
+ * read by the shared helpers (readSyncOutcome, linkExitOutcome, postLinkExit,
+ * keepLinkFlow / forgetLinkFlow / takeReturnOutcome).
+ *
+ * Fail-loud, unchanged: a failed or partial sync is SHOWN (never swallowed); a
+ * link token with no expiration is refused rather than opened; a Link exit that
+ * carries an error is reported to the log and said out loud; a cancel is a plain
+ * note, not an error. Nothing here retries and nothing defaults.
+ *
+ * The caller passes what to re-read after a change; the hook owns no data.
+ */
+import { useCallback, useEffect, useState } from 'react';
+import { readSyncOutcome, syncLine, type SyncOutcome } from '@/lib/plaid/failLoud';
+import { LINK_CANCELLED, RECONNECT_CANCELLED, linkExitOutcome, notLoggedSuffix, postLinkExit, type LinkExitError, type LinkExitMetadata } from '@/lib/plaid/linkExit';
+import { forgetLinkFlow, keepLinkFlow, takeReturnOutcome } from '@/lib/plaid/oauth';
+
+/** Plaid Link, as the browser exposes it once the CDN script has loaded. */
+type PlaidGlobal = { create: (config: Record<string, unknown>) => { open(): void } } | undefined;
+const plaidGlobal = (): PlaidGlobal => (window as unknown as { Plaid?: PlaidGlobal }).Plaid;
+
+export interface ReconnectNote {
+  itemId: string;
+  text: string;
+  /** 'note' is BANK-01b's third tone: a plain outcome (a cancel) that is neither ok nor an error. */
+  tone: 'ok' | 'error' | 'note';
+}
+
+export interface BankConnection {
+  /** True once a link token (and its expiration) is in hand — the connect button no-ops until then, never fakes. */
+  ready: boolean;
+  linkAccount: () => void;
+  syncAccounts: () => Promise<void>;
+  syncing: boolean;
+  /** The declared outcome of the last sync / link — shown, never swallowed. */
+  message: SyncOutcome | null;
+  setMessage: (m: SyncOutcome | null) => void;
+  reconnect: (itemId: string, institution: string) => Promise<void>;
+  /** The item whose reconnect is opening, or null. */
+  reconnecting: string | null;
+  reconnectNote: ReconnectNote | null;
+}
+
+export function useBankConnection({ onChanged, enabled = true }: {
+  /** Re-read whatever the caller shows, after a link, a sync or a reconnect. */
+  onChanged: () => void | Promise<void>;
+  /** False while the viewer may not see this surface at all (a locked cockpit tab) — no token is fetched. */
+  enabled?: boolean;
+}): BankConnection {
+  const [linkToken, setLinkToken] = useState<string | null>(null);
+  const [linkExpiration, setLinkExpiration] = useState<string | null>(null);
+  const [syncing, setSyncing] = useState(false);
+  const [message, setMessage] = useState<SyncOutcome | null>(null);
+  const [reconnecting, setReconnecting] = useState<string | null>(null);
+  const [reconnectNote, setReconnectNote] = useState<ReconnectNote | null>(null);
+
+  // The link token, and the outcome line an OAuth round trip left behind.
+  useEffect(() => {
+    if (!enabled) return;
+    // BANK-01c: an OAuth round trip that ended on /plaid/oauth-return left its outcome line
+    // for this surface (the 'new' flow; a reconnect's line goes to its own row).
+    const back = takeReturnOutcome(window.localStorage, 'new');
+    if (back) setMessage(back.outcome);
+    const backReconnect = takeReturnOutcome(window.localStorage, 'reconnect');
+    if (backReconnect && backReconnect.flow.kind === 'reconnect') {
+      setReconnectNote({
+        itemId: backReconnect.flow.itemId,
+        text: backReconnect.outcome.text,
+        tone: backReconnect.outcome.tone === 'ok' ? 'ok' : backReconnect.outcome.tone === 'error' ? 'error' : 'note',
+      });
+    }
+    fetch('/api/plaid/link-token', { method: 'POST' })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d) => {
+        // BANK-01c: the token is usable only with its expiration — the round-trip entry
+        // must expire with it; a token without one is a contract break, not a link.
+        if (d?.link_token && typeof d.expiration === 'string') {
+          setLinkToken(d.link_token);
+          setLinkExpiration(d.expiration);
+        }
+      })
+      .catch(() => { /* no token → linkAccount guards on it, fail-loud (the button no-ops until ready) */ });
+  }, [enabled]);
+
+  // POST the auth-gated /api/transactions/sync-complete, then re-read. No auth weakened.
+  const syncAccounts = useCallback(async () => {
+    setSyncing(true);
+    setMessage(null);
+    try {
+      const res = await fetch('/api/transactions/sync-complete', { method: 'POST' });
+      // HYG-01: read the declared outcome — a failed or partial sync is shown, never swallowed.
+      setMessage(await readSyncOutcome(res));
+      await onChanged();
+    } finally {
+      setSyncing(false);
+    }
+  }, [onChanged]);
+
+  // Open Plaid Link with the auth-gated link token; on success POST the auth-gated
+  // /api/plaid/exchange-token then re-read. Guards on token + window.Plaid (no fallback).
+  const linkAccount = useCallback(() => {
+    const plaid = plaidGlobal();
+    if (!linkToken || !linkExpiration || !plaid) return;
+    // BANK-01c: keep the token + flow for the OAuth return page before Link opens (Plaid's
+    // guide: the same link_token must re-open Link after the bank's redirect).
+    keepLinkFlow(window.localStorage, { linkToken, flow: { kind: 'new' }, expiresAt: linkExpiration });
+    plaid.create({
+      token: linkToken,
+      onSuccess: async (publicToken: string, metadata: { institution?: { institution_id?: string; name?: string } }) => {
+        forgetLinkFlow(window.localStorage, linkToken);
+        await fetch('/api/plaid/exchange-token', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            publicToken,
+            institutionId: metadata.institution?.institution_id,
+            institutionName: metadata.institution?.name,
+            entityId: 'personal',
+          }),
+        });
+        await onChanged();
+      },
+      // BANK-01b: an error → the line under the bar ("Plaid Link: CODE — message") and the
+      // report to the log; a cancel → "Account link cancelled". No itemId: there is no item yet.
+      onExit: async (error: LinkExitError | null, metadata: LinkExitMetadata) => {
+        forgetLinkFlow(window.localStorage, linkToken);
+        const exit = linkExitOutcome(error, metadata ?? {}, LINK_CANCELLED);
+        if (exit.kind === 'connected') return;
+        if (exit.kind === 'cancelled') {
+          setMessage(syncLine('ok', exit.note));
+          return;
+        }
+        setMessage(syncLine('error', exit.note));
+        const posted = await postLinkExit(exit.report);
+        if (!posted.logged) setMessage(syncLine('error', exit.note + notLoggedSuffix(posted.status)));
+      },
+    }).open();
+  }, [linkToken, linkExpiration, onChanged]);
+
+  // BANK-01: Plaid Link in UPDATE MODE for an existing item. The server mints the
+  // update-mode token from the stored (encrypted) access token; the browser sees the link
+  // token only. After onSuccess there is NO public-token exchange — reconnect-complete asks
+  // /item/get whether the item is healthy and answers with the HYG-01 envelope.
+  const reconnect = useCallback(async (itemId: string, institution: string) => {
+    const plaid = plaidGlobal();
+    if (!plaid) {
+      setReconnectNote({ itemId, text: 'Plaid Link has not loaded yet — try again in a moment.', tone: 'error' });
+      return;
+    }
+    setReconnecting(itemId);
+    setReconnectNote(null);
+    try {
+      const res = await fetch('/api/plaid/link-token', {
+        method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ itemId }),
+      });
+      if (!res.ok) {
+        const out = await readSyncOutcome(res);
+        setReconnectNote({ itemId, text: out.text, tone: 'error' });
+        return;
+      }
+      const { link_token: token, expiration } = (await res.json()) as { link_token: string; expiration?: unknown };
+      if (typeof expiration !== 'string') {
+        setReconnectNote({ itemId, text: 'The link token answer carried no expiration — not opening Plaid Link.', tone: 'error' });
+        return;
+      }
+      keepLinkFlow(window.localStorage, { linkToken: token, flow: { kind: 'reconnect', itemId, institution }, expiresAt: expiration });
+      plaid.create({
+        token,
+        onSuccess: async () => {
+          forgetLinkFlow(window.localStorage, token);
+          const done = await fetch('/api/plaid/reconnect-complete', {
+            method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ itemId }),
+          });
+          const out = await readSyncOutcome(done);
+          setReconnectNote({ itemId, text: out.text, tone: out.tone === 'ok' ? 'ok' : 'error' });
+          await onChanged();
+        },
+        onExit: async (error: LinkExitError | null, metadata: LinkExitMetadata) => {
+          setReconnecting(null);
+          forgetLinkFlow(window.localStorage, token);
+          const exit = linkExitOutcome(error, metadata ?? {}, RECONNECT_CANCELLED, itemId);
+          if (exit.kind === 'connected') return;
+          if (exit.kind === 'cancelled') {
+            setReconnectNote({ itemId, text: exit.note, tone: 'note' });
+            return;
+          }
+          setReconnectNote({ itemId, text: exit.note, tone: 'error' });
+          const posted = await postLinkExit(exit.report);
+          if (!posted.logged) setReconnectNote({ itemId, text: exit.note + notLoggedSuffix(posted.status), tone: 'error' });
+        },
+      }).open();
+    } finally {
+      setReconnecting(null);
+    }
+  }, [onChanged]);
+
+  return {
+    ready: Boolean(linkToken && linkExpiration),
+    linkAccount,
+    syncAccounts,
+    syncing,
+    message,
+    setMessage,
+    reconnect,
+    reconnecting,
+    reconnectNote,
+  };
+}

--- a/src/components/home/BooksPipeline.tsx
+++ b/src/components/home/BooksPipeline.tsx
@@ -30,13 +30,11 @@ import StageStrip, { type StagePhase } from '@/components/ui/StageStrip';
 import { PIPE_PHASES } from '@/lib/pipePhases';
 // BANK-01: the HYG-01 envelope reader — the Reconnect flow reads link-token /
 // reconnect-complete answers exactly as the Sync button reads sync-complete.
-import { readSyncOutcome } from '@/lib/plaid/failLoud';
+import { useBankConnection } from '@/components/bank/useBankConnection';
 // BANK-01b: Plaid Link's onExit is surfaced — the reason on the row, the report in the log.
-import { RECONNECT_CANCELLED, linkExitOutcome, notLoggedSuffix, postLinkExit, type LinkExitError, type LinkExitMetadata } from '@/lib/plaid/linkExit';
 // BANK-01c: the OAuth round trip — the update-mode token and the reconnect flow (item +
 // bank) are kept before Link opens so /plaid/oauth-return re-opens Link with the SAME
 // token; the return page's outcome line lands on the row.
-import { forgetLinkFlow, keepLinkFlow, takeReturnOutcome } from '@/lib/plaid/oauth';
 
 const [PIPE_FEED, PIPE_CODE, PIPE_RECONCILE, PIPE_CLOSE, PIPE_REPORTS, PIPE_EXPORT] = PIPE_PHASES.books;
 import SectionHeader from '@/components/ui/SectionHeader';
@@ -194,78 +192,13 @@ export default function BooksPipeline() {
     setEntityId(def?.id ?? null);
   }, []);
 
-  // BANK-01: Reconnect a bank — Plaid Link in UPDATE MODE for the existing item. The
-  // server mints the update-mode token from the stored (encrypted) access token; the
-  // browser sees the link token only. After Link's onSuccess there is NO public-token
-  // exchange — reconnect-complete asks /item/get whether the item is healthy and answers
-  // with the HYG-01 envelope, which renders inline (fail-loud, never swallowed).
-  // BANK-01b: a third tone — 'note' — for a plain outcome (a cancel) that is neither ok nor an error.
-  const [reconnectNote, setReconnectNote] = useState<{ itemId: string; text: string; tone: 'ok' | 'error' | 'note' } | null>(null);
-  const [reconnecting, setReconnecting] = useState<string | null>(null);
-  // BANK-01c: a reconnect that went through the OAuth return page left its outcome line
-  // for this row (ok / error / a cancel as the plain tone).
-  useEffect(() => {
-    const back = takeReturnOutcome(window.localStorage, 'reconnect');
-    if (!back || back.flow.kind !== 'reconnect') return;
-    setReconnectNote({ itemId: back.flow.itemId, text: back.outcome.text, tone: back.outcome.tone === 'ok' ? 'ok' : back.outcome.tone === 'error' ? 'error' : 'note' });
-  }, []);
-  const reconnectItem = async (itemId: string, institution: string) => {
-    const plaid = (window as unknown as { Plaid?: { create: (cfg: Record<string, unknown>) => { open(): void } } }).Plaid;
-    if (!plaid) {
-      setReconnectNote({ itemId, text: 'Plaid Link has not loaded yet — try again in a moment.', tone: 'error' });
-      return;
-    }
-    setReconnecting(itemId);
-    setReconnectNote(null);
-    try {
-      const res = await fetch('/api/plaid/link-token', {
-        method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ itemId }),
-      });
-      if (!res.ok) {
-        const out = await readSyncOutcome(res);
-        setReconnectNote({ itemId, text: out.text, tone: 'error' });
-        return;
-      }
-      const { link_token: token, expiration } = (await res.json()) as { link_token: string; expiration?: unknown };
-      if (typeof expiration !== 'string') {
-        setReconnectNote({ itemId, text: 'The link token answer carried no expiration — not opening Plaid Link.', tone: 'error' });
-        return;
-      }
-      // BANK-01c: keep the token + the reconnect flow for the OAuth return page before Link
-      // opens (Plaid's guide: the same link_token must re-open Link after the bank's redirect).
-      keepLinkFlow(window.localStorage, { linkToken: token, flow: { kind: 'reconnect', itemId, institution }, expiresAt: expiration });
-      plaid.create({
-        token,
-        onSuccess: async () => {
-          forgetLinkFlow(window.localStorage, token);
-          const done = await fetch('/api/plaid/reconnect-complete', {
-            method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ itemId }),
-          });
-          const out = await readSyncOutcome(done);
-          setReconnectNote({ itemId, text: out.text, tone: out.tone === 'ok' ? 'ok' : 'error' });
-          await reloadAll();
-        },
-        // BANK-01b: Link's exit is the only place it says why it closed. An error →
-        // the row's line ("Plaid Link: CODE — message") and the report to
-        // /api/plaid/link-exit so the log carries it; a cancel → "Reconnect cancelled".
-        onExit: async (error: LinkExitError | null, metadata: LinkExitMetadata) => {
-          setReconnecting(null);
-          forgetLinkFlow(window.localStorage, token);
-          const exit = linkExitOutcome(error, metadata ?? {}, RECONNECT_CANCELLED, itemId);
-          if (exit.kind === 'connected') return;
-          if (exit.kind === 'cancelled') {
-            setReconnectNote({ itemId, text: exit.note, tone: 'note' });
-            return;
-          }
-          setReconnectNote({ itemId, text: exit.note, tone: 'error' });
-          const posted = await postLinkExit(exit.report);
-          if (!posted.logged) setReconnectNote({ itemId, text: exit.note + notLoggedSuffix(posted.status), tone: 'error' });
-        },
-      }).open();
-    } finally {
-      setReconnecting(null);
-    }
-  };
+  // ACCOUNTS-01: Reconnect is the shared hook now — the SAME update-mode Link,
+  // reconnect-complete and link-exit report step 1's screen (/accounts) drives. Books'
+  // Source Accounts phase is unchanged: it still offers Reconnect on a flagged row.
+  const bank = useBankConnection({ onChanged: () => reloadAll() });
+  const reconnectNote = bank.reconnectNote;
+  const reconnecting = bank.reconnecting;
+  const reconnectItem = bank.reconnect;
 
   const reloadAll = useCallback(async () => {
     setState('loading');

--- a/src/components/home/ModuleLauncher.tsx
+++ b/src/components/home/ModuleLauncher.tsx
@@ -8,7 +8,8 @@ import {
 } from 'lucide-react';
 import { SECTION_HEADER, STATE } from '@/lib/ds';
 import Rail from '@/components/shell/Rail';
-import { readSyncOutcome, syncLine, type SyncOutcome } from '@/lib/plaid/failLoud';
+// ACCOUNTS-01: the connect / sync glue is the shared hook (src/components/bank/useBankConnection.ts).
+import { useBankConnection } from '@/components/bank/useBankConnection';
 import CreateTripForm from '@/components/trips/CreateTripForm';
 import TripBookings from '@/components/trips/TripBookings';
 import UnattachedBookings from '@/components/trips/UnattachedBookings';
@@ -67,11 +68,9 @@ import BookkeepingCockpitBar from '@/components/bookkeeping/BookkeepingCockpitBa
 import BooksPipeline from '@/components/home/BooksPipeline';
 // BANK-01b: the new-item Link's onExit is surfaced too — the reason under the cockpit
 // bar (the sync line's slot), the report to /api/plaid/link-exit for the log.
-import { LINK_CANCELLED, linkExitOutcome, notLoggedSuffix, postLinkExit, type LinkExitError, type LinkExitMetadata } from '@/lib/plaid/linkExit';
 // BANK-01c: the OAuth round trip — the link token and the flow are kept before Link
 // opens (Plaid's guide: local storage, same browser session) so /plaid/oauth-return can
 // re-open Link with the SAME token; the return page's outcome line lands here.
-import { forgetLinkFlow, keepLinkFlow, takeReturnOutcome } from '@/lib/plaid/oauth';
 // TAX-1: the closed-books handoff gate — shows the tax wizard only once a period is
 // closed, otherwise a "close your books first" screen that jumps to the Books tab.
 import TaxHandoffGate from '@/components/home/TaxHandoffGate';
@@ -412,14 +411,6 @@ export default function ModuleLauncher({ onRequireAuth, onTabChange, offerAvaila
     totalAssets: number; totalLiabilities: number; totalEquity: number;
     isBalanced: boolean; hasActivity: boolean; connectedAccounts: number; periodStatus: 'open' | 'closed';
   } | null>(null);
-  const [booksSyncing, setBooksSyncing] = useState(false);
-  // HYG-01: the sync route's returned line (200 ok / 207 partial / non-2xx failure),
-  // rendered inline under the cockpit bar. Cleared when the next sync starts.
-  const [booksSyncMessage, setBooksSyncMessage] = useState<SyncOutcome | null>(null);
-  // Plaid Link token for onLinkAccount (fetched from the auth-gated /api/plaid/link-token).
-  const [booksLinkToken, setBooksLinkToken] = useState<string | null>(null);
-  // BANK-01c: Plaid's `expiration` for that token — the kept round-trip entry expires with it.
-  const [booksLinkExpiration, setBooksLinkExpiration] = useState<string | null>(null);
 
   const loadBooksCockpit = useCallback(async () => {
     setBooksState('loading');
@@ -470,84 +461,14 @@ export default function ModuleLauncher({ onRequireAuth, onTabChange, offerAvaila
   useEffect(() => {
     if (booksLocked) return;
     loadBooksCockpit();
-    // BANK-01c: an OAuth round trip that ended on /plaid/oauth-return left its outcome line
-    // for this banner (the 'new' flow; a reconnect's line goes to its row in the pipe).
-    const back = takeReturnOutcome(window.localStorage, 'new');
-    if (back) setBooksSyncMessage(back.outcome);
-    fetch('/api/plaid/link-token', { method: 'POST' })
-      .then((r) => (r.ok ? r.json() : null))
-      .then((d) => {
-        // BANK-01c: the token is usable only with its expiration — the round-trip entry
-        // must expire with it; a token without one is a contract break, not a link.
-        if (d?.link_token && typeof d.expiration === 'string') {
-          setBooksLinkToken(d.link_token);
-          setBooksLinkExpiration(d.expiration);
-        }
-      })
-      .catch(() => { /* no token → onLinkAccount guards on it, fail-loud (button no-ops until ready) */ });
   }, [booksLocked, loadBooksCockpit]);
 
-  // onSync — faithful to dashboard/page.tsx:348 (syncAccounts): POST the auth-gated
-  // /api/transactions/sync-complete, then re-read the cockpit. No auth weakened.
-  const booksSyncAccounts = async () => {
-    setBooksSyncing(true);
-    setBooksSyncMessage(null);
-    try {
-      const res = await fetch('/api/transactions/sync-complete', { method: 'POST' });
-      // HYG-01: read the declared outcome — a failed or partial sync is shown, never swallowed.
-      setBooksSyncMessage(await readSyncOutcome(res));
-      await loadBooksCockpit();
-    } finally {
-      setBooksSyncing(false);
-    }
-  };
-
-  // onLinkAccount — faithful to dashboard/page.tsx:334 (openPlaidLink): open Plaid Link
-  // with the auth-gated link token; on success POST the auth-gated /api/plaid/exchange-token
-  // then re-read the cockpit. The dashboard's free-tier upgrade-modal branch is intentionally
-  // omitted: this surface and the server routes it calls are both tab:books-gated
-  // (TAB-SHOW-AND-GATE client-side; TAB-SERVER-GATE flipped /api/plaid/link-token +
-  // exchange-token to requireTabAccess('tab:books')) — an unentitled user gets no link
-  // token, so this button no-ops. Guards on token + window.Plaid exactly like the
-  // dashboard (no fallback).
-  const booksLinkAccount = () => {
-    if (!booksLinkToken || !booksLinkExpiration || !(window as any).Plaid) return; // eslint-disable-line @typescript-eslint/no-explicit-any
-    // BANK-01c: keep the token + flow for the OAuth return page before Link opens (Plaid's
-    // guide: the same link_token must re-open Link after the bank's redirect).
-    keepLinkFlow(window.localStorage, { linkToken: booksLinkToken, flow: { kind: 'new' }, expiresAt: booksLinkExpiration });
-    (window as any).Plaid.create({ // eslint-disable-line @typescript-eslint/no-explicit-any
-      token: booksLinkToken,
-      onSuccess: async (publicToken: string, metadata: any) => { // eslint-disable-line @typescript-eslint/no-explicit-any
-        forgetLinkFlow(window.localStorage, booksLinkToken);
-        await fetch('/api/plaid/exchange-token', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            publicToken,
-            institutionId: metadata.institution?.institution_id,
-            institutionName: metadata.institution?.name,
-            entityId: 'personal',
-          }),
-        });
-        await loadBooksCockpit();
-      },
-      // BANK-01b: same wiring as the Reconnect flow — an error → the line under the
-      // cockpit bar ("Plaid Link: CODE — message") and the report to the log; a cancel →
-      // "Account link cancelled". No itemId: there is no item yet.
-      onExit: async (error: LinkExitError | null, metadata: LinkExitMetadata) => {
-        forgetLinkFlow(window.localStorage, booksLinkToken);
-        const exit = linkExitOutcome(error, metadata ?? {}, LINK_CANCELLED);
-        if (exit.kind === 'connected') return;
-        if (exit.kind === 'cancelled') {
-          setBooksSyncMessage(syncLine('ok', exit.note));
-          return;
-        }
-        setBooksSyncMessage(syncLine('error', exit.note));
-        const posted = await postLinkExit(exit.report);
-        if (!posted.logged) setBooksSyncMessage(syncLine('error', exit.note + notLoggedSuffix(posted.status)));
-      },
-    }).open();
-  };
+  // ACCOUNTS-01: the link token, Plaid Link, exchange-token, sync-complete and the OAuth
+  // return line all live in the shared hook now — the SAME glue step 1's screen (/accounts)
+  // and Books' Source Accounts drive, against the same routes. Enabled only for a viewer who
+  // actually sees this surface: a locked tab fetches no token.
+  const bank = useBankConnection({ onChanged: loadBooksCockpit, enabled: !booksLocked });
+  const booksSyncMessage = bank.message;
 
   // Travel register-gate: guests fill the form freely, but "Create trip" while
   // unauthenticated opens the register modal instead of POSTing. Returns true
@@ -1333,9 +1254,9 @@ export default function ModuleLauncher({ onRequireAuth, onTabChange, offerAvaila
                     connectedAccounts={booksData.connectedAccounts}
                     periodLabel={`${new Date().toLocaleString('en-US', { month: 'long' })} ${booksYear}`}
                     periodStatus={booksData.periodStatus}
-                    onSync={booksSyncAccounts}
-                    syncing={booksSyncing}
-                    onLinkAccount={booksLinkAccount}
+                    onSync={bank.syncAccounts}
+                    syncing={bank.syncing}
+                    onLinkAccount={bank.linkAccount}
                   />
                 )}
                 {booksSyncMessage && (

--- a/src/components/shell/Rail.tsx
+++ b/src/components/shell/Rail.tsx
@@ -13,8 +13,10 @@
  * under the family navigation has one here. Nothing is retyped.
  *
  * Open / collapsed is REACT STATE ONLY — no localStorage, no sessionStorage, no
- * cookie (SHELL-01 forbids browser storage): open on load, collapsed to a strip
- * of step numbers when the viewer says so, for as long as the page lives.
+ * cookie (SHELL-01 forbids browser storage). ACCOUNTS-01: that state is held by
+ * the provider the ROOT LAYOUT mounts (src/components/shell/RailState.tsx), which
+ * client navigation never unmounts — so a collapsed rail stays collapsed as you
+ * walk from one step's room to another.
  *
  * Doors: on the cockpit a cockpit-hosted room opens in place through the SAME
  * selectTab funnel the family menu used (onSelectModule — the URL is written as
@@ -39,6 +41,7 @@ import { TOOL_GATE } from '@/lib/offer';
 import { FLOW_ORDER, STEPS, stepBySlug, stepGates, stepHref, stepLinks, stepOfTool, stepStatus, stepsOf, type Step } from '@/lib/steps';
 import { COCKPIT_PRIMARY_TOOL, type ToolDoor } from '@/lib/toolRegistry';
 import { StatusChip } from '@/components/home/ToolChrome';
+import { useRailState } from '@/components/shell/RailState';
 
 interface Props {
   /** The cockpit's active section key (ModuleLauncher activeModule). Absent off the cockpit. */
@@ -93,7 +96,9 @@ function stepLocked(step: Step, entitledKeys: readonly string[] | undefined, isA
 
 export default function Rail({ activeModule, onSelectModule, entitledKeys, isAdmin = false }: Props) {
   const pathname = usePathname();
-  const [open, setOpen] = useState(true);
+  // Above the pages, so navigating between steps does not reopen a collapsed rail.
+  const { open, setOpen } = useRailState();
+  // The drawer is per-page and ephemeral: it closes when you pick a step.
   const [drawer, setDrawer] = useState(false);
   const drawerButton = useRef<HTMLButtonElement>(null);
   const active = activeStepOf(pathname, activeModule);

--- a/src/components/shell/RailState.tsx
+++ b/src/components/shell/RailState.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+/**
+ * ACCOUNTS-01 — the rail's open/collapsed state, held ABOVE the pages.
+ *
+ * SHELL-01 kept it in the Rail itself, which is mounted per page: navigating
+ * from one room to another unmounted the rail and reset it to open. The state
+ * lives here instead, in a provider the ROOT LAYOUT mounts
+ * (src/app/layout.tsx → Providers), which client navigation never unmounts — so
+ * a collapsed rail stays collapsed as you walk the steps.
+ *
+ * Still REACT STATE ONLY: no localStorage, no sessionStorage, no cookie
+ * (SHELL-01's rule, unchanged) — it lasts as long as the tab, not longer.
+ */
+import { createContext, useContext, useMemo, useState } from 'react';
+
+interface RailState {
+  open: boolean;
+  setOpen: (next: boolean | ((previous: boolean) => boolean)) => void;
+}
+
+const RailStateContext = createContext<RailState | null>(null);
+
+export function RailStateProvider({ children }: { children: React.ReactNode }) {
+  const [open, setOpen] = useState(true);
+  const value = useMemo(() => ({ open, setOpen }), [open]);
+  return <RailStateContext.Provider value={value}>{children}</RailStateContext.Provider>;
+}
+
+/** The rail's state. Throws when the provider is missing — the root layout mounts it, so its absence is a bug, not a state to paper over. */
+export function useRailState(): RailState {
+  const value = useContext(RailStateContext);
+  if (!value) throw new Error('useRailState: no RailStateProvider above this rail — the root layout (src/app/layout.tsx → Providers) mounts it');
+  return value;
+}

--- a/src/components/ui/AppLayout.tsx
+++ b/src/components/ui/AppLayout.tsx
@@ -5,6 +5,10 @@ import { useSession, signOut } from 'next-auth/react';
 import { useEffect, useState, Suspense } from 'react';
 import TripCreationBar from '@/components/trips/TripCreationBar';
 import ShellBar from '@/components/ui/ShellBar';
+// ACCOUNTS-01: the rail is on every signed-in page. AppLayout is where most rooms
+// mount their shell, so mounting it here gives them all the same navigation — its
+// open/collapsed state lives above the pages (RailState), so walking does not reset it.
+import Rail from '@/components/shell/Rail';
 
 export interface LedgerMetrics {
   balance: number;
@@ -49,6 +53,8 @@ interface CookieUser {
   name: string;
   /** /api/auth/me → isAdmin (src/lib/admin.ts, ADMIN_USER_ID in the env); gates the utilities menu. */
   isAdmin?: boolean;
+  /** /api/auth/me → entitledCategories; the rail's lock chip reads these (no second request). */
+  entitledCategories?: string[];
 }
 
 // ─── Route Groups ────────────────────────────────────────────────────────────
@@ -185,6 +191,11 @@ export default function AppLayout({ children, ledgerMetrics, engineMetrics, onOp
         onSignOut={handleSignOut}
       />
 
+      <div className="flex flex-1 min-w-0 flex-col sm:flex-row">
+      <Rail
+        entitledKeys={(currentUser as CookieUser | null | undefined)?.entitledCategories}
+        isAdmin={Boolean((currentUser as { isAdmin?: boolean } | null | undefined)?.isAdmin)}
+      />
       <div className="flex-1 min-w-0 flex flex-col">
         {/* Travel Search Bar (only on Travel routes) */}
         {showTravelSearch && (
@@ -278,6 +289,7 @@ export default function AppLayout({ children, ledgerMetrics, engineMetrics, onOp
         )}
 
         <main className="max-w-[1800px] mx-auto w-full">{children}</main>
+      </div>
       </div>
     </div>
   );

--- a/src/lib/__tests__/accountsView.test.ts
+++ b/src/lib/__tests__/accountsView.test.ts
@@ -1,0 +1,112 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  ACCOUNT_GROUPS, RETIREMENT_SUBTYPES, UNKNOWN_WORD, describeWord, groupAccounts, groupOf,
+  isReported, money, rowsOf, when, type ApiItem,
+} from '../accountsView';
+
+// ACCOUNTS-01 — step 1's screen never invents a number and never invents a word.
+// The page it replaced did both: it called balance.toFixed(2) straight, and stamped
+// lastSync with `new Date()` — a value the database never held.
+
+test('money: null, undefined, NaN and Infinity all render "—"; a real number renders as money, including zero', () => {
+  assert.equal(money(null), '—');
+  assert.equal(money(undefined), '—');
+  assert.equal(money(Number.NaN), '—');
+  assert.equal(money(Number.POSITIVE_INFINITY), '—');
+  assert.equal(money(0), '$0.00', 'a reported zero IS a number — it is not the same as no answer');
+  assert.equal(money(1234.5), '$1,234.50');
+  assert.equal(money(-42), '-$42.00');
+});
+
+test('when: a missing or unparseable timestamp renders "—" — never today\'s date as a stand-in', () => {
+  assert.equal(when(null), '—');
+  assert.equal(when(undefined), '—');
+  assert.equal(when(''), '—');
+  assert.equal(when('not a date'), '—');
+  assert.equal(when('2026-09-09T12:00:00.000Z'), 'Sep 9, 2026');
+});
+
+test('a missing type or subtype says so; a reported one is passed through, trimmed', () => {
+  assert.equal(describeWord(null), UNKNOWN_WORD);
+  assert.equal(describeWord(undefined), UNKNOWN_WORD);
+  assert.equal(describeWord('   '), UNKNOWN_WORD);
+  assert.equal(describeWord(' checking '), 'checking');
+  assert.equal(isReported('checking'), true);
+  assert.equal(isReported(null), false);
+  assert.equal(isReported('  '), false);
+});
+
+test('grouping is by the account\'s own type: depository and credit are Banking, loan is Debt, an unknown type is Unrecognized — never re-filed on a guess', () => {
+  assert.equal(groupOf({ type: 'depository', subtype: 'checking' }), 'banking');
+  assert.equal(groupOf({ type: 'credit', subtype: 'credit card' }), 'banking');
+  assert.equal(groupOf({ type: 'loan', subtype: 'student' }), 'debt');
+  assert.equal(groupOf({ type: 'payroll', subtype: null }), 'unrecognized');
+  assert.equal(groupOf({ type: null, subtype: null }), 'unrecognized');
+});
+
+test('a known retirement subtype goes to Retirement; an unknown investment subtype stays in its type\'s group (Brokerage) and is labelled unknown', () => {
+  for (const subtype of ['401k', '403b', 'ira', 'roth', 'hsa', '529']) {
+    assert.equal(groupOf({ type: 'investment', subtype }), 'retirement', subtype);
+  }
+  // as the institution actually writes them — case and punctuation vary
+  assert.equal(groupOf({ type: 'investment', subtype: '403B' }), 'retirement');
+  assert.equal(groupOf({ type: 'investment', subtype: 'Roth' }), 'retirement');
+  assert.equal(groupOf({ type: 'investment', subtype: 'sep_ira' }), 'retirement');
+  assert.equal(groupOf({ type: 'investment', subtype: 'ROTH 401K' }), 'retirement');
+  // brokerage and cash management are taxable
+  assert.equal(groupOf({ type: 'investment', subtype: 'brokerage' }), 'brokerage');
+  assert.equal(groupOf({ type: 'investment', subtype: 'cash management' }), 'brokerage');
+  // an investment subtype nobody recognises: its TYPE's group, and the word says it is unknown to us
+  assert.equal(groupOf({ type: 'investment', subtype: 'mystery wrapper' }), 'brokerage');
+  assert.equal(groupOf({ type: 'investment', subtype: null }), 'brokerage');
+  assert.equal(describeWord(null), UNKNOWN_WORD);
+  assert.ok(RETIREMENT_SUBTYPES.includes('401k'));
+});
+
+const items: ApiItem[] = [
+  {
+    id: 'item-1', institutionName: 'First Bank', lastErrorCode: null,
+    accounts: [
+      { id: 'a1', name: 'Checking', type: 'depository', subtype: 'checking', mask: '1111', balance: 100.5, entityType: 'business', updatedAt: '2026-09-01T00:00:00.000Z' },
+      { id: 'a2', name: 'Card', type: 'credit', subtype: 'credit card', mask: '2222', balance: null, entityType: null, updatedAt: null },
+    ],
+  },
+  {
+    id: 'item-2', institutionName: null, lastErrorCode: 'ITEM_LOGIN_REQUIRED',
+    accounts: [
+      { id: 'a3', name: 'Roth', type: 'investment', subtype: 'roth', mask: '3333', balance: 900, entityType: null, updatedAt: null },
+      { id: 'a4', name: 'Something', type: 'crypto', subtype: null, mask: null, balance: 7, entityType: null, updatedAt: null },
+    ],
+  },
+];
+
+test('rows carry their institution and their item\'s error; groups keep ACCOUNT_GROUPS order, and a group total is null when NO row carries a number', () => {
+  const rows = rowsOf(items);
+  assert.equal(rows.length, 4);
+  assert.deepEqual(rows.map((r) => r.institutionName), ['First Bank', 'First Bank', null, null]);
+  assert.deepEqual(rows.map((r) => r.lastErrorCode), [null, null, 'ITEM_LOGIN_REQUIRED', 'ITEM_LOGIN_REQUIRED']);
+  assert.deepEqual(rows.map((r) => r.itemId), ['item-1', 'item-1', 'item-2', 'item-2']);
+
+  const groups = groupAccounts(rows);
+  assert.deepEqual(groups.map((g) => g.key), ACCOUNT_GROUPS.map((g) => g.key));
+  const by = Object.fromEntries(groups.map((g) => [g.key, g]));
+  assert.deepEqual(by.banking.rows.map((r) => r.id), ['a1', 'a2']);
+  assert.equal(by.banking.total, 100.5, 'the one reported balance — the null is not counted as zero');
+  assert.deepEqual(by.retirement.rows.map((r) => r.id), ['a3']);
+  assert.deepEqual(by.unrecognized.rows.map((r) => r.id), ['a4']);
+  assert.equal(by.debt.rows.length, 0);
+  assert.equal(by.debt.total, null, 'no rows → no total, and "—" on the screen; never $0.00');
+  assert.equal(money(by.debt.total), '—');
+  // Fixed Assets has no feed at all and never gains one from the data
+  assert.equal(by['fixed-assets'].rows.length, 0);
+  assert.match(by['fixed-assets'].noFeed ?? '', /entered by hand, and that is not built/);
+  // every group names what would appear there, so an empty one is never blank
+  for (const g of groups) assert.ok(g.empty.trim().length > 10, `${g.key} says what belongs there`);
+});
+
+test('an item with no accounts contributes no rows, and an absent accounts list does not throw', () => {
+  assert.deepEqual(rowsOf([{ id: 'x', institutionName: 'Bank', lastErrorCode: null, accounts: [] }]), []);
+  assert.deepEqual(rowsOf([{ id: 'x', institutionName: 'Bank', lastErrorCode: null } as ApiItem]), []);
+  assert.deepEqual(rowsOf([]), []);
+});

--- a/src/lib/accountsView.ts
+++ b/src/lib/accountsView.ts
@@ -1,0 +1,149 @@
+/**
+ * ACCOUNTS-01 — what step 1's screen shows, as pure functions over the API's
+ * real shape (/api/accounts → { items: [{ institutionName, accounts: [...] }] }).
+ *
+ * Two rules the old page broke, kept here so no renderer can break them again:
+ *   1. A NUMBER IS NEVER INVENTED. A null / undefined / non-finite balance
+ *      renders "—", never NaN and never a silent 0 (the old page called
+ *      account.balance.toFixed(2) straight, and read a fabricated lastSync of
+ *      `new Date()` — a value the database never held).
+ *   2. A MISSING WORD SAYS SO. A null type or subtype renders
+ *      "unknown — reported by the institution", never a guess.
+ *
+ * GROUPING is by what the account IS, from Plaid's own type/subtype:
+ *   depository, credit → Banking      (a card is a bank feed; what is owed on
+ *                                      it shows as its balance)
+ *   loan               → Debt
+ *   investment         → Retirement when the subtype is a retirement wrapper,
+ *                        else Brokerage (an unrecognized investment subtype
+ *                        stays in its type's group and is labelled unknown —
+ *                        it is never re-filed on a guess)
+ *   anything else      → Unrecognized (named, never hidden, never re-filed)
+ * Fixed Assets has no feed at all: the screen states that; this module gives it
+ * a group with no members so the renderer never invents one.
+ */
+
+export interface ApiAccount {
+  id: string;
+  name: string;
+  type: string | null;
+  subtype: string | null;
+  mask: string | null;
+  balance: number | null;
+  entityType: string | null;
+  /** The row's last write (a sync, or an entity assignment) — accounts.updatedAt. NOT a sync timestamp: the product records none. */
+  updatedAt?: string | null;
+}
+
+export interface ApiItem {
+  id: string;
+  institutionName: string | null;
+  lastErrorCode: string | null;
+  lastErrorAt?: string | null;
+  accounts: ApiAccount[];
+}
+
+/** One row of the screen: the account, flattened onto its institution. */
+export interface AccountRow extends ApiAccount {
+  itemId: string;
+  institutionName: string | null;
+  lastErrorCode: string | null;
+}
+
+export type GroupKey = 'banking' | 'brokerage' | 'retirement' | 'debt' | 'fixed-assets' | 'unrecognized';
+
+export interface GroupDef {
+  key: GroupKey;
+  label: string;
+  /** What WOULD appear here — shown verbatim when the group is empty. Never "nothing yet". */
+  empty: string;
+  /** A group no feed can ever fill (Fixed Assets): stated, never a form. */
+  noFeed?: string;
+}
+
+export const ACCOUNT_GROUPS: readonly GroupDef[] = [
+  { key: 'banking', label: 'Banking', empty: 'Checking, savings and credit-card accounts you connect through your bank.' },
+  { key: 'brokerage', label: 'Brokerage', empty: 'Taxable investment accounts — brokerage and cash management.' },
+  { key: 'retirement', label: 'Retirement', empty: 'Retirement wrappers your institution reports as such — 401(k), 403(b), IRA, Roth, HSA, 529.' },
+  { key: 'debt', label: 'Debt', empty: 'Loan accounts — mortgage, student, auto. A credit card is listed under Banking, where the balance is what you owe.' },
+  { key: 'fixed-assets', label: 'Fixed Assets', empty: 'Property and equipment.', noFeed: 'No feed — a fixed asset is entered by hand, and that is not built. Nothing here is connected, and nothing here is estimated.' },
+  { key: 'unrecognized', label: 'Unrecognized', empty: 'Accounts whose type this product does not yet file.' },
+];
+
+/**
+ * The investment subtypes that mean "retirement wrapper". Matched case- and
+ * punctuation-insensitively against what the institution actually reports
+ * (Plaid sends e.g. "401k", "403B", "roth", "ira", "hsa", "529"). An investment
+ * subtype outside this set is NOT assumed to be one — it stays in Brokerage and
+ * shows the institution's own word.
+ */
+export const RETIREMENT_SUBTYPES: readonly string[] = ['401k', '401a', '403b', '457b', '529', 'ira', 'roth', 'roth 401k', 'sep ira', 'simple ira', 'sarsep', 'hsa', 'keogh', 'pension', 'retirement', 'stock plan', 'thrift savings plan'];
+
+const norm = (s: string | null | undefined): string => (typeof s === 'string' ? s.trim().toLowerCase().replace(/[_-]+/g, ' ') : '');
+
+export const UNKNOWN_WORD = 'unknown — reported by the institution';
+
+/** A type or subtype as the institution reported it; a missing one says it is missing. */
+export function describeWord(value: string | null | undefined): string {
+  return typeof value === 'string' && value.trim() ? value.trim() : UNKNOWN_WORD;
+}
+
+/** Whether a word is one the institution actually gave (drives the "unknown" styling). */
+export function isReported(value: string | null | undefined): boolean {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+/**
+ * A balance as money. Null, undefined, NaN and Infinity all render "—" — the
+ * screen says it does not know, and never shows a number the data never had.
+ */
+export function money(value: number | null | undefined, currency = 'USD'): string {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return '—';
+  return value.toLocaleString('en-US', { style: 'currency', currency, minimumFractionDigits: 2, maximumFractionDigits: 2 });
+}
+
+/** A timestamp as a date, or "—". Never "just now", never today's date as a stand-in. */
+export function when(value: string | null | undefined): string {
+  if (typeof value !== 'string' || !value.trim()) return '—';
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return '—';
+  return d.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
+}
+
+/** Which group an account belongs in — from its own type and subtype, never from its name. */
+export function groupOf(account: Pick<ApiAccount, 'type' | 'subtype'>): GroupKey {
+  const type = norm(account.type);
+  if (type === 'depository' || type === 'credit') return 'banking';
+  if (type === 'loan') return 'debt';
+  if (type === 'investment') {
+    return RETIREMENT_SUBTYPES.includes(norm(account.subtype)) ? 'retirement' : 'brokerage';
+  }
+  return 'unrecognized';
+}
+
+export interface AccountGroup extends GroupDef {
+  rows: AccountRow[];
+  /** The group's total, or null when NO row carries a number — null renders "—", never 0. */
+  total: number | null;
+}
+
+/** Every item's accounts flattened onto their institution, in the order the API gave them. */
+export function rowsOf(items: readonly ApiItem[]): AccountRow[] {
+  return items.flatMap((item) =>
+    (item.accounts ?? []).map((account) => ({
+      ...account,
+      itemId: item.id,
+      institutionName: item.institutionName,
+      lastErrorCode: item.lastErrorCode ?? null,
+    })),
+  );
+}
+
+/** The screen's groups, in ACCOUNT_GROUPS order, each with its rows and its honest total. */
+export function groupAccounts(rows: readonly AccountRow[]): AccountGroup[] {
+  return ACCOUNT_GROUPS.map((group) => {
+    const mine = rows.filter((r) => groupOf(r) === group.key);
+    const numbers = mine.map((r) => r.balance).filter((b): b is number => typeof b === 'number' && Number.isFinite(b));
+    return { ...group, rows: mine, total: numbers.length ? numbers.reduce((a, b) => a + b, 0) : null };
+  });
+}


### PR DESCRIPTION
**Do not merge — Alex merges after Vercel Preview (SOC 2 gate).**

Step 1 of the rail ("What you own → Connected accounts") was a dead screen: a loose client page with no shell, no rail, and a runtime exception on load. It is now a real screen that reuses Books' connect/sync/reconnect glue instead of copying it, and the rail is mounted for every signed-in page by the shell — with a build law that keeps it that way.

---

## HARD GATE

| Gate | Touched? | Note |
|---|---|---|
| Auth | **no** | `/accounts` stays a middleware-protected path; `/api/accounts` keeps its existing `verifyCookie()` → `getCurrentUser()` → tab gate. No gate added, removed or relaxed. |
| Migrations | **no** | No `schema.prisma` change, no SQL, no `ALTER TABLE`. `updatedAt` already exists on `accounts`. |
| Cost / paid calls | **no** | No new Plaid call, route or product. The screen drives the **existing** `/api/plaid/link-token`, `/api/plaid/exchange-token`, `/api/plaid/sync-complete`, `/api/plaid/reconnect-complete` through the same hook Books uses. |
| Security | **no** | Every read is the already user-scoped `/api/accounts`. No new route. |
| User financial data | **read-only** | Nothing writes a balance or a transaction. The one write is the pre-existing `/api/accounts/update-entity` (entity label), unchanged. |

---

## STEP 0 — AUDIT (read-only, before any edit)

### 0.1 — Why `/accounts` threw in production

**The ruling named `account.balance.toFixed(2)` (`src/app/accounts/page.tsx:133`) as the crash. I read both files first — that is not the cause.** `currentBalance` is `Float?`, and the route coerced it: `balance: account.currentBalance || 0` (`src/app/api/accounts/route.ts:45` on `main`). `balance` was therefore *always* a number, and `.toFixed` could not throw. Reported rather than repeated.

**The real crash is the transactions block:**

| Fact | Citation |
|---|---|
| The route returns an **object**, not an array | `src/app/api/transactions/route.ts:139` — `return NextResponse.json({ transactions: transformedTransactions });` |
| The page stored that object as if it were the array | `src/app/accounts/page.tsx:76` (on `main`) — `setTransactions(transactionsData);` |
| The render called an array method on it | `src/app/accounts/page.tsx:146` (on `main`) — `{transactions.slice(0, 10).map(...)}` |

`transactions.slice is not a function` — an unhandled TypeError thrown during render, killing the page for **every** viewer who got past the tab gate (entitled or admin). The `try/catch` at `:79` only wraps the fetch; a render-phase throw escapes it. This is why the screen was blank in production rather than merely empty.

The rebuild does not carry the transactions panel at all: step 1 is *connected accounts*, and recent transactions are Books' job (Phase 02), which already renders them correctly.

### 0.2 — What the old page did that was not true

| Line (on `main`) | Finding |
|---|---|
| `page.tsx:12` + the row render | `lastSync` was **fabricated client-side** — the product records no per-account sync timestamp. |
| `route.ts:45` | `\|\| 0` turned "the institution reported nothing" into "$0.00" — a silent fallback, forbidden by CLAUDE.md. |
| `page.tsx:1-23` | `'use client'` page with **no shell**: no header, no rail, no door. |
| `page.tsx` overall | 169 lines, **4 eslint errors / 1 warning**, `any` throughout, its own `<select>` entity writer. |

### 0.3 — What already exists and must be reused, not rewritten

| Concern | Existing owner | Citation |
|---|---|---|
| Link token → Plaid Link → exchange → sync | `ModuleLauncher` | `src/components/home/ModuleLauncher.tsx` (Books cockpit bar) |
| Update-mode Link (reconnect a flagged item) | `BooksPipeline` | `src/components/home/BooksPipeline.tsx` (Phase 01, Source Accounts) |
| Fail-loud sync reading | `src/lib/plaid/failLoud.ts` | `readSyncOutcome`, `syncLine`, `linkExitOutcome`, `postLinkExit`, `notLoggedSuffix` |
| Link-flow handoff across the OAuth return | `src/lib/plaid/oauth.ts` | `keepLinkFlow`, `forgetLinkFlow`, `takeReturnOutcome` |
| The account list | `/api/accounts` | `src/app/api/accounts/route.ts` — already gated and user-scoped |
| Entity label write | `/api/accounts/update-entity` | pre-existing route |
| The shell + bar | `src/components/ui/ShellFrame.tsx` | as `/step/[slug]` mounts it |

**Two copies of the same glue existed** (launcher + pipeline). Rather than adding a third for `/accounts`, both were extracted into one hook and rewired to it.

### 0.4 — The shell scan (corrected)

My first scan grepped only `page.tsx` files and reported `/operations/*` as shell-less — wrong: `src/app/operations/layout.tsx` already mounts `AppLayout`. **Rescanned walking every ancestor `layout.tsx`.** Across **68 pages**, 16 mounted no shell.

The deeper finding: **`AppLayout` did not render the rail at all**, so ~28 pages that *did* wear a shell still had no rail. Fixing `AppLayout` was worth more than wrapping pages one by one.

**Wrapped in `AppLayout` (6 signed-in rooms):** `/auto`, `/business`, `/growth`, `/health`, `/home`, `/personal` — each was a bare `<BudgetingPage …/>`.

**Deliberately NOT wrapped, and why:**

| Page | Reason |
|---|---|
| `/developer` | Carries its own full-screen gate; wrapping it needs a restyle. The ruling says **report, don't restyle** — reported here. |
| `/login`, `/plaid/oauth-return`, `/trips/rsvp`, `/trips/[id]` | Flow / guest pages — a rail on them would be a door to nowhere for a signed-out visitor. |
| `/booking/confirm`, `/how-pricing-works`, `/privacy`, `/terms`, `/work-with-me` | Public marketing / legal pages — outside the signed-in shell. |

---

## STEP 1 — `/accounts` is a real screen

`src/app/accounts/page.tsx` is now 24 lines: read the verified cookie for the bar's viewer, mount `ShellFrame`, render the client. **0 eslint errors / 0 warnings** (was 4/1).

- **`src/lib/accountsView.ts` (new, pure)** — `money()` returns **`—` for null / undefined / NaN / Infinity** and `$0.00` only for a genuinely reported zero; `when()` returns `—` for a missing or unparseable date and **never stands in today's date**; `groupOf()` maps type/subtype to one of six groups; `groupAccounts()` returns `total: null` when no row in a group carries a number (a group of unknowns shows no total rather than a false one).
- **Grouping** — Banking (`depository`, `credit`), Brokerage, Retirement (by subtype: `401k`, `403B`, `Roth`, `sep_ira`, `ROTH 401K`, …), Debt (`loan`), Fixed assets (**no feed** — nothing connects here), Unrecognized. The ruling let `credit` fall in either Banking or Debt; resolved **deterministically to Banking** (first listed, and how Plaid groups it), with Debt's empty line saying where cards are.
- **Connect / Sync / Reconnect** come from the shared hook — no new Plaid code.
- **`Last updated`** is `accounts.updatedAt` (newly surfaced by the route), labelled as the row's last write with a footnote stating plainly that **the product records no per-account sync time**. The old page's fabricated `lastSync` is gone rather than reproduced.
- **Entity select** writes optimistically to the existing `/api/accounts/update-entity` and **reverts on failure with the route's own error text** — no swallowed catch.
- The route's error text (including the tab gate's 403) is rendered verbatim; the screen never invents a reason.

### `src/app/api/accounts/route.ts` — two honest changes, no new route

| Before (`main`) | After | Why |
|---|---|---|
| `balance: account.currentBalance \|\| 0` (`:45`) | `balance: account.currentBalance` (`:48`) | The `\|\| 0` was itself a silent fallback. A missing balance is now missing. |
| — | `updatedAt: account.updatedAt` (`:52`) | So the screen can show a real timestamp instead of inventing one. |

**Every live reader of `/api/accounts` was read before dropping the coercion:** `AnswersClient` counts rows only; `ModuleLauncher` counts rows only (its money comes from `/api/trial-balance`); `BooksPipeline` coerces for itself; both `ImportDataSection` copies are dead code. No caller can now receive `undefined` where it expected a number.

---

## Reuse, not rewrite — one hook, three surfaces

**`src/components/bank/useBankConnection.ts` (new)** is the connect/sync/reconnect glue, extracted **verbatim** from the two places it already lived:

```ts
useBankConnection({ onChanged, enabled })
  → { ready, linkAccount, syncAccounts, syncing, message, setMessage,
      reconnect, reconnecting, reconnectNote }
```

| Surface | Before | After |
|---|---|---|
| `ModuleLauncher` | 4 inline state decls + link-token effect + `booksLinkAccount` + `booksSyncAccounts` | `useBankConnection({ onChanged: loadBooksCockpit, enabled: !booksLocked })` |
| `BooksPipeline` | its own inline reconnect block | `useBankConnection({ onChanged: () => reloadAll() })` |
| `AccountsClient` | *(did not exist)* | the same hook |

**Books' Phase 01 (Source Accounts) was not deleted** — it still renders its own accounts view and its own reconnect affordance; only the glue underneath moved to the shared copy. No route, no component, no product was created for Plaid.

---

## STEP 2 — the rail is on every signed-in page

- **`src/components/ui/AppLayout.tsx`** now mounts `<Rail entitledKeys={…} isAdmin={…} />` inside a `flex` row — one change that gave the rail to every page already wearing `AppLayout`.
- **`src/components/shell/RailState.tsx` (new)** lifts open/collapsed into a provider mounted in `src/components/Providers.tsx` (inside `SessionProvider`, i.e. in the **root layout**), so **the rail does not remount or reset on client navigation**. Still **React state only — no localStorage, no sessionStorage, no cookie**, as the steps law requires.

---

## STEP 3 — the law extension

`scripts/assert-tool-registry.ts`'s steps law now requires **every step screen to wear a shell**, checking the page file *and every ancestor `layout.tsx`*:

```
✔ The steps law passed — 12 steps over 6 families in flow order, every one of 25 jobs
  walked once, every screen a page file that wears the shell; the rail and the sheet
  render from steps.ts.
```

**Negative proof** — stripping `AppLayout` from `/business` fails the build:

```
BUDGET: /business (src/app/business/page.tsx) mounts no shell — the rail must be
on every step's screen (ShellFrame, AppLayout, or the cockpit, in the page or a
layout above it)
```

The Rail's no-storage law was also tightened: it previously matched its own doc comment ("no localStorage, no sessionStorage"). The regex now matches real access only — `/(?:local|session)Storage\s*[.[]/`.

---

## VERIFY

| Check | Result |
|---|---|
| `npx tsc --noEmit` | **exit 0** |
| `npm run lint` | **854 problems (576 errors, 278 warnings)** vs `main`'s **859 (580, 279)** — **five fewer, zero new** |
| `src/app/accounts/page.tsx` | **4 errors / 1 warning → 0 / 0** |
| All five new files | **0 / 0** |
| `npm test` | **268 / 268** (`main`: 261 — `accountsView.test.ts` adds 7) |
| Full build (all eleven asserts) | **exit 0** |
| Reachability law | `✔ 68 pages, every one has a door` |
| Steps law | `✔ 12 steps over 6 families … every screen a page file that wears the shell` |

**The 7 new tests pin the honesty rules:** `money` → `—` for null/undefined/NaN/Infinity but `$0.00` for a reported zero; `when` never stands in today's date; known retirement subtypes land in Retirement; an *unknown* investment subtype falls to Brokerage (its type's group) and carries the label `unknown — reported by the institution`; a group with no numbers has `total: null`.

**Live probe** (dev server, six seeded accounts): groups `banking:3, brokerage:2, retirement:1, debt:0, fixed-assets:0, unrecognized:0`; the null balance rendered `—`; two empty states and the no-feed block rendered; **collapsing the rail, walking to `/books`, and returning to `/accounts` kept `data-rail-open="false"` throughout** — the state survives navigation. Phone width shows the drawer toggle and all six groups. Screenshots are in the session chat (audit output is never committed — the repo is public).

`Connect` read `Connect — loading Plaid…` on the probe because `/api/plaid/link-token` 500s on fake sandbox credentials — the only 500s in the run were link-token, `/api/travel/locations/countries` and `/api/workbench/corpus-context`. **No 500 came from `/accounts`.**

---

## FILES TOUCHED — 19 files, +928 / −347

**New (5)**
- `src/lib/accountsView.ts` — the pure view leaf
- `src/lib/__tests__/accountsView.test.ts` — 7 tests
- `src/components/bank/useBankConnection.ts` — the one copy of the Plaid glue
- `src/components/accounts/AccountsClient.tsx` — step 1's screen
- `src/components/shell/RailState.tsx` — the rail's cross-navigation state

**Changed (14)**
- `src/app/accounts/page.tsx` — 169 loose lines → 24, shell-mounted
- `src/app/api/accounts/route.ts` — drop the `|| 0`, add `updatedAt`
- `src/components/home/ModuleLauncher.tsx`, `src/components/home/BooksPipeline.tsx` — rewired to the hook
- `src/components/ui/AppLayout.tsx` — mounts the rail
- `src/components/Providers.tsx` — mounts `RailStateProvider`
- `src/components/shell/Rail.tsx` — reads the provider
- `src/app/{auto,business,growth,health,home,personal}/page.tsx` — wrapped in `AppLayout`
- `scripts/assert-tool-registry.ts` — the shell requirement + the tightened storage regex

---

## FINDINGS FOR ALEX

1. **The ruling's stated crash cause was wrong** — `balance.toFixed` could not throw (the route coerced). The real killer was `transactions.slice` on an object (§0.1). Fixed by not carrying that panel; the underlying route is untouched and Books renders transactions correctly.
2. **`/developer` still has no rail** — it carries its own full-screen gate and wrapping it needs a restyle, which the ruling puts out of scope. Reported, not redirected, not hidden.
3. **The product records no per-account sync time.** `Last updated` is the row's last write, and the screen says so. If a true "last synced at" is wanted, that is a schema change — a separate, migration-bearing PR.
4. **The old page's `lastSync` was fabricated data on a customer surface.** It is gone. Worth checking whether any other screen invents a timestamp the same way.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc

---
_Generated by [Claude Code](https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc)_