### PR TITLE
ACCOUNTS-01b: step 1's tools live at step 1 — Banking's home is /accounts, Brokerage's is /trading

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,8 +285,8 @@ The app lands on `/answers` — HOME: the four answers, then the whole sheet (25
 
 | # | Step | Family | Status | Opens | Jobs |
 |---|---|---|---|---|---|
-| 1 | ACCOUNTS | WHAT YOU OWN | PARTIAL | `/accounts` | Banking (PARTIAL), Brokerage (PARTIAL), Retirement (NOT_BUILT), Fixed Assets (NOT_BUILT) |
-| 2 | TRADING | WHAT YOU OWN | PARTIAL | `/trading` | Trade Log (PARTIAL) |
+| 1 | ACCOUNTS | WHAT YOU OWN | PARTIAL | `/accounts` | Banking (PARTIAL), Retirement (NOT_BUILT), Fixed Assets (NOT_BUILT) |
+| 2 | TRADING | WHAT YOU OWN | PARTIAL | `/trading` | Brokerage (PARTIAL), Trade Log (PARTIAL) |
 | 3 | BOOKS | THE PROOF | LIVE | `/books` | Bookkeeping (LIVE) |
 | 4 | TAX | THE PROOF | PARTIAL | `/tax` | Tax (PARTIAL) |
 | 5 | COMPLIANCE | THE PROOF | PARTIAL | `/compliance` | Compliance (PARTIAL) |

--- a/src/lib/__tests__/steps.test.ts
+++ b/src/lib/__tests__/steps.test.ts
@@ -54,14 +54,19 @@ test('a step with no room opens /step/<slug>; one with a room opens the room', (
 
 test('sub-links are derived from the registry — every door the family navigation gave a page, the rail gives it too; the step\'s own screen is not repeated and an href is listed once', () => {
   const byStep = Object.fromEntries(STEPS.map((s) => [s.slug, stepLinks(s).map((l) => (l.door.kind === 'none' ? 'none' : l.door.href))]));
-  assert.deepEqual(byStep.accounts, ['/books', '/trade', '/trading']);
+  // ACCOUNTS-01b: step 1 has NO sub-link — Banking's home is the step's own screen
+  // (dropped as the step row's own door) and Retirement and Fixed Assets are
+  // NOT_BUILT. Step 2 keeps one room: /trade, the cockpit tab that carries the
+  // grade and the coverage declaration, which /trading does not.
+  assert.deepEqual(byStep.accounts, []);
+  assert.deepEqual(byStep.trading, ['/trade']);
   assert.deepEqual(byStep.books, ['/chart-of-accounts']);
   assert.deepEqual(byStep.tax, ['/dashboard/tax-filing']);
   assert.deepEqual(byStep.compliance, ['/?tab=compliance', '/soc2']);
   assert.deepEqual(byStep.travel, ['/budgets/trips']);
   assert.deepEqual(byStep.budget, ['/personal', '/home', '/auto', '/growth', '/health', '/shopping', '/hub/itinerary', '/runway']);
   assert.deepEqual(byStep.operations, ['/agenda', '/routines', '/operations/issues', '/operations/audit-log', '/content', '/operations']);
-  for (const slug of ['fpa', 'owed', 'sales', 'spend']) assert.deepEqual(byStep[slug], [], `${slug} has no door to give`);
+  for (const slug of ['accounts', 'fpa', 'owed', 'sales', 'spend']) assert.deepEqual(byStep[slug], [], `${slug} has no door to give`);
   // no step repeats its own screen, and no href twice within a step
   for (const s of STEPS) {
     const hrefs = stepLinks(s).map((l) => (l.door.kind === 'none' ? 'none' : l.door.href));
@@ -79,7 +84,10 @@ test('the room at /content is labelled Narrative — label only, the route is un
 
 test('a step names the entitlement keys its jobs are gated by — the tab keys, from the offer\'s gate map', () => {
   assert.deepEqual(stepGates(stepBySlug('books')!, TOOL_GATE), ['tab:books']);
-  assert.deepEqual(stepGates(stepBySlug('accounts')!, TOOL_GATE), ['tab:books', 'tab:trade']);
+  // ACCOUNTS-01b: step 1 is tab:books only — the key /api/accounts actually asks
+  // for (route.ts:22). Brokerage's tab:trade walks with step 2, where it is used.
+  assert.deepEqual(stepGates(stepBySlug('accounts')!, TOOL_GATE), ['tab:books']);
+  assert.deepEqual(stepGates(stepBySlug('trading')!, TOOL_GATE), ['tab:trade', 'tab:books']);
   assert.deepEqual(stepGates(stepBySlug('travel')!, TOOL_GATE), []);
   assert.deepEqual(stepGates(stepBySlug('sales')!, TOOL_GATE), [], 'CRM is the founder\'s own surface (gate "owner"), not a sold tab');
 });
@@ -119,4 +127,30 @@ test('the law rejects: a job in two steps, a job in no step, a numbering gap, a 
   // and it throws by default
   assert.throws(() => stepsLaw({ steps: dropped }), StepsLawError);
   assert.throws(() => stepsLaw({ steps: dropped }), /STEPS LAW: /);
+});
+
+test('ACCOUNTS-01b — a job\'s home lives inside its own step: neither the registry home nor the door the rail opens may be another step\'s screen', () => {
+  // the real steps hold it: every home is its own step's screen, or no step's screen at all
+  const owner = new Map(STEPS.flatMap((s) => (s.screen ? [[s.screen, s] as const] : [])));
+  for (const s of STEPS) {
+    for (const t of toolsOfStep(s)) {
+      if (t.home === null) continue;
+      const held = owner.get(t.home);
+      assert.ok(!held || held.slug === s.slug, `${t.name}: home ${t.home} is ${held?.name}'s screen, not ${s.name}'s`);
+    }
+  }
+
+  // the bug this rule exists to stop: Banking's home back at /books, step 3's room
+  const asBanking = (facts: Partial<ToolEntry>) =>
+    TOOL_REGISTRY.map((t) => (t.name === 'Banking' ? { ...t, ...facts } : t));
+  const homeOut = stepsLaw({ throwOnFail: false, registry: asBanking({ home: '/books' }) }).join('\n');
+  assert.match(homeOut, /Banking: home \/books is BOOKS's screen, but Banking sits in ACCOUNTS — a job's home is inside its own step/);
+
+  // and the door, not only the home: a home inside the step whose cockpitKey points out of it
+  const doorOut = stepsLaw({ throwOnFail: false, registry: asBanking({ cockpitKey: 'books' }) }).join('\n');
+  assert.match(doorOut, /Banking: door \/books is BOOKS's screen, but Banking sits in ACCOUNTS/);
+  assert.doesNotMatch(doorOut, /Banking: home/, 'the home is /accounts and legal — only the door it resolves through is not');
+
+  // a home that is no step's screen is fine — Calendar's /agenda and Time's /content are rooms, not steps
+  assert.deepEqual(stepsLaw({ throwOnFail: false }), []);
 });

--- a/src/lib/steps.ts
+++ b/src/lib/steps.ts
@@ -17,7 +17,11 @@
  *   4. steps are numbered 1..12 with no gaps, in the order listed;
  *   5. a step's screen is a route or null; a step with no screen holds no LIVE
  *      tool (nothing finished hides behind an honest page);
- *   6. slugs are unique and kebab-case.
+ *   6. slugs are unique and kebab-case;
+ *   7. (ACCOUNTS-01b) a job's HOME lives inside its own step — neither the home
+ *      the registry names nor the DOOR the rail opens for it (doorOf, which
+ *      prefers a cockpit path) may be another step's screen. Without this the
+ *      rail sent step 1 ACCOUNTS to /books, step 3's room.
  * The build adds what only the filesystem can answer: every non-null screen
  * resolves to a page file.
  */
@@ -47,8 +51,14 @@ export interface Step {
 }
 
 export const STEPS: readonly Step[] = [
-  { number: 1, slug: 'accounts', name: 'ACCOUNTS', family: 'WHAT YOU OWN', tools: ['Banking', 'Brokerage', 'Retirement', 'Fixed Assets'], screen: '/accounts' },
-  { number: 2, slug: 'trading', name: 'TRADING', family: 'WHAT YOU OWN', tools: ['Trade Log'], screen: '/trading' },
+  // ACCOUNTS-01b: Brokerage walks with step 2, not step 1. Its home is /trading —
+  // step 2's screen — and rule 7 below holds a job's home inside its own step. Both
+  // steps are WHAT YOU OWN, so rule 2 is untouched; the counts and every status are.
+  // It also fixes a gate mismatch: /api/accounts is tab:books-gated (route.ts:22),
+  // so step 1 carrying Brokerage's tab:trade told a trade-only viewer the step was
+  // open when its data route would 403 them.
+  { number: 1, slug: 'accounts', name: 'ACCOUNTS', family: 'WHAT YOU OWN', tools: ['Banking', 'Retirement', 'Fixed Assets'], screen: '/accounts' },
+  { number: 2, slug: 'trading', name: 'TRADING', family: 'WHAT YOU OWN', tools: ['Brokerage', 'Trade Log'], screen: '/trading' },
   { number: 3, slug: 'books', name: 'BOOKS', family: 'THE PROOF', tools: ['Bookkeeping'], screen: '/books' },
   { number: 4, slug: 'tax', name: 'TAX', family: 'THE PROOF', tools: ['Tax'], screen: '/tax' },
   { number: 5, slug: 'compliance', name: 'COMPLIANCE', family: 'THE PROOF', tools: ['Compliance'], screen: '/compliance' },
@@ -199,6 +209,30 @@ export function stepsLaw(opts: { throwOnFail?: boolean; steps?: readonly Step[];
     if (s.screen !== null) continue;
     const live = s.tools.filter((n) => registry.find((t) => t.name === n)?.status === 'LIVE');
     if (live.length) violations.push(`${s.name}: no screen, but ${live.join(', ')} ${live.length === 1 ? 'is' : 'are'} LIVE — a finished job has a room`);
+  }
+
+  // 7. a job's home is inside its own step — never another step's screen
+  // (ACCOUNTS-01b). Both the registry's `home` and the door the rail actually
+  // opens are checked: doorOf prefers a tool's cockpit path over its home, so a
+  // home inside the step with a cockpitKey pointing out of it would still send
+  // the rail to another step's room — the exact bug this rule exists to stop.
+  const screenOwner = new Map<string, Step>();
+  for (const s of steps) if (s.screen) screenOwner.set(s.screen, s);
+  for (const s of steps) {
+    for (const name of s.tools) {
+      const tool = registry.find((t) => t.name === name);
+      if (!tool || tool.home === null) continue;
+      const seen = new Set<string>();
+      const door = doorOf(tool);
+      for (const [what, href] of [['home', tool.home], ['door', door.kind === 'none' ? null : door.href]] as const) {
+        if (href === null || seen.has(href)) continue;
+        seen.add(href);
+        const owner = screenOwner.get(href);
+        if (owner && owner.slug !== s.slug) {
+          violations.push(`${name}: ${what} ${href} is ${owner.name}'s screen, but ${name} sits in ${s.name} — a job's home is inside its own step`);
+        }
+      }
+    }
   }
 
   if (violations.length && opts.throwOnFail !== false) throw new StepsLawError(violations.join('\n  '));

--- a/src/lib/toolRegistry.ts
+++ b/src/lib/toolRegistry.ts
@@ -146,22 +146,37 @@ const FACTS: Readonly<Record<ToolName, ToolFacts>> = {
     note: 'Six category pages, reachable from no menu until this PR; the draft form works on /business only (coaAccounts, census note B).',
   },
   // ── WHAT YOU OWN ──
+  // ACCOUNTS-01b: Banking's home is its OWN screen. Until ACCOUNTS-01 the tool had
+  // no room of its own, so the registry pointed it at Books' Source Accounts phase
+  // and carried /accounts as a "legacy page" link. /accounts is now step 1's screen
+  // and shows these accounts, so the home IS /accounts and the link is gone (a tool
+  // does not link to itself). No cockpitKey: Banking is no longer a cockpit section.
   Banking: {
-    slug: 'banking', status: 'PARTIAL', beats: some({ discover: true }), home: '/books', cockpitKey: 'books',
-    links: [{ label: 'Accounts · the legacy page', href: '/accounts' }],
-    citation: 'src/components/home/BooksPipeline.tsx:296 (Source Accounts) · src/app/api/accounts/route.ts:6; no transfer route exists',
+    slug: 'banking', status: 'PARTIAL', beats: some({ discover: true }), home: '/accounts',
+    citation: 'src/components/accounts/AccountsClient.tsx:118 (connect) · :127 (sync) · :201 (reconnect), through src/components/bank/useBankConnection.ts:83 · :101 · :122 · :164 · src/app/api/accounts/route.ts:6; no transfer route exists',
   },
   'Fixed Assets': { slug: 'fixed-assets', status: 'NOT_BUILT', beats: NONE, home: null, citation: 'TOOL CENSUS row 15 — no depreciation or placed-in-service field' },
   Retirement: { slug: 'retirement', status: 'NOT_BUILT', beats: NONE, home: null, citation: 'TOOL CENSUS row 16 — 1099-R intake at src/app/api/tax/calculate/route.ts:250 is Tax' },
+  // ACCOUNTS-01b: the home is /trading, the full room — it is the only surface that
+  // CONNECTS a brokerage (src/app/trading/page.tsx:263 /api/tastytrade/connect) and it
+  // carries chains, positions and the journal. The cockpit's Trade tab connects
+  // nothing, so it was never this tool's home; the old "Standalone cockpit" link is
+  // deleted because the standalone cockpit IS the home. /trade keeps its door from
+  // Trade Log's "Grade · on the Trade tab" link — see that row.
   Brokerage: {
-    slug: 'brokerage', status: 'PARTIAL', beats: some({ discover: true, decide: true }), home: '/trade', cockpitKey: 'trade',
-    links: [{ label: 'Standalone cockpit · chains, connect, observatory, journal', href: '/trading' }],
+    slug: 'brokerage', status: 'PARTIAL', beats: some({ discover: true, decide: true }), home: '/trading',
     citation: 'src/app/api/tastytrade/chains/route.ts:58 · scanner/route.ts:205 · src/app/api/trade-cards/route.ts:72 (status queued :92); no order is ever sent (ConvergenceIntelligence.tsx:840)',
   },
+  // ACCOUNTS-01b: home /books → /trading. Trade Log sits in step 2 TRADING, whose
+  // screen is /trading — a job's home may not be another step's screen (the steps
+  // law). /trading is where the job is done for a customer: it posts the balanced
+  // entry (page.tsx:640 → api/trading/commit-to-ledger/route.ts:168 postJournal) and
+  // saves the journal (page.tsx:733 → /api/trading-journal). The Books pipeline
+  // still READS investment transactions; that is Bookkeeping's row, not this one.
   'Trade Log': {
-    slug: 'trade-log', status: 'PARTIAL', beats: some({ discover: true, commit: true, record: true }), home: '/books', cockpitKey: 'books',
+    slug: 'trade-log', status: 'PARTIAL', beats: some({ discover: true, commit: true, record: true }), home: '/trading',
     links: [{ label: 'Grade · on the Trade tab', cockpitKey: 'trade' }],
-    citation: 'src/app/api/transactions/sync-complete/route.ts:185 → :242 · investment-transactions/commit-to-ledger/route.ts:106 → src/lib/position-tracker-service.ts:170, :307-311 · :601, :619; no persisted draft',
+    citation: 'src/app/trading/page.tsx:640 → src/app/api/trading/commit-to-ledger/route.ts:168 · page.tsx:733 → /api/trading-journal · src/app/api/transactions/sync-complete/route.ts:185 → :242 · investment-transactions/commit-to-ledger/route.ts:106 → src/lib/position-tracker-service.ts:170, :307-311 · :601, :619; no persisted draft',
   },
   // ── WHAT YOU OWE ──
   Debt: { slug: 'debt', status: 'NOT_BUILT', beats: NONE, home: null, citation: 'TOOL CENSUS row 19 — src/app/api/net-worth/route.ts:36 is a totals read; no schedule, no lender' },


### PR DESCRIPTION
**Do not merge — Alex merges after Vercel Preview (SOC 2 gate).**

The rail listed three sub-links under step 1 ACCOUNTS that left step 1. All three are gone, and a new law stops them coming back. **Statuses, beats and counts unchanged: 2 LIVE · 9 PARTIAL · 14 NOT_BUILT.**

> ⚠️ **One ruling contradiction, resolved by Alex mid-task.** Brokerage's ruled home `/trading` **is** step 2 TRADING's screen, so STEP 1 and the STEP 3 law could not both hold while Brokerage sat in step 1. Alex chose **move Brokerage to step 2**. Detail in §Findings 1.

---

## HARD GATE

| Gate | Touched? | Note |
|---|---|---|
| Auth | **no** | No gate added, removed or relaxed. `TOOL_GATE` is byte-identical — Banking `tab:books`, Brokerage `tab:trade`, Trade Log `tab:books`. What changed is which *step* carries which key, and it now matches the routes (§Findings 2). |
| Migrations | **no** | No `schema.prisma`, no SQL. |
| Cost / paid calls | **no** | No route added, moved or called. Registry `home`/`links` are link metadata. |
| Security | **no** | No page moved or deleted. |
| User financial data | **untouched** | Nothing reads or writes it in this diff. |

---

## STEP 0 — AUDIT (read-only, before any edit)

### 0.1 — The six registry rows, as they stood on `main`

| Row | Status · beats | home | cockpitKey | links | citation (`src/lib/toolRegistry.ts`) |
|---|---|---|---|---|---|
| **Banking** `:149-153` | PARTIAL · discover | `/books` | `books` | `Accounts · the legacy page` → `/accounts` | `BooksPipeline.tsx:296 · api/accounts/route.ts:6` |
| **Brokerage** `:156-160` | PARTIAL · discover, decide | `/trade` | `trade` | `Standalone cockpit · chains, connect, observatory, journal` → `/trading` | `tastytrade/chains:58 · scanner:205 · trade-cards:72` |
| **Retirement** `:155` | NOT_BUILT · none | `null` | — | — | census row 16 |
| **Fixed Assets** `:154` | NOT_BUILT · none | `null` | — | — | census row 15 |
| **Trade Log** `:161-165` | PARTIAL · discover, commit, record | `/books` | `books` | `Grade · on the Trade tab` → cockpit `trade` | `sync-complete:185→:242 · investment-transactions/commit-to-ledger:106` |
| **Bookkeeping** `:171-175` | LIVE · four | `/books` | `books` | `Chart of accounts` → `/chart-of-accounts` | `BooksPipeline.tsx:198 · journal-entry-service.ts:131` |

### 0.2 — `steps.ts`: how a sub-link is derived

- `stepLinks` (`src/lib/steps.ts:124-140`) — for each job it adds **`doorOf(tool)`** (`:135`) then every `doorOfLink` (`:137`); the step's own screen is dropped (`:126`) and an href is listed once (`:130`).
- `doorOf` (`toolRegistry.ts:237-241`) — **cockpitKey wins over home**: `if (tool.cockpitKey) return COCKPIT_PATH[tool.cockpitKey]`. So Banking's door was `/books` twice over.
- `doorOfLink` `:244-248` · `ROOM_LABELS` `steps.ts:69-71` (only `/content` → `Narrative`) · `stepHref` `:74`.

### 0.3 — The reachability law's door accounting (`scripts/assert-tool-registry.ts:200-259`)

Doors are pushed from `stepHref(step)` + `stepLinks(step)` (`:210-215`), the sheet's steps + `FAMILY_READS` (`:216-219`), `OWNER_UTILITIES` (`:220`), `GUEST_ROUTES` (`:221`) and the answers (`:223-224`). Then **`:253` every page must have a door** and **`:257` every door must point at a page**. `findDoor` (`:230-235`) prefers an exact match, so **the first door pushed for a route owns it** — which is why `/trading` was credited to step 1's "Standalone cockpit" link rather than to step 2, its own screen.

### 0.4 — Every reader of Banking.home and Brokerage.home

Grepped `.home`, `doorOf`, `doorOfLink`, `COCKPIT_PATH`, `COCKPIT_PRIMARY_TOOL` across `src/` and `scripts/`:

| Reader | Reads | Moves with this PR? |
|---|---|---|
| `steps.ts:135,137` → `Rail.tsx`, `TheSheet.tsx`, `/step/[slug]` | `doorOf` / `doorOfLink` | **yes — this is the rail** |
| `assert-tool-registry.ts:183,196` | `t.home` → census table + `pageFor` | yes (table text only) |
| `Rail.tsx:70-73` `activeStepOf` | `COCKPIT_PRIMARY_TOOL[activeModule]` → `stepOfTool` | **yes** — on the cockpit's Trade tab the rail now highlights **2. TRADING** instead of 1. ACCOUNTS. Correct. |
| `offer.ts:191-196` `claimForCockpit` | `COCKPIT_PRIMARY_TOOL` | no — reads status/beats, not home. **Has no caller today** (grepped); kept, the offer law still checks it. |
| `answersState.ts:61-62` | Bookkeeping's home only | no |
| `AnswersClient.tsx:244` | `ANSWER_READS[].home` (`answers.ts`) | no — a different structure |
| `toolRegistry.ts:279-285`, `steps.test.ts:77` | the laws / a Time assertion | no |

**Nothing besides the rail moves.** `COCKPIT_PRIMARY_TOOL` and `COCKPIT_PATH` are untouched.

### 0.5 — Does `/trade` still earn a link? (the ruling's condition)

- **A page file exists**: `src/app/[tab]/page.tsx` serves it — `TAB_PATHS` includes `'trade'` (`:45-47`), and `pageFor` resolves it that way (`assert:174`).
- **It shows something `/trading` does not**: the cockpit's Trade section mounts **`TradeRecord`** (`ModuleLauncher.tsx:1125`) and **`CoverageDeclaration`** (`:1127`); `/trading` imports neither.
- Conversely `/trading` has what `/trade` lacks: **`/api/tastytrade/connect`** (`trading/page.tsx:263`), positions (`:297`), chains (`:367`), the journal (`:733`), `DataObservatory`, `CalendarGrid`, `COAManagementTable`.

**So `/trade` is kept as a link — carried by Trade Log's existing `Grade · on the Trade tab`, which names exactly the surface `/trading` lacks.** No second link was added to Brokerage: `stepLinks` lists an href once (`:130`), so a duplicate would only shadow that label with a vaguer one. Both jobs now sit in step 2, so the one row serves both.

---

## STEP 1 — the registry tells the truth about where these tools live

### Each row, before → after

| Row | Field | Before | After |
|---|---|---|---|
| **Banking** | home | `/books` | **`/accounts`** |
| | cockpitKey | `books` | **removed** — it is not a cockpit section any more |
| | links | `Accounts · the legacy page` → `/accounts` | **deleted** — the legacy page *is* the home |
| | citation | `BooksPipeline.tsx:296 · api/accounts/route.ts:6` | **`AccountsClient.tsx:118` (connect) · `:127` (sync) · `:201` (reconnect), through `useBankConnection.ts:83 · :101 · :122 · :164` · `api/accounts/route.ts:6`** |
| **Brokerage** | home | `/trade` | **`/trading`** |
| | cockpitKey | `trade` | **removed** |
| | links | `Standalone cockpit …` → `/trading` | **deleted** — the standalone cockpit *is* the home |
| **Trade Log** | home | `/books` | **`/trading`** (§Findings 3) |
| | cockpitKey | `books` | **removed** |
| | links | `Grade · on the Trade tab` | **kept, unchanged** — it is what carries `/trade`'s door |
| | citation | sync-complete + investment-transactions | **prefixed** with `trading/page.tsx:640 → api/trading/commit-to-ledger/route.ts:168` (postJournal) and `page.tsx:733 → /api/trading-journal`; the old cites are kept |
| **Retirement**, **Fixed Assets** | — | NOT_BUILT, `home: null` | **unchanged** — the accounts screen groups them; the tools are not built |
| **Bookkeeping** | — | LIVE, `/books`, cockpit `books` | **unchanged** |

Removing a `cockpitKey` is necessary, not cosmetic: `doorOf` prefers it over `home`, so leaving `books` on Banking would have kept the rail pointing at `/books` no matter what the home said.

### `steps.ts` — Brokerage walks with step 2

```
1 ACCOUNTS  /accounts   Banking, Retirement, Fixed Assets     (was: … Brokerage …)
2 TRADING   /trading    Brokerage, Trade Log                  (was: Trade Log)
```

Both steps are `WHAT YOU OWN`, so rule 2 (a step's jobs are its family's) is untouched, and the twelve steps, their numbers, families, screens and flow order are otherwise byte-identical.

---

## STEP 2 — the rail reads right

### `stepLinks`, before → after

| Step | Before | After |
|---|---|---|
| **1 ACCOUNTS** | `Banking` → `/books` **← step 3's screen** · `Brokerage` → `/trade` · `Standalone cockpit …` → `/trading` **← step 2's screen** | **(none)** |
| **2 TRADING** | `Trade Log` → `/books` **← step 3's screen** · `Grade · on the Trade tab` → `/trade` | `Grade · on the Trade tab` → **`/trade`** |

**Step 1 now yields no sub-link at all** — Banking's home is the step's own screen (dropped as the step row's own door) and Retirement and Fixed Assets are NOT_BUILT. **Step 2 TRADING's room still reaches `/trading`**: the step row *is* `/trading`, and its one sub-link is `/trade`. Screenshots of both are in the session chat (audit output is never committed — the repo is public).

### Reachability, before → after

```
before:  pages: 68 · doors: 72
after:   pages: 68 · doors: 68
✔ Reachability law passed — 68 pages, every one has a door.
```

**No page lost a door.** Four doors were removed because they were wrong or duplicate: Banking → `/books`, Brokerage → `/trade` (from step 1), `Standalone cockpit` → `/trading`, Trade Log → `/books`.

**Six pages changed door OWNER — every one to a truer owner:**

| Page | Before | After |
|---|---|---|
| `/trading` | rail · 1. ACCOUNTS · "Standalone cockpit · chains, connect, observatory, journal" | rail · **2. TRADING** |
| `/dashboard` | redirect → /books (rail: 1. ACCOUNTS · "Banking") | redirect → /books (rail: **3. BOOKS**) |
| `/journal-entries` | ″ | ″ |
| `/ledger` | ″ | ″ |
| `/statements` | ″ | ″ |
| `/transactions` | ″ | ″ |

Those five are `/books` redirects that were being credited to step 1 only because step 1's Banking door was pushed first.

---

## STEP 3 — the law

`stepsLaw` gains **rule 7** (`src/lib/steps.ts`): *a job's home lives inside its own step — never another step's screen.*

It checks **both** the registry `home` **and the door the rail actually opens** (`doorOf`), because `doorOf` prefers a cockpit path over the home: a home inside the step whose `cockpitKey` points out of it would still send the rail to another step's room — the exact bug this rule exists to stop.

**Negative proof — `Banking.home` back at `/books`:**

```
StepsLawError: STEPS LAW: Banking: home /books is BOOKS's screen, but Banking sits
in ACCOUNTS — a job's home is inside its own step
    at stepsLaw (src/lib/steps.ts:238:62)
ASSERT EXIT 1
```

**And the door half — home stays `/accounts`, `cockpitKey: 'books'` restored:**

```
StepsLawError: STEPS LAW: Banking: door /books is BOOKS's screen, but Banking sits
in ACCOUNTS — a job's home is inside its own step
```

Both throw at **module scope** (`steps.ts:242`), so the import itself fails — the build cannot proceed past it. The registry was restored and the assert is green again.

---

## VERIFY

| Check | Result |
|---|---|
| `npx tsc --noEmit` | **exit 0** |
| `npm run lint` | **854 problems (576 errors, 278 warnings)** — identical to `main`; **zero new**. Per-file, all three source files: **0 errors / 0 warnings on `main` and now.** |
| `npm test` | **269 / 269** (`main`: 268 — +1, the rule-7 test) |
| Full build (eleven laws) | **exit 0** |
| Census | `counts: LIVE 2 · PARTIAL 9 · NOT_BUILT 14 (census 2/9/14) · sheet cells 25` — **unchanged** |
| Reachability | `✔ 68 pages, every one has a door` · `pages: 68 · doors: 68` (was 72) |
| Steps law | `✔ 12 steps over 6 families in flow order, every one of 25 jobs walked once, every screen a page file that wears the shell` |
| Registry law | `✔ 25/25 cells, homes resolve to page files, counts match the census` |
| Live probe | dev server, admin viewer: **step 1 open on `/accounts` renders zero rooms**; **step 2 open on `/trading` renders one room, `Grade · on the Trade tab` → `/trade`**. The only 500 was `/api/plaid/link-token` (fake sandbox credentials) — none from `/accounts` or `/trading`. |

**Tests changed** (`src/lib/__tests__/steps.test.ts`), each reflecting the ruled move:
- `byStep.accounts` `['/books','/trade','/trading']` → **`[]`**; new `byStep.trading` → **`['/trade']`**
- `stepGates('accounts')` `['tab:books','tab:trade']` → **`['tab:books']`**; new `stepGates('trading')` → **`['tab:trade','tab:books']`**
- **new test** for rule 7: the real steps hold it; `Banking.home = '/books'` is rejected by name; `cockpitKey: 'books'` with a legal home is rejected on the **door** and explicitly **not** on the home.

---

## FILES TOUCHED — 4 files, +98 / −15

| File | Change |
|---|---|
| `src/lib/toolRegistry.ts` | Banking, Brokerage, Trade Log rows — homes, cockpitKeys, links, two citations |
| `src/lib/steps.ts` | Brokerage moves step 1 → step 2; rule 7 in `stepsLaw` + the law's doc comment |
| `src/lib/__tests__/steps.test.ts` | four assertions updated, one test added |
| `README.md` | the steps table's two rows, regenerated by the generator (run twice, byte-stable) |

No component, no page, no route, no `scripts/` file changed — the rail and the sheet already render from `steps.ts`, so they picked this up with no edit.

---

## FINDINGS FOR ALEX

1. **The ruling could not satisfy itself.** STEP 1 sets `Brokerage.home = '/trading'`; STEP 3's law forbids a home that is another step's screen; `/trading` **is** step 2 TRADING's screen (`steps.ts:51`). STEP 2's "step 1 yields no cross-step door" failed the same way. I stopped and put it to you rather than guessing; you chose **move Brokerage to step 2**, which is what this PR does. The two alternatives were: keep the twelve steps frozen and leave Brokerage's home at `/trade` (legal — no step owns `/trade` — but that surface cannot connect a brokerage), or weaken the law to "another *family's* step screen".

2. **The move fixed a gate mismatch you did not ask about.** `/api/accounts` gates on **`tab:books` alone** (`src/app/api/accounts/route.ts:22`). Step 1 also carried Brokerage's `tab:trade`, and `stepLocked` treats "one key in hand" as unlocked — so a **trade-only subscriber saw step 1 ACCOUNTS as open while its data route would 403 them**. Step 1 is now `tab:books` only.

3. **Trade Log's home had the same disease and was not in your STEP 1 list.** Its home was `/books` — step 3's screen — while it sits in step 2. Rule 7 rejects it, so it had to move; `/trading` is where the job is actually done for a customer: it posts the balanced entry (`trading/page.tsx:640` → `api/trading/commit-to-ledger/route.ts:168` `postJournal`) and saves the journal (`page.tsx:733` → `/api/trading-journal`). Its citation now names those first. Its status, beats and `Grade` link are unchanged.

4. **`claimForCockpit` (`offer.ts:191`) has no caller.** Grepped `src/`: nothing imports it. The offer law still validates it, so it costs nothing, but the free showcases it was written for do not read it. Flagging, not touching.

5. **Two pre-existing homes are legal but worth knowing**: Calendar's `/agenda` and Time's `/content` are no step's screen — rooms, not steps. Rule 7 permits that by design; only *another step's screen* is forbidden.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc

---
_Generated by [Claude Code](https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc)_