### PR TITLE
OBSERVATORY-01: the observatory measures or says nothing — every feed carries its cost

### DIFF
--- a/scripts/assert-tool-registry.ts
+++ b/scripts/assert-tool-registry.ts
@@ -99,6 +99,7 @@ import { KIND_VIEWS_HONEST_LINE, KIND_VIEW_CENSUS, STOPPED_TABLES, VIEW_COLUMNS,
 // SELL-02: the offer law — every sales claim from the registry, every price from one source.
 import { FREE_TOOLS, OFFERS, TOOL_GATE, heroCountsLine, offerCard, offerLaw, priceEnvName } from '../src/lib/offer';
 import { DYNAMIC_READ_ENV, LIBRARY_READ_ENV } from '../src/lib/envLaw';
+import { FEED_COST, FEED_IDS, SCAN_COST, feedCostLaw, scanCostLine } from '../src/lib/observatory/feedCost';
 import { PURCHASABLE_ENTITLEMENT_KEYS } from '../src/lib/stripe';
 
 /**
@@ -546,11 +547,19 @@ for (const e of LIBRARY_READ_ENV) {
   else if (!row.includes(e.readBy)) violations.push(`env: README.md's row for ${e.name} does not name its reader '${e.readBy}'`);
 }
 
+// The FIRST gate: everything checked above this line. Laws below push onto the
+// same list and are raised by the second gate at the end of this file.
+// OBSERVATORY-01 found that gate missing: the kind-views law (below) pushed
+// violations no gate ever read, so it could not fail a build. `raised` marks
+// what this gate already reported so the second one does not repeat it.
 if (violations.length) {
   console.error('\n✖ TOOL REGISTRY LAW FAILED:');
   for (const v of violations) console.error(`  ${v}`);
   process.exit(1);
 }
+// Nothing above survived unreported (the gate exits), so this is 0 — it marks
+// where the second gate starts reading, and says so rather than assuming it.
+const raised = violations.length;
 console.log('✔ Tool registry law passed — 25/25 cells, homes resolve to page files, counts match the census.');
 console.log(`✔ Reachability law passed — ${pages.length} pages, every one has a door (the rail, the sheet, the utilities menu, a listed route, or a redirect to one).`);
 console.log(`✔ The steps law passed — ${STEPS.length} steps over ${FLOW_ORDER.length} families in flow order, every one of ${TOOL_REGISTRY.length} jobs walked once, every screen a page file that wears the shell; the rail and the sheet render from steps.ts.`);
@@ -586,4 +595,64 @@ console.log(`✔ The rule book law passed — ${RULE_BOOK.length} rules, ${callS
 console.log(`✔ The kind views law passed — ${ARRIVAL_KINDS.length} views over ${KIND_VIEW_CENSUS.length} feed tables, each once, the kind from the rule book; posting unions nothing; ${STOPPED_TABLES.length} tables reported, not viewed.`);
 console.log(`✔ The posting law passed — every journal and ledger row is created by postJournal.ts (SET CONSTRAINTS ALL IMMEDIATE first, one statement for the lines, read back after commit); ${postingPaths.size} files post through it.`);
 console.log(`✔ The env law passed — ${srcEnv.size} names read as src literals, ${libraryEnv.size} read by a library (src/lib/envLaw.ts), ${dynamicEnv.size} by a computed key; every one documented in README.md, nothing documented that nothing reads.`);
+// ── THE OBSERVATORY LAW (OBSERVATORY-01) ──────────────────────────
+// The observatory measures or says nothing. It rendered a 33-row
+// HARDCODED_SOURCES array — typed statuses, typed latencies, typed values, dates
+// frozen at 2026-03-02 — whenever no check had run, and a spend decision was
+// read off it. No file under src/components/data-observatory may hold a typed
+// array of statuses, latencies or record counts again: the pattern is banned by
+// name, and by shape for a renamed copy.
+violations.push(...feedCostLaw({ throwOnFail: false }));
+const OBSERVATORY_DIR = 'src/components/data-observatory';
+const BANNED_NAMES = /\b(HARDCODED_[A-Z_]+|SAMPLE_[A-Z_]+|MOCK_[A-Z_]+|FALLBACK_[A-Z_]+)\b/;
+// A typed measurement: an object literal carrying a status AND a latency or a
+// record count, written into source rather than measured.
+const TYPED_MEASUREMENT = /status:\s*'(LIVE|BROKEN|PARTIAL|MKT-HRS|SKIPPED)'[^\n]*(latency|records):/;
+const NOT_MEASURED_MARK = 'data-not-measured';
+const observatoryFiles = existsSync(resolve(ROOT, OBSERVATORY_DIR))
+  ? readdirSync(resolve(ROOT, OBSERVATORY_DIR)).filter((f) => f.endsWith('.tsx') || f.endsWith('.ts'))
+  : [];
+if (observatoryFiles.length === 0) violations.push(`observatory: ${OBSERVATORY_DIR} holds no file — the screen is the law's subject`);
+let observatoryRowsTyped = 0;
+for (const f of observatoryFiles) {
+  const rel = `${OBSERVATORY_DIR}/${f}`;
+  const src = readFileSync(resolve(ROOT, rel), 'utf8');
+  // The doc comment names the deleted array on purpose; only real code counts.
+  const code = src.split('\n').filter((l) => !/^\s*(\*|\/\/|\/\*)/.test(l)).join('\n');
+  const named = code.match(BANNED_NAMES);
+  if (named) {
+    observatoryRowsTyped += 1;
+    violations.push(`observatory: ${rel} declares ${named[0]} — the observatory measures or says nothing; no typed status, latency or record array`);
+  }
+  const shaped = code.match(TYPED_MEASUREMENT);
+  if (shaped) {
+    observatoryRowsTyped += 1;
+    violations.push(`observatory: ${rel} writes a status with a latency or record count into source (${shaped[0].slice(0, 60)}…) — a row renders only from a measurement`);
+  }
+}
+const observatorySrc = observatoryFiles.includes('DataObservatory.tsx')
+  ? readFileSync(resolve(ROOT, `${OBSERVATORY_DIR}/DataObservatory.tsx`), 'utf8')
+  : '';
+if (!observatorySrc) violations.push(`observatory: ${OBSERVATORY_DIR}/DataObservatory.tsx is missing — it is the screen`);
+else if (!observatorySrc.includes(NOT_MEASURED_MARK)) {
+  violations.push(`observatory: DataObservatory.tsx must render the not-measured state (${NOT_MEASURED_MARK}) — with no check run there is nothing to show`);
+}
+console.log('THE OBSERVATORY — what each feed costs, read from the call sites');
+for (const id of FEED_IDS) {
+  const c = FEED_COST[id];
+  console.log(`${String(id).padStart(2, '0')}  ${c.provider.padEnd(11)} ${(c.billable ? 'METERED' : 'not metered').padEnd(12)} ${String(c.upstreamCalls).padStart(2)} call(s)  probes ${c.probes.padEnd(9)} scan: ${c.usedByScan ? 'yes' : 'NO '}  ${c.scanCitation.slice(0, 72)}`);
+}
+console.log(scanCostLine());
+console.log(`✔ The observatory law passed — ${FEED_IDS.length} feeds each carry provider, metered, calls and scan use; ${observatoryFiles.length} file(s) under ${OBSERVATORY_DIR} hold ${observatoryRowsTyped} typed measurement(s); the screen renders a not-measured state. One scan of one symbol: ${SCAN_COST.filter((c) => (c.callsPerSymbol ?? 0) > 0).map((c) => `${c.callsPerSymbol} ${c.provider}`).join(' · ')}.`);
 console.log(`✔ The offer law passed — ${OFFERS.length} offers over ${new Set(OFFERS.flatMap((o) => o.tools)).size} tools (LIVE or PARTIAL only), ${FREE_TOOLS.length} free; the purchasable keys are the offers'; "built and running" typed nowhere but offer.ts; ${SELLING_SURFACES.length} selling surfaces render the offer.`);
+
+// ── THE SECOND GATE ─────────────────────────────────────────────────────────
+// Every law below the first gate — kind views, arrivals, the rule book,
+// posting, env, the observatory, the offer — pushes onto `violations`. Without
+// this, those pushes were printed by nothing and failed nothing. A law that
+// cannot fail the build is not a law.
+if (violations.length > raised) {
+  console.error('\n✖ BUILD LAW FAILED:');
+  for (const v of violations.slice(raised)) console.error(`  ${v}`);
+  process.exit(1);
+}

--- a/src/app/api/data-observatory/check/route.ts
+++ b/src/app/api/data-observatory/check/route.ts
@@ -3,6 +3,8 @@ import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { requireAdmin } from '@/lib/require-admin';
 import { prisma } from '@/lib/prisma';
 import { getTastytradeClient } from '@/lib/tastytrade';
+// OBSERVATORY-01: what each feed costs, derived from the call sites — counts only, no rates.
+import { FEED_COST, callsMade, type FeedProvider } from '@/lib/observatory/feedCost';
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -19,6 +21,21 @@ interface CheckResult {
   rawData: unknown;
   dataSource?: string;
   lastConfirmedLive?: string | null;
+  // OBSERVATORY-01 — every row says what it cost and what it asked about.
+  /** Who this probe called. */
+  provider?: FeedProvider;
+  /** Metered by the vendor (lands on an invoice). */
+  billable?: boolean;
+  /** The evidence for `billable` — never a guessed rate. */
+  costBasis?: string;
+  /** Upstream calls THIS probe made. 0 when it was skipped or the market was closed. */
+  upstreamCalls?: number;
+  /** Does the convergence scan use this same feed? */
+  usedByScan?: boolean;
+  /** Where the scan calls it, or why it does not. */
+  scanCitation?: string;
+  /** The symbol this probe actually asked about — not always the selected one. */
+  probedSymbol?: string | null;
 }
 
 // ─── Constants ──────────────────────────────────────────────────────────────
@@ -85,7 +102,7 @@ async function checkTastyTradeIVHV(): Promise<CheckResult> {
     return { id: 1, source: 'TastyTrade IV/HV', endpoint: 'TastyTrade API', status: 'MKT-HRS', records: '—', lastValue: 'Requires open market', latency: '—', rawData: null, dataSource: 'TastyTrade' };
   }
   if (!(process.env.TASTYTRADE_CLIENT_SECRET && process.env.TASTYTRADE_REFRESH_TOKEN)) {
-    return { id: 1, source: 'TastyTrade IV/HV', endpoint: 'TastyTrade API', status: 'BROKEN', records: '0', lastValue: 'Missing credentials — market is OPEN', latency: '—', rawData: null, dataSource: 'TastyTrade' };
+    return { id: 1, source: 'TastyTrade IV/HV', endpoint: 'TastyTrade API', status: 'BROKEN', records: '0', lastValue: 'Missing credentials — market is OPEN', latency: '—', rawData: null, dataSource: 'TastyTrade', upstreamCalls: 0 };
   }
   try {
     const start = performance.now();
@@ -660,7 +677,7 @@ async function checkTastyTradeGreeks(): Promise<CheckResult> {
     return { id: 23, source: 'TastyTrade Greeks', endpoint: 'TastyTrade API', status: 'MKT-HRS', records: '—', lastValue: 'Requires open market', latency: '—', rawData: null, dataSource: 'TastyTrade' };
   }
   if (!(process.env.TASTYTRADE_CLIENT_SECRET && process.env.TASTYTRADE_REFRESH_TOKEN)) {
-    return { id: 23, source: 'TastyTrade Greeks', endpoint: 'TastyTrade API', status: 'BROKEN', records: '0', lastValue: 'Missing credentials — market is OPEN', latency: '—', rawData: null, dataSource: 'TastyTrade' };
+    return { id: 23, source: 'TastyTrade Greeks', endpoint: 'TastyTrade API', status: 'BROKEN', records: '0', lastValue: 'Missing credentials — market is OPEN', latency: '—', rawData: null, dataSource: 'TastyTrade', upstreamCalls: 0 };
   }
   try {
     const start = performance.now();
@@ -693,7 +710,7 @@ async function checkTastyTradeCandles(): Promise<CheckResult> {
     return { id: 24, source: 'TastyTrade Candles', endpoint: 'TastyTrade API', status: 'MKT-HRS', records: '—', lastValue: 'Requires open market', latency: '—', rawData: null, dataSource: 'TastyTrade' };
   }
   if (!(process.env.TASTYTRADE_CLIENT_SECRET && process.env.TASTYTRADE_REFRESH_TOKEN)) {
-    return { id: 24, source: 'TastyTrade Candles', endpoint: 'TastyTrade API', status: 'BROKEN', records: '0', lastValue: 'Missing credentials — market is OPEN', latency: '—', rawData: null, dataSource: 'TastyTrade' };
+    return { id: 24, source: 'TastyTrade Candles', endpoint: 'TastyTrade API', status: 'BROKEN', records: '0', lastValue: 'Missing credentials — market is OPEN', latency: '—', rawData: null, dataSource: 'TastyTrade', upstreamCalls: 0 };
   }
   try {
     // Candle streaming is too heavy for a health check — validate TT auth
@@ -728,7 +745,7 @@ async function checkTastyTradeOptionsFlow(): Promise<CheckResult> {
     return { id: 31, source: 'TastyTrade Options Flow', endpoint: 'TastyTrade chain API', status: 'MKT-HRS', records: '—', lastValue: 'Requires open market', latency: '—', rawData: null, dataSource: 'TastyTrade' };
   }
   if (!(process.env.TASTYTRADE_CLIENT_SECRET && process.env.TASTYTRADE_REFRESH_TOKEN)) {
-    return { id: 31, source: 'TastyTrade Options Flow', endpoint: 'TastyTrade chain API', status: 'BROKEN', records: '0', lastValue: 'Missing credentials — market is OPEN', latency: '—', rawData: null, dataSource: 'TastyTrade' };
+    return { id: 31, source: 'TastyTrade Options Flow', endpoint: 'TastyTrade chain API', status: 'BROKEN', records: '0', lastValue: 'Missing credentials — market is OPEN', latency: '—', rawData: null, dataSource: 'TastyTrade', upstreamCalls: 0 };
   }
   try {
     const start = performance.now();
@@ -759,7 +776,7 @@ async function checkTastyTradeSPYCorrelation(): Promise<CheckResult> {
     return { id: 32, source: 'TastyTrade SPY Correlation', endpoint: 'TastyTrade API', status: 'MKT-HRS', records: '—', lastValue: 'Requires open market', latency: '—', rawData: null, dataSource: 'TastyTrade' };
   }
   if (!(process.env.TASTYTRADE_CLIENT_SECRET && process.env.TASTYTRADE_REFRESH_TOKEN)) {
-    return { id: 32, source: 'TastyTrade SPY Correlation', endpoint: 'TastyTrade API', status: 'BROKEN', records: '0', lastValue: 'Missing credentials — market is OPEN', latency: '—', rawData: null, dataSource: 'TastyTrade' };
+    return { id: 32, source: 'TastyTrade SPY Correlation', endpoint: 'TastyTrade API', status: 'BROKEN', records: '0', lastValue: 'Missing credentials — market is OPEN', latency: '—', rawData: null, dataSource: 'TastyTrade', upstreamCalls: 0 };
   }
   try {
     const start = performance.now();
@@ -785,13 +802,20 @@ async function checkTastyTradeSPYCorrelation(): Promise<CheckResult> {
   }
 }
 
+/**
+ * OBSERVATORY-01: this probe measures NOTHING — it makes no call and reads no
+ * result. It used to return status LIVE with latency '0ms', which is a claim
+ * with nothing behind it. It now reports SKIPPED with the reason, which is the
+ * truth: whether the derived peer stats work is decided by feeds 14 and 27,
+ * and this check does not compute them.
+ */
 function checkPeerStats(): CheckResult {
   return {
     id: 33, source: 'Peer Stats (computed)', endpoint: 'Derived: Finnhub peers + 10-K',
-    status: 'LIVE',
+    status: 'SKIPPED',
     records: '—',
-    lastValue: 'Computed from Finnhub peers + 10-K text + GICS sectors',
-    latency: '0ms',
+    lastValue: 'Not probed — derived from feeds 14 (peers) and 27 (10-K); this check computes nothing and calls nothing',
+    latency: '—',
     rawData: null,
     dataSource: 'Internal',
   };
@@ -1070,7 +1094,7 @@ export async function GET(request: NextRequest) {
     checkTastyTradeOptionsFlow(),
     // Check 32: TastyTrade SPY Correlation (market-hours gated)
     checkTastyTradeSPYCorrelation(),
-    // Check 33: Peer Stats (computed — always LIVE)
+    // Check 33: Peer Stats — derived, never probed (reports SKIPPED with its reason)
     Promise.resolve(checkPeerStats()),
   ]);
 
@@ -1102,6 +1126,29 @@ export async function GET(request: NextRequest) {
     if (!r.dataSource) {
       r.dataSource = SOURCE_PROVIDER[r.id] ?? 'Internal';
     }
+  }
+
+  // ── OBSERVATORY-01: every row carries its cost, read from the call sites ──
+  // A SKIPPED or market-closed probe made no call, so it is charged nothing —
+  // the status is the evidence. `probedSymbol` is the symbol the probe actually
+  // asked about: the TastyTrade feeds ask about a FIXED ticker (AAPL, and SPY
+  // for the correlation), not the one the viewer selected.
+  // A probe that returned at one of its OWN guards before calling anything
+  // declares upstreamCalls: 0 on the spot; that declaration wins. Otherwise a
+  // SKIPPED or market-closed probe made no call, and everything else made the
+  // calls its cost row names — including a BROKEN one, which called and got a
+  // bad answer.
+  const marketClosedOrSkipped = (status: SourceStatus) => status === 'SKIPPED' || status === 'MKT-HRS';
+  for (const r of results) {
+    const cost = FEED_COST[r.id];
+    if (!cost) continue;
+    r.provider = cost.provider;
+    r.billable = cost.billable;
+    r.costBasis = cost.basis;
+    r.upstreamCalls = r.upstreamCalls ?? (marketClosedOrSkipped(r.status) ? 0 : cost.upstreamCalls);
+    r.usedByScan = cost.usedByScan;
+    r.scanCitation = cost.scanCitation;
+    r.probedSymbol = cost.probes === 'none' ? null : cost.probes === 'selected' ? symbol : cost.probes;
   }
 
   // ── Write results to ObservatoryHealthLog ──
@@ -1152,6 +1199,10 @@ export async function GET(request: NextRequest) {
   return NextResponse.json({
     symbol,
     checkedAt: new Date().toISOString(),
+    marketOpen,
+    // OBSERVATORY-01: what THIS check spent, by provider, counted from the rows
+    // that actually ran. Counts only — the rate lives in the vendor's invoice.
+    spend: callsMade(results),
     results,
   });
 }

--- a/src/components/data-observatory/DataObservatory.tsx
+++ b/src/components/data-observatory/DataObservatory.tsx
@@ -1,9 +1,32 @@
 'use client';
 
-import { useState, useCallback } from 'react';
+import { Fragment, useState, useCallback } from 'react';
 import { Badge } from '@/components/ui';
 // TRADE-SHELL-DARK: the one section-header idiom (ds.ts).
 import { SECTION_HEADER } from '@/lib/ds';
+// OBSERVATORY-01: what each feed costs, derived from the call sites (counts only).
+import { FEED_COST, SCAN_COST, scanCostLine, callsMadeLine, type ProviderSpend } from '@/lib/observatory/feedCost';
+
+/**
+ * OBSERVATORY-01 — THE OBSERVATORY MEASURES OR SAYS NOTHING.
+ *
+ * This screen used to render a 33-row HARDCODED_SOURCES array whenever no
+ * check had run — typed statuses, typed latencies ("12ms"), typed values
+ * ("beta: 1.09") and dates frozen at 2026-03-02. A spend decision was being
+ * read off numbers nobody measured. That array is deleted.
+ *
+ * THE RULE NOW: no row, no status, no latency, no value renders without a
+ * measurement behind it. With no check run this session the screen says so and
+ * shows the button. Every rendered table carries the timestamp it was measured
+ * at and the symbol each probe actually asked about — which is NOT always the
+ * one selected: the TastyTrade probes ask about a fixed ticker.
+ *
+ * Results live in component state only. The check DOES persist a row per feed
+ * to ObservatoryHealthLog (check/route.ts:1120), but that table holds no
+ * latency, records or raw payload, so it cannot reconstitute this table — and
+ * a partial reconstruction rendered as a measurement is the thing this PR
+ * deletes. Reading the last run back is a separate change with its own route.
+ */
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -22,69 +45,35 @@ interface DataSource {
   rawData?: unknown;
   dataSource: DataProvider;
   gate: GateName;
-  lastConfirmedLive?: string;
+  lastConfirmedLive?: string | null;
+  // OBSERVATORY-01 — the cost facts the route derives from the call sites.
+  provider?: DataProvider;
+  billable?: boolean;
+  costBasis?: string;
+  upstreamCalls?: number;
+  usedByScan?: boolean;
+  scanCitation?: string;
+  probedSymbol?: string | null;
 }
 
 interface CheckResponse {
   symbol: string;
   checkedAt: string;
+  marketOpen?: boolean;
+  spend?: ProviderSpend[];
   results: DataSource[];
 }
 
-// ─── Sample Data (fallback when no live results) ────────────────────────────
+/** What a measured run looks like — the ONLY shape that renders a row. */
+interface Measurement {
+  symbol: string;
+  checkedAt: string;
+  marketOpen: boolean | null;
+  spend: ProviderSpend[];
+  rows: DataSource[];
+}
 
 const SYMBOLS = ['MSFT', 'BAC', 'NFLX'];
-
-const HARDCODED_SOURCES: DataSource[] = [
-  { id: 1,  source: 'TastyTrade IV/HV',       endpoint: 'TastyTrade API',           status: 'MKT-HRS',  records: '—',        lastValue: 'Requires open market',    latency: '—',    dataSource: 'TastyTrade', gate: 'Vol-Edge' },
-  { id: 2,  source: 'Finnhub Basic Metrics',   endpoint: '/stock/metric',            status: 'PARTIAL',  records: '8 fields', lastValue: 'beta: 1.09',              latency: '12ms', dataSource: 'Finnhub',    gate: 'Quality' },
-  { id: 3,  source: 'EPS Estimates',           endpoint: '/stock/eps-estimate',      status: 'LIVE',     records: '4 qtrs',   lastValue: 'Next: $3.28 avg',         latency: '8ms',  dataSource: 'Finnhub',    gate: 'Info-Edge' },
-  { id: 4,  source: 'Revenue Estimates',       endpoint: '/stock/revenue-estimate',  status: 'LIVE',     records: '4 qtrs',   lastValue: 'Next: $72.1B',            latency: '9ms',  dataSource: 'Finnhub',    gate: 'Info-Edge' },
-  { id: 5,  source: 'Price Targets',           endpoint: '/stock/price-target',      status: 'LIVE',     records: '59 anal',  lastValue: 'Mean: $608',              latency: '7ms',  dataSource: 'Finnhub',    gate: 'Info-Edge' },
-  { id: 6,  source: 'Upgrades/Downgrades',     endpoint: '/stock/upgrade-downgrade', status: 'PARTIAL',  records: '5 rec',    lastValue: 'down by Stifel (date pending)', latency: '11ms', dataSource: 'Finnhub',    gate: 'Info-Edge' },
-  { id: 7,  source: 'Recommendations',         endpoint: '/stock/recommendation',    status: 'LIVE',     records: '4 mo',     lastValue: 'Buy: 60 / Hold: 6',      latency: '6ms',  dataSource: 'Finnhub',    gate: 'Info-Edge' },
-  { id: 8,  source: 'Earnings History',        endpoint: '/stock/earnings',          status: 'LIVE',     records: '40 qtrs',  lastValue: 'Beat rate: 87%',          latency: '14ms', dataSource: 'Finnhub',    gate: 'Quality' },
-  { id: 9,  source: 'Earnings Quality',        endpoint: '/stock/earnings-quality',  status: 'BROKEN',   records: '0 curr',   lastValue: 'Returning 1983 data',     latency: '18ms', dataSource: 'Finnhub',    gate: 'Quality' },
-  { id: 10, source: 'Revenue Breakdown',       endpoint: '/stock/revenue-breakdown2',status: 'PARTIAL',  records: '3 seg',    lastValue: 'Parser bug',              latency: '10ms', dataSource: 'Finnhub',    gate: 'Quality' },
-  { id: 11, source: 'Insider Transactions',    endpoint: '/stock/insider-trans',     status: 'LIVE',     records: '5 rec',    lastValue: 'F: -639 (2026-03-02)',    latency: '9ms',  dataSource: 'Finnhub',    gate: 'Info-Edge' },
-  { id: 12, source: 'Insider Sentiment',       endpoint: '/stock/insider-sentiment', status: 'BROKEN',   records: '0',        lastValue: 'Empty response',          latency: '8ms',  dataSource: 'Finnhub',    gate: 'Info-Edge' },
-  { id: 13, source: 'Institutional Own.',      endpoint: '/stock/ownership',         status: 'PARTIAL',  records: '5 hold',   lastValue: 'Names: NULL',             latency: '13ms', dataSource: 'Finnhub',    gate: 'Info-Edge' },
-  { id: 14, source: 'Peers',                   endpoint: '/stock/peers',             status: 'LIVE',     records: '12 sym',   lastValue: 'ORCL, PLTR, CRM...',      latency: '5ms',  dataSource: 'Finnhub',    gate: 'All' },
-  { id: 15, source: 'Financials (Annual)',      endpoint: '/stock/financials-rep',    status: 'BROKEN',   records: '0 curr',   lastValue: 'All fields NULL',         latency: '16ms', dataSource: 'Finnhub',    gate: 'Quality' },
-  { id: 16, source: 'Financials (Quarterly)',   endpoint: '/stock/financials',        status: 'PARTIAL',  records: '4 qtrs',   lastValue: 'grossIncome: PARTIAL',    latency: '11ms', dataSource: 'Finnhub',    gate: 'Quality' },
-  { id: 17, source: 'FinBERT Sentiment',       endpoint: '/news-sentiment',          status: 'LIVE',     records: '—',        lastValue: 'Bullish: 0.93',           latency: '22ms', dataSource: 'Finnhub',    gate: 'Info-Edge' },
-  { id: 18, source: 'Company News',            endpoint: '/company-news',            status: 'LIVE',     records: '3 rec',    lastValue: '2026-03-04',              latency: '19ms', dataSource: 'Finnhub',    gate: 'Info-Edge' },
-  { id: 19, source: 'FRED Macro (14 series)',  endpoint: 'FRED API',                 status: 'LIVE',     records: '14 ser',   lastValue: 'VIX: 22.1, 10Y: 4.31%',  latency: '31ms', dataSource: 'FRED',       gate: 'Regime' },
-  { id: 20, source: 'SEC EDGAR Submissions',   endpoint: 'EDGAR direct',             status: 'LIVE',     records: '—',        lastValue: 'CIK: 789019',            latency: '44ms', dataSource: 'SEC',        gate: 'Info-Edge' },
-  { id: 21, source: 'SEC Company Tickers',     endpoint: '/files/company_tickers',   status: 'LIVE',     records: '—',        lastValue: 'CIK: 789019',            latency: '12ms', dataSource: 'SEC',        gate: 'Info-Edge' },
-  { id: 22, source: 'xAI/Grok Sentiment',      endpoint: 'xAI API',                  status: 'LIVE',     records: '—',        lastValue: 'Bullish',                 latency: '287ms',dataSource: 'xAI',        gate: 'Info-Edge' },
-  { id: 23, source: 'TastyTrade Greeks',       endpoint: 'TastyTrade API',           status: 'MKT-HRS', records: '—',        lastValue: 'Requires open market',    latency: '—',    dataSource: 'TastyTrade', gate: 'Vol-Edge' },
-  { id: 24, source: 'TastyTrade Candles',      endpoint: 'TastyTrade API',           status: 'MKT-HRS', records: '—',        lastValue: 'Requires open market',    latency: '—',    dataSource: 'TastyTrade', gate: 'Vol-Edge' },
-  { id: 25, source: 'FRED Cross-Asset Daily',  endpoint: 'FRED API',                 status: 'LIVE',     records: '3 series', lastValue: 'DGS10/SP500/OIL',         latency: '—',    dataSource: 'FRED',       gate: 'Regime' },
-  { id: 26, source: 'SEC EDGAR XBRL Facts',    endpoint: 'EDGAR XBRL API',           status: 'BROKEN',   records: '0',        lastValue: 'CIK lookup failed',       latency: '—',    dataSource: 'SEC',        gate: 'Info-Edge' },
-  { id: 27, source: '10-K Business Description', endpoint: 'SEC EDGAR',              status: 'BROKEN',   records: '0',        lastValue: 'CIK lookup failed',       latency: '—',    dataSource: 'SEC',        gate: 'All' },
-  { id: 28, source: 'Finnhub Recommendations', endpoint: '/stock/recommendation',    status: 'LIVE',     records: '4 mo',     lastValue: 'Buy: 60 / Hold: 6',      latency: '—',    dataSource: 'Finnhub',    gate: 'Info-Edge' },
-  { id: 29, source: 'News Classifier',         endpoint: '/company-news',            status: 'LIVE',     records: '—',        lastValue: 'Bullish: 0.87',           latency: '—',    dataSource: 'Internal',   gate: 'Info-Edge' },
-  { id: 30, source: 'Finnhub Earnings Quality', endpoint: '/stock/earnings-quality-score', status: 'BROKEN', records: '0 curr', lastValue: 'Returning 1983 data',  latency: '—',    dataSource: 'Finnhub',    gate: 'Quality' },
-  { id: 31, source: 'TastyTrade Options Flow', endpoint: 'TastyTrade chain API', status: 'MKT-HRS', records: '—', lastValue: 'Requires open market', latency: '—', dataSource: 'TastyTrade', gate: 'Vol-Edge' },
-  { id: 32, source: 'TastyTrade SPY Correlation', endpoint: 'TastyTrade API', status: 'MKT-HRS', records: '—', lastValue: 'Requires open market', latency: '—', dataSource: 'TastyTrade', gate: 'Regime' },
-  { id: 33, source: 'Peer Stats (computed)', endpoint: 'Derived: Finnhub peers + 10-K', status: 'LIVE', records: '—', lastValue: 'Computed from peers + sectors', latency: '—', dataSource: 'Internal', gate: 'All' },
-];
-
-const HARDCODED_STATUS_COUNTS: { label: string; status: SourceStatus; count: number; colorClass: string }[] = [
-  { label: 'LIVE',     status: 'LIVE',     count: 17, colorClass: 'text-brand-green' },
-  { label: 'PARTIAL',  status: 'PARTIAL',  count: 5,  colorClass: 'text-brand-amber' },
-  { label: 'BROKEN',   status: 'BROKEN',   count: 6,  colorClass: 'text-brand-red' },
-  { label: 'MKT-HRS',  status: 'MKT-HRS',  count: 5,  colorClass: 'text-brand-gold' },
-  { label: 'SKIPPED',  status: 'SKIPPED',  count: 0,  colorClass: 'text-text-muted' },
-];
-
-const HARDCODED_SCANNER_GATES: { name: string; ok: boolean; detail: string }[] = [
-  { name: 'Vol-Edge',  ok: false, detail: 'IV/HV null' },
-  { name: 'Quality',   ok: false, detail: 'D/E null, earnings quality broken' },
-  { name: 'Info-Edge', ok: false, detail: 'MSPR broken, filing dates null' },
-  { name: 'Regime',    ok: true,  detail: 'FRED flowing' },
-];
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
@@ -118,14 +107,13 @@ const PROVIDER_BADGE_CLASSES: Record<DataProvider, string> = {
 function formatLastLive(iso: string): string {
   const d = new Date(iso);
   const months = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
-  const month = months[d.getMonth()];
-  const day = d.getDate();
-  const hours = d.getHours();
-  const mins = d.getMinutes().toString().padStart(2, '0');
-  return `${month} ${day}, ${hours}:${mins} ET`;
+  return `${months[d.getMonth()]} ${d.getDate()}, ${d.getHours()}:${d.getMinutes().toString().padStart(2, '0')} ET`;
 }
 
-// Map source ID to gate for live results (API doesn't return gate)
+/**
+ * Which gate a feed feeds. A MAPPING, not a measurement — the check reports a
+ * feed's health, not which gate consumed it, and this says which gate would.
+ */
 const SOURCE_GATE_MAP: Record<number, GateName> = {
   1: 'Vol-Edge', 2: 'Quality', 3: 'Info-Edge', 4: 'Info-Edge', 5: 'Info-Edge',
   6: 'Info-Edge', 7: 'Info-Edge', 8: 'Quality', 9: 'Quality', 10: 'Quality',
@@ -136,24 +124,15 @@ const SOURCE_GATE_MAP: Record<number, GateName> = {
   31: 'Vol-Edge', 32: 'Regime', 33: 'All',
 };
 
-const SOURCE_PROVIDER_MAP: Record<number, DataProvider> = {
-  1: 'Finnhub', 2: 'Finnhub', 3: 'Finnhub', 4: 'Finnhub', 5: 'Finnhub',
-  6: 'Finnhub', 7: 'Finnhub', 8: 'Finnhub', 9: 'Finnhub', 10: 'Finnhub',
-  11: 'Finnhub', 12: 'Finnhub', 13: 'Finnhub', 14: 'Finnhub', 15: 'Finnhub',
-  16: 'Finnhub', 17: 'Finnhub', 18: 'Finnhub', 19: 'FRED', 20: 'SEC',
-  21: 'SEC', 22: 'xAI', 23: 'TastyTrade', 24: 'TastyTrade', 25: 'FRED',
-  26: 'SEC', 27: 'SEC', 28: 'Finnhub', 29: 'Internal', 30: 'Finnhub',
-  31: 'TastyTrade', 32: 'TastyTrade', 33: 'Internal',
-};
-
-function enrichLiveResults(results: DataSource[]): DataSource[] {
+function enrichMeasuredResults(results: DataSource[]): DataSource[] {
   return results.map(r => ({
     ...r,
     gate: SOURCE_GATE_MAP[r.id] ?? 'All',
-    dataSource: (r.dataSource as DataProvider) || SOURCE_PROVIDER_MAP[r.id] || 'Internal',
+    dataSource: (r.provider ?? r.dataSource ?? FEED_COST[r.id]?.provider ?? 'Internal') as DataProvider,
   }));
 }
 
+/** Counts, computed from the measured rows. Never typed. */
 function computeStatusCounts(rows: DataSource[]) {
   const counts: Record<SourceStatus, number> = { LIVE: 0, PARTIAL: 0, BROKEN: 0, 'MKT-HRS': 0, SKIPPED: 0 };
   for (const r of rows) counts[r.status] = (counts[r.status] || 0) + 1;
@@ -162,36 +141,40 @@ function computeStatusCounts(rows: DataSource[]) {
   }));
 }
 
-function computeScannerGates(rows: DataSource[]) {
-  const byId = new Map(rows.map(r => [r.id, r]));
-  const ivhv = byId.get(1);
-  const earningsQ = byId.get(9);
-  const insiderSent = byId.get(12);
-  const financialsA = byId.get(15);
-  const fred = byId.get(19);
+/**
+ * Scanner readiness, read off the measured rows. A gate whose feed was not
+ * measured (SKIPPED, or the market was closed) is UNKNOWN — it is never called
+ * ready and never called degraded on a probe that did not run.
+ */
+type GateReadiness = { name: string; state: 'READY' | 'DEGRADED' | 'UNKNOWN'; detail: string };
 
+function computeScannerGates(rows: DataSource[]): GateReadiness[] {
+  const byId = new Map(rows.map(r => [r.id, r]));
+  const read = (name: string, id: number, label: string): GateReadiness => {
+    const row = byId.get(id);
+    if (!row) return { name, state: 'UNKNOWN', detail: `${label} not in this run` };
+    if (row.status === 'SKIPPED' || row.status === 'MKT-HRS') {
+      return { name, state: 'UNKNOWN', detail: `${label} not measured — ${row.lastValue}` };
+    }
+    if (row.status === 'LIVE') return { name, state: 'READY', detail: `${label} flowing` };
+    return { name, state: 'DEGRADED', detail: `${label} ${row.status.toLowerCase()} — ${row.lastValue}` };
+  };
   return [
-    {
-      name: 'Vol-Edge',
-      ok: ivhv?.status === 'LIVE',
-      detail: ivhv?.status === 'LIVE' ? 'IV/HV flowing' : 'IV/HV null',
-    },
-    {
-      name: 'Quality',
-      ok: earningsQ?.status === 'LIVE' && financialsA?.status === 'LIVE',
-      detail: earningsQ?.status !== 'LIVE' ? 'Earnings quality broken' : (financialsA?.status !== 'LIVE' ? 'Financials broken' : 'Quality data flowing'),
-    },
-    {
-      name: 'Info-Edge',
-      ok: insiderSent?.status === 'LIVE',
-      detail: insiderSent?.status === 'LIVE' ? 'Insider data flowing' : 'MSPR broken, filing dates null',
-    },
-    {
-      name: 'Regime',
-      ok: fred?.status === 'LIVE',
-      detail: fred?.status === 'LIVE' ? 'FRED flowing' : 'FRED broken',
-    },
+    read('Vol-Edge', 1, 'IV/HV'),
+    read('Quality', 9, 'Earnings quality'),
+    read('Info-Edge', 12, 'Insider sentiment'),
+    read('Regime', 19, 'FRED macro'),
   ];
+}
+
+/** The symbols this run actually asked about, in the order first seen. */
+function symbolsProbed(rows: DataSource[]): string[] {
+  const seen: string[] = [];
+  for (const r of rows) {
+    const s = r.probedSymbol ?? (FEED_COST[r.id]?.probes === 'none' ? null : null);
+    if (s && !seen.includes(s)) seen.push(s);
+  }
+  return seen;
 }
 
 // ─── Component ──────────────────────────────────────────────────────────────
@@ -199,14 +182,13 @@ function computeScannerGates(rows: DataSource[]) {
 export default function DataObservatory() {
   const [selectedSymbol, setSelectedSymbol] = useState('MSFT');
   const [expandedRow, setExpandedRow] = useState<number | null>(null);
-  const [liveResults, setLiveResults] = useState<DataSource[] | null>(null);
+  // NULL means: nothing has been measured this session. It renders the
+  // not-measured state — never a row.
+  const [measurement, setMeasurement] = useState<Measurement | null>(null);
   const [loading, setLoading] = useState(false);
-  const [checkedAt, setCheckedAt] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
-  const toggleRow = (id: number) => {
-    setExpandedRow(prev => (prev === id ? null : id));
-  };
+  const toggleRow = (id: number) => setExpandedRow(prev => (prev === id ? null : id));
 
   const runCheck = useCallback(async () => {
     setLoading(true);
@@ -218,47 +200,47 @@ export default function DataObservatory() {
         throw new Error(body.error || `HTTP ${res.status}`);
       }
       const data: CheckResponse = await res.json();
-      setLiveResults(enrichLiveResults(data.results));
-      setCheckedAt(data.checkedAt);
+      setMeasurement({
+        symbol: data.symbol,
+        checkedAt: data.checkedAt,
+        marketOpen: data.marketOpen ?? null,
+        spend: data.spend ?? [],
+        rows: enrichMeasuredResults(data.results),
+      });
     } catch (e) {
+      // FAIL LOUD: a failed check leaves the screen unmeasured and says why.
+      // It never falls back to a previous run or to typed rows.
       setError(e instanceof Error ? e.message : 'Check failed');
     } finally {
       setLoading(false);
     }
   }, [selectedSymbol]);
 
-  // Use live results if available, otherwise hardcoded
-  const displayRows = liveResults ?? HARDCODED_SOURCES;
-  const statusCounts = liveResults ? computeStatusCounts(liveResults) : HARDCODED_STATUS_COUNTS;
-  const scannerGates = liveResults ? computeScannerGates(liveResults) : HARDCODED_SCANNER_GATES;
+  const rows = measurement?.rows ?? [];
+  const statusCounts = measurement ? computeStatusCounts(rows) : null;
+  const scannerGates = measurement ? computeScannerGates(rows) : null;
+  const probed = measurement ? symbolsProbed(rows) : [];
 
   return (
     <>
-      {/* ── Header Bar — TRADE-SHELL-DARK: the SECTION_HEADER idiom (the 7th
-            of the audit's divergent purple/80 strips). Right-side content
-            (error, symbol select, RUN CHECK) preserved verbatim. */}
+      {/* ── Header Bar — TRADE-SHELL-DARK: the SECTION_HEADER idiom. ── */}
       <div className="rounded-t-lg overflow-hidden">
         <div className={SECTION_HEADER}>
-          <span>
-            Data Observatory
-          </span>
+          <span>Data Observatory</span>
           <div className="flex items-center gap-2">
-            {error && (
-              <span className="text-xs font-mono text-red-300">{error}</span>
-            )}
+            {error && <span className="text-xs font-mono text-red-300" data-observatory-error>{error}</span>}
             <select
               value={selectedSymbol}
               onChange={e => setSelectedSymbol(e.target.value)}
               disabled={loading}
               className="bg-brand-purple-deep text-white text-xs font-mono px-2 py-1 border border-white/10 rounded focus:outline-none focus:ring-1 focus:ring-brand-gold disabled:opacity-50"
             >
-              {SYMBOLS.map(s => (
-                <option key={s} value={s}>{s}</option>
-              ))}
+              {SYMBOLS.map(s => <option key={s} value={s}>{s}</option>)}
             </select>
             <button
               onClick={runCheck}
               disabled={loading}
+              data-run-check
               className="bg-brand-gold text-white text-xs font-semibold font-mono px-3 py-1 rounded hover:bg-brand-gold-bright transition-colors disabled:opacity-50 flex items-center gap-1.5"
             >
               {loading && (
@@ -273,134 +255,206 @@ export default function DataObservatory() {
         </div>
       </div>
 
-      {/* ── Main Content ────────────────────────────────────────────── */}
       <div className="p-4 lg:p-6">
-        <div className="flex flex-col lg:flex-row gap-4">
-
-          {/* ── Left Column: Data Source Table ──────────────────────── */}
-          <div className="flex-1 min-w-0">
-            <div className="bg-white border border-border shadow-sm overflow-hidden">
-              <div className="bg-brand-purple-hover text-white px-4 py-2 text-xs font-semibold uppercase tracking-wider font-mono">
-                Data Sources — {selectedSymbol}
-                {liveResults && <span className="ml-2 opacity-60">(live)</span>}
-              </div>
-              <div className="overflow-x-auto">
-                <table className="w-full text-xs">
-                  <thead className="bg-bg-row sticky top-0">
-                    <tr>
-                      <th className="px-3 py-2 text-left font-medium text-text-muted w-8">#</th>
-                      <th className="px-3 py-2 text-left font-medium text-text-muted">PROVIDER</th>
-                      <th className="px-3 py-2 text-left font-medium text-text-muted">GATE</th>
-                      <th className="px-3 py-2 text-left font-medium text-text-muted">SOURCE</th>
-                      <th className="px-3 py-2 text-left font-medium text-text-muted">ENDPOINT</th>
-                      <th className="px-3 py-2 text-center font-medium text-text-muted">STATUS</th>
-                      <th className="px-3 py-2 text-right font-medium text-text-muted">RECORDS</th>
-                      <th className="px-3 py-2 text-left font-medium text-text-muted">LAST VALUE</th>
-                      <th className="px-3 py-2 text-right font-medium text-text-muted">LATENCY</th>
-                    </tr>
-                  </thead>
-                  <tbody className="divide-y divide-border">
-                    {displayRows.map(row => (
-                      <>
-                        <tr
-                          key={row.id}
-                          onClick={() => toggleRow(row.id)}
-                          className="hover:bg-bg-row cursor-pointer transition-colors"
-                        >
-                          <td className="px-3 py-2 font-mono text-text-muted">{row.id}</td>
-                          <td className="px-3 py-2">
-                            <span className={`inline-block px-1.5 py-0.5 text-[10px] rounded ${PROVIDER_BADGE_CLASSES[row.dataSource]}`}>
-                              {row.dataSource}
-                            </span>
-                          </td>
-                          <td className="px-3 py-2 text-xs font-mono text-gray-500">{row.gate}</td>
-                          <td className="px-3 py-2 font-medium text-text-primary">{row.source}</td>
-                          <td className="px-3 py-2 font-mono text-text-secondary">{row.endpoint}</td>
-                          <td className="px-3 py-2 text-center">
-                            <Badge variant={statusBadgeVariant(row.status)} size="sm">{row.status}</Badge>
-                            {row.status === 'MKT-HRS' && (
-                              row.lastConfirmedLive
-                                ? <div className="text-[9px] text-brand-green font-mono mt-0.5">Last LIVE: {formatLastLive(row.lastConfirmedLive)}</div>
-                                : <div className="text-[9px] text-text-muted font-mono mt-0.5">Never confirmed</div>
-                            )}
-                          </td>
-                          <td className="px-3 py-2 text-right font-mono text-text-secondary">{row.records}</td>
-                          <td className="px-3 py-2 font-mono text-text-primary">{row.lastValue}</td>
-                          <td className="px-3 py-2 text-right font-mono text-text-muted">{row.latency}</td>
-                        </tr>
-                        {expandedRow === row.id && (
-                          <tr key={`${row.id}-detail`}>
-                            <td colSpan={9} className="px-0 py-0">
-                              <div className="bg-bg-row border-t border-border px-4 py-3">
-                                <pre className="font-mono text-terminal-sm text-text-muted whitespace-pre-wrap">{
-                                  row.rawData
-                                    ? JSON.stringify(row.rawData, null, 2)
-                                    : `// raw data will appear here when API is wired\n{\n  "source": "${row.source}",\n  "endpoint": "${row.endpoint}",\n  "symbol": "${selectedSymbol}",\n  "status": "${row.status}",\n  "data": null\n}`
-                                }</pre>
-                              </div>
-                            </td>
-                          </tr>
-                        )}
-                      </>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-            </div>
-          </div>
-
-          {/* ── Right Column: System Status Panel ──────────────────── */}
-          <div className="w-full lg:w-72 flex-shrink-0">
-            <div className="bg-white border border-border shadow-sm overflow-hidden">
-              {/* Panel Header */}
-              <div className="bg-brand-purple-hover text-white px-4 py-2 text-xs font-semibold uppercase tracking-wider font-mono">
-                System Status
-              </div>
-
-              {/* Status Counts */}
-              <div className="p-3 border-b border-border">
-                <div className="space-y-1.5">
-                  {statusCounts.map(s => (
-                    <div key={s.label} className="flex items-center justify-between">
-                      <Badge variant={statusBadgeVariant(s.status)} size="sm">{s.label}</Badge>
-                      <span className={`font-mono font-semibold text-sm ${s.colorClass}`}>{s.count}</span>
-                    </div>
-                  ))}
-                </div>
-              </div>
-
-              {/* Scanner Readiness */}
-              <div className="p-3 border-b border-border">
-                <div className="text-[9px] text-text-muted uppercase tracking-wider font-mono mb-2">Scanner Readiness</div>
-                <div className="space-y-1.5">
-                  {scannerGates.map(gate => (
-                    <div key={gate.name} className="flex items-start gap-2">
-                      <span className="flex-shrink-0 mt-px">
-                        {gate.ok
-                          ? <Badge variant="success" size="sm">LIVE</Badge>
-                          : <Badge variant="warning" size="sm">DEGRADED</Badge>
-                        }
-                      </span>
-                      <div className="min-w-0">
-                        <span className="text-terminal-sm font-semibold text-text-primary font-mono">{gate.name}</span>
-                        <span className="text-terminal-xs text-text-muted font-mono ml-1">({gate.detail})</span>
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              </div>
-
-              {/* Last Checked */}
-              <div className="p-3">
-                <div className="text-[9px] text-text-muted uppercase tracking-wider font-mono mb-1">Last Checked</div>
-                <span className="text-terminal-sm font-mono text-text-faint">
-                  {checkedAt ? new Date(checkedAt).toLocaleString() : '—'}
-                </span>
-              </div>
-            </div>
-          </div>
-
+        {/* ── What a run costs — printed whether or not one has run, because it
+              is read from the call sites, not from a measurement. ── */}
+        <div className="mb-4 border border-border bg-bg-row px-4 py-3" data-cost-summary>
+          <div className="text-[9px] uppercase tracking-wider font-mono text-text-muted mb-1">What this costs upstream</div>
+          <p className="font-mono text-terminal-sm text-text-primary">{scanCostLine()}</p>
+          <p className="font-mono text-terminal-sm text-text-secondary mt-1">
+            {measurement ? callsMadeLine(measurement.spend) : 'No check has run this session, so this screen has spent nothing.'}
+          </p>
+          <p className="font-mono text-terminal-xs text-text-muted mt-1">
+            Counts, never dollars: this product does not know any vendor&rsquo;s rate. The rate lives in the vendor&rsquo;s invoice.
+            Ceilings, not averages — the scan gates its later stages, and three caches can serve a repeat for free.
+          </p>
         </div>
+
+        {!measurement ? (
+          /* ── NOT MEASURED. No row, no status, no latency, no value. ── */
+          <div className="border border-border bg-white px-6 py-10 text-center" data-not-measured>
+            <div className="font-mono text-sm font-semibold text-text-primary">Not measured yet</div>
+            <p className="mt-2 font-mono text-terminal-sm text-text-secondary max-w-2xl mx-auto">
+              Nothing has been probed in this session, so there is nothing to show. This screen renders no
+              status, no latency and no value it did not measure. Press <span className="font-semibold">RUN CHECK</span> above to
+              probe all {Object.keys(FEED_COST).length} feeds for {selectedSymbol}.
+            </p>
+            <p className="mt-3 font-mono text-terminal-xs text-text-muted max-w-2xl mx-auto">
+              Running it spends real upstream calls, per the counts above. Feeds needing an open market report
+              MKT-HRS and call nothing; feeds with no key report SKIPPED and call nothing.
+            </p>
+          </div>
+        ) : (
+          <div className="flex flex-col lg:flex-row gap-4">
+
+            {/* ── Left: the measured table ── */}
+            <div className="flex-1 min-w-0">
+              <div className="bg-white border border-border shadow-sm overflow-hidden">
+                <div className="bg-brand-purple-hover text-white px-4 py-2 font-mono" data-measured-at>
+                  <div className="text-xs font-semibold uppercase tracking-wider">
+                    Data Sources — measured at {new Date(measurement.checkedAt).toLocaleString()}
+                  </div>
+                  <div className="text-[10px] opacity-80 mt-0.5">
+                    Symbols probed: {probed.length > 0 ? probed.join(', ') : 'none'}
+                    {' · '}selected {measurement.symbol}
+                    {probed.some(p => p !== measurement.symbol) && ' — the TastyTrade probes ask about a fixed ticker, not the selected one'}
+                    {measurement.marketOpen !== null && ` · market ${measurement.marketOpen ? 'OPEN' : 'CLOSED'}`}
+                  </div>
+                </div>
+                <div className="overflow-x-auto">
+                  <table className="w-full text-xs">
+                    <thead className="bg-bg-row sticky top-0">
+                      <tr>
+                        <th className="px-3 py-2 text-left font-medium text-text-muted w-8">#</th>
+                        <th className="px-3 py-2 text-left font-medium text-text-muted">PROVIDER</th>
+                        <th className="px-3 py-2 text-left font-medium text-text-muted">GATE</th>
+                        <th className="px-3 py-2 text-left font-medium text-text-muted">SOURCE</th>
+                        <th className="px-3 py-2 text-left font-medium text-text-muted">ENDPOINT</th>
+                        <th className="px-3 py-2 text-left font-medium text-text-muted">PROBED</th>
+                        <th className="px-3 py-2 text-center font-medium text-text-muted">STATUS</th>
+                        <th className="px-3 py-2 text-right font-medium text-text-muted">RECORDS</th>
+                        <th className="px-3 py-2 text-left font-medium text-text-muted">LAST VALUE</th>
+                        <th className="px-3 py-2 text-right font-medium text-text-muted">LATENCY</th>
+                        <th className="px-3 py-2 text-center font-medium text-text-muted">METERED</th>
+                        <th className="px-3 py-2 text-right font-medium text-text-muted">CALLS</th>
+                        <th className="px-3 py-2 text-center font-medium text-text-muted">IN SCAN</th>
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-border">
+                      {rows.map(row => (
+                        <Fragment key={row.id}>
+                          <tr
+                            onClick={() => toggleRow(row.id)}
+                            data-feed-row={row.id}
+                            className="hover:bg-bg-row cursor-pointer transition-colors"
+                          >
+                            <td className="px-3 py-2 font-mono text-text-muted">{row.id}</td>
+                            <td className="px-3 py-2">
+                              <span className={`inline-block px-1.5 py-0.5 text-[10px] rounded ${PROVIDER_BADGE_CLASSES[row.dataSource]}`}>
+                                {row.dataSource}
+                              </span>
+                            </td>
+                            <td className="px-3 py-2 text-xs font-mono text-gray-500">{row.gate}</td>
+                            <td className="px-3 py-2 font-medium text-text-primary">{row.source}</td>
+                            <td className="px-3 py-2 font-mono text-text-secondary">{row.endpoint}</td>
+                            <td className="px-3 py-2 font-mono text-text-secondary">{row.probedSymbol ?? '— none'}</td>
+                            <td className="px-3 py-2 text-center">
+                              <Badge variant={statusBadgeVariant(row.status)} size="sm">{row.status}</Badge>
+                              {row.status === 'MKT-HRS' && (
+                                row.lastConfirmedLive
+                                  ? <div className="text-[9px] text-brand-green font-mono mt-0.5">Last LIVE: {formatLastLive(row.lastConfirmedLive)}</div>
+                                  : <div className="text-[9px] text-text-muted font-mono mt-0.5">Never confirmed LIVE</div>
+                              )}
+                            </td>
+                            <td className="px-3 py-2 text-right font-mono text-text-secondary">{row.records}</td>
+                            <td className="px-3 py-2 font-mono text-text-primary">{row.lastValue}</td>
+                            <td className="px-3 py-2 text-right font-mono text-text-muted">{row.latency}</td>
+                            <td className="px-3 py-2 text-center font-mono text-[10px]">
+                              {row.billable ? <span className="text-brand-red font-semibold">METERED</span> : <span className="text-text-muted">no</span>}
+                            </td>
+                            <td className="px-3 py-2 text-right font-mono text-text-primary">{row.upstreamCalls ?? '—'}</td>
+                            <td className="px-3 py-2 text-center font-mono text-[10px] text-text-secondary">{row.usedByScan ? 'yes' : 'no'}</td>
+                          </tr>
+                          {expandedRow === row.id && (
+                            <tr>
+                              <td colSpan={13} className="px-0 py-0">
+                                <div className="bg-bg-row border-t border-border px-4 py-3 space-y-2">
+                                  <div className="font-mono text-terminal-xs text-text-secondary">
+                                    <span className="text-text-muted">Cost basis:</span> {row.costBasis ?? 'not recorded'}
+                                  </div>
+                                  <div className="font-mono text-terminal-xs text-text-secondary">
+                                    <span className="text-text-muted">In the scan:</span> {row.scanCitation ?? 'not recorded'}
+                                  </div>
+                                  <pre className="font-mono text-terminal-sm text-text-muted whitespace-pre-wrap">
+                                    {row.rawData != null
+                                      ? JSON.stringify(row.rawData, null, 2)
+                                      : 'No payload was captured for this probe — it returned none, or it did not run.'}
+                                  </pre>
+                                </div>
+                              </td>
+                            </tr>
+                          )}
+                        </Fragment>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            </div>
+
+            {/* ── Right: the panel, all of it computed from the same rows ── */}
+            <div className="w-full lg:w-72 flex-shrink-0">
+              <div className="bg-white border border-border shadow-sm overflow-hidden">
+                <div className="bg-brand-purple-hover text-white px-4 py-2 text-xs font-semibold uppercase tracking-wider font-mono">
+                  System Status
+                </div>
+
+                <div className="p-3 border-b border-border">
+                  <div className="space-y-1.5">
+                    {statusCounts?.map(s => (
+                      <div key={s.label} className="flex items-center justify-between">
+                        <Badge variant={statusBadgeVariant(s.status)} size="sm">{s.label}</Badge>
+                        <span className={`font-mono font-semibold text-sm ${s.colorClass}`}>{s.count}</span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+
+                <div className="p-3 border-b border-border">
+                  <div className="text-[9px] text-text-muted uppercase tracking-wider font-mono mb-2">Scanner Readiness</div>
+                  <div className="space-y-1.5">
+                    {scannerGates?.map(gate => (
+                      <div key={gate.name} className="flex items-start gap-2">
+                        <span className="flex-shrink-0 mt-px">
+                          {gate.state === 'READY'
+                            ? <Badge variant="success" size="sm">READY</Badge>
+                            : gate.state === 'DEGRADED'
+                              ? <Badge variant="warning" size="sm">DEGRADED</Badge>
+                              : <Badge variant="default" size="sm">UNKNOWN</Badge>}
+                        </span>
+                        <div className="min-w-0">
+                          <span className="text-terminal-sm font-semibold text-text-primary font-mono">{gate.name}</span>
+                          <span className="text-terminal-xs text-text-muted font-mono ml-1">({gate.detail})</span>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+
+                <div className="p-3 border-b border-border">
+                  <div className="text-[9px] text-text-muted uppercase tracking-wider font-mono mb-2">Calls this check made</div>
+                  <div className="space-y-1">
+                    {measurement.spend.length === 0
+                      ? <span className="font-mono text-terminal-sm text-text-muted">none recorded</span>
+                      : measurement.spend.map(s => (
+                        <div key={s.provider} className="flex items-center justify-between font-mono text-terminal-sm">
+                          <span className="text-text-secondary">{s.provider}{s.billable ? ' · metered' : ''}</span>
+                          <span className="text-text-primary font-semibold">{s.calls}</span>
+                        </div>
+                      ))}
+                  </div>
+                </div>
+
+                <div className="p-3">
+                  <div className="text-[9px] text-text-muted uppercase tracking-wider font-mono mb-1">One scan, one symbol</div>
+                  <div className="space-y-1">
+                    {SCAN_COST.map(c => (
+                      <div key={c.provider} className="flex items-center justify-between font-mono text-terminal-sm">
+                        <span className="text-text-secondary">{c.provider}</span>
+                        <span className="text-text-primary">
+                          {c.callsPerSymbol !== null && c.callsPerSymbol > 0
+                            ? `${c.callsPerSymbol} / symbol`
+                            : c.callsPerScan !== null ? `${c.callsPerScan} / scan` : '—'}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            </div>
+
+          </div>
+        )}
       </div>
     </>
   );

--- a/src/lib/__tests__/observatory.test.ts
+++ b/src/lib/__tests__/observatory.test.ts
@@ -1,0 +1,122 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import * as React from 'react';
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+// tsconfig sets jsx: "preserve" for Next, so tsx compiles the component's JSX
+// with the CLASSIC runtime (React.createElement) — which expects a global React
+// that Next's automatic runtime makes unnecessary in the app. Supplying it here
+// is a harness detail; the component under test is unchanged.
+Object.assign(globalThis, { React });
+import {
+  FEED_COST, FEED_IDS, SCAN_COST, FeedCostLawError,
+  callsMade, callsMadeLine, feedCostLaw, scanCostLine,
+} from '../observatory/feedCost';
+import DataObservatory from '@/components/data-observatory/DataObservatory';
+
+// OBSERVATORY-01 — the observatory measures or says nothing, and every feed
+// carries its cost. These pin the two halves: the cost facts are complete and
+// count-only, and the screen renders nothing it did not measure.
+
+test('every one of the 33 feeds carries provider, metered, calls and scan use — and the law holds on the real map', () => {
+  assert.deepEqual(feedCostLaw({ throwOnFail: false }), []);
+  assert.equal(FEED_IDS.length, 33);
+  assert.deepEqual(FEED_IDS, Array.from({ length: 33 }, (_, i) => i + 1));
+  for (const id of FEED_IDS) {
+    const c = FEED_COST[id];
+    assert.ok(c.basis.trim().length > 0, `feed ${id} states its basis`);
+    assert.ok(c.scanCitation.trim().length > 0, `feed ${id} cites the scan`);
+    if (c.billable) assert.ok(c.upstreamCalls > 0, `feed ${id}: billable means it calls`);
+  }
+  // Only the metered providers are billable — SEC and FRED are public APIs,
+  // and TastyTrade is a brokerage session, not a per-call invoice.
+  const billableProviders = new Set(FEED_IDS.filter(id => FEED_COST[id].billable).map(id => FEED_COST[id].provider));
+  assert.deepEqual([...billableProviders].sort(), ['Finnhub', 'xAI']);
+});
+
+test('the law rejects: a missing feed, a billable feed that calls nothing, an unmetered Finnhub call, a basis-less row', () => {
+  const without = { ...FEED_COST };
+  delete (without as Record<number, unknown>)[9];
+  assert.match(feedCostLaw({ throwOnFail: false, cost: without, ids: FEED_IDS.filter(i => i !== 9) }).join('\n'), /feed 9 has no cost row/);
+
+  const freeCall = { ...FEED_COST, 22: { ...FEED_COST[22], upstreamCalls: 0 } };
+  assert.match(feedCostLaw({ throwOnFail: false, cost: freeCall }).join('\n'), /feed 22: billable but makes no upstream call/);
+
+  const unmetered = { ...FEED_COST, 2: { ...FEED_COST[2], billable: false } };
+  assert.match(feedCostLaw({ throwOnFail: false, cost: unmetered }).join('\n'), /feed 2: a Finnhub call is metered — billable must be true/);
+
+  const noBasis = { ...FEED_COST, 5: { ...FEED_COST[5], basis: '  ' } };
+  assert.match(feedCostLaw({ throwOnFail: false, cost: noBasis }).join('\n'), /feed 5: billable=true with no basis/);
+
+  assert.throws(() => feedCostLaw({ cost: freeCall }), FeedCostLawError);
+});
+
+test('a probe that did not run is charged nothing — SKIPPED and MKT-HRS make no call', () => {
+  const rows = [
+    { id: 2, status: 'LIVE' },       // Finnhub, 1 call
+    { id: 3, status: 'BROKEN' },     // Finnhub, still called — BROKEN means it answered badly
+    { id: 5, status: 'SKIPPED' },    // no key — no call
+    { id: 1, status: 'MKT-HRS' },    // market closed — no call
+    { id: 23, status: 'LIVE' },      // TastyTrade, 2 calls
+    { id: 22, status: 'SKIPPED' },   // xAI, no key — no call
+  ];
+  const spend = callsMade(rows);
+  const finnhub = spend.find(s => s.provider === 'Finnhub');
+  assert.equal(finnhub?.calls, 2, 'the two that answered are charged; the skipped one is not');
+  assert.equal(finnhub?.billable, true);
+  assert.equal(spend.find(s => s.provider === 'TastyTrade')?.calls, 2);
+  assert.equal(spend.find(s => s.provider === 'xAI')?.calls, 0, 'no key, no call, no charge');
+  assert.match(callsMadeLine(spend), /2 Finnhub \(metered\)/);
+  assert.match(callsMadeLine(spend), /rate lives in the vendor's invoice/);
+  assert.equal(callsMadeLine(callsMade([{ id: 5, status: 'SKIPPED' }])), 'This check made no upstream call.');
+});
+
+test('a probe stopped at its OWN guard is charged nothing, even when it reports BROKEN', () => {
+  // The five TastyTrade probes return BROKEN "Missing credentials — market is
+  // OPEN" BEFORE touching getTastytradeClient (check/route.ts:88 · :663 · :696
+  // · :731 · :762). They declare upstreamCalls: 0 on the spot, and that wins
+  // over the cost row's 2 — a BROKEN status alone is not evidence of a call.
+  const guarded = [1, 23, 24, 31, 32].map(id => ({ id, status: 'BROKEN', upstreamCalls: 0 }));
+  assert.equal(callsMade(guarded).find(s => s.provider === 'TastyTrade')?.calls, 0);
+  // …while a BROKEN row that does NOT declare one DID call and got a bad answer.
+  const answeredBadly = [{ id: 1, status: 'BROKEN' }];
+  assert.equal(callsMade(answeredBadly).find(s => s.provider === 'TastyTrade')?.calls, 2);
+});
+
+test('the cost lines are COUNTS — no currency symbol, no rate, anywhere in the cost facts', () => {
+  const everything = [
+    scanCostLine(), callsMadeLine(callsMade([{ id: 2, status: 'LIVE' }])),
+    ...SCAN_COST.map(c => c.note),
+    ...FEED_IDS.map(id => FEED_COST[id].basis),
+    ...FEED_IDS.map(id => FEED_COST[id].scanCitation),
+  ].join('\n');
+  assert.doesNotMatch(everything, /\$[0-9]/, 'no price is ever printed — the product does not know one');
+  assert.doesNotMatch(everything, /\bper (call|token) (rate|price)\b/i);
+  assert.match(scanCostLine(), /One scan of one symbol = 28 Finnhub, 2 xAI, 1 TastyTrade, 6 SEC/);
+  assert.match(scanCostLine(), /once per scan, 24 FRED/);
+});
+
+test('the screen with no results renders the not-measured state and ZERO rows', () => {
+  const html = renderToStaticMarkup(createElement(DataObservatory));
+
+  // the not-measured state is there, by its marker and by its words
+  assert.match(html, /data-not-measured/);
+  assert.match(html, /Not measured yet/);
+  assert.match(html, /renders no\s+status, no latency and no value it did not measure/);
+
+  // and NOT ONE row
+  assert.equal((html.match(/data-feed-row=/g) ?? []).length, 0, 'no row renders without a measurement');
+  assert.doesNotMatch(html, /data-measured-at/, 'no "measured at" header without a measurement');
+
+  // none of the deleted fabrications survive
+  for (const lie of ['beta: 1.09', '12ms', 'Returning 1983 data', '2026-03-02', 'Bullish: 0.93', 'CIK: 789019']) {
+    assert.ok(!html.includes(lie), `the screen must not print "${lie}" — it measured nothing`);
+  }
+
+  // the button that would measure, and the cost of pressing it
+  assert.match(html, /data-run-check/);
+  assert.match(html, /RUN CHECK/);
+  assert.match(html, /data-cost-summary/);
+  assert.match(html, /has spent nothing/);
+});

--- a/src/lib/observatory/feedCost.ts
+++ b/src/lib/observatory/feedCost.ts
@@ -1,0 +1,221 @@
+/**
+ * OBSERVATORY-01 — WHAT EACH FEED COSTS, read from the code that calls it.
+ *
+ * The observatory's check (src/app/api/data-observatory/check/route.ts) fires
+ * real upstream calls. Alex is judging a per-call spend from that screen, so
+ * every row must say who it called, whether that call is metered, how many
+ * calls THIS probe made, and whether the convergence scan uses the same feed.
+ *
+ * NO PRICES. This product does not know Finnhub's per-call rate, xAI's token
+ * price, or any other vendor's schedule — the rate lives in the vendor's
+ * invoice. Everything here is a COUNT, derived by reading the call sites, and
+ * every count carries its file:line so it can be re-checked against the code.
+ *
+ * `billable` means: this call is metered by the vendor and lands on an invoice.
+ * `basis` says on what evidence — never a guess dressed as a fact.
+ *
+ * THE LAW (feedCostLaw — module scope, re-run at build by
+ * scripts/assert-tool-registry.ts): every one of the 33 feed ids carries a
+ * cost row; a billable feed makes at least one upstream call; a feed that
+ * makes no upstream call is not billable.
+ */
+
+export type FeedProvider = 'TastyTrade' | 'Finnhub' | 'FRED' | 'SEC' | 'xAI' | 'Internal';
+
+export interface FeedCost {
+  /** Who this probe calls. */
+  provider: FeedProvider;
+  /** Metered by the vendor — the call lands on an invoice. */
+  billable: boolean;
+  /** The evidence for `billable`. Never a guessed rate. */
+  basis: string;
+  /** Upstream calls THIS probe makes when it runs (not when it is skipped or market-closed). */
+  upstreamCalls: number;
+  /** Does the convergence scan use this same feed? */
+  usedByScan: boolean;
+  /** Where the scan calls it, or why it does not — file:line. */
+  scanCitation: string;
+  /** The symbol this probe actually asks about: the selected one, a fixed one, or none. */
+  probes: 'selected' | 'AAPL' | 'SPY' | 'none';
+}
+
+const METERED_FINNHUB =
+  'Finnhub is metered per call — the founder\'s COA carries B-B-5130 Finnhub (Per-Call). The rate is on Finnhub\'s invoice, not in this product.';
+const METERED_XAI =
+  'xAI bills per token on the completion this probe requests (model grok-3-mini, max_tokens 10 — route.ts:637-639). The rate is on xAI\'s invoice.';
+const FREE_FRED = 'St. Louis Fed FRED — a free public API behind a free key (FRED_API_KEY). No invoice known to this product.';
+const FREE_SEC = 'SEC EDGAR — a free public API, no key, User-Agent only (route.ts:572). No invoice known to this product.';
+const TT_ACCOUNT =
+  'No per-call invoice: this spends the SHARED FIRM TastyTrade session (getTastytradeClient — env credentials), which is why the route is admin-gated (route.ts:930-935).';
+const NO_CALL = 'Makes no upstream call — nothing is metered.';
+
+/** The 33 feeds the check probes, keyed by the id the route and the screen both use. */
+export const FEED_COST: Readonly<Record<number, FeedCost>> = {
+  // ── TastyTrade: each of these probes calls getCustomerResource() then
+  //    getMarketMetrics() — two SDK calls, on a fixed symbol, market hours only.
+  1:  { provider: 'TastyTrade', billable: false, basis: TT_ACCOUNT, upstreamCalls: 2, usedByScan: true,  scanCitation: 'pipeline.ts:399 getMarketMetrics — batched over all symbols, one call per batch', probes: 'AAPL' },
+  23: { provider: 'TastyTrade', billable: false, basis: TT_ACCOUNT, upstreamCalls: 2, usedByScan: true,  scanCitation: 'pipeline.ts:399 — the same batched market-metrics call carries the greeks fields', probes: 'AAPL' },
+  24: { provider: 'TastyTrade', billable: false, basis: TT_ACCOUNT, upstreamCalls: 2, usedByScan: true,  scanCitation: 'data-fetchers.ts:2271 fetchTTCandlesBatch — a quote-stream subscription per symbol (pipeline.ts:1221), not a REST call', probes: 'AAPL' },
+  31: { provider: 'TastyTrade', billable: false, basis: TT_ACCOUNT, upstreamCalls: 2, usedByScan: true,  scanCitation: 'chain-fetcher.ts:166 getNestedOptionChain — one call per surviving symbol', probes: 'AAPL' },
+  32: { provider: 'TastyTrade', billable: false, basis: TT_ACCOUNT, upstreamCalls: 2, usedByScan: true,  scanCitation: 'pipeline.ts:399 — corr-spy-3month and beta ride the same batched call', probes: 'SPY' },
+
+  // ── Finnhub: one probe = one GET on finnhub.io, metered.
+  2:  { provider: 'Finnhub', billable: true, basis: METERED_FINNHUB, upstreamCalls: 1, usedByScan: true,  scanCitation: 'data-fetchers.ts:214 /stock/metric', probes: 'selected' },
+  3:  { provider: 'Finnhub', billable: true, basis: METERED_FINNHUB, upstreamCalls: 1, usedByScan: true,  scanCitation: 'data-fetchers.ts:110 /stock/eps-estimate', probes: 'selected' },
+  4:  { provider: 'Finnhub', billable: true, basis: METERED_FINNHUB, upstreamCalls: 1, usedByScan: true,  scanCitation: 'data-fetchers.ts:111 /stock/revenue-estimate', probes: 'selected' },
+  5:  { provider: 'Finnhub', billable: true, basis: METERED_FINNHUB, upstreamCalls: 1, usedByScan: true,  scanCitation: 'data-fetchers.ts:112 /stock/price-target', probes: 'selected' },
+  6:  { provider: 'Finnhub', billable: true, basis: METERED_FINNHUB, upstreamCalls: 1, usedByScan: true,  scanCitation: 'data-fetchers.ts:113 /stock/upgrade-downgrade', probes: 'selected' },
+  7:  { provider: 'Finnhub', billable: true, basis: METERED_FINNHUB, upstreamCalls: 1, usedByScan: true,  scanCitation: 'data-fetchers.ts:230 /stock/recommendation', probes: 'selected' },
+  8:  { provider: 'Finnhub', billable: true, basis: METERED_FINNHUB, upstreamCalls: 1, usedByScan: true,  scanCitation: 'data-fetchers.ts:262 /stock/earnings', probes: 'selected' },
+  9:  { provider: 'Finnhub', billable: true, basis: METERED_FINNHUB, upstreamCalls: 1, usedByScan: true,  scanCitation: 'data-fetchers.ts:2074 /stock/earnings-quality-score (the scan asks freq=quarterly; this probe asks freq=annual)', probes: 'selected' },
+  10: { provider: 'Finnhub', billable: true, basis: METERED_FINNHUB, upstreamCalls: 1, usedByScan: true,  scanCitation: 'data-fetchers.ts:1920 /stock/revenue-breakdown2', probes: 'selected' },
+  11: { provider: 'Finnhub', billable: true, basis: METERED_FINNHUB, upstreamCalls: 1, usedByScan: true,  scanCitation: 'data-fetchers.ts:1038 /stock/insider-transactions', probes: 'selected' },
+  12: { provider: 'Finnhub', billable: true, basis: METERED_FINNHUB, upstreamCalls: 1, usedByScan: true,  scanCitation: 'data-fetchers.ts:247 /stock/insider-sentiment', probes: 'selected' },
+  13: { provider: 'Finnhub', billable: true, basis: METERED_FINNHUB, upstreamCalls: 1, usedByScan: true,  scanCitation: 'data-fetchers.ts:1823 /stock/ownership', probes: 'selected' },
+  14: { provider: 'Finnhub', billable: true, basis: METERED_FINNHUB, upstreamCalls: 1, usedByScan: true,  scanCitation: 'data-fetchers.ts:1210 /stock/peers (pipeline.ts:555)', probes: 'selected' },
+  15: { provider: 'Finnhub', billable: true, basis: METERED_FINNHUB, upstreamCalls: 1, usedByScan: true,  scanCitation: 'data-fetchers.ts:389 /stock/financials-reported', probes: 'selected' },
+  16: { provider: 'Finnhub', billable: true, basis: METERED_FINNHUB, upstreamCalls: 1, usedByScan: true,  scanCitation: 'data-fetchers.ts:445-447 /stock/financials — the scan asks bs, ic and cf (three calls); this probe asks ic only', probes: 'selected' },
+  17: { provider: 'Finnhub', billable: true, basis: METERED_FINNHUB, upstreamCalls: 1, usedByScan: true,  scanCitation: 'data-fetchers.ts:2024 /news-sentiment', probes: 'selected' },
+  18: { provider: 'Finnhub', billable: true, basis: METERED_FINNHUB, upstreamCalls: 1, usedByScan: true,  scanCitation: 'data-fetchers.ts:2143 · :2146 /company-news — the scan asks two windows (7d and 30d); this probe asks one', probes: 'selected' },
+  28: { provider: 'Finnhub', billable: true, basis: METERED_FINNHUB, upstreamCalls: 1, usedByScan: true,  scanCitation: 'data-fetchers.ts:230 — the SAME endpoint feed 7 probes; this check pays for it twice', probes: 'selected' },
+  30: { provider: 'Finnhub', billable: true, basis: METERED_FINNHUB, upstreamCalls: 1, usedByScan: true,  scanCitation: 'data-fetchers.ts:2074 — the SAME endpoint feed 9 probes; this check pays for it twice', probes: 'selected' },
+
+  // ── FRED: free public API behind a free key.
+  19: { provider: 'FRED', billable: false, basis: FREE_FRED, upstreamCalls: 2, usedByScan: true, scanCitation: 'data-fetchers.ts:638 · :663 · :683 fetchFredMacro (pipeline.ts:650) — 21 series, once per SCAN, 1-hour cached (:568)', probes: 'none' },
+  25: { provider: 'FRED', billable: false, basis: FREE_FRED, upstreamCalls: 1, usedByScan: true, scanCitation: 'data-fetchers.ts:761 fetchFredDailySeries (pipeline.ts:651) — 3 series, once per SCAN, 1-hour cached (:725)', probes: 'none' },
+
+  // ── SEC: free public API. Feeds 20/21/26/27 share ONE fetch pass in the route.
+  20: { provider: 'SEC', billable: false, basis: FREE_SEC, upstreamCalls: 1, usedByScan: true,  scanCitation: 'data-fetchers.ts:1588 data.sec.gov/submissions (inside fetch10KBusinessDescription)', probes: 'selected' },
+  21: { provider: 'SEC', billable: false, basis: FREE_SEC, upstreamCalls: 1, usedByScan: false, scanCitation: 'the scan never reads company_tickers.json — it resolves the CIK through Finnhub /stock/profile2 (data-fetchers.ts:894 lookupCIK), a METERED call this probe avoids', probes: 'selected' },
+  26: { provider: 'SEC', billable: false, basis: FREE_SEC, upstreamCalls: 1, usedByScan: true,  scanCitation: 'data-fetchers.ts:931 data.sec.gov/api/xbrl/companyfacts', probes: 'selected' },
+  27: { provider: 'SEC', billable: false, basis: FREE_SEC, upstreamCalls: 0, usedByScan: true,  scanCitation: 'data-fetchers.ts:1569 · :1621 · :1672 fetch10KBusinessDescription (pipeline.ts:961) — the SCAN reads the filing; this probe only reports whether the CIK resolved', probes: 'selected' },
+
+  // ── xAI: metered per token.
+  22: { provider: 'xAI', billable: true, basis: METERED_XAI, upstreamCalls: 1, usedByScan: true, scanCitation: 'sentiment.ts:152 /v1/responses · :218 /v1/chat/completions — the scan makes TWO calls per symbol (pipeline.ts:1564)', probes: 'selected' },
+
+  // ── Internal: derived from feeds already fetched, no call of its own.
+  29: { provider: 'Internal', billable: false, basis: NO_CALL, upstreamCalls: 0, usedByScan: true, scanCitation: 'news-classifier.ts — classifies the headlines feed 18 already fetched', probes: 'selected' },
+  33: { provider: 'Internal', billable: false, basis: NO_CALL, upstreamCalls: 0, usedByScan: true, scanCitation: 'sector-stats.ts — computed from the peers (feed 14) and the 10-K text (feed 27)', probes: 'none' },
+};
+
+export const FEED_IDS: readonly number[] = Object.keys(FEED_COST).map(Number).sort((a, b) => a - b);
+
+/**
+ * What ONE SCAN of ONE SYMBOL costs upstream, counted by reading every call
+ * site the pipeline reaches. Upper bounds: the pipeline gates its later stages,
+ * so a symbol dropped early makes fewer, and three caches (Finnhub estimates
+ * 1h, quarterly financials 6h, CIK for the process) can serve a repeat for free.
+ */
+export interface ScanCost {
+  provider: FeedProvider;
+  callsPerSymbol: number | null;
+  callsPerScan: number | null;
+  note: string;
+}
+
+export const SCAN_COST: readonly ScanCost[] = [
+  {
+    provider: 'Finnhub', callsPerSymbol: 28, callsPerScan: null,
+    note: '8 in fetchFinnhubTicker (data-fetchers.ts:214 · :230 · :247 · :262 plus the four estimate calls :110-113), then financials-reported :389, company-news ×2 :2143 · :2146, news-sentiment :2024, earnings-quality-score :2074, ownership + fund-ownership :1823 · :1824, revenue-breakdown2 :1920, financials bs/ic/cf :445-447, profile2 :894, insider-transactions :1038, ebitda-estimate :2405, ebit-estimate :2436, dividend :2470, price-metric :2506, fund-ownership again :2546, calendar/earnings :2632 and peers :1210. Ceiling, not average: a symbol dropped at an early gate makes fewer.',
+  },
+  {
+    provider: 'xAI', callsPerSymbol: 2, callsPerScan: null,
+    note: 'sentiment.ts:152 (/v1/responses, x_search) then :218 (/v1/chat/completions, scoring) — both per symbol, and only when XAI_API_KEY is set (pipeline.ts:1564).',
+  },
+  {
+    provider: 'TastyTrade', callsPerSymbol: 1, callsPerScan: null,
+    note: 'One getNestedOptionChain per surviving symbol (chain-fetcher.ts:166). The market-metrics read is BATCHED over all symbols (pipeline.ts:399), and candles arrive on a quote-stream subscription (data-fetchers.ts:2271), so neither is one call per symbol.',
+  },
+  {
+    provider: 'SEC', callsPerSymbol: 6, callsPerScan: null,
+    note: 'companyfacts :931, then the 10-K walk — efts search :1569, submissions :1588, index.json :1621, the document :1672 — and the 8-K scan :2582.',
+  },
+  {
+    provider: 'FRED', callsPerSymbol: 0, callsPerScan: 24,
+    note: 'Macro is per SCAN, not per symbol: 19 series in the seriesMap loop (:638) plus PAYEMS (:663) and CPIAUCSL (:683), and 3 cross-asset series (:761). 1-hour cached (:568, :725).',
+  },
+];
+
+/** The one-line answer the screen prints above the table. Counts only — the rate is the vendor's. */
+export function scanCostLine(cost: readonly ScanCost[] = SCAN_COST): string {
+  const perSymbol = cost
+    .filter((c) => c.callsPerSymbol !== null && c.callsPerSymbol > 0)
+    .map((c) => `${c.callsPerSymbol} ${c.provider}`);
+  const perScan = cost
+    .filter((c) => c.callsPerScan !== null && c.callsPerScan > 0)
+    .map((c) => `${c.callsPerScan} ${c.provider}`);
+  return `One scan of one symbol = ${perSymbol.join(', ')} — plus, once per scan, ${perScan.join(', ')}.`;
+}
+
+/** What THIS check spent, by provider, counted from the rows it actually ran. */
+export interface ProviderSpend {
+  provider: FeedProvider;
+  calls: number;
+  billable: boolean;
+  feeds: number;
+}
+
+/**
+ * A row counts its calls only when it RAN. A skipped feed and a market-closed
+ * feed made no call, so neither is charged — the status is the evidence.
+ */
+export function callsMade(
+  rows: readonly { id: number; status: string; upstreamCalls?: number }[],
+  cost: Readonly<Record<number, FeedCost>> = FEED_COST,
+): ProviderSpend[] {
+  const by = new Map<FeedProvider, ProviderSpend>();
+  for (const row of rows) {
+    const c = cost[row.id];
+    if (!c) continue;
+    // A probe that stopped at one of its OWN guards reports its own 0 — a
+    // TastyTrade feed with no credentials returns BROKEN having called nothing.
+    const ran = row.status !== 'SKIPPED' && row.status !== 'MKT-HRS';
+    const made = row.upstreamCalls ?? (ran ? c.upstreamCalls : 0);
+    const entry = by.get(c.provider) ?? { provider: c.provider, calls: 0, billable: c.billable, feeds: 0 };
+    entry.calls += made;
+    entry.feeds += 1;
+    by.set(c.provider, entry);
+  }
+  return [...by.values()].sort((a, b) => b.calls - a.calls || a.provider.localeCompare(b.provider));
+}
+
+/** The sentence the screen prints for what this check itself spent. */
+export function callsMadeLine(spend: readonly ProviderSpend[]): string {
+  const spent = spend.filter((s) => s.calls > 0);
+  if (spent.length === 0) return 'This check made no upstream call.';
+  const parts = spent.map((s) => `${s.calls} ${s.provider}${s.billable ? ' (metered)' : ''}`);
+  return `This check made ${parts.join(', ')}. Counts only — the rate lives in the vendor's invoice.`;
+}
+
+export class FeedCostLawError extends Error {
+  constructor(message: string) {
+    super(`FEED COST LAW: ${message}`);
+    this.name = 'FeedCostLawError';
+  }
+}
+
+/** THE LAW. Throws on the first violation; returns the list when asked not to throw. */
+export function feedCostLaw(opts: { throwOnFail?: boolean; cost?: Readonly<Record<number, FeedCost>>; ids?: readonly number[] } = {}): string[] {
+  const cost = opts.cost ?? FEED_COST;
+  const ids = opts.ids ?? FEED_IDS;
+  const violations: string[] = [];
+
+  if (ids.length !== 33) violations.push(`${ids.length} feeds carry a cost row, expected 33 — every feed the check probes says what it costs`);
+  for (let i = 1; i <= 33; i += 1) {
+    if (!(i in cost)) violations.push(`feed ${i} has no cost row — no row may render without one`);
+  }
+  for (const id of ids) {
+    const c = cost[id];
+    if (!c) continue;
+    if (!c.basis.trim()) violations.push(`feed ${id}: billable=${c.billable} with no basis — say on what evidence`);
+    if (c.billable && c.upstreamCalls === 0) violations.push(`feed ${id}: billable but makes no upstream call`);
+    if (!c.billable && c.provider === 'Finnhub') violations.push(`feed ${id}: a Finnhub call is metered — billable must be true`);
+    if (c.upstreamCalls === 0 && c.billable) violations.push(`feed ${id}: no call, so nothing can be metered`);
+    if (c.upstreamCalls < 0) violations.push(`feed ${id}: negative call count`);
+    if (!c.scanCitation.trim()) violations.push(`feed ${id}: usedByScan=${c.usedByScan} with no citation — say where the scan calls it, or why it does not`);
+  }
+  if (violations.length && opts.throwOnFail !== false) throw new FeedCostLawError(violations.join('\n  '));
+  return violations;
+}
+
+feedCostLaw();


### PR DESCRIPTION
**Do not merge — Alex merges after Vercel Preview (SOC 2 gate).**

`HARDCODED_SOURCES` is deleted. With no check run the screen says so. Every rendered row is a measurement, and every feed says what it cost. **This report is the input to the cost ruling — it is long on purpose.**

---

## HARD GATE

| Gate | Touched? | Note |
|---|---|---|
| Auth | **no** | `requireAdmin()` first (`check/route.ts:934`) unchanged — the route fires the shared firm TastyTrade account, so it stays admin-only. |
| Migrations | **no** | No `schema.prisma` change. `ObservatoryHealthLog` already exists (`schema.prisma:2042`) and is written exactly as before. |
| Cost / paid calls | **NO NEW CALL** | Not one upstream call added, removed or re-pointed. The diff only *counts and labels* the calls the route already made. Verified live: my probe run spent **0 Finnhub, 0 xAI, 0 TastyTrade** — the 3 calls it made were free SEC. |
| Security | **no** | No route added. No gate relaxed. |
| User financial data | **untouched** | Nothing in this diff reads or writes it. |

---

## STEP 0.1 — `DataObservatory.tsx` before this PR

| Fact | Citation (on `main`) |
|---|---|
| The array, under its own comment `// ─── Sample Data (fallback when no live results) ───` | `:34`, `:38-72` — 33 rows |
| Where it rendered | `:231` — `const displayRows = liveResults ?? HARDCODED_SOURCES;` |
| Typed status counts, rendered as the System Status panel | `:74-80` — LIVE 17 · PARTIAL 5 · BROKEN 6 · MKT-HRS 5 · SKIPPED 0 |
| Typed scanner-gate verdicts | `:82-87` — e.g. `{ name: 'Quality', ok: false, detail: 'D/E null, earnings quality broken' }` |
| Stale dates rendered as current | `:49` `F: -639 (2026-03-02)` · `:56` `2026-03-04` |
| Typed latencies | `12ms`, `8ms`, `287ms` … `:40-71` |
| What it did with no check run | rendered all 33 fabricated rows; the only honest cell was **Last Checked: —** (`:397`) |
| Are results persisted? | **Yes, but not readable back as a table.** The route writes one row per feed to `ObservatoryHealthLog` (`check/route.ts:1120`) — but that table holds only symbol, sourceId, sourceName, dataSource, status, lastValue, wasMarketHours, checkedAt (`schema.prisma:2042-2055`). **No latency, no records, no payload.** The component never read it back: results lived only in `useState` (`:202-205`), set only by `runCheck` (`:211-228`). |
| One more fabrication | `:338` — an expanded row with no payload printed an invented JSON stub ending `"data": null` |

---

## STEP 0.2 — the 33 feeds: provider, upstream call, billable, how status is decided

Every row read from `src/app/api/data-observatory/check/route.ts`. **One probe = one upstream call** unless the count says otherwise. `FINNHUB_BASE` = `https://finnhub.io/api/v1` (`:27`).

| # | Feed | Provider | Upstream call | Billable | Calls | How the status is decided |
|---|---|---|---|---|---|---|
| 1 | TastyTrade IV/HV | TastyTrade | SDK `getCustomerResource()` + `getMarketMetrics({symbols:'AAPL'})` `:93-94` | no (firm account) | 2 | closed → MKT-HRS `:84`; no creds → BROKEN `:87`; 0 items → BROKEN `:97`; else LIVE `:104`; throw → BROKEN `:110` |
| 2 | Finnhub Basic Metrics | Finnhub | `/stock/metric?metric=all` `:78` | **yes** | 1 | `:120-123` — 0 of 6 fields → BROKEN; beta present **and** all 6 → LIVE; else **PARTIAL** |
| 3 | EPS Estimates | Finnhub | `/stock/eps-estimate?freq=quarterly` `:140` | **yes** | 1 | `:148` `items.length > 0 ? 'LIVE' : 'BROKEN'` |
| 4 | Revenue Estimates | Finnhub | `/stock/revenue-estimate?freq=quarterly` `:162` | **yes** | 1 | `:171` same rule |
| 5 | Price Targets | Finnhub | `/stock/price-target` `:185` | **yes** | 1 | `:191` `d?.targetMean != null ? 'LIVE' : 'BROKEN'` |
| 6 | Upgrades/Downgrades | Finnhub | `/stock/upgrade-downgrade` `:205` | **yes** | 1 | `:210-211` `let status='BROKEN'; if (items.length>0) status = hasDate ? 'LIVE' : 'PARTIAL'` — **rows without `gradeTime` are PARTIAL** |
| 7 | Recommendations | Finnhub | `/stock/recommendation` `:229` | **yes** | 1 | `:237` `items.length > 0 ? 'LIVE' : 'BROKEN'` |
| 8 | Earnings History | Finnhub | `/stock/earnings?limit=40` `:251` | **yes** | 1 | `:258` same rule |
| 9 | Earnings Quality | Finnhub | `/stock/earnings-quality-score?freq=annual` `:272` | **yes** | 1 | `:281-288` **`if (year < 2020) { status='BROKEN'; lastValue = \`Returning ${year} data\` }`** else LIVE. This is the "1983 data" row — the vendor answers with a pre-2020 period. |
| 10 | Revenue Breakdown | Finnhub | `/stock/revenue-breakdown2` `:306` | **yes** | 1 | four BROKEN exits — no annual `:312`, no segments `:317`, empty group `:322`, no positive segments `:333`; else LIVE `:339` |
| 11 | Insider Transactions | Finnhub | `/stock/insider-transactions` `:353` | **yes** | 1 | `:361` `items.length > 0 ? 'LIVE' : 'BROKEN'` |
| 12 | Insider Sentiment | Finnhub | `/stock/insider-sentiment?from=2024-01-01&to=2025-12-31` `:375` | **yes** | 1 | `:383` `items.length > 0 ? 'LIVE' : 'BROKEN'`; empty → `lastValue: 'Empty response'` `:385`. **Note the window is hard-coded and now in the past.** |
| 13 | Institutional Own. | Finnhub | `/stock/ownership?limit=5` `:397` | **yes** | 1 | `:404-405` `let status='BROKEN'; if (items.length>0) status = hasName ? 'LIVE' : 'PARTIAL'` — **holders with a null `name` are PARTIAL** |
| 14 | Peers | Finnhub | `/stock/peers` `:422` | **yes** | 1 | `:427` `items.length > 0 ? 'LIVE' : 'BROKEN'` |
| 15 | Financials (Annual) | Finnhub | `/stock/financials-reported?freq=annual` `:441` | **yes** | 1 | `:452` **`items.length > 0 ? (hasRevenue ? 'LIVE' : 'BROKEN') : 'BROKEN'`** where `hasRevenue` scans `report.ic` for a concept containing "revenue" with a non-null value `:449` — reports arriving with all-null fields are BROKEN |
| 16 | Financials (Quarterly) | Finnhub | `/stock/financials?statement=ic&freq=quarterly` `:466` | **yes** | 1 | `:474-477` **`present.length === 4 ? 'LIVE' : (present.length > 0 ? 'PARTIAL' : 'BROKEN')`** over `revenue, netIncome, grossIncome, ebit` — a missing `grossIncome` alone makes it PARTIAL |
| 17 | FinBERT Sentiment | Finnhub | `/news-sentiment` `:495` | **yes** | 1 | `:502` `bullish != null ? 'LIVE' : 'BROKEN'` |
| 18 | Company News | Finnhub | `/company-news?from=-7d&to=today` `:997` (shared with 29) | **yes** | 1 | `:1006` `items.length > 0 ? 'LIVE' : 'BROKEN'` |
| 19 | FRED Macro (14 series) | FRED | 2 × `api.stlouisfed.org/fred/series/observations` (VIXCLS, DGS10) `:546-547` | no (free key) | 2 | no key → SKIPPED `:541`; `:554,557` **`bothLive ? 'LIVE' : 'PARTIAL'`** where a value of `'.'` counts as missing. **Labelled "14 series" but probes 2.** |
| 20 | SEC EDGAR Submissions | SEC | `data.sec.gov/submissions/CIK…json` `:593` | no (free) | 1 | `:608` `hasEntity ? 'LIVE' : (secData.cik ? 'PARTIAL' : 'BROKEN')` |
| 21 | SEC Company Tickers | SEC | `www.sec.gov/files/company_tickers.json` `:571` | no (free) | 1 | `:619` `secData.cik ? 'LIVE' : 'BROKEN'` |
| 22 | xAI/Grok Sentiment | xAI | POST `api.x.ai/v1/chat/completions`, `grok-3-mini`, `max_tokens: 10` `:633-640` | **yes (tokens)** | 1 | no key → SKIPPED `:630`; `:647` `content ? 'LIVE' : 'BROKEN'` |
| 23 | TastyTrade Greeks | TastyTrade | `getCustomerResource()` + `getMarketMetrics({symbols:'AAPL'})` `:668-669` | no | 2 | closed → MKT-HRS `:659`; no creds → BROKEN `:662`; 0 items → BROKEN `:672`; else LIVE `:681` |
| 24 | TastyTrade Candles | TastyTrade | same two SDK calls `:703-704` (a comment at `:699` says candle streaming is too heavy for a health check) | no | 2 | as above, then `:716` **`count > 0 ? 'LIVE' : 'PARTIAL'`** over HV30/60/90 |
| 25 | FRED Cross-Asset Daily | FRED | `…observations?series_id=DGS10&limit=5` `:807` | no | 1 | no key → SKIPPED `:803`; `:817` `hasValue ? 'LIVE' : 'BROKEN'`. **Labelled "3 series" but probes 1 (DGS10).** |
| 26 | SEC EDGAR XBRL Facts | SEC | `data.sec.gov/api/xbrl/companyfacts/CIK….json` `:1032` | no | 1 | no CIK → BROKEN `:830`; fetch failed → BROKEN `:833`; `:837` `entityName ? 'LIVE' : 'BROKEN'` |
| 27 | 10-K Business Description | SEC | **none — it reads feed 20/21's CIK** | no | 0 | `:848` `secData.cik ? 'LIVE' : 'BROKEN'`. **It never fetches a 10-K; it reports whether the CIK resolved.** |
| 28 | Finnhub Recommendations | Finnhub | `/stock/recommendation` `:859` | **yes** | 1 | `:868` `items.length > 0 ? 'LIVE' : 'BROKEN'` — **the same endpoint as feed 7; this check pays twice** |
| 29 | News Classifier | Internal | none — classifies feed 18's payload | no | 0 | `:884` `newsItems.length > 0 ? 'LIVE' : 'BROKEN'` |
| 30 | Finnhub Earnings Quality | Finnhub | `/stock/earnings-quality-score?freq=annual` `:895` | **yes** | 1 | `:902-911` identical `year < 2020 → BROKEN` rule — **the same endpoint as feed 9; paid twice** |
| 31 | TastyTrade Options Flow | TastyTrade | `getCustomerResource()` + `getMarketMetrics({symbols:'AAPL'})` `:736-737` | no | 2 | closed → MKT-HRS `:727`; no creds → BROKEN `:730`; 0 items → BROKEN `:740`; else LIVE `:747`. **Named "chain API" but reads market metrics.** |
| 32 | TastyTrade SPY Correlation | TastyTrade | same two SDK calls, `{symbols:'SPY'}` `:767-768` | no | 2 | as above, LIVE `:778` |
| 33 | Peer Stats (computed) | Internal | **none** | no | 0 | **`status: 'LIVE'` typed into the source with `latency: '0ms'`** (`:791`, `:794`) — a claim with no measurement behind it. **Fixed in this PR: SKIPPED with its reason.** |

**The six the sample called BROKEN — the decision lines, verbatim:**

- **9** `if (year < 2020) { status = 'BROKEN'; lastValue = \`Returning ${year} data\`; }` (`:282-284`)
- **12** `status: items.length > 0 ? 'LIVE' : 'BROKEN'` with `lastValue: latest?.mspr != null ? … : 'Empty response'` (`:383`, `:385`)
- **15** `status: items.length > 0 ? (hasRevenue ? 'LIVE' : 'BROKEN') : 'BROKEN'` (`:452`)
- **26** `return { … status: 'BROKEN', … lastValue: 'CIK lookup failed' }` (`:830`) / `'XBRL fetch failed'` (`:833`), else `status: xbrlResult.entityName ? 'LIVE' : 'BROKEN'` (`:837`)
- **27** `status: secData.cik ? 'LIVE' : 'BROKEN'` (`:848`)
- **30** `if (year < 2020) { status = 'BROKEN'; lastValue = \`Returning ${year} data\`; }` (`:905-907`)

**The four the sample called PARTIAL** (the ruling lists five ids — 2, 6, 10, 13, 16 — and the sample marks 2, 6, 10, 13, 16 PARTIAL, five rows; feed 10's prober has no PARTIAL branch at all, only LIVE or one of four BROKENs):

- **2** `if (nonNull.length === 0) status='BROKEN'; else if (beta != null) status = nonNull.length === fields.length ? 'LIVE' : 'PARTIAL'; else status='PARTIAL';` (`:121-123`)
- **6** `let status: SourceStatus = 'BROKEN'; if (items.length > 0) status = hasDate ? 'LIVE' : 'PARTIAL';` (`:210-211`)
- **13** `let status: SourceStatus = 'BROKEN'; if (items.length > 0) status = hasName ? 'LIVE' : 'PARTIAL';` (`:404-405`)
- **16** `status = present.length === fields.length ? 'LIVE' : (present.length > 0 ? 'PARTIAL' : 'BROKEN');` (`:476`)
- **10** — **no PARTIAL branch exists** (`:312`, `:317`, `:322`, `:333` BROKEN; `:339` LIVE). The sample's `PARTIAL / "Parser bug"` for feed 10 was a state the prober cannot produce.

---

## STEP 0.3 — what one scan of one symbol actually costs

Counted by reading every call site `src/lib/convergence/pipeline.ts` reaches. **Ceilings**: the pipeline gates its later stages, so a symbol dropped early makes fewer.

| Provider | Per symbol | Per scan | Where |
|---|---|---|---|
| **Finnhub** | **28** | — | see the breakdown below |
| **xAI** | **2** | — | `sentiment.ts:152` (`/v1/responses`, x_search) then `:218` (`/v1/chat/completions`, scoring); gated on `XAI_API_KEY` at `pipeline.ts:1564` |
| **TastyTrade** | **1** | + 1 batched metrics call per batch | `chain-fetcher.ts:166` `getNestedOptionChain` per surviving symbol. Market metrics are **batched over all symbols** (`pipeline.ts:399`), and candles arrive on a **quote-stream subscription** (`data-fetchers.ts:2271`), so neither is one call per symbol. |
| **SEC** | **6** | — | companyfacts `:931`; the 10-K walk — efts search `:1569`, submissions `:1588`, index.json `:1621`, the document `:1672`; the 8-K scan `:2582` |
| **FRED** | **0** | **24** | 19 series in the loop `:638` + PAYEMS `:663` + CPIAUCSL `:683` + 3 cross-asset `:761`. Once per scan, 1-hour cached (`:568`, `:725`). |

**The 28 Finnhub calls, one by one:**

| Calls | Fetcher | Endpoint(s) | Pipeline call site |
|---|---|---|---|
| 8 | `fetchFinnhubTicker` `:180` | `/stock/metric` `:214`, `/stock/recommendation` `:230`, `/stock/insider-sentiment` `:247`, `/stock/earnings` `:262`, then `fetchFinnhubEstimates` `:90` → eps-estimate `:110`, revenue-estimate `:111`, price-target `:112`, upgrade-downgrade `:113` | `:765` `fetchFinnhubBatch` |
| 1 | `fetchAnnualFinancials` | `/stock/financials-reported` `:389` | `:784` |
| 2 | `fetchNewsSentiment` | `/company-news` ×2 (7d `:2143`, 30d `:2146`) | `:825` |
| 1 | `fetchFinnhubNewsSentiment` | `/news-sentiment` `:2024` | `:842` |
| 1 | `fetchFinnhubEarningsQuality` | `/stock/earnings-quality-score` `:2074` | `:859` |
| 2 | `fetchFinnhubInstitutionalOwnership` | `/stock/ownership` `:1823`, `/stock/fund-ownership` `:1824` | `:876` |
| 1 | `fetchFinnhubRevenueBreakdown` | `/stock/revenue-breakdown2` `:1920` | `:893` |
| 3 | `fetchQuarterlyFinancials` | `/stock/financials` bs `:445`, ic `:446`, cf `:447` | `:910` |
| 1 | `lookupCIK` | `/stock/profile2` `:894` | via `:927`, `:961` |
| 1 | `fetchInsiderTransactions` | `/stock/insider-transactions` `:1038` | `:944` |
| 1 | `fetchFinnhubEbitdaEstimates` | `/stock/ebitda-estimate` `:2405` | `:979` |
| 1 | `fetchFinnhubEbitEstimates` | `/stock/ebit-estimate` `:2436` | `:990` |
| 1 | `fetchFinnhubDividendHistory` | `/stock/dividend` `:2470` | `:1001` |
| 1 | `fetchFinnhubPriceMetrics` | `/stock/price-metric` `:2506` | `:1012` |
| 1 | `fetchFinnhubFundOwnership` | `/stock/fund-ownership` `:2546` | `:1023` |
| 1 | `fetchFinnhubEarningsCalendar` | `/calendar/earnings` `:2632` | `:1045` |
| 1 | `fetchPeerTickers` | `/stock/peers` `:1210` | `:555` |

**Four things that move the real number, all read from the code:**

1. **`fetchWithRetry` retries once on HTTP 429** (`data-fetchers.ts:77-81`) — every throttled call is **billed twice**.
2. **`/stock/fund-ownership` is fetched twice per symbol** — `:1824` inside institutional ownership and `:2546` in its own fetcher.
3. Three caches cut a repeat: Finnhub estimates 1h (`:88`), quarterly financials 6h (`:417`), CIK for the process (`:877`).
4. The observatory's own check duplicates two endpoints (feeds 7/28 and 9/30), so **one check = 19 Finnhub calls for 17 distinct endpoints**.

---

## STEP 0.4 — swallowed failures

I checked every catch that could put a neutral value into a score. **The composite discipline holds** — `weighted-combiner.ts:24-31` excludes a null component and renormalizes, exactly as ruled, and `fetchFinnhubTicker` declares every per-endpoint failure into `feedErrors` (`:205-209`, `:103-107`). What I found is a **diagnosis** loss, not a scoring lie:

| Where | What is swallowed | Consequence |
|---|---|---|
| **`data-fetchers.ts:905-907`** `lookupCIK` — a bare `} catch { return null; }`, the only catch in convergence with no `declare` | A network or parse failure returns `null`, **identical to "this symbol has no CIK"** | Every SEC fetcher that depends on it — `fetchSECFilingData:924`, `fetchSECForm4Data:1253`, `fetch10KBusinessDescription:1557` — then reports "no filing" instead of "the lookup failed". **It does not reach the composite as a neutral** (below), but the operator cannot tell an outage from an absence. |
| `check/route.ts:1038` | XBRL fetch → `xbrlResult = null` | Honest: feed 26 then says `XBRL fetch failed` (`:833`) |
| `check/route.ts:1124` | The `ObservatoryHealthLog` write | A failed persist is **invisible** — the response looks identical |
| `check/route.ts:1148` | The last-confirmed-LIVE query | On failure every MKT-HRS row silently reads "Never confirmed" |

**Explicitly NOT a violation, checked rather than assumed:** `info-edge.ts:1082` returns `filing_recency_score: 50` when there is no filing — which looks like an imputed neutral. It is not consumed: the guard at **`info-edge.ts:1461`** is `if (score !== null && filingRecency.filing_signal_active && filingRecency.filing_modifier !== 0)`, and the dormant branch sets `filing_signal_active: false` **and** `filing_modifier: 0` (`:1077`, `:1083`). The 50 is a trace field; the signal is excluded. Likewise `pipeline.ts:403-408` catches a market-metrics batch error but **pushes it to `errors`** — declared, not silent.

---

## STEP 0.5 — every other hardcoded/sample array in `src`

Grepped `HARDCODED`, `SAMPLE_`, `MOCK_`, `DEMO_`, `PLACEHOLDER_`, `"fallback when no"`. **Nothing outside the observatory was changed.**

| Location | What it is | Rendering as fact? |
|---|---|---|
| `src/components/data-observatory/DataObservatory.tsx:38, :74, :82` | the three arrays | **YES — this PR deletes them** |
| `src/components/landing/Landing.tsx:495-515` `IMPORT_ARRIVALS` | 19 typed arrival rows with invented ids, hashes and timestamps, on the public landing | **Illustration, declared in code** — `:491` says "times and ids are invented display data". It diagrams the mechanism; it makes no claim about a viewer's data. Reported, untouched. |
| `src/components/home/tradeShowcaseRows.ts:38` `DEMO_MACRO` | declared synthetic inputs run through the **real** scorer `scoreAll` (`:1-22`) | No — the scores are engine output; the SHOWROOM-TRUTH-FIX exists precisely so the demo cannot drift |
| `src/components/workbench/…/showroom/demoData.ts` | the projects showroom's demo entity | No — declared demo, guarded by `assert-showroom-fetch-free.mjs` |
| `src/components/home/EvolutionPreview.tsx:21` `PLACEHOLDER_NODES` | two structural nodes | No — `:19-20` says it asserts no date or count; values render as em-dashes |
| `src/lib/liteapiFlightsClient.ts:535` | a comment noting `usePaymentSdk` is hardcoded true | Not a rendered array |

---

## STEP 1 — delete the lie

- `HARDCODED_SOURCES`, `HARDCODED_STATUS_COUNTS` and `HARDCODED_SCANNER_GATES` are **gone**. `displayRows = liveResults ?? HARDCODED_SOURCES` is gone with them.
- With no check run, the screen renders a **not-measured state** and **zero rows** — no status, no latency, no value, no count.
- Every rendered table carries **`Data Sources — measured at <timestamp>`** and **`Symbols probed: …`**.
- A skipped feed reads **SKIPPED with its reason** (`FINNHUB_API_KEY not set`), straight from the route.
- **A failed check leaves the screen unmeasured and says why** — it never falls back to a previous run or to typed rows.
- The invented JSON stub is gone: an expanded row with no payload now says *"No payload was captured for this probe — it returned none, or it did not run."*
- **Scanner readiness gained a third state.** It used to call a gate DEGRADED whenever its feed was not LIVE — including when the probe never ran. A gate whose feed was SKIPPED or market-closed is now **UNKNOWN**, with the reason.
- **The prober's own lie is fixed.** Feed 33 returned `status: 'LIVE'`, `latency: '0ms'` while calling nothing and computing nothing. It now returns **SKIPPED** — *"Not probed — derived from feeds 14 (peers) and 27 (10-K); this check computes nothing and calls nothing."*

### On not reading the last run back

The check persists to `ObservatoryHealthLog`, so "show the last run" looks free. It is not: that table has **no latency, no records and no payload**, so a table built from it would be a partial reconstruction rendered as a measurement — the exact thing this PR deletes. The ruling says *"With no check run, the screen states: not measured yet"*, and that is what it does. Reading the last run back honestly needs its own route and its own columns.

---

## STEP 2 — every feed carries its cost

New pure leaf **`src/lib/observatory/feedCost.ts`** (221 lines), read by both the route and the screen so there is one source. Per feed: `provider`, `billable`, `basis`, `upstreamCalls`, `usedByScan`, `scanCitation`, `probes`.

**`billable` always states its evidence** — never a guessed rate:

| Provider | Billable | Basis |
|---|---|---|
| Finnhub | **yes** | metered per call — the COA carries **B-B-5130 Finnhub (Per-Call)**; the rate is on Finnhub's invoice |
| xAI | **yes** | per token on the completion this probe requests (`grok-3-mini`, `max_tokens: 10`, `route.ts:637-639`) |
| TastyTrade | no | no per-call invoice — it spends the **shared firm session**, which is why the route is admin-gated |
| FRED | no | free public API behind a free key |
| SEC | no | free public API, User-Agent only |
| Internal | no | makes no upstream call |

**A probe stopped at its own guard is charged nothing.** The five TastyTrade feeds return BROKEN for missing credentials **before touching `getTastytradeClient()`** (`:88`, `:663`, `:696`, `:731`, `:762`). They now declare `upstreamCalls: 0` on the spot, and that declaration wins over the cost row's 2. *(I got this wrong first: my initial attribution charged them 2 each because it only zeroed SKIPPED and MKT-HRS. The live probe caught it — the fix and its test are in the diff.)*

**No prices, anywhere.** A test asserts no `$`-and-digit appears in any cost line, basis or note.

**One finding the cost map surfaced:** feed 21 is the only probe the scan does **not** use — the scan resolves the CIK through Finnhub `/stock/profile2` (`data-fetchers.ts:894`), a **metered** call, where the observatory uses SEC's free `company_tickers.json`.

---

## STEP 3 — the law and the tests

`scripts/assert-tool-registry.ts` gains the **observatory law**: no file under `src/components/data-observatory` may hold a typed status/latency/records array — banned **by name** (`HARDCODED_*`, `SAMPLE_*`, `MOCK_*`, `FALLBACK_*`) and **by shape**, so a rename does not evade it — and `DataObservatory.tsx` must render the not-measured state. It also runs `feedCostLaw()` and prints the 33-row cost census.

```
✔ The observatory law passed — 33 feeds each carry provider, metered, calls and scan use;
  1 file(s) under src/components/data-observatory hold 0 typed measurement(s); the screen
  renders a not-measured state. One scan of one symbol: 28 Finnhub · 2 xAI · 1 TastyTrade · 6 SEC.
```

**Negative proof, three ways — each fails the build:**

```
✖ BUILD LAW FAILED:
  observatory: …/DataObservatory.tsx declares HARDCODED_SOURCES — the observatory measures
  or says nothing; no typed status, latency or record array
```
```
✖ BUILD LAW FAILED:
  observatory: …/DataObservatory.tsx writes a status with a latency or record count into
  source (status: 'PARTIAL', records: '8 fields', latency:…) — a row renders only from a
  measurement                                    ← renamed to `lastKnownRows`; caught by shape
```
```
✖ BUILD LAW FAILED:
  observatory: DataObservatory.tsx must render the not-measured state (data-not-measured)
  — with no check run there is nothing to show
```

### The assert had no gate for any of this

Writing the law found a defect on `main`: **the assert's only `if (violations.length)` gate is at line 550**, and the kind-views law (`:561-578`) pushes violations *after* it. Those pushes were read by nothing and could not fail a build — the law printed `✔ passed` regardless. My law landed in the same dead zone and passed with `HARDCODED_SOURCES` reinstated. **A second gate at the end of the file now raises everything pushed below the first.** With it armed, the whole suite still passes — nothing was hiding.

**6 new tests** (`src/lib/__tests__/observatory.test.ts`): the cost map is complete and only Finnhub/xAI are billable; the law rejects a missing feed, a billable feed that calls nothing, an unmetered Finnhub call and a basis-less row; SKIPPED and MKT-HRS are charged nothing; **a probe stopped at its own guard is charged nothing even when it reports BROKEN**; no price appears in any cost text; and — rendering the real component with `renderToStaticMarkup` — **the screen with no results renders the not-measured state and zero rows**, printing none of `beta: 1.09`, `12ms`, `Returning 1983 data`, `2026-03-02`, `Bullish: 0.93` or `CIK: 789019`.

---

## VERIFY

| Check | Result |
|---|---|
| `npx tsc --noEmit` | **exit 0** |
| `npm run lint` | **854 problems (576 errors, 278 warnings)** — identical to `main`; **zero new**. Per-file: `DataObservatory.tsx` 0/0, `feedCost.ts` 0/0, `observatory.test.ts` 0/0, `assert-tool-registry.ts` 0/0, `check/route.ts` 0 errors / 1 pre-existing warning (unchanged). |
| `npm test` | **275 / 275** (`main`: 269 — +6) |
| Full build (twelve laws) | **exit 0** |
| Registry census | `LIVE 2 · PARTIAL 9 · NOT_BUILT 14` — untouched |
| Reachability | `✔ 68 pages, every one has a door` · `pages: 68 · doors: 68` |

**Live probe** (dev server, admin viewer, **no vendor keys set — nothing metered could be spent**):

- **State 1, never measured:** `0` rows rendered, no measured-at header, the not-measured panel, and *"No check has run this session, so this screen has spent nothing."*
- **State 2, after a real run:** 33 rows, header `Data Sources — measured at 9/9/2026, 5:20:33 PM · Symbols probed: AAPL, MSFT, SPY · selected MSFT — the TastyTrade probes ask about a fixed ticker, not the selected one · market OPEN`. Statuses **4 LIVE · 5 BROKEN · 24 SKIPPED · 0 PARTIAL · 0 MKT-HRS** — every one earned. **Spend: SEC 3, Finnhub 0, xAI 0, TastyTrade 0, FRED 0** — the only calls made were free SEC ones.

Screenshots of both states are in the session chat (audit output is never committed — the repo is public).

---

## FILES TOUCHED — 5 files, +761 / −244

| File | Change |
|---|---|
| `src/components/data-observatory/DataObservatory.tsx` | the three arrays deleted; not-measured state; measured-at + symbols-probed header; cost columns; UNKNOWN gate state; no invented payload stub; the row fragment properly keyed |
| `src/lib/observatory/feedCost.ts` | **new** — the 33 cost rows, the scan counts, `callsMade`, and `feedCostLaw` |
| `src/app/api/data-observatory/check/route.ts` | attaches provider/billable/calls/scan-use/probed-symbol; feed 33 no longer claims LIVE; the five TT credential guards declare 0 calls; the response carries `marketOpen` and `spend`. **No upstream call added or changed.** |
| `scripts/assert-tool-registry.ts` | the observatory law, the cost census, and the **missing second gate** |
| `src/lib/__tests__/observatory.test.ts` | **new** — 6 tests |

---

## FINDINGS FOR THE COST RULING

1. **The check pays for two endpoints twice.** Feeds 7 and 28 both GET `/stock/recommendation`; feeds 9 and 30 both GET `/stock/earnings-quality-score`. **One check = 19 Finnhub calls for 17 distinct endpoints.** Deduplicating is a ~10% cut on every check, with no loss.
2. **`fetchWithRetry` bills a throttled call twice** (`data-fetchers.ts:77-81`): on HTTP 429 it waits 5s and refires. Under rate-limiting the real per-scan Finnhub number is above 28.
3. **`/stock/fund-ownership` is fetched twice per symbol in the scan** — `:1824` and `:2546`. One is redundant.
4. **The scan pays Finnhub for a CIK that SEC gives away.** `lookupCIK` uses `/stock/profile2` (metered, `:894`); the observatory gets the same CIK from SEC's free `company_tickers.json`. One metered call per uncached symbol.
5. **Three feeds are labelled larger than they probe.** Feed 19 says "14 series" and fetches 2; feed 25 says "3 series" and fetches 1; feed 31 says "chain API" and reads market metrics. The rows now show real call counts, but the *names* still overstate.
6. **Feed 12's window is hard-coded and expired** — `from=2024-01-01&to=2025-12-31` (`:375`). Today is 2026-09-09, so the probe asks about a window that ended nine months ago and reads "Empty response" as BROKEN. That may be the whole of the "MSPR broken" story.
7. **Feed 27 never fetches a 10-K.** It reports whether the CIK resolved (`:848`). The scan does read the filing (`:1569`→`:1672`), so a green row here is not evidence the scan's 10-K path works.
8. **The TastyTrade probes do not probe the selected symbol** — four ask about AAPL, one about SPY. The screen now says so on every run.
9. **`lookupCIK`'s bare catch** (`:905`) is the one swallowed failure worth fixing: a SEC outage is reported as "no filing exists". It does not corrupt a score, but it hides an outage. Out of scope here — one concept per PR.
10. **The assert's second gate was missing** on `main`, so the kind-views law could not fail a build. Now armed; nothing was hiding behind it.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc

---
_Generated by [Claude Code](https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc)_