### PR TITLE
LOCK-01: a locked step shows its room, not a sales pitch — and every paid surface checks its key

### DIFF
--- a/scripts/assert-tool-registry.ts
+++ b/scripts/assert-tool-registry.ts
@@ -698,6 +698,64 @@ if (existsSync(resolve(ROOT, 'src/components/ui/ShellFrame.tsx'))) {
   violations.push('shell: ShellFrame is back — AppLayout is the ONE wrapper (SHELL-02)');
 }
 console.log(`✔ The shell law passed — ${shellFiles.length} files scanned, ${shellOffenders} outside ShellBar render a sign-out, a brand bar or the module band; ${DECK_HEADER_FILES.length} declared deck surfaces keep LandingHeader; AppLayout is the one wrapper.`);
+// ── THE LOCK LAW (LOCK-01) ────────────────────────────────────────────────
+// (a) EVERY page that mounts a paid module's root component asks for its key
+//     first. src/app/dashboard/tax-filing/page.tsx mounted the FULL filing
+//     wizard with no check at all: an account holding nothing got the whole
+//     wizard at that URL. The table below is the component → key map; a page
+//     that mounts one of them without naming a gate fails the build.
+// (b) NO offer inside the app. The offer card, its price line and its billing
+//     copy belong at /pricing and on the deck; a locked step shows its room.
+const PAID_COMPONENTS: ReadonlyArray<{ component: string; key: string }> = [
+  { component: 'TaxFilingWizard', key: 'tab:tax' },
+  { component: 'BooksPipeline', key: 'tab:books' },
+  { component: 'ConvergenceIntelligence', key: 'tab:trade' },
+  { component: 'TradeLabPanel', key: 'tab:trade' },
+  { component: 'COAManagementTable', key: 'tab:books' },
+  { component: 'BookkeepingSection', key: 'tab:books' },
+  { component: 'ComplianceWorkbench', key: 'tab:compliance' },
+];
+// The gate is one of the two twins — the server's roomGate/hasTabAccess or the
+// client's useTabLock/isTabLocked — and both resolve through keysGranting.
+const GATE_MARK = /(roomGate|useTabLock|hasTabAccess|isTabLocked)\s*\(/;
+const OFFER_ALLOWLIST = [
+  'src/app/pricing/',
+  'src/components/landing/',
+  'src/app/modules/',
+  // The offer card itself and the tab card that renders it — leaves the deck imports.
+  'src/components/OfferCard.tsx',
+  'src/components/home/LockedTabCard.tsx',
+  'src/components/home/TabShowcases.tsx',
+  'src/components/home/TabShowcaseTemplate.tsx',
+  'src/components/home/ComplianceShowcaseSections.tsx',
+];
+const BILLING_COPY = /(BILLED MONTHLY|CANCEL ANYTIME|Billed monthly|Cancel anytime)/;
+const OFFER_MOUNT = /<LockedTabCard\b/;
+let ungated = 0;
+let offerInApp = 0;
+for (const f of shellFiles) {
+  const src = readFileSync(resolve(ROOT, f), 'utf8');
+  const code = src.split('\n').filter((l) => !/^\s*(\*|\/\/|\/\*)/.test(l)).join('\n');
+  if (f.endsWith('/page.tsx')) {
+    for (const { component, key } of PAID_COMPONENTS) {
+      if (!new RegExp(`<${component}\\b`).test(code)) continue;
+      if (!GATE_MARK.test(code)) {
+        ungated += 1;
+        violations.push(`lock: ${f} mounts ${component} (${key}) with no entitlement check — every paid surface asks for its key (LOCK-01)`);
+      }
+    }
+  }
+  if (OFFER_ALLOWLIST.some((a) => f.startsWith(a))) continue;
+  if (BILLING_COPY.test(code)) {
+    offerInApp += 1;
+    violations.push(`lock: ${f} carries billing copy — the offer lives at /pricing and on the deck, never inside the app (LOCK-01)`);
+  }
+  if (OFFER_MOUNT.test(code)) {
+    offerInApp += 1;
+    violations.push(`lock: ${f} renders LockedTabCard — a locked step shows its room, not a sales pitch (LOCK-01)`);
+  }
+}
+console.log(`✔ The lock law passed — ${PAID_COMPONENTS.length} paid components mapped to their keys, ${ungated} page(s) mount one without a check; ${offerInApp} file(s) outside /pricing and the deck carry an offer or billing copy.`);
 console.log(`✔ The offer law passed — ${OFFERS.length} offers over ${new Set(OFFERS.flatMap((o) => o.tools)).size} tools (LIVE or PARTIAL only), ${FREE_TOOLS.length} free; the purchasable keys are the offers'; "built and running" typed nowhere but offer.ts; ${SELLING_SURFACES.length} selling surfaces render the offer.`);
 
 // ── THE SECOND GATE ─────────────────────────────────────────────────────────

--- a/src/app/accounts/page.tsx
+++ b/src/app/accounts/page.tsx
@@ -1,32 +1,22 @@
-import { getVerifiedEmail } from '@/lib/cookie-auth';
-import { prisma } from '@/lib/prisma';
-// SHELL-02: the lock card renders the offer from the server's price-id presence map.
-import { offerAvailabilityFromEnv } from '@/lib/offer';
 import AppLayout from '@/components/ui/AppLayout';
 import AccountsClient from '@/components/accounts/AccountsClient';
 
 /**
- * ACCOUNTS-01 — /accounts, THE RAIL'S STEP 1 SCREEN. The shell (and with it the
- * rail) is mounted here, the way /step/[slug] does it: this page reads the
- * verified cookie for the shell bar's viewer and nothing else — every account
- * read happens in the client component, against the already-authed,
- * user-scoped /api/accounts.
+ * ACCOUNTS-01 → LOCK-01 — /accounts, THE RAIL'S STEP 1 SCREEN. The shell (and
+ * with it the rail) is mounted here; AppLayout reads the viewer itself. Every
+ * account read happens in the client component against the already-authed,
+ * user-scoped /api/accounts, and a 403 from that gate renders the room's EMPTY
+ * state under the locked note — never an error, never an HTTP status.
  *
  * Auth: a protected path — middleware bounces an unverified visitor to '/'
  * before this renders.
  */
 export const dynamic = 'force-dynamic';
 
-export default async function AccountsPage() {
-  const viewer = await getVerifiedEmail();
-  // SHELL-02: the viewer's id, for the lock card's checkout door. No entitlement
-  // is read here — the gate lives in /api/accounts, and a refusal renders the lock.
-  const user = viewer
-    ? await prisma.users.findFirst({ where: { email: { equals: viewer, mode: 'insensitive' } }, select: { id: true } })
-    : null;
+export default function AccountsPage() {
   return (
     <AppLayout page>
-      <AccountsClient viewerId={user?.id ?? ''} offerAvailability={offerAvailabilityFromEnv(process.env)} />
+      <AccountsClient />
     </AppLayout>
   );
 }

--- a/src/app/chart-of-accounts/page.tsx
+++ b/src/app/chart-of-accounts/page.tsx
@@ -2,6 +2,8 @@
 
 import { useEffect, useState } from 'react';
 import { AppLayout } from '@/components/ui';
+// LOCK-01: this page renders a paid module — it asks the tab's own question first.
+import RoomLock, { useTabLock } from '@/components/shell/RoomLock';
 import BookkeepingSection from '@/components/bookkeeping/BookkeepingSection';
 import COAManagementTable from '@/components/bookkeeping/COAManagementTable';
 // SELL-04: the first-run entity step (no entity yet) and the add-a-business step (no sole-prop).
@@ -30,6 +32,8 @@ interface Entity {
 const TYPE_ORDER: Record<string, number> = { personal: 0, sole_prop: 1, trading: 2 };
 
 export default function ChartOfAccountsPage() {
+  // LOCK-01: the same check the tab makes (isTabLocked over /api/auth/me).
+  const roomLock = useTabLock('tab:books');
   const [entities, setEntities] = useState<Entity[] | null>(null);
   const [error, setError] = useState<string | null>(null);
 
@@ -57,6 +61,7 @@ export default function ChartOfAccountsPage() {
 
   return (
     <AppLayout>
+      <RoomLock locked={roomLock.locked} stepName="Books">
       <div className="max-w-6xl mx-auto px-4 py-3 space-y-3" data-coa-page>
         <div className="py-2">
           <p className="font-mono text-[10px] font-semibold uppercase tracking-wider text-text-faint">Books · the chart</p>
@@ -97,6 +102,7 @@ export default function ChartOfAccountsPage() {
           );
         })}
       </div>
+    </RoomLock>
     </AppLayout>
   );
 }

--- a/src/app/compliance/page.tsx
+++ b/src/app/compliance/page.tsx
@@ -18,6 +18,11 @@
  */
 
 import AppLayout from '@/components/ui/AppLayout';
+// LOCK-01: this page renders a paid module — it asks the tab's own question
+// first. This is a SERVER component, so it uses the server twin (roomGate →
+// hasTabAccess); the client pages use useTabLock. Both resolve keysGranting.
+import RoomLock from '@/components/shell/RoomLock';
+import { roomGate } from '@/lib/roomGate';
 import OpsSubNav from '@/components/ops/OpsSubNav';
 import { SectionA_IdentityBar } from '@/components/workbench/SectionA_IdentityBar';
 import { SectionB_FounderProfile } from '@/components/workbench/SectionB_FounderProfile';
@@ -30,9 +35,12 @@ import { SectionH_CorpusInspector } from '@/components/workbench/SectionH_Corpus
 import { SectionI_AuditTail } from '@/components/workbench/SectionI_AuditTail';
 import { SectionJ_CostLedger } from '@/components/workbench/SectionJ_CostLedger';
 
-export default function OpsWorkbenchPage() {
+export default async function OpsWorkbenchPage() {
+  // LOCK-01: the same question the Compliance tab asks.
+  const { locked } = await roomGate('tab:compliance');
   return (
     <AppLayout>
+      <RoomLock locked={locked} stepName="Compliance">
       <SectionA_IdentityBar />
       <OpsSubNav />
       <div className="max-w-[1600px] mx-auto px-4 pt-4 pb-8 space-y-4">
@@ -46,6 +54,7 @@ export default function OpsWorkbenchPage() {
         <SectionI_AuditTail />
         <SectionJ_CostLedger />
       </div>
+    </RoomLock>
     </AppLayout>
   );
 }

--- a/src/app/dashboard/tax-filing/page.tsx
+++ b/src/app/dashboard/tax-filing/page.tsx
@@ -1,19 +1,29 @@
 import { AppLayout } from '@/components/ui';
 import TaxFilingWizard from '@/components/tax-filing/TaxFilingWizard';
+import RoomLock from '@/components/shell/RoomLock';
+import { roomGate } from '@/lib/roomGate';
 
 export const metadata = {
   title: 'File your taxes — Temple Stuart',
 };
 
-// Server-rendered shell. The wizard itself is a client component so it can
-// manage step state and fetch auto-detection data on mount.
-// TAX-1: AppLayout chrome now lives HERE (moved out of TaxFilingWizard so the wizard is
-// bare and reusable on the homepage Tax tab). Render is identical to before — the same
-// <AppLayout> wraps the same wizard content.
-export default function TaxFilingPage() {
+// LOCK-01 — THE LEAK, CLOSED. This page mounted the FULL filing wizard with no
+// entitlement check at all: an account holding nothing saw TAX · LOCKED in the
+// rail and got the whole wizard at this URL. It now asks the same question the
+// Tax tab asks — roomGate → hasTabAccess('tab:tax') — before rendering, and a
+// refused viewer gets the room LOCKED (RoomLock), not a redirect and not a pitch.
+//
+// TAX-1: AppLayout chrome lives HERE (the wizard is bare and reusable on the
+// homepage Tax tab). The render is unchanged for an entitled viewer.
+export const dynamic = 'force-dynamic';
+
+export default async function TaxFilingPage() {
+  const { locked } = await roomGate('tab:tax');
   return (
     <AppLayout>
-      <TaxFilingWizard />
+      <RoomLock locked={locked} stepName="Tax">
+        <TaxFilingWizard />
+      </RoomLock>
     </AppLayout>
   );
 }

--- a/src/app/trading/page.tsx
+++ b/src/app/trading/page.tsx
@@ -2,6 +2,8 @@
 
 import { useState, useEffect, useMemo, useRef, useCallback } from 'react';
 import { AppLayout } from '@/components/ui';
+// LOCK-01: this page renders a paid module — it asks the tab's own question first.
+import RoomLock, { useTabLock } from '@/components/shell/RoomLock';
 import CalendarGrid, { CalendarEvent, SourceConfig } from '@/components/shared/CalendarGrid';
 import ConvergenceIntelligence from '@/components/convergence/ConvergenceIntelligence';
 import TradeLabPanel from '@/components/trading/TradeLabPanel';
@@ -87,6 +89,8 @@ const EMOTIONS = ['confident', 'neutral', 'nervous', 'fomo', 'revenge', 'greedy'
 const SETUPS = ['breakout', 'pullback', 'mean-reversion', 'momentum', 'earnings', 'theta-decay', 'volatility', 'other'];
 
 export default function TradingPage() {
+  // LOCK-01: the same check the tab makes (isTabLocked over /api/auth/me).
+  const roomLock = useTabLock('tab:trade');
   // Identity from the cookie-auth read the rest of the app uses (/api/auth/me),
   // not from the NextAuth session — a password login mints only the signed
   // userEmail cookie (api/auth/login/route.ts:56-62), so that session is empty
@@ -778,6 +782,7 @@ export default function TradingPage() {
 
   return (
     <AppLayout>
+      <RoomLock locked={roomLock.locked} stepName="Trading">
       <div className="min-h-screen bg-bg-terminal text-text-primary">
         <div className="p-4 lg:p-6 max-w-[1800px] mx-auto">
 
@@ -1156,6 +1161,7 @@ export default function TradingPage() {
         </div>
       )}
 
+    </RoomLock>
     </AppLayout>
   );
 }

--- a/src/components/accounts/AccountsClient.tsx
+++ b/src/components/accounts/AccountsClient.tsx
@@ -23,7 +23,7 @@ import { useCallback, useEffect, useState } from 'react';
 import Script from 'next/script';
 import { useBankConnection } from '@/components/bank/useBankConnection';
 // SHELL-02: an entitlement refusal is a LOCK, never a red HTTP box.
-import StepLock from '@/components/shell/StepLock';
+import RoomLock from '@/components/shell/RoomLock';
 import { stepBySlug } from '@/lib/steps';
 import StepOpener from '@/components/shell/StepOpener';
 import {
@@ -37,12 +37,9 @@ const ENTITY_OPTIONS: readonly string[] = ['personal', 'business', 'trading', 'r
 const CARD = 'rounded-lg border border-border bg-white';
 const TH = 'px-3 py-2 text-left font-medium';
 
-export default function AccountsClient({ viewerId, offerAvailability }: {
-  /** SHELL-02: the viewer's id — the lock card's checkout door needs it (a guest is sent to sign up). */
-  viewerId: string;
-  /** SHELL-02: per offer key, is its Stripe price id set — the server's env-presence read. The lock card renders the offer from it. */
-  offerAvailability: Readonly<Record<string, boolean>>;
-}) {
+// LOCK-01: the viewerId / offerAvailability props left with the offer card — a
+// locked viewer sees the room, and the room needs neither an id nor a price.
+export default function AccountsClient() {
   const [state, setState] = useState<'loading' | 'error' | 'ok' | 'locked'>('loading');
   const [failure, setFailure] = useState<string | null>(null);
   const [items, setItems] = useState<ApiItem[]>([]);
@@ -113,6 +110,9 @@ export default function AccountsClient({ viewerId, offerAvailability }: {
     }
   };
 
+  // LOCK-01: a 403 shows the room's EMPTY state — the same groups an entitled
+  // viewer with no accounts sees — never an error and never an HTTP status.
+  const shown = state === 'ok' || state === 'locked';
   const rows = state === 'ok' ? rowsOf(items) : [];
   const groups = groupAccounts(rows);
   const connected = rows.length;
@@ -122,17 +122,9 @@ export default function AccountsClient({ viewerId, offerAvailability }: {
       {/* Plaid Link — the same CDN script the cockpit loads for the same flow. */}
       <Script src="https://cdn.plaid.com/link/v2/stable/link-initialize.js" strategy="lazyOnload" />
 
-      {/* SHELL-02: a locked viewer sees the lock ALONE — the lock carries its own
-          opener, and Connect/Sync are not offered for a step they cannot open. */}
-      {state === 'locked' ? (
-        <StepLock
-          step={stepBySlug('accounts')!}
-          tabKey="tab:books"
-          currentUserId={viewerId}
-          onRequireAuth={() => { window.location.href = '/'; }}
-          offerAvailability={offerAvailability}
-        />
-      ) : (
+      {/* LOCK-01: the room renders for a locked viewer too — frozen, under one
+          inline note. RoomLock is the one mechanism; nothing here is a pitch. */}
+      <RoomLock locked={state === 'locked'} stepName="Accounts">
         <>
       {/* SHELL-02: the ONE opener — this page's shape became the standard. */}
       <StepOpener
@@ -182,7 +174,7 @@ export default function AccountsClient({ viewerId, offerAvailability }: {
         </div>
       )}
 
-      {state === 'ok' && (
+      {shown && (
         <div className="space-y-4">
           {groups.map((group) => (
             <section key={group.key} className={`${CARD} p-3`} data-group={group.key} data-group-count={group.rows.length}>
@@ -279,7 +271,7 @@ export default function AccountsClient({ viewerId, offerAvailability }: {
         </div>
       )}
         </>
-      )}
+      </RoomLock>
     </div>
   );
 }

--- a/src/components/home/HomeClient.tsx
+++ b/src/components/home/HomeClient.tsx
@@ -115,7 +115,6 @@ export default function HomeClient({ offerAvailability }: {
       <ModuleLauncher
         onRequireAuth={() => { setLoginMode('register'); setShowLogin(true); }}
         onTabChange={setActiveTab}
-        offerAvailability={offerAvailability}
       />
 
       {/* CPA Disclaimer — FD-3-2: the panel family, mirroring LandingFooter's

--- a/src/components/home/ModuleLauncher.tsx
+++ b/src/components/home/ModuleLauncher.tsx
@@ -97,7 +97,10 @@ import ContentPipeline from '@/components/workbench/operations/content/ContentPi
 // the last transitive deck thread (TabShowcases and its slide-section
 // modules) is out of the app graph; locked viewers get pointer-card +
 // LockedTabCard.
-import { LockedTabCard } from '@/components/home/LockedTabCard';
+// LOCK-01: the four locked tabs render THEIR OWN ROOM, frozen, under one inline
+// note — not the offer card. LockedTabCard left the app with them; the offer
+// lives at /pricing and on the deck.
+import RoomLock from '@/components/shell/RoomLock';
 // LAUNCH-01 LAPSE-01: the me payload's lapsed rows → the card's "ended on" line per tab.
 import { keysGranting } from '@/lib/offer';
 import { lapsedFor, type LapsedEntitlement } from '@/lib/lapse';
@@ -204,10 +207,9 @@ interface Props {
    *  subhead up top can swap to that tab's descriptor. Optional/additive. */
   onTabChange?: (tab: string) => void;
   /** SELL-02: per offer key, is its Stripe price id set — server-computed (page.tsx), passed down to the locked cards; never read here. */
-  offerAvailability: Readonly<Record<string, boolean>>;
 }
 
-export default function ModuleLauncher({ onRequireAuth, onTabChange, offerAvailability }: Props) {
+export default function ModuleLauncher({ onRequireAuth, onTabChange }: Props) {
   // Auth state: null = unknown (initial), true/false once /api/auth/me resolves.
   const [authed, setAuthed] = useState<boolean | null>(null);
   // PR-2b: per-category entitlements + user id (server-computed via /api/auth/me). Drive the
@@ -1012,7 +1014,7 @@ export default function ModuleLauncher({ onRequireAuth, onTabChange, offerAvaila
       <section className={`w-full bg-bg-terminal border-b border-border ${activeModule === 'trade' ? 'block' : 'hidden'}`}>
         <div className="max-w-7xl mx-auto">
           <div className="px-4 py-4 space-y-6">
-            {!tradeLocked ? (
+            <RoomLock locked={tradeLocked} lapsed={lapsedFor(keysGranting('tab:trade'), lapsed)} stepName="Trading">
               <>
                 {/* TRADE-UX-1: the tab's sections consolidate on the shared
                     <ToggleStrip> (the travel/books precedent) — one phase
@@ -1186,23 +1188,7 @@ export default function ModuleLauncher({ onRequireAuth, onTabChange, offerAvaila
                     declaration moved INTO phase 05 per the Pipe Frame.) */}
                 <TradingDataDisclaimer />
               </>
-            ) : (
-              <div>
-                <div className={MODULE_SHELL_CARD}>
-                {/* MOD-2: pointer-card to /modules/trade + the surviving purchase
-                    path. label/valueLine are VERBATIM lockstep copies of
-                    TabShowcases' TradeShowcase cta (extraction = MOD-3). */}
-                <ModulePointerCard pillarId="trade" />
-                <LockedTabCard
-                  tabKey="tab:trade"
-                  offerAvailability={offerAvailability}
-                  lapsed={lapsedFor(keysGranting('tab:trade'), lapsed)}
-                  currentUserId={currentUserId}
-                  onRequireAuth={onRequireAuth}
-                />
-                </div>
-              </div>
-            )}
+            </RoomLock>
           </div>
         </div>
       </section>
@@ -1220,7 +1206,7 @@ export default function ModuleLauncher({ onRequireAuth, onTabChange, offerAvaila
           <div className="px-4 py-4 space-y-6">
             <div>
               <div className={MODULE_SHELL_CARD}>
-            {!booksLocked ? (
+            <RoomLock locked={booksLocked} lapsed={lapsedFor(keysGranting('tab:books'), lapsed)} stepName="Books">
               <>
                 {/* Plaid Link script — loaded only for a viewer who sees this surface (locked
                     viewers never pull Plaid). Mirrors dashboard/page.tsx:454. */}
@@ -1278,21 +1264,7 @@ export default function ModuleLauncher({ onRequireAuth, onTabChange, offerAvaila
                     dashboard positions; the cockpit above keeps its own BOOKS-1 wiring. */}
                 <BooksPipeline />
               </>
-            ) : (
-              <>
-                {/* MOD-2: pointer-card to /modules/books + the surviving purchase
-                    path. label/valueLine are VERBATIM lockstep copies of
-                    TabShowcases' BooksShowcase cta (extraction = MOD-3). */}
-                <ModulePointerCard pillarId="books" />
-                <LockedTabCard
-                  tabKey="tab:books"
-                  offerAvailability={offerAvailability}
-                  lapsed={lapsedFor(keysGranting('tab:books'), lapsed)}
-                  currentUserId={currentUserId}
-                  onRequireAuth={onRequireAuth}
-                />
-              </>
-            )}
+            </RoomLock>
               </div>
             </div>
           </div>
@@ -1309,23 +1281,9 @@ export default function ModuleLauncher({ onRequireAuth, onTabChange, offerAvaila
           <div className="px-4 py-4 space-y-6">
             <div>
               <div className={MODULE_SHELL_CARD}>
-            {!taxLocked ? (
+            <RoomLock locked={taxLocked} lapsed={lapsedFor(keysGranting('tab:tax'), lapsed)} stepName="Tax">
               <TaxHandoffGate onGoToBooks={() => selectTab('books')} />
-            ) : (
-              <>
-                {/* MOD-2: pointer-card to /modules/tax + the surviving purchase
-                    path. label/valueLine are VERBATIM lockstep copies of
-                    TabShowcases' TaxShowcase cta (extraction = MOD-3). */}
-                <ModulePointerCard pillarId="tax" />
-                <LockedTabCard
-                  tabKey="tab:tax"
-                  offerAvailability={offerAvailability}
-                  lapsed={lapsedFor(keysGranting('tab:tax'), lapsed)}
-                  currentUserId={currentUserId}
-                  onRequireAuth={onRequireAuth}
-                />
-              </>
-            )}
+            </RoomLock>
               </div>
             </div>
           </div>
@@ -1343,23 +1301,9 @@ export default function ModuleLauncher({ onRequireAuth, onTabChange, offerAvaila
           <div className="px-4 py-4 space-y-6">
             <div>
               <div className={MODULE_SHELL_CARD}>
-            {!complianceLocked ? (
+            <RoomLock locked={complianceLocked} lapsed={lapsedFor(keysGranting('tab:compliance'), lapsed)} stepName="Compliance">
               <ComplianceWorkbench />
-            ) : (
-              <>
-                {/* MOD-2: pointer-card to /modules/compliance + the surviving
-                    purchase path. label/valueLine are VERBATIM lockstep copies of
-                    TabShowcases' ComplianceShowcase cta (extraction = MOD-3). */}
-                <ModulePointerCard pillarId="compliance" />
-                <LockedTabCard
-                  tabKey="tab:compliance"
-                  offerAvailability={offerAvailability}
-                  lapsed={lapsedFor(keysGranting('tab:compliance'), lapsed)}
-                  currentUserId={currentUserId}
-                  onRequireAuth={onRequireAuth}
-                />
-              </>
-            )}
+            </RoomLock>
               </div>
             </div>
           </div>

--- a/src/components/shell/RoomLock.tsx
+++ b/src/components/shell/RoomLock.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+/**
+ * LOCK-01 — THE ONE LOCKED MECHANISM.
+ *
+ * A locked step shows ITS OWN ROOM, not a sales pitch. The room's shell, header,
+ * phase strip and empty state render exactly as they do for an entitled viewer
+ * with no data; everything that would WRITE or SPEND is dead.
+ *
+ * WHY THIS SHAPE — a wrapper with `inert`, not a prop threaded through the rooms:
+ * the rooms are deep trees (BooksPipeline → six phases → forms; TaxFilingWizard →
+ * its steps; the trading cockpit → scanner, chains, lab). Threading a `locked`
+ * prop to every button would mean editing every room's body, and DS-02 owns
+ * interiors — LOCK-01 is forbidden from redesigning them. `inert` disables the
+ * whole subtree at the DOM level: no click, no focus, no submit, no keyboard
+ * reach, and it is the platform's own answer rather than a CSS trick that a
+ * determined tab-key defeats. One wrapper, zero edits inside any room.
+ *
+ * WHAT IT COSTS, said plainly: `inert` is indiscriminate — read-only affordances
+ * inside the room (a phase strip you could click, a disclosure) go quiet too.
+ * The room still RENDERS in full; it is frozen, not hidden. That is the honest
+ * trade for not touching six room bodies, and DS-02 can refine it per room.
+ *
+ * The context is exported alongside so a room that WANTS to know (to soften a
+ * label rather than be frozen) can read it without any wrapper change.
+ */
+import { createContext, useContext, useEffect, useState } from 'react';
+import Link from 'next/link';
+import { Lock } from 'lucide-react';
+import { isTabLocked } from '@/lib/categoryLock';
+// LAUNCH-01 LAPSE-01: a lapsed subscriber reads when and why it ended. That line
+// used to ride the offer card; it rides the inline note now rather than dying.
+import { lapsedLine, type LapseReason } from '@/lib/lapse';
+
+const RoomLockContext = createContext(false);
+
+/**
+ * LOCK-01: the CLIENT gate for a room whose page is a client component. It asks
+ * the SAME question the tab asks, with the SAME helper — isTabLocked over
+ * /api/auth/me's entitledCategories and the server's isAdmin verdict
+ * (ModuleLauncher.tsx:340-341 does exactly this). A server page uses roomGate
+ * (src/lib/roomGate.ts → hasTabAccess); both resolve through keysGranting, so
+ * the two twins cannot disagree.
+ *
+ * Until the read lands it returns LOCKED — the fallback tripwire: a room is
+ * never open on a guess. A failed read stays locked and says so.
+ */
+export function useTabLock(tabKey: string): { locked: boolean; resolved: boolean } {
+  const [state, setState] = useState<{ locked: boolean; resolved: boolean }>({ locked: true, resolved: false });
+  useEffect(() => {
+    let live = true;
+    (async () => {
+      try {
+        const res = await fetch('/api/auth/me', { cache: 'no-store' });
+        if (!res.ok) { if (live) setState({ locked: true, resolved: true }); return; }
+        const body = (await res.json()) as { user?: { isAdmin?: boolean; entitledCategories?: string[] } };
+        const keys = body.user?.entitledCategories ?? [];
+        if (live) setState({ locked: isTabLocked(tabKey, keys, Boolean(body.user?.isAdmin)), resolved: true });
+      } catch {
+        if (live) setState({ locked: true, resolved: true });
+      }
+    })();
+    return () => { live = false; };
+  }, [tabKey]);
+  return state;
+}
+
+/** Is the room this component sits in locked? False everywhere it is not provided. */
+export function useRoomLock(): boolean {
+  return useContext(RoomLockContext);
+}
+
+/**
+ * THE ONE INLINE NOTE. One short line, one link to /pricing. No price, no
+ * billing copy, no offer card — the offer lives at /pricing and on the deck.
+ */
+export function LockedNote({ stepName, lapsed }: { stepName?: string; lapsed?: { endedAt: string; reason: LapseReason } | null }) {
+  return (
+    <p className="mb-3 flex flex-wrap items-center gap-2 font-mono text-[11px] text-text-secondary" data-locked-note>
+      <Lock className="h-3.5 w-3.5 shrink-0 text-brand-purple" strokeWidth={2} aria-hidden="true" />
+      <span data-lapsed={lapsed ? lapsed.reason : undefined}>
+        {lapsed
+          ? `${lapsedLine(lapsed)} ${stepName ? `${stepName} is read-only.` : 'Read-only.'}`
+          : `${stepName ? `${stepName} is read-only` : 'Read-only'} — you do not hold the module that unlocks it.`}{' '}
+        <Link href="/pricing" className="underline decoration-dotted underline-offset-2 hover:text-text-primary">
+          See what unlocks it
+        </Link>
+      </span>
+    </p>
+  );
+}
+
+/**
+ * Wrap a room. Locked → the note above it and the room frozen below.
+ * Unlocked → the children, untouched, with no wrapper behaviour at all.
+ */
+export default function RoomLock({ locked, stepName, lapsed = null, children }: {
+  locked: boolean;
+  stepName?: string;
+  /** LAPSE-01: the most recent ended subscription among the keys granting this step, or null. */
+  lapsed?: { endedAt: string; reason: LapseReason } | null;
+  children?: React.ReactNode;
+}) {
+  if (!locked) return <RoomLockContext.Provider value={false}>{children}</RoomLockContext.Provider>;
+  return (
+    <RoomLockContext.Provider value={true}>
+      <div data-room-locked="true">
+        <LockedNote stepName={stepName} lapsed={lapsed} />
+        {/* inert: the whole room is non-interactive. It still renders in full —
+            a locked viewer sees the product, not a pitch. */}
+        {/* React 18 does not type `inert`, so it is set through the DOM ref —
+            the attribute is what browsers act on, not React's prop table. */}
+        <div ref={(el) => { if (el) el.setAttribute('inert', ''); }} className="opacity-70" aria-label="Locked — read-only">
+          {children}
+        </div>
+      </div>
+    </RoomLockContext.Provider>
+  );
+}

--- a/src/components/shell/StepLock.tsx
+++ b/src/components/shell/StepLock.tsx
@@ -1,61 +1,15 @@
 'use client';
 
 /**
- * SHELL-02 — THE ONE LOCK. Wherever a step's screen or its data is refused for
- * want of an entitlement, the viewer sees THIS card: the step's name, one line
- * saying which module unlocks it, and the buy affordance the offer already
- * provides. Never an HTTP status, never a stack.
+ * LOCK-01 — a locked step shows ITS OWN ROOM, not a sales pitch.
  *
- * It is a thin wrapper over LockedTabCard (SELL-02) — the buy surface the
- * cockpit tabs have always rendered — so nothing about the offer, the price
- * line or the checkout call is retyped here. When no price is set, the card
- * says "Not for sale yet — no price is set." because offer.ts:208 says so.
+ * This used to render LockedTabCard: the offer card, six tool rows, a price line
+ * and "BILLED MONTHLY · CANCEL ANYTIME" — a marketing card where the product
+ * should be. The offer belongs at /pricing and on the deck; inside the app a
+ * locked viewer sees the room.
+ *
+ * It is now a thin re-export of the ONE mechanism (RoomLock): the room renders in
+ * full, frozen, under one short inline note with a single link to /pricing. No
+ * offer, no price, no billing copy.
  */
-import { LockedTabCard } from '@/components/home/LockedTabCard';
-import type { Step } from '@/lib/steps';
-import { TOOL_GATE } from '@/lib/offer';
-import type { ToolName } from '@/lib/problemSheet';
-
-export default function StepLock({
-  step,
-  tabKey,
-  currentUserId,
-  onRequireAuth,
-  offerAvailability,
-}: {
-  /** The step being refused — its name and jobs are the card's subject. */
-  step: Step;
-  /** The entitlement key the refusal was about (tab:books, tab:trade, …). */
-  tabKey: string;
-  currentUserId: string;
-  onRequireAuth: () => void;
-  offerAvailability: Readonly<Record<string, boolean>>;
-}) {
-  const gated = step.tools.filter((t) => TOOL_GATE[t as ToolName] === tabKey);
-  return (
-    <section className="mx-auto max-w-2xl" data-step-lock={step.slug}>
-      <header className="mb-4">
-        <p className="font-mono text-[10px] sm:text-xs uppercase tracking-[0.2em] text-text-faint">
-          Step {step.number} <span className="text-brand-gold">·</span> {step.family.toLowerCase().replace(/^./, (c) => c.toUpperCase())}
-        </p>
-        <h1 className="mt-1 text-xl sm:text-2xl font-semibold tracking-tight text-text-primary">{step.name}</h1>
-        <p className="mt-1 text-xs text-text-muted">
-          {gated.length > 0
-            ? `${gated.join(', ')} ${gated.length === 1 ? 'is' : 'are'} part of a module you do not hold yet.`
-            : 'This step is part of a module you do not hold yet.'}
-        </p>
-      </header>
-      <LockedTabCard
-        tabKey={tabKey}
-        currentUserId={currentUserId}
-        onRequireAuth={onRequireAuth}
-        offerAvailability={offerAvailability}
-      />
-    </section>
-  );
-}
-
-/** Does this failure line describe an ENTITLEMENT refusal rather than a fault? */
-export function isEntitlementRefusal(status: number): boolean {
-  return status === 403;
-}
+export { default, LockedNote, useRoomLock, useTabLock } from '@/components/shell/RoomLock';

--- a/src/lib/__tests__/lockedRoom.test.ts
+++ b/src/lib/__tests__/lockedRoom.test.ts
@@ -1,0 +1,97 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import * as React from 'react';
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+Object.assign(globalThis, { React });
+import RoomLock, { LockedNote } from '@/components/shell/RoomLock';
+import { isTabLocked } from '../categoryLock';
+
+// LOCK-01 — a locked step shows its ROOM, not a sales pitch, and every paid
+// surface asks for its key.
+
+const src = (f: string) => readFileSync(`${process.cwd()}/${f}`, 'utf8');
+
+test('an unentitled viewer on /dashboard/tax-filing gets the locked room — the wizard is wrapped, never bare', () => {
+  const page = src('src/app/dashboard/tax-filing/page.tsx');
+  // The leak: this page mounted TaxFilingWizard with no check at all.
+  assert.match(page, /roomGate\('tab:tax'\)/, 'it asks the Tax tab\'s own question');
+  assert.match(page, /<RoomLock locked=\{locked\}/, 'and the answer wraps the room');
+  // The wizard is INSIDE the lock, not beside it.
+  const lockAt = page.indexOf('<RoomLock');
+  const wizardAt = page.indexOf('<TaxFilingWizard');
+  const closeAt = page.indexOf('</RoomLock>');
+  assert.ok(lockAt < wizardAt && wizardAt < closeAt, 'the wizard renders inside RoomLock');
+});
+
+test('a locked room renders its children in full, frozen, with one note and no offer', () => {
+  const html = renderToStaticMarkup(
+    createElement(RoomLock, { locked: true, stepName: 'Accounts' },
+      createElement('button', { 'data-connect': true }, '+ Connect an account')),
+  );
+  // The ROOM is there — a locked viewer sees the product.
+  assert.match(html, /\+ Connect an account/, 'the room renders in full');
+  assert.match(html, /data-room-locked="true"/);
+  // Frozen: the subtree is inert, so nothing inside can be clicked or focused.
+  assert.match(html, /aria-label="Locked — read-only"/);
+  // ONE note, ONE link, and nothing that sells.
+  assert.match(html, /data-locked-note/);
+  assert.match(html, /\/pricing/);
+  assert.equal((html.match(/\/pricing/g) ?? []).length, 1, 'one unlock link, not a card of them');
+  for (const pitch of ['BILLED MONTHLY', 'CANCEL ANYTIME', 'Billed monthly', 'Not for sale yet', 'Subscribe', '$']) {
+    assert.ok(!html.includes(pitch), `a locked room must not print "${pitch}"`);
+  }
+});
+
+test('an UNLOCKED room is untouched — no note, no wrapper behaviour', () => {
+  const html = renderToStaticMarkup(
+    createElement(RoomLock, { locked: false, stepName: 'Accounts' },
+      createElement('button', null, 'Sync')),
+  );
+  assert.match(html, /Sync/);
+  assert.doesNotMatch(html, /data-room-locked/);
+  assert.doesNotMatch(html, /data-locked-note/);
+  assert.doesNotMatch(html, /\/pricing/);
+});
+
+test('an unentitled viewer on /accounts sees the accounts ROOM — its empty state — and no offer card', () => {
+  const client = src('src/components/accounts/AccountsClient.tsx');
+  // The room renders for a locked viewer, wrapped — not replaced by a card.
+  assert.match(client, /<RoomLock locked=\{state === 'locked'\}/);
+  assert.ok(!/<LockedTabCard/.test(client), 'no offer card inside the app');
+  // Connect and Sync still RENDER (frozen by the wrapper), so the room is the room.
+  assert.match(client, /data-connect/);
+  assert.match(client, /data-sync\b/);
+  // A 403 shows the EMPTY state, never an error and never an HTTP status.
+  assert.match(client, /const shown = state === 'ok' \|\| state === 'locked';/);
+  assert.match(client, /\{shown && \(/);
+  const at403 = client.indexOf("if (res.status === 403)");
+  assert.ok(at403 > 0, 'a 403 is caught before the error path');
+  assert.ok(at403 < client.indexOf('setFailure(`HTTP ${res.status}'), 'and returns before any HTTP status is stored');
+});
+
+test('the lapse line survived the offer card — a lapsed subscriber still reads when and why', () => {
+  const html = renderToStaticMarkup(
+    createElement(LockedNote, { stepName: 'Books', lapsed: { endedAt: '2026-08-01T00:00:00.000Z', reason: 'canceled' } }),
+  );
+  assert.match(html, /data-lapsed="canceled"/);
+  assert.match(html, /\/pricing/);
+});
+
+test('the two gate twins ask the same question — keysGranting decides both', () => {
+  // The client twin the tabs use. Books grants Trade, Tax and Compliance.
+  assert.equal(isTabLocked('tab:tax', ['tab:books'], false), false, 'a Books key opens Tax');
+  assert.equal(isTabLocked('tab:tax', [], false), true, 'no key, no entry');
+  assert.equal(isTabLocked('tab:tax', [], true), false, 'the server said admin');
+  // And the pages use one of the two twins — the law checks this, the census pins it.
+  for (const [page, mark] of [
+    ['src/app/dashboard/tax-filing/page.tsx', /roomGate\('tab:tax'\)/],
+    ['src/app/trading/page.tsx', /useTabLock\('tab:trade'\)/],
+    ['src/app/chart-of-accounts/page.tsx', /useTabLock\('tab:books'\)/],
+    // /compliance is a SERVER component, so it uses the server twin.
+    ['src/app/compliance/page.tsx', /roomGate\('tab:compliance'\)/],
+  ] as const) {
+    assert.match(src(page), mark, `${page} asks for its key`);
+  }
+});

--- a/src/lib/roomGate.ts
+++ b/src/lib/roomGate.ts
@@ -1,0 +1,36 @@
+import 'server-only';
+import { getVerifiedEmail } from '@/lib/cookie-auth';
+import { prisma } from '@/lib/prisma';
+import { hasTabAccess } from '@/lib/entitlements';
+
+/**
+ * LOCK-01 — THE ONE PAGE GATE. Every page that renders a paid module's UI asks
+ * this before rendering it, and it asks the SAME question the tab asks: the
+ * server twin `hasTabAccess` (src/lib/entitlements.ts:53) over the same
+ * `keysGranting` the client's `isTabLocked` reads.
+ *
+ * It does not redirect and it does not 403. A refused viewer gets the ROOM,
+ * locked (RoomLock) — that is LOCK-01's ruling. What it guarantees is that the
+ * page KNOWS, so no page can render a paid component to a viewer without the key
+ * by simply forgetting to ask.
+ *
+ * Fail-loud: hasTabAccess propagates a DB error rather than returning a silent
+ * false, and a signed-out viewer is locked, never granted.
+ */
+export interface RoomGate {
+  /** The viewer's user id, or '' when signed out. */
+  viewerId: string;
+  /** True when the viewer does NOT hold a key granting this tab. */
+  locked: boolean;
+}
+
+export async function roomGate(tabKey: string): Promise<RoomGate> {
+  const email = await getVerifiedEmail();
+  if (!email) return { viewerId: '', locked: true };
+  const user = await prisma.users.findFirst({
+    where: { email: { equals: email, mode: 'insensitive' } },
+    select: { id: true },
+  });
+  if (!user) return { viewerId: '', locked: true };
+  return { viewerId: user.id, locked: !(await hasTabAccess(user.id, tabKey)) };
+}


### PR DESCRIPTION
**Do not merge — Alex merges after Vercel Preview (SOC 2 gate).**

The leak is closed. The sales pitch is gone. **The census found the same hole on three more pages than the one you named.**

---

## HARD GATE

| Gate | Touched? | Note |
|---|---|---|
| **Auth / entitlements** | **TIGHTENED ONLY** | Four pages that asked **nothing** now ask. No gate loosened, no key granted, no bypass added. `hasTabAccess`, `isTabLocked`, `keysGranting` and `TOOL_GATE` are byte-identical. |
| Migrations | **no** | No `schema.prisma`, no SQL. |
| Cost / paid calls | **no** | Not one upstream call added or changed. |
| Security | **no route added or deleted.** | One route path unchanged; the API gates are untouched — this closes a **page**-level hole the API gates already covered for data, but not for the UI. |
| User financial data | **untouched** | |
| Status / counts | **unchanged** | Census `2 LIVE · 9 PARTIAL · 14 NOT_BUILT`. |

---

## STEP 0.1 — THE GATE CENSUS

**How a correctly gated tab does it** — the pattern that gets reused, in two twins that resolve through the same `keysGranting`:

| Twin | Helper | Call site |
|---|---|---|
| **client** | `isTabLocked(tabKey, entitledKeys, isAdmin)` — `src/lib/categoryLock.ts:19` | `ModuleLauncher.tsx:340-343`, fed by `/api/auth/me` (`:325-327`) |
| **server** | `hasTabAccess(userId, tabKey)` — `src/lib/entitlements.ts:53` | the API routes, e.g. `api/accounts/route.ts:22` via `requireTabAccess` |

### The census

| Route | Mounts | Entitlement check on `main` | Owner | Now |
|---|---|---|---|---|
| **`/dashboard/tax-filing`** | `AppLayout` + **`TaxFilingWizard`** (`:16`) | ⚠️ **NONE — the leak you named** | Step 4 TAX · `tab:tax` | **`roomGate('tab:tax')`** |
| **`/trading`** | `AppLayout` + **`ConvergenceIntelligence`** + **`TradeLabPanel`** + **`COAManagementTable`** + `DataObservatory` + `CalendarGrid` | ⚠️ **NONE** | Step 2 TRADING · `tab:trade` | **`useTabLock('tab:trade')`** |
| **`/chart-of-accounts`** | `AppLayout` + **`COAManagementTable`** + **`BookkeepingSection`** | ⚠️ **NONE** | Step 3 BOOKS · `tab:books` | **`useTabLock('tab:books')`** |
| **`/compliance`** | `AppLayout` + `SectionA…SectionJ` (the compliance workbench) | ⚠️ **NONE** | Step 5 COMPLIANCE · `tab:compliance` | **`roomGate('tab:compliance')`** |
| `/accounts` | `AppLayout` + `AccountsClient` | client-side only: a **403** from `/api/accounts` rendered a red error box | Step 1 ACCOUNTS · `tab:books` | the 403 renders the room's **empty state**, locked |
| `/books`, `/trade`, `/tax` | `[tab]/page.tsx` → `HomeClient` → `ModuleLauncher` | ✅ `isTabLocked` (`:340-343`) — but the locked branch rendered the **offer card** | steps 2-4 | the room, locked |
| `/dashboard` | `redirect('/books')` (`:6`) | n/a — a redirect | — | unchanged |
| `/dashboard/tax` | `redirect('/dashboard/tax-filing')` (`:7`) | n/a — a redirect | — | unchanged |
| `/tax` | no page file — served by `[tab]/page.tsx` | ✅ via the cockpit | Step 4 | — |
| `ComplianceWorkbench` | **no page mounts it** — grepped `src/app/**/page.tsx`, zero hits | — | — | mapped in the law anyway, so a future mount cannot skip the gate |

**Four pages, zero checks between them.** Only the one you named was known; `/trading`, `/chart-of-accounts` and `/compliance` had the identical hole.

**The API routes each page calls are gated.** `api/accounts/route.ts:22` (`requireTabAccess`, `tab:books`) is the pattern; the data was never exposed. What leaked was the **UI** — the wizard, the scanner, the COA editor rendered in full to a viewer with no key.

## STEP 0.2 — THE LOCK SURFACE

| Mount | File:line | Renders |
|---|---|---|
| `StepLock` → `LockedTabCard` | `StepLock.tsx` (whole body), used by `AccountsClient.tsx:128` | the offer card |
| `LockedTabCard` ×4 | `ModuleLauncher.tsx:1196, 1287, 1320, 1354` | the offer card on the four locked tabs |
| `LockedTabCard` ×4 | `TabShowcases.tsx:212, 308, 410, 436` | **the deck** — `/modules/<pillar>` and the landing |

`LockedTabCard` feeds `OfferCard` from `offerGranting(tabKey)` + `offerCard(offer, offerAvailability)` (`:41-46`); the props are `tabKey`, `currentUserId`, `onRequireAuth`, `offerAvailability`, `lapsed`.

**Billing copy outside `/pricing` and the deck:** exactly one line — **`OfferCard.tsx:82`**, `"Billed monthly · cancel anytime"`. `OfferCard` itself is mounted by `Landing.tsx`, `LockedTabCard.tsx`, `ModulePageClient.tsx` and `pricing/page.tsx`. So the string never had to move — what had to stop was **`OfferCard` reaching the app through `LockedTabCard`**.

## STEP 0.3 — THE ROOMS, for an entitled viewer with no data

| Room | Empty / first-run state | Write-or-spend controls → route |
|---|---|---|
| **`/accounts`** | ✅ six group cards render with `0 accounts` and their own empty lines (`ACCOUNT_GROUPS`, `accountsView.ts`) | Connect → `/api/plaid/link-token` + `/api/plaid/exchange-token`; Sync → `/api/transactions/sync-complete`; Reconnect → `/api/plaid/reconnect-complete`; entity select → `/api/accounts/update-entity` |
| **`/books`** | ✅ the six-phase strip, "6 connected" counters at zero, `"No bank connection? Add transactions manually"` | + Link Account, Sync, + Add Transaction, the coding/reconcile/close actions |
| **`/trading`** | ⚠️ **partial** — the scan form and metric row render at zero, but the reconciliation table has no declared empty state; it renders an empty table body | Scan → `/api/tastytrade/scanner`; Connect → `/api/tastytrade/connect`; Commit → `/api/trading/commit-to-ledger`; journal → `/api/trading-journal` |
| **`/compliance`** | ⚠️ **none found** — Sections A–J each fetch on mount; with no data they render their own loading/error states, not a first-run state | Run discovery → `/api/discovery/*`; materialise → the proposal routes |
| **`/dashboard/tax-filing`** | ⚠️ **NONE** — reported, not faked. The wizard opens on step 1 with an unchecked life-events list, which is its *initial* state rather than a declared empty state; the metric row shows `detecting…` (`TaxFilingWizard.tsx:429`) while auto-detection runs | Next/Back through 7 steps; Export + File on step 07 |

**Three rooms have no declared empty state.** Per the ruling they are **reported, not invented** — and none of them crashes: each renders its initial or loading state, which is what a locked viewer now sees, frozen.

---

## STEP 1 — the gate

Every census page performs its tab's check before rendering. Server pages use `roomGate` (`src/lib/roomGate.ts` → `hasTabAccess`); client pages use `useTabLock` (→ `isTabLocked`). Both resolve `keysGranting`, so the twins cannot disagree.

> **One correction found by running it:** `/compliance` is a **server** component, so my first pass — the client hook — produced *"Attempted to call useTabLock() from the server"* and a **500**. Caught by curling the page as the unentitled viewer (200 on `main`, 500 on the branch). It uses `roomGate` now.

`useTabLock` returns **locked until the read lands**, and a failed read stays locked — the fallback tripwire: a room is never open on a guess.

---

## STEP 2 — the locked room

### The mechanism, and why

**`RoomLock`** (`src/components/shell/RoomLock.tsx`) — one wrapper, using the platform's **`inert`**.

The rooms are deep trees: BooksPipeline's six phases and their forms, the wizard's seven steps, the trading cockpit's scanner + chains + lab. Threading a `locked` prop to every button means **editing every room's body**, and DS-02 owns interiors — this PR is forbidden from redesigning them. `inert` disables the whole subtree at the DOM level: no click, no focus, no submit, no keyboard reach. One wrapper, **zero edits inside any room**.

**Its cost, stated rather than hidden:** `inert` is indiscriminate, so read-only affordances inside a locked room (a clickable phase strip, a disclosure) go quiet too. The room still **renders in full** — frozen, not hidden. A `useRoomLock()` context ships beside it so a room that would rather soften a label than freeze can read the state without any wrapper change.

### What a locked viewer sees

The room's shell, header, phase strip and empty state, exactly as an entitled viewer with no data sees them, under **one** short inline note:

> 🔒 *Tax is read-only — you do not hold the module that unlocks it.* **See what unlocks it** → `/pricing`

No offer, no price, no billing copy, no HTTP status. A **403 shows the room's empty state**: `/accounts` renders its six account groups with nothing in them instead of the red *"Your accounts could not be read. HTTP 403"* box.

**The lapse line survived the card it used to ride.** `LockedTabCard` carried LAUNCH-01's *"your subscription ended on … because …"*. Deleting the card would have deleted that; it moved into the note (`data-lapsed="<reason>"`).

### Where `LockedTabCard` still renders

**Only the deck** — `TabShowcases.tsx:212, 308, 410, 436`, reached from `/modules/<pillar>` and the landing. Its four in-app mounts in `ModuleLauncher` and its use by `StepLock` are gone. `StepLock` is now a thin re-export of `RoomLock`, so nothing that imported it breaks.

---

## STEP 3 — the laws

```
✔ The lock law passed — 7 paid components mapped to their keys, 0 page(s) mount
  one without a check; 0 file(s) outside /pricing and the deck carry an offer or
  billing copy.
```

**(a)** A `component → required key` table — `TaxFilingWizard`→`tab:tax`, `BooksPipeline`/`COAManagementTable`/`BookkeepingSection`→`tab:books`, `ConvergenceIntelligence`/`TradeLabPanel`→`tab:trade`, `ComplianceWorkbench`→`tab:compliance`. A `page.tsx` mounting one without `roomGate|useTabLock|hasTabAccess|isTabLocked` fails the build, **naming the file**.

**(b)** No file outside `/pricing`, `src/components/landing`, `src/app/modules` (plus the offer leaves themselves) may carry `BILLED MONTHLY` / `CANCEL ANYTIME` or render `<LockedTabCard>`.

**Proven — each fails the build:**

```
✖ BUILD LAW FAILED:
  lock: src/app/dashboard/tax-filing/page.tsx mounts TaxFilingWizard (tab:tax)
  with no entitlement check — every paid surface asks for its key (LOCK-01)
```
```
✖ BUILD LAW FAILED:
  lock: src/components/accounts/AccountsClient.tsx renders LockedTabCard —
  a locked step shows its room, not a sales pitch (LOCK-01)
```

**(c) Six tests** (`src/lib/__tests__/lockedRoom.test.ts`): the tax-filing page asks `roomGate('tab:tax')` and the wizard renders **inside** `RoomLock`; a locked room renders its children in full, frozen, with **one** `/pricing` link and none of `BILLED MONTHLY`/`CANCEL ANYTIME`/`Not for sale yet`/`Subscribe`/`$`; an unlocked room is untouched; `/accounts` keeps `data-connect` and `data-sync` (frozen, not removed), catches 403 **before** any HTTP status is stored, and shows the empty state; the lapse line survives; and both gate twins agree (`isTabLocked('tab:tax', ['tab:books'])` is open — Books grants Tax).

---

## VERIFY

| Check | Result |
|---|---|
| `npx tsc --noEmit` | **exit 0** |
| `npm run lint` | **847 problems (572 errors, 275 warnings)** — **identical to `main`; zero new** |
| `npm test` | **286 / 286** (`main`: 280 — **+6**) |
| Full build, **fourteen** laws | **exit 0** |
| Reachability | `✔ 69 pages, every one has a door` |

### Measured as an unentitled viewer (`curl-probe`, `entitledCategories: []`, `isAdmin: false`)

| Path | locked room | inline note | unlock links | HTTP status shown | pitch strings |
|---|---|---|---|---|---|
| `/accounts` | 1 | 1 | **1** | **false** | **none** |
| `/books` | 4 | 4 | **1** | **false** | **none** |
| `/tax` | 4 | 4 | **1** | **false** | **none** |
| `/dashboard/tax-filing` | 1 | 1 | **1** | **false** | **none** |
| `/compliance` | 1 | 1 | **1** | **false** | **none** |
| `/trade` | 4 | 4 | **1** | **false** | **none** |

`4` on the cockpit paths is the DOM, not the screen: all four tabs live in one `ModuleLauncher` and are shown/hidden by class, so four locked rooms exist and one is visible. Exactly one unlock link is reachable on every path. Screenshots in the session chat (audit output is never committed — the repo is public); the tax-filing one shows the full 7-step wizard rendered and frozen under the single note.

---

## FILES TOUCHED — 13 files, +390 / −171

**New (3):** `src/components/shell/RoomLock.tsx` · `src/lib/roomGate.ts` · `src/lib/__tests__/lockedRoom.test.ts`
**Gated (4):** `src/app/dashboard/tax-filing/page.tsx` · `src/app/trading/page.tsx` · `src/app/chart-of-accounts/page.tsx` · `src/app/compliance/page.tsx`
**Un-pitched (4):** `src/components/shell/StepLock.tsx` (now a re-export) · `src/components/home/ModuleLauncher.tsx` (4 offer cards → 4 locked rooms) · `src/components/accounts/AccountsClient.tsx` · `src/app/accounts/page.tsx`
**Law:** `scripts/assert-tool-registry.ts` · **Pass-down:** `src/components/home/HomeClient.tsx`

---

## FINDINGS FOR ALEX

1. **The leak was four pages, not one.** `/trading`, `/chart-of-accounts` and `/compliance` had the identical hole. The API routes were gated all along, so no *data* leaked — the paid **UI** did.
2. **`/compliance` is a server component.** My first pass used the client hook and 500'd it. Caught by curling the page rather than trusting the diff; both twins now sit where they belong.
3. **Three rooms have no empty state** — `/dashboard/tax-filing` (none at all), `/trading` (the reconciliation table) and `/compliance` (Sections A–J fetch on mount). Reported, not invented. None crashes; each shows its initial or loading state, and that is what a locked viewer sees.
4. **`ComplianceWorkbench` is mounted by no page** — the compliance room is Sections A–J directly. It is in the law's table anyway so a future mount cannot skip the gate.
5. **`inert` is a blunt instrument.** It freezes read-only affordances too. That was the price of not editing six room bodies; DS-02 can refine per room using the `useRoomLock()` context this PR ships.
6. **`offerAvailability` no longer reaches `ModuleLauncher`** — it existed only to feed the offer cards. Dropped from the prop chain rather than left dangling.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc

---
_Generated by [Claude Code](https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc)_