### PR TITLE
CAL-01: the calendar is the calendar — /calendar is its home, and the agenda planner is Budget's

### DIFF
--- a/src/app/calendar/page.tsx
+++ b/src/app/calendar/page.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+/**
+ * CAL-01 — /calendar, THE CALENDAR. Tool 01's home was /agenda: a planner whose
+ * items carry a cadence, a coa_code and a budget_amount, whose commit writes a
+ * calendar_events row with those two money columns and then a `budgets` plan row
+ * (src/app/api/agenda/[id]/route.ts:84-96, :113-133). That is recurring-spend
+ * planning — Budget's work — and it is Budget's now.
+ *
+ * THE CALENDAR is the merged grid: trip events, daily-plan blocks and routine
+ * occurrences over one CalendarGrid. It had no room of its own — it rendered
+ * only inside the cockpit's Runway tab (ModuleLauncher.tsx:688) and, since
+ * ROOM-02, as Operations' phase 02. This page gives it one.
+ *
+ * The SAME component, the SAME three sources, no interior edit and no new data
+ * path: HubCalendar takes only optional props (demoEvents, onRequireAuth) and
+ * self-fetches, which is exactly how both existing mounts use it. Nothing here
+ * comes from ModuleLauncher.
+ */
+import AppLayout from '@/components/ui/AppLayout';
+import HubCalendar from '@/components/hub/HubCalendar';
+import ToolOpener from '@/components/shell/ToolOpener';
+import { navToolByName } from '@/lib/nav';
+import { TOOL_GATE } from '@/lib/offer';
+
+export default function CalendarPage() {
+  return (
+    <AppLayout page>
+      <ToolOpener
+        tools={[navToolByName('Calendar', TOOL_GATE)]}
+        line="Your trips, the blocks you planned for the day, and the routines that come round — on one grid."
+      />
+      <div data-calendar-room>
+        <HubCalendar />
+      </div>
+    </AppLayout>
+  );
+}

--- a/src/lib/__tests__/budgetRoom.test.ts
+++ b/src/lib/__tests__/budgetRoom.test.ts
@@ -68,8 +68,9 @@ test('Budget opens /budget, and no category page is a door anywhere', () => {
     if (tool.href) assert.ok(!legacy.has(tool.href), `${tool.name} opens the category page ${tool.href}`);
     for (const sub of tool.subRows) assert.ok(!legacy.has(sub.door.href), `${tool.name} still links ${sub.label}`);
   }
-  // What Budget keeps: Shopping, the itinerary builder and Runway — reported, not moved.
-  assert.deepEqual(budget.subRows.map((r) => r.door.href), ['/shopping', '/hub/itinerary', '/runway']);
+  // What Budget keeps, plus the agenda planner CAL-01 handed it: recurring-spend
+  // planning is Budget's work, and the planner is where it is done.
+  assert.deepEqual(budget.subRows.map((r) => r.door.href), ['/agenda', '/shopping', '/hub/itinerary', '/runway']);
 });
 
 test('only the PROVABLY identical routes were collapsed — business and home kept their own', () => {

--- a/src/lib/__tests__/calendarRoom.test.ts
+++ b/src/lib/__tests__/calendarRoom.test.ts
@@ -1,0 +1,89 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import * as React from 'react';
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+Object.assign(globalThis, { React });
+import HubCalendar from '@/components/hub/HubCalendar';
+import { navLaw, navToolByName } from '../nav';
+import { TOOL_GATE } from '../offer';
+import { TOOL_REGISTRY } from '../toolRegistry';
+
+// CAL-01 — the calendar is the calendar; the agenda planner is Budget's.
+
+const src = (f: string) => readFileSync(`${process.cwd()}/${f}`, 'utf8');
+const code = (f: string) => src(f).split('\n').filter((l) => !/^\s*(\*|\/\/|\/\*)/.test(l)).join('\n');
+
+test('/calendar mounts the SAME grid, bare — nothing only ModuleLauncher could supply', () => {
+  const page = code('src/app/calendar/page.tsx');
+  assert.match(page, /<HubCalendar \/>/, 'the same component, mounted with no props');
+  assert.match(page, /<AppLayout page>/, 'it wears the one shell');
+  assert.match(page, /navToolByName\('Calendar'/, 'its opener names the tool from the registry');
+  // Both existing mounts pass nothing either — so the page needs nothing new.
+  for (const f of ['src/components/home/ModuleLauncher.tsx', 'src/app/operations/OperationsRoom.tsx']) {
+    assert.match(code(f), /<HubCalendar \/>/, `${f} mounts it bare too`);
+  }
+  // Every prop HubCalendar takes is optional, and the page passes none.
+  assert.match(src('src/components/hub/HubCalendar.tsx'), /demoEvents\?:/);
+  assert.match(src('src/components/hub/HubCalendar.tsx'), /onRequireAuth\?:/);
+});
+
+test('the grid needs nothing but a Next page — its one context is the app router', () => {
+  // It cannot be rendered in a bare node test: CalendarGrid.tsx:338 and
+  // HubEventCard.tsx:111 both call useRouter(), which throws "invariant expected
+  // app router to be mounted" outside Next. That is not a blocker for /calendar —
+  // every Next page provides it — but it IS why this proof is structural and the
+  // rendering proof is the live screenshot pass, not a stubbed renderToStaticMarkup.
+  assert.throws(
+    () => renderToStaticMarkup(createElement(HubCalendar, { demoEvents: [] } as never)),
+    /app router/,
+    'the router is the one thing it needs, and a page is the only place that has one',
+  );
+  for (const f of ['src/components/shared/CalendarGrid.tsx', 'src/components/hub/HubEventCard.tsx']) {
+    assert.match(src(f), /useRouter\(\)/, `${f} is where the dependency lives`);
+  }
+});
+
+test('the three sources are the three routes — unchanged, no new data path', () => {
+  const hub = src('src/components/hub/HubCalendar.tsx');
+  for (const route of ['/api/calendar?', '/api/operations/daily-plan/items?', '/api/hub/operations-routines?']) {
+    assert.ok(hub.includes(route), `${route} is still one of the three`);
+  }
+  // Read-only: three GETs, no write anywhere in the grid.
+  assert.ok(!/method:\s*'(POST|PATCH|PUT|DELETE)'/.test(hub), 'the grid writes nothing');
+  // And it shows only 'trip' rows out of calendar_events — the registry note says so.
+  assert.match(hub, /source === 'trip'/);
+  assert.match(TOOL_REGISTRY.find((t) => t.name === 'Calendar')!.note ?? '', /source "trip"/);
+});
+
+test('Calendar opens /calendar and owns no agenda page; Budget owns all three', () => {
+  assert.deepEqual(navLaw({ throwOnFail: false, gate: TOOL_GATE }), []);
+  const calendar = navToolByName('Calendar', TOOL_GATE);
+  assert.equal(calendar.href, '/calendar');
+  assert.equal(calendar.status, 'PARTIAL', 'the census does not move');
+  assert.deepEqual(calendar.subRows.map((r) => r.door.href), [], 'no agenda row under Calendar');
+  // Its four phases are the routines pipe — NAV-25's sort, untouched.
+  assert.deepEqual(calendar.phases.map((p) => `${p.pipe} ${p.num}`), ['routines 01', 'routines 02', 'routines 03', 'routines 04']);
+
+  const budget = navToolByName('Budget', TOOL_GATE);
+  assert.ok(budget.subRows.some((r) => r.door.href === '/agenda'), 'the planner hangs under Budget');
+  assert.equal(budget.subRows[0].label, 'Recurring plan · the agenda', 'labelled for what it is');
+  assert.equal(budget.status, 'PARTIAL');
+});
+
+test('the agenda planner is untouched — the same pages, the same routes, the same tables', () => {
+  // What made it Budget's: a cadence, a coa_code, a budget_amount, and a commit
+  // that writes a `budgets` plan row.
+  const commit = src('src/app/api/agenda/[id]/route.ts');
+  assert.match(commit, /INSERT INTO calendar_events/);
+  assert.match(commit, /INSERT INTO budgets/);
+  assert.match(commit, /coa_code/);
+  assert.match(commit, /budget_amount/);
+  // Still raw SQL over tables Prisma does not model — nothing migrated here.
+  assert.ok(!/model agenda/i.test(src('prisma/schema.prisma')), 'agenda_items is still not in the schema');
+  // The three pages still exist and still mount their own bodies.
+  for (const f of ['src/app/agenda/page.tsx', 'src/app/agenda/new/page.tsx', 'src/app/agenda/[id]/page.tsx']) {
+    assert.ok(src(f).length > 0, `${f} still exists`);
+  }
+});

--- a/src/lib/__tests__/nav.test.ts
+++ b/src/lib/__tests__/nav.test.ts
@@ -100,7 +100,7 @@ test('every legacy page hangs under the tool that OWNS it — never another tool
   const subs = Object.fromEntries(navRows(TOOL_GATE).filter((t) => t.subRows.length).map((t) => [t.name, t.subRows.map((r) => r.door.href)]));
   assert.deepEqual(subs, {
     Travel: ['/budgets/trips'],
-    Budget: ['/shopping', '/hub/itinerary', '/runway'],
+    Budget: ['/agenda', '/shopping', '/hub/itinerary', '/runway'],
     Bookkeeping: ['/chart-of-accounts'],
     Tax: ['/dashboard/tax-filing'],
     Compliance: ['/soc2'],

--- a/src/lib/__tests__/offer.test.ts
+++ b/src/lib/__tests__/offer.test.ts
@@ -70,7 +70,7 @@ test('claim lines come from the registry: "built and running" for LIVE only, "pa
     assert.equal(claimLine(t), `partial — ${t.why}`);
     assert.ok(!claimLine(t).includes('discover'), `${name}: the why, not the beats`);
   }
-  assert.equal(claimLine(tool('Calendar')), 'partial — an agenda list whose commit lands on calendar_events; the calendar grid itself lives on /runway');
+  assert.equal(claimLine(tool('Calendar')), 'partial — a read-only grid over three feeds it does not own, beside a routine builder whose occurrences are the only thing on it this tool writes');
   // a four-beat PARTIAL with no why is thrown, not rendered as the beats form
   assert.throws(() => claimLine({ ...tool('Calendar'), why: undefined }), /Calendar is PARTIAL with four beats and no why/);
   assert.throws(() => claimLine({ ...tool('Calendar'), why: '  ' }), /Calendar is PARTIAL with four beats and no why/);

--- a/src/lib/__tests__/operationsRoom.test.ts
+++ b/src/lib/__tests__/operationsRoom.test.ts
@@ -84,8 +84,10 @@ test('Tasks and Time open the room, and no folded route is a door', () => {
       assert.ok(!tool.subRows.some((s) => s.door.href === r.path), `${r.path} is a phase inside the room, not a door`);
     }
   }
-  // /agenda is Calendar's, and Calendar keeps it — the island's only door.
-  assert.equal(navToolByName('Calendar', TOOL_GATE).href, '/agenda');
+  // CAL-01: /agenda was Calendar's home; it is Budget's sub-row now, and Calendar
+  // opens the calendar. Neither is one of the room's folded routes.
+  assert.equal(navToolByName('Calendar', TOOL_GATE).href, '/calendar');
+  assert.ok(navToolByName('Budget', TOOL_GATE).subRows.some((r) => r.door.href === '/agenda'));
 });
 test('the room mounts the existing components — no interior rewritten, one shell', () => {
   const room = src('src/app/operations/OperationsRoom.tsx');

--- a/src/lib/__tests__/toolRegistry.test.ts
+++ b/src/lib/__tests__/toolRegistry.test.ts
@@ -25,7 +25,9 @@ test('the counts are the dated census — 2 LIVE · 9 PARTIAL · 14 NOT_BUILT �
 test('the four four-beat PARTIALs each carry the census note; no LIVE or NOT_BUILT tool carries one', () => {
   const fourBeatPartials = TOOL_REGISTRY.filter((t) => t.status === 'PARTIAL' && beats(t) === 4).map((t) => t.name);
   assert.deepEqual(fourBeatPartials, ['Calendar', 'Tasks', 'Time', 'Budget']);
-  assert.equal(byName('Calendar').why, 'an agenda list whose commit lands on calendar_events; the calendar grid itself lives on /runway');
+  // CAL-01: the why states what /calendar actually is — a read-only grid over
+  // three feeds it does not own, beside the routine builder it does write.
+  assert.equal(byName('Calendar').why, 'a read-only grid over three feeds it does not own, beside a routine builder whose occurrences are the only thing on it this tool writes');
   assert.equal(byName('Tasks').why, "the founder's build pipeline — accepting a task fires a paid Claude Code build; not a customer's task tool");
   assert.equal(byName('Time').why, 'day blocks and a daily log inside the Narrative pipeline; no time tool');
   assert.equal(byName('Budget').why, 'actuals by entity plus recurring lines on module_expenses; no plan vs actual; no personal · trade · travel roll-up');

--- a/src/lib/toolRegistry.ts
+++ b/src/lib/toolRegistry.ts
@@ -22,8 +22,9 @@
  * that IS its home, selected in place); an off-cockpit tool is a plain link.
  * A NOT_BUILT tool has no home, no screen, no copy.
  *
- * SHELL-01: which STEP a tool sits in, and the order a human walks them, is
- * src/lib/steps.ts — this file stays the one source for what a tool IS.
+ * NAV-25: the order the rail walks the tools, and which phases each owns, is
+ * src/lib/nav.ts — this file stays the one source for what a tool IS. (The
+ * steps layer SHELL-01 invented was deleted with it; src/lib/steps.ts is gone.)
  *
  * THE LAW (module scope — the deck's LAYOUT LAW idiom; also re-run at build by
  * scripts/assert-tool-registry.ts, which adds the filesystem check that every
@@ -33,8 +34,9 @@
  *   3. NOT_BUILT ⇔ no beats; LIVE ⇒ four beats; a PARTIAL with four beats
  *      carries a `why` note (thrown without it) — four beats never imply LIVE;
  *   4. status counts == the dated census (EXPECTED_STATUS_COUNTS);
- * SHELL-01: the six family MENUS and PAGES are retired — the rail walks the
- * steps (src/lib/steps.ts) and HOME carries the whole sheet — so FAMILY_PAGES,
+ * SHELL-01 → NAV-25: the six family MENUS and PAGES are retired — the rail
+ * renders the twenty-five tools (src/lib/nav.ts) and HOME carries the whole
+ * sheet — so FAMILY_PAGES,
  * familyMenu, familyCards, familyOfPath and toolsOf went with them. What the
  * rail and the sheet still read lives here: the facts, the doors (doorOf /
  * doorOfLink), the cockpit paths and the family reads.
@@ -92,18 +94,19 @@ export const EXPECTED_STATUS_COUNTS: Readonly<Record<ToolStatus, number>> = { LI
 
 const FACTS: Readonly<Record<ToolName, ToolFacts>> = {
   // ── THE WORK ──
-  // ROOM-02: the Routines sub-link is GONE — the recurring form is the room's
-  // phase 03. HOME STAYS /agenda, deliberately: /agenda is an island (its
-  // agenda_items + agenda_checkins are read by no other route, and neither
-  // table is in schema.prisma), and this row is its ONLY door. Dropping it
-  // from step 12 as ruled would leave /agenda, /agenda/new and /agenda/[id]
-  // with no door at all and fail the reachability law — reported, not done.
+  // CAL-01: the calendar is THE CALENDAR. Its home was /agenda — a recurring-spend
+  // planner (cadence + coa_code + budget_amount, committing a `budgets` row) that
+  // is Budget's work and is Budget's now. The merged grid had no room of its own;
+  // it has one at /calendar. The four beats are the ROUTINES pipe, which is what
+  // NAV-25's sort gives this tool: define, schedule, run, prove. The grid itself
+  // is READ-ONLY — three GETs, no write anywhere in it or in EventDetailPanel —
+  // so it carries discover and nothing more, and the citation says which is which.
   Calendar: {
-    slug: 'calendar', status: 'PARTIAL', beats: ALL, home: '/agenda',
-    why: 'an agenda list whose commit lands on calendar_events; the calendar grid itself lives on /runway',
+    slug: 'calendar', status: 'PARTIAL', beats: ALL, home: '/calendar',
+    why: 'a read-only grid over three feeds it does not own, beside a routine builder whose occurrences are the only thing on it this tool writes',
     links: [],
-    citation: 'src/app/api/agenda/route.ts:5 (discover) · :56 (decide, draft :86) · src/app/api/agenda/[id]/route.ts:54 (commit) · :84 (record → calendar_events)',
-    note: 'Reachable from no menu until this PR; the tab keyed "calendar" is Runway.',
+    citation: 'discover: src/components/hub/HubCalendar.tsx:128 (/api/calendar) · :141 (/api/operations/daily-plan/items) · :153 (/api/hub/operations-routines) — three GETs, no write · decide/commit/record: src/app/api/operations/routines/route.ts:264 (create) · routines/[id]/route.ts (edit) · routines/[id]/completions/route.ts (record)',
+    note: 'The grid shows only calendar_events with source "trip" (HubCalendar.tsx:132) — the agenda planner\'s own "agenda" rows are written and never read back.',
   },
   Tasks: {
     // ROOM-02: home is the room. The cockpitKey is gone with the cockpit tab —
@@ -151,6 +154,11 @@ const FACTS: Readonly<Record<ToolName, ToolFacts>> = {
     // ROOM-01: the six category sub-links are gone — they are the switcher inside
     // /budget now, not six doors in the rail. Shopping stays a room of its own.
     links: [
+      // CAL-01: the agenda planner is Budget's. Its items carry a cadence, a
+      // coa_code and a budget_amount, and committing one writes a `budgets`
+      // plan row (src/app/api/agenda/[id]/route.ts:113-133). ONE sub-row covers
+      // all three pages — /agenda/new and /agenda/[id] are reached through it.
+      { label: 'Recurring plan · the agenda', href: '/agenda' },
       { label: 'Shopping · meal & cart plans', href: '/shopping' },
       { label: 'Itinerary budget builder', href: '/hub/itinerary' },
       { label: 'Runway · the read-only view', cockpitKey: 'calendar' },


### PR DESCRIPTION
**Do not merge — Alex merges after Vercel Preview (SOC 2 gate).**

The grid has a room. The planner is Budget's.

---

## HARD GATE

| Gate | Touched? | Detail |
|---|---|---|
| Auth | **no** | No route touched at all. |
| Migrations / tables / raw SQL | **no** | `agenda_items` and `agenda_checkins` are byte-for-byte untouched, still raw-SQL-only, still absent from `schema.prisma`. No data migrated. |
| Cost / paid calls | **no** | No external call. |
| Status / counts | **no** | Calendar stays PARTIAL with four beats. Census **2 / 9 / 14** stands. |
| Gate | **no** | Calendar is free before and after (`TOOL_GATE.Calendar === null`). |
| Pages deleted | **none** | `/runway`, `/agenda`, `/agenda/new`, `/agenda/[id]` all keep their pages and their doors. |

**No component interior edited.** `git diff --stat` over `src/components/` is **empty** — the only changed source files are the new page, the registry and six test files.

---

## STEP 0 — the audit

### 0.1 `HubCalendar` and `CalendarGrid` — and a correction to the mount list

`HubCalendar({ demoEvents, onRequireAuth }: HubCalendarProps = {})` (`:104`) — **both props optional, the whole signature defaulted.** It self-fetches three sources:

| Source | Call site | Table |
|---|---|---|
| trip events | `HubCalendar.tsx:128` → `/api/calendar` | `calendar_events`, **filtered to `source === 'trip'` at `:132`** |
| daily-plan blocks | `:141` → `/api/operations/daily-plan/items` | `operations_daily_plan_items` (via `mapOperationsBlocks`) |
| routine occurrences | `:153` → `/api/hub/operations-routines` | `operations_routines` (via `mapOperationsRoutines`) |

merged into one `<CalendarGrid>` at `:243`.

**Every mount today — two, not five.** Your list needs correcting on three counts:

| You named | Reality |
|---|---|
| `/hub` | **a redirect to `/home`** (`src/app/hub/page.tsx:7`) — it mounts nothing |
| ModuleLauncher's runway tab | **confirmed** — `ModuleLauncher.tsx:688`, and its own comment declares the grid sits *outside* the runway phase axis |
| `/operations` | **confirmed** — `OperationsRoom.tsx:42`, ROOM-02's phase 02 |
| `/trading`'s P&L view | mounts **`CalendarGrid` directly** (`trading/page.tsx:887`) with its own `plCalendarEvents` and `PL_SOURCE_CONFIG` — a different calendar, not the merged grid |
| the showcases | **no mounts** — `RoutinesShowcaseSections.tsx:266` and `RunwayShowcaseSections.tsx:56, :281` only *cite* HubCalendar in comments |

**What a standalone `/calendar` must pass: nothing.** Both existing mounts are the bare `<HubCalendar />`, and the page uses the same. Nothing comes from ModuleLauncher — **no STOP.**

The one thing it does need is a Next page, because `CalendarGrid.tsx:338` and `HubEventCard.tsx:111` call `useRouter()`. That is satisfied by any page; it is also why the render proof here is the live screenshot pass rather than a stubbed `renderToStaticMarkup` (a test asserts the throw, so the reason is recorded rather than worked around).

### 0.2 `/agenda` — the planner, and what its commit writes

Three pages (`/agenda` 269 lines, `/agenda/new`, `/agenda/[id]`) over two API routes. `agenda_items` columns, from the INSERT at `api/agenda/route.ts:76-88`:

`user_id · name · category · subcategory · cadence · start_date · end_date · time_block · start_time · end_time · duration_mins · custom_days · intensity · goal · definition_of_done · tags · **coa_code** · **budget_amount** · status`

`agenda_checkins` is read at `api/agenda/[id]/route.ts:25` and deleted at `:187`. **Neither table is in `prisma/schema.prisma`** — raw SQL only, as you said.

**The commit (`api/agenda/[id]/route.ts:54-135`) does three things:**
1. flips the item to `committed` (`:56-60`);
2. INSERTs a **`calendar_events`** row carrying `coa_code` and `budget_amount` (`:84-96`);
3. when `budget_amount > 0 && coa_code`, INSERTs a **`budgets`** plan row spread across the twelve months from the start month, `ON CONFLICT … DO UPDATE` (`:113-133`).

**Readers of those tables: only `/api/agenda/*`.** Nothing else in `src` reads `agenda_items` or `agenda_checkins`.

**And the finding that settles it:** the merged grid shows only `calendar_events` with `source === 'trip'` (`HubCalendar.tsx:132`). The commit writes `source: 'agenda'`. **So the planner's calendar rows are written and never read back by the calendar** — it does not feed the grid in any sense. It writes a `budgets` plan. It is Budget's.

### 0.3 The runway pipe and whether `/runway` keeps a purpose

| Phase | Renders | NAV-25 owner |
|---|---|---|
| 01 Source | **nothing** — `ModuleLauncher.tsx:619-626` declares it state-only | Banking |
| 02 History | **nothing** — same declaration | HOME |
| 03 Burn | `RunwayBudgetPanel` (`show='burn'`) | HOME |
| 04 Match | `MatchReviewSection` | Bookkeeping |
| 05 Project | `RunwayBudgetPanel` (`show='project'`) | Budget |

**The grid sits under none of them.** `ModuleLauncher:628` says so in its own words: *"HubCalendar is the tab's cross-module FOUNDATION … NOT a runway phase — it stays persistent below the phase surfaces, outside the phase axis (declared audit call)."* So moving it to `/calendar` disturbs no phase assignment.

**Does `/runway` still earn its page? Yes — see the finding below.**

### 0.4 `nav.ts` before

| | Calendar | Budget |
|---|---|---|
| row | 01, THE WORK, PARTIAL | 13, MONEY OUT, PARTIAL |
| door | `/agenda` | `/budget` |
| phases | routines 01 Define · 02 Scheduled · 03 Run · 04 Proven | runway 05 Project |
| sub-rows | (none) | `/shopping`, `/hub/itinerary`, `/runway` |

`pages: 72 · doors: 53`. `/agenda` (+2 children) doored by Calendar's row; `/runway` by the `/[tab]` listed route and Budget's sub-row; `/hub` a redirect to `/home`.

---

## What changed

**`src/app/calendar/page.tsx`** — `<AppLayout page>` + `ToolOpener` + `<HubCalendar />`. Same component, same three sources, no interior edit, no new data path. One header, one rail (measured).

**Calendar's registry row** — home `/calendar`; `why` rewritten to state what is now true; citation split so each beat is traceable:

- **discover** → the grid's three GETs (`HubCalendar.tsx:128`, `:141`, `:153`) — I verified the grid **writes nothing**: no POST/PATCH/PUT/DELETE anywhere in `HubCalendar` or `EventDetailPanel`
- **decide / commit / record** → the **routines pipe**, which is exactly what NAV-25's sort gives this tool: `api/operations/routines/route.ts:264` (create), `routines/[id]` (edit), `routines/[id]/completions` (record)

So the four beats survive on evidence rather than on the agenda API, **the status stays PARTIAL and the census does not move.** The `note` now records the `source === 'trip'` finding.

**Budget's registry row** gains `Recurring plan · the agenda → /agenda` as its first sub-row. One sub-row covers all three pages — `/agenda/new` and `/agenda/[id]` are reached through it by the reachability law's prefix match. **navLaw rule 7 still passes:** `/agenda` is no tool's screen now that Calendar's is `/calendar`.

I also re-pointed two stale citations in `toolRegistry.ts`'s header that still named `src/lib/steps.ts` — a file NAV-25 deleted.

---

## Doors before / after

**pages 72 → 73 · doors 53 → 54.** Every page has a door; the reachability law passes at 73/73.

| Route | Before | After |
|---|---|---|
| `/calendar` | did not exist | **rail · 1. Calendar** |
| `/agenda` | rail · 1. Calendar | **rail · 13. Budget · "Recurring plan · the agenda"** |
| `/agenda/new`, `/agenda/[id]` | rail · 1. Calendar | **rail · 13. Budget** (same sub-row, prefix) |
| `/runway` | listed route + Budget's sub-row | **unchanged** |
| `/hub` | redirect → `/home` | **unchanged** |

Measured live, signed in: the rail on `/budget` reads `["Recurring plan · the agenda", "Shopping · meal & cart plans", "Itinerary budget builder", "Runway · the read-only view"]`; the rail on `/calendar` shows Calendar with **no** sub-rows.

---

## Verification

| Check | Result |
|---|---|
| `npx tsc --noEmit` | **exit 0** |
| `npm test` | **303 / 303** (298 before + 5 new) |
| `npm run lint` | **821 (551 errors, 270 warnings)** — identical to base. **Zero new.** |
| `npx tsx scripts/assert-tool-registry.ts` | **exit 0** — all fourteen laws |
| Full `next build` | **BUILD EXIT 0**; `/calendar` present as a static route |

Live at 1600×1200 and 390×844:

| | Result |
|---|---|
| `/calendar` opener | `Calendar` — `THE WORK / 1 Calendar [PARTIAL]`, its registry line, `01 DEFINE · 02 SCHEDULED · 03 RUN · 04 PROVEN` |
| grid mounted | **1** · headers **1** · rails **1** |
| Day / Week / Month | all three render |
| `/runway` | grid present, headers 1 — **unchanged** |

**Screenshots are in the session chat** (`audit-reports/` is gitignored, the repo is public).

Five existing tests asserted the old home and had to move with it — `budgetRoom` (Budget's sub-rows), `nav` (the legacy-page map), `operationsRoom` (Calendar's door), `toolRegistry` and `offer` (Calendar's `why`, which is the customer-facing claim line through `claimLine`). All five now assert the new truth; none was weakened.

---

## Findings

**1. `/runway` still earns its page — but only just, and not as a calendar.** With the grid at `/calendar`, what remains on `/runway` is `RunwayBudgetPanel` (03 Burn / 05 Project), `MatchReviewSection` (04 Match) and the ProofStrip — the surfaces for **HOME's "how long can I last?" answer**, **Bookkeeping's 04 Match** and **Budget's 05 Project**. Three owners, no tool of its own, which is exactly why NAV-25 left it without a rail row.

**If it were to go**, here is what would move where: 03 Burn → `/home` (it *is* the answer card's surface, and `/home` already links to `/runway` from that card); 04 Match → `/books`, Bookkeeping's screen; 05 Project → `/budget`, Budget's screen. All three are inside `ModuleLauncher`'s runway `<section>`, so that is the cockpit's PR, not this one. **Not deleted, not redirected, as ruled.**

**2. The planner's `calendar_events` rows are a dead write.** `source: 'agenda'` is written on every commit and the grid reads only `source === 'trip'`. Nothing else reads `calendar_events` for that source either. The `budgets` write is the one that matters — which is the case for it being Budget's.

**3. Calendar's screen does not render Calendar's phases.** Its four phases are the routines pipe, which renders at `/operations?phase=routines` (ROOM-02). `/calendar` shows the grid. NAV-25 created this shape and CAL-01 keeps it; the honest question — should the routine builder move to `/calendar`? — is a DS ruling, not this one.

**4. `agenda_items` is still outside Prisma.** Two tables, nineteen columns, reached only by raw SQL in two route files. The ROOM-02 row-count query still applies if you want to decide the planner's fate; nothing here changes a row.

---

## Files touched

| File | Change |
|---|---|
| `src/app/calendar/page.tsx` | **new** — the grid's own room |
| `src/lib/toolRegistry.ts` | Calendar home `/calendar`, new `why`, new citation, new note; Budget gains the agenda sub-row; two stale `steps.ts` citations re-pointed |
| `src/lib/__tests__/calendarRoom.test.ts` | **new** — 5 tests |
| `src/lib/__tests__/{budgetRoom,nav,operationsRoom,toolRegistry,offer}.test.ts` | assertions moved with the home |

**No component interior edited. No table, migration or raw-SQL change. No data migrated. No page deleted. No status, count or gate change. No fallback.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc

---
_Generated by [Claude Code](https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc)_