### PR TITLE
BOOKS-PIPE-01: the pipeline is the page — and the opener stops printing source citations

### DIFF
--- a/scripts/assert-tool-registry.ts
+++ b/scripts/assert-tool-registry.ts
@@ -91,7 +91,7 @@ import { resolve } from 'node:path';
 import { readdirSync, statSync } from 'node:fs';
 import { PROBLEM_SHEET } from '../src/lib/problemSheet';
 import { EXPECTED_STATUS_COUNTS, FAMILY_READS, TOOL_REGISTRY, registryLaw, statusCounts } from '../src/lib/toolRegistry';
-import { HOME_ANSWER, HOME_OWNER, HOME_PHASES, THE_SORT, navFamilies, navLaw, navRows } from '../src/lib/nav';
+import { HOME_ANSWER, HOME_OWNER, HOME_PHASES, PHASES_RENDERED_AT, THE_SORT, navFamilies, navLaw, navRows } from '../src/lib/nav';
 import { TOOL_GATE } from '../src/lib/offer';
 import { PIPE_PHASES } from '../src/lib/pipePhases';
 import { OWNER_UTILITIES } from '../src/lib/shellMenu';
@@ -1026,6 +1026,90 @@ for (const p of pages) {
 }
 if (!calendarPage) { toolViolations += 1; violations.push(`tool law 5: ${CALENDAR_HOME} has no page — the merged grid has nowhere to be (TOOL-LAW-01)`); }
 if (!existsSync(resolve(ROOT, COCKPIT_COMPONENT))) { toolViolations += 1; violations.push(`tool law: ${COCKPIT_COMPONENT} is missing — the cockpit's grandfathered tabs are checked against it`); }
+// ── THE CITATION LAW (BOOKS-PIPE-01) ────────────────────────────────────────
+// A registry `citation` is INTERNAL EVIDENCE for these laws — a list of
+// file:line pairs proving a tool's beats. It is not customer copy, and it must
+// never reach a rendered surface. It did: nav.ts's `line` fell back to it when
+// a tool had no `why`, and ToolOpener printed it verbatim on SEVEN tool pages
+// (Travel, Banking, Brokerage, Trade Log, Bookkeeping, Tax, Compliance), while
+// TheSheet printed it on HOME. Both now read `why` or nothing.
+//
+// The registry itself, its tests and these scripts may read the field; nothing
+// that renders may.
+const CITATION_ALLOWED = [
+  'src/lib/toolRegistry.ts',   // the field's own home
+  'src/lib/problemSheet.ts',
+];
+// Compliance renders LEGAL citations of its own — citation_string, citation_key,
+// a TaskCitation's `.citation`, a `citations` array from the discovery API. A
+// different thing entirely, and none of it is the registry's field. The
+// discriminator is not the word: it is whether a ToolEntry can be in scope at
+// all, which requires importing the registry or the nav model. Compliance's
+// pages import neither.
+const REGISTRY_IMPORT = /from '@\/lib\/(toolRegistry|nav)'|from '\.\.?\/(toolRegistry|nav)'/;
+let citationLeaks = 0;
+for (const f of shellFiles) {
+  if (CITATION_ALLOWED.includes(f)) continue;
+  const body = readFileSync(resolve(ROOT, f), 'utf8');
+  if (!REGISTRY_IMPORT.test(body)) continue;
+  const code = body.split('\n').filter((l) => !/^\s*(\*|\/\/|\/\*)/.test(l)).join('\n');
+  // Any read of the field, however it is reached: `t.citation`, `x?.citation`,
+  // `find(...)?.citation`, `['citation']`. The import guard above already
+  // excludes Compliance's legal citations, so this can be as wide as it needs.
+  const hits = [...code.matchAll(/\??\.citation\b|\['citation'\]|\["citation"\]/g)].map((m) => m[0]);
+  if (!hits.length) continue;
+  citationLeaks += 1;
+  violations.push(`citation law: ${f} reads a registry citation (${hits.join(', ')}) — a citation is file:line evidence for these laws, never customer copy (BOOKS-PIPE-01)`);
+}
+// nav.ts must not hand it on either.
+const NAV_FILE = 'src/lib/nav.ts';
+const navBody = readFileSync(resolve(ROOT, NAV_FILE), 'utf8');
+if (/line:\s*tool\.why[^\n]*tool\.citation/.test(navBody)) {
+  citationLeaks += 1;
+  violations.push(`citation law: ${NAV_FILE} falls back to the citation for a tool's rendered line — a tool with no \`why\` gets no line (BOOKS-PIPE-01)`);
+}
+if (citationLeaks) console.log(`✖ The citation law FAILED — ${citationLeaks} file(s) can render a registry citation.`);
+else console.log(`✔ The citation law passed — ${shellFiles.length} rendered files scanned, 0 read a registry citation; ${CITATION_ALLOWED.length} declared holders of the field.`);
+
+// ── THE OPENER LAW (BOOKS-PIPE-01) ──────────────────────────────────────────
+// An opener lists only the phases ITS PAGE DRAWS. nav.ts declares that per
+// route (PHASES_RENDERED_AT); this checks every entry against the real strip
+// census, so the declaration cannot drift from the code.
+console.log('THE OPENER — what each tool page advertises vs what it draws');
+let openerViolations = 0;
+for (const [route, tools] of screenTools) {
+  const page = pages.find((p) => p.route === route);
+  if (!page) continue;
+  const seen = new Set<string>();
+  const stack = [page.file];
+  const drawn = new Set<string>();
+  while (stack.length) {
+    const f = stack.pop()!;
+    if (seen.has(f)) continue;
+    seen.add(f);
+    const body = existsSync(resolve(ROOT, f)) ? readFileSync(resolve(ROOT, f), 'utf8') : '';
+    if (body.includes('<StageStrip')) for (const m of body.matchAll(/PIPE_PHASES\.([a-z]+)/g)) drawn.add(m[1]);
+    for (const next of importsFor(f)) stack.push(next);
+  }
+  const declared = [...(PHASES_RENDERED_AT[route] ?? [])].sort();
+  const real = [...drawn].sort();
+  const owned = [...new Set(toolRows.filter((t) => t.href === route).flatMap((t) => t.phases.map((p) => p.pipe)))].sort();
+  const elsewhere = owned.filter((p) => !real.includes(p));
+  console.log(`  ${route.padEnd(13)} ${tools.join(' + ').padEnd(24)} draws [${real.join(' ') || '—'}]  owns [${owned.join(' ') || '—'}]${elsewhere.length ? `  drawn elsewhere: ${elsewhere.join(' ')}` : ''}`);
+  if (declared.join('|') !== real.join('|')) {
+    openerViolations += 1;
+    violations.push(`opener law: ${route} declares it draws [${declared.join(' ') || '—'}] but its tree draws [${real.join(' ') || '—'}] — nav.ts PHASES_RENDERED_AT must match the code (BOOKS-PIPE-01)`);
+  }
+}
+for (const route of Object.keys(PHASES_RENDERED_AT)) {
+  if (!screenTools.has(route)) {
+    openerViolations += 1;
+    violations.push(`opener law: PHASES_RENDERED_AT names ${route}, which is no tool's screen (BOOKS-PIPE-01)`);
+  }
+}
+if (openerViolations) console.log(`✖ The opener law FAILED — ${openerViolations} route(s) advertise a pipeline they do not draw.`);
+else console.log(`✔ The opener law passed — ${screenTools.size} tool pages, every one advertising only the phases it draws.`);
+
 if (toolViolations) console.log(`✖ The tool law FAILED — ${toolViolations} violation(s).`);
 else console.log(`✔ The tool law passed — ${screenTools.size} tool pages, ${MULTI_TOOL_ALLOWED.length} grandfathered (closed, shrink-only); ${stripFiles.length} phase strips, every one reading src/lib/pipePhases.ts; the merged grid mounts only on ${CALENDAR_HOME}.`);
 

--- a/src/components/home/BooksPipeline.tsx
+++ b/src/components/home/BooksPipeline.tsx
@@ -256,6 +256,33 @@ export default function BooksPipeline() {
   const pendingCount = uncommittedSpending.length + investmentQueue;
   const reconciledCount = reconciliations.filter((r) => r.status === 'reconciled').length;
   const closedThisYear = periodCloses.filter((p) => p.year === year && p.status === 'closed').length;
+
+  // BOOKS-PIPE-01: THE PIPELINE IS THE PAGE. The strip is hoisted out of the
+  // main return so the FIRST-RUN state renders it too. It used to be below an
+  // early `return <EntitySetup/>` (the old :277), so a customer with no entity
+  // never saw the six phases at all — the page opened on a setup card with no
+  // sense of what it was setting up. Same JSX, same derived states, same
+  // handler; ORDER ONLY.
+  const strip = (
+    <StageStrip
+      phases={([
+        { key: 'feed', num: PIPE_FEED.num, label: PIPE_FEED.name,
+          state: phase === 'feed' ? 'active' : accounts.length > 0 ? 'done' : 'pending' },
+        { key: 'code', num: PIPE_CODE.num, label: PIPE_CODE.name,
+          state: phase === 'code' ? 'active' : committedCount > 0 && pendingCount === 0 ? 'done' : 'pending' },
+        { key: 'reconcile', num: PIPE_RECONCILE.num, label: PIPE_RECONCILE.name,
+          state: phase === 'reconcile' ? 'active' : reconciledCount > 0 ? 'done' : 'pending' },
+        { key: 'close', num: PIPE_CLOSE.num, label: PIPE_CLOSE.name,
+          state: phase === 'close' ? 'active' : closedThisYear > 0 ? 'done' : 'pending' },
+        { key: 'reports', num: PIPE_REPORTS.num, label: PIPE_REPORTS.name,
+          state: phase === 'reports' ? 'active' : tbTotals?.hasActivity && tbTotals?.isBalanced ? 'done' : 'pending' },
+        { key: 'export', num: PIPE_EXPORT.num, label: PIPE_EXPORT.name,
+          state: phase === 'export' ? 'active' : 'pending' },
+      ] as StagePhase[])}
+      onSelect={(k) => setPhase(k as typeof phase)}
+    />
+  );
+
   const closedPeriods = periodCloses.filter((p) => p.status === 'closed' && p.closedAt);
   // NAV-01b: the December close of the selected year IS the year-end close.
   const yearEndClosed = periodCloses.some((p) => p.year === year && p.month === 12 && p.status === 'closed');
@@ -274,7 +301,19 @@ export default function BooksPipeline() {
     );
   }
   if (state === 'setup') {
-    return <EntitySetup existing={[]} mode="first-run" onCreated={reloadAll} />;
+    // FIRST RUN IS PHASE 01's CONTENT, not a card in front of the pipeline: the
+    // strip renders first, 01 Feed is the phase you are on, and the entity form
+    // is what that phase asks for. Nothing is hidden and nothing is invented —
+    // the later phases read `pending`, which is what they are.
+    return (
+      <>
+        {strip}
+        <div className="space-y-3">
+          <SectionHeader kicker={`${PIPE_FEED.num} / ${PIPE_FEED.name}`} right={`PHASE ${PIPE_FEED.num} OF 06`} />
+          <EntitySetup existing={[]} mode="first-run" onCreated={reloadAll} />
+        </div>
+      </>
+    );
   }
   if (state === 'error') {
     return (
@@ -325,23 +364,7 @@ export default function BooksPipeline() {
           export-completion signal exists client-side, so it renders pending
           (never hardcoded done). States are indicators, never locks — every
           phase stays clickable (the ratified StageStrip amendment). */}
-      <StageStrip
-        phases={([
-          { key: 'feed', num: PIPE_FEED.num, label: PIPE_FEED.name,
-            state: phase === 'feed' ? 'active' : accounts.length > 0 ? 'done' : 'pending' },
-          { key: 'code', num: PIPE_CODE.num, label: PIPE_CODE.name,
-            state: phase === 'code' ? 'active' : committedCount > 0 && pendingCount === 0 ? 'done' : 'pending' },
-          { key: 'reconcile', num: PIPE_RECONCILE.num, label: PIPE_RECONCILE.name,
-            state: phase === 'reconcile' ? 'active' : reconciledCount > 0 ? 'done' : 'pending' },
-          { key: 'close', num: PIPE_CLOSE.num, label: PIPE_CLOSE.name,
-            state: phase === 'close' ? 'active' : closedThisYear > 0 ? 'done' : 'pending' },
-          { key: 'reports', num: PIPE_REPORTS.num, label: PIPE_REPORTS.name,
-            state: phase === 'reports' ? 'active' : tbTotals?.hasActivity && tbTotals?.isBalanced ? 'done' : 'pending' },
-          { key: 'export', num: PIPE_EXPORT.num, label: PIPE_EXPORT.name,
-            state: phase === 'export' ? 'active' : 'pending' },
-        ] as StagePhase[])}
-        onSelect={(k) => setPhase(k as typeof phase)}
-      />
+      {strip}
 
       <div className={phase === 'feed' ? 'block space-y-3' : 'hidden'}>
         <SectionHeader kicker="01 / Feed" right="PHASE 01 OF 06" />

--- a/src/components/shell/TheSheet.tsx
+++ b/src/components/shell/TheSheet.tsx
@@ -23,9 +23,14 @@ import { TOOL_GATE } from '@/lib/offer';
 import { FAMILY_READS, TOOL_REGISTRY, type ToolEntry } from '@/lib/toolRegistry';
 import { StatusChip } from '@/components/home/ToolChrome';
 
-/** The line a job expands to: why it is not finished when the registry says why, else the census citation that placed it. */
+/**
+ * The line a job expands to: the registry's `why` — what is not finished for a
+ * customer. BOOKS-PIPE-01: it used to fall back to `citation`, the census's
+ * file:line evidence, and printed source paths on HOME. A job with no `why`
+ * says plainly that the registry holds no note, which is true and is not a path.
+ */
 function proofLine(tool: ToolEntry): string {
-  return tool.why?.trim() ? tool.why : tool.citation;
+  return tool.why?.trim() ? tool.why : 'No note in the registry for this job.';
 }
 
 export default function TheSheet() {

--- a/src/components/shell/ToolOpener.tsx
+++ b/src/components/shell/ToolOpener.tsx
@@ -10,16 +10,22 @@
  * and registry line — so a customer reading the rail's row finds that row's name
  * on the screen it opens.
  *
- * PHASES: the opener PRINTS the phases each tool owns (nav.ts THE SORT) but
- * renders no strip of its own. Every one of these screens already mounts the
- * StageStrip its pipe belongs to, and the ratified Pipe Frame holds ONE phase
- * control, never two.
+ * PHASES: the opener PRINTS the phases THIS PAGE DRAWS (nav.ts
+ * PHASES_RENDERED_AT, cross-checked at build against the real strip census) and
+ * renders no strip of its own — the ratified Pipe Frame holds ONE phase control,
+ * never two. A phase the tool owns but that is drawn somewhere else is not
+ * advertised here: the header must describe the pipeline the page HAS.
+ *
+ * THE LINE is the registry's `why` and nothing else. It used to fall back to
+ * `citation` — file:line evidence for the build laws — and seven tool pages
+ * printed source paths to customers. A tool with no `why` gets no line.
  *
  * Nothing here is typed: every family name, tool name, number, status, line and
  * phase name is read from the registry or from pipePhases.ts.
  */
+import { usePathname } from 'next/navigation';
 import { StatusChip } from '@/components/home/ToolChrome';
-import type { NavTool } from '@/lib/nav';
+import { phasesRenderedOn, type NavTool } from '@/lib/nav';
 
 /** "WHAT YOU OWN" → "What you own" — the eyebrow's sentence case, computed. */
 function familyWord(family: string): string {
@@ -33,6 +39,7 @@ export default function ToolOpener({ tools, line, actions }: {
   line?: string;
   actions?: React.ReactNode;
 }) {
+  const pathname = usePathname() ?? '';
   const [first] = tools;
   if (!first) return null;
   return (
@@ -47,10 +54,17 @@ export default function ToolOpener({ tools, line, actions }: {
             <h1 className="text-xl sm:text-2xl font-semibold tracking-tight text-text-primary">{tool.name}</h1>
             <StatusChip status={tool.status} />
           </div>
-          <p className="mt-1 max-w-3xl font-mono text-[10px] leading-relaxed text-text-muted">{tool.line}</p>
-          {tool.phases.length > 0 && (
+          {/* The registry's `why`, or nothing. NEVER the citation — that is
+              internal evidence for the build laws, and the law throws if a
+              rendered file so much as reads it. */}
+          {tool.line && (
+            <p className="mt-1 max-w-3xl text-xs leading-relaxed text-text-muted">{tool.line}</p>
+          )}
+          {/* Only the phases THIS PAGE DRAWS. A phase the tool owns but that is
+              drawn elsewhere is not advertised here (nav.ts PHASES_RENDERED_AT). */}
+          {phasesRenderedOn(pathname, tool).length > 0 && (
             <p className="mt-1 font-mono text-[10px] uppercase tracking-wider text-text-faint" data-opener-phases={tool.name}>
-              {tool.phases.map((p) => `${p.num} ${p.name}`).join(' · ')}
+              {phasesRenderedOn(pathname, tool).map((p) => `${p.num} ${p.name}`).join(' · ')}
             </p>
           )}
         </div>

--- a/src/lib/__tests__/booksPipe.test.ts
+++ b/src/lib/__tests__/booksPipe.test.ts
@@ -1,0 +1,95 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import * as React from 'react';
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+Object.assign(globalThis, { React });
+import { PHASES_RENDERED_AT, navRows, navToolByName, phasesRenderedOn } from '../nav';
+import { PIPE_PHASES } from '../pipePhases';
+import { TOOL_GATE } from '../offer';
+import { TOOL_REGISTRY } from '../toolRegistry';
+
+// BOOKS-PIPE-01 — the pipeline is the page, and the opener stops printing citations.
+
+const src = (f: string) => readFileSync(`${process.cwd()}/${f}`, 'utf8');
+const code = (f: string) => src(f).split('\n').filter((l) => !/^\s*(\*|\/\/|\/\*)/.test(l)).join('\n');
+
+test('no tool\'s rendered line is a citation — a tool with no `why` gets no line', () => {
+  for (const t of navRows(TOOL_GATE)) {
+    const reg = TOOL_REGISTRY.find((r) => r.name === t.name)!;
+    assert.equal(t.line, reg.why?.trim() ? reg.why : null, `${t.name}: the line is the why, or nothing`);
+    if (t.line !== null) {
+      assert.doesNotMatch(t.line, /\.tsx?:/, `${t.name}: no file path in the line`);
+      assert.doesNotMatch(t.line, /src\//, `${t.name}: no source path in the line`);
+    }
+  }
+  // The seven that used to print a path now print none.
+  const silent = navRows(TOOL_GATE).filter((t) => t.href && t.line === null).map((t) => t.name);
+  assert.deepEqual(silent, ['Travel', 'Banking', 'Brokerage', 'Trade Log', 'Bookkeeping', 'Tax', 'Compliance']);
+});
+
+test('the opener renders no file path, for any tool, on any page', () => {
+  // The rule is that nothing rendered READS the field — however it is reached
+  // (`t.citation`, `x?.citation`, `['citation']`), which is what the build law
+  // scans for. The word may appear in a comment saying not to.
+  const READS_FIELD = /\??\.citation\b|\['citation'\]|\["citation"\]/;
+  for (const f of ['src/components/shell/ToolOpener.tsx', 'src/lib/nav.ts', 'src/components/shell/TheSheet.tsx']) {
+    assert.doesNotMatch(code(f), READS_FIELD, `${f} does not read the registry's citation`);
+  }
+  assert.match(src('src/components/shell/TheSheet.tsx'), /No note in the registry for this job\./);
+});
+
+test('the opener lists only the phases its page draws', () => {
+  // Bookkeeping owns runway 04 Match; /books does not draw it.
+  const books = navToolByName('Bookkeeping', TOOL_GATE);
+  assert.deepEqual([...new Set(books.phases.map((p) => p.pipe))], ['books', 'runway'], 'it owns two pipes');
+  assert.deepEqual(phasesRenderedOn('/books', books).map((p) => `${p.pipe} ${p.num}`),
+    ['books 02', 'books 03', 'books 04', 'books 05', 'books 06'], '/books lists only what it draws');
+  // Banking owns books 01 (drawn on /books) and runway 01 (drawn nowhere).
+  assert.deepEqual(phasesRenderedOn('/accounts', navToolByName('Banking', TOOL_GATE)), []);
+  // Brokerage and Trade Log own the trade pipe; /trading draws no strip at all.
+  assert.equal(code('src/app/trading/page.tsx').includes('<StageStrip'), false);
+  assert.deepEqual(phasesRenderedOn('/trading', navToolByName('Brokerage', TOOL_GATE)), []);
+  // The three tools whose page draws their own pipe still list it, in pipe order.
+  for (const [tool, route, pipe] of [['Calendar', '/calendar', 'routines'], ['Tasks', '/tasks', 'projects'], ['Time', '/time', 'content']] as const) {
+    const listed = phasesRenderedOn(route, navToolByName(tool, TOOL_GATE));
+    assert.deepEqual(listed.map((p) => p.num), PIPE_PHASES[pipe].map((p) => p.num), `${tool} lists ${pipe} in order`);
+  }
+});
+
+test('what a route declares it draws is what the page\'s strip reads', () => {
+  // The declaration is cross-checked at build; here, that it is not empty prose.
+  assert.deepEqual(PHASES_RENDERED_AT['/books'], ['books']);
+  assert.deepEqual(PHASES_RENDERED_AT['/calendar'], ['routines']);
+  assert.deepEqual(PHASES_RENDERED_AT['/budget'], []);
+  // Every route named is a real tool screen.
+  const screens = new Set(navRows(TOOL_GATE).map((t) => t.href).filter(Boolean));
+  for (const route of Object.keys(PHASES_RENDERED_AT)) assert.ok(screens.has(route), `${route} is a tool's screen`);
+});
+
+test('the opener\'s rendered output carries no source path', () => {
+  const html = renderToStaticMarkup(createElement('div', null,
+    ...navRows(TOOL_GATE).filter((t) => t.href).map((t) => createElement('p', { key: t.name }, t.line ?? '')),
+  ));
+  assert.doesNotMatch(html, /\.ts:/);
+  assert.doesNotMatch(html, /\.tsx:/);
+  assert.doesNotMatch(html, /src\//);
+});
+
+test('the pipeline is the page — the strip renders on first run, above the entity card', () => {
+  const body = src('src/components/home/BooksPipeline.tsx');
+  // The strip is hoisted into a const, so both the first-run branch and the
+  // main return draw it — it used to sit below an early return.
+  assert.match(body, /const strip = \(/);
+  const stripAt = body.indexOf('const strip = (');
+  const setupAt = body.indexOf("if (state === 'setup')");
+  assert.ok(stripAt < setupAt, 'the strip is defined before the first-run branch');
+  // First run renders the strip FIRST, then phase 01's header, then the form.
+  const setupBlock = body.slice(setupAt, body.indexOf("if (state === 'error')"));
+  assert.ok(setupBlock.indexOf('{strip}') < setupBlock.indexOf('<EntitySetup'), 'the strip is above the entity card');
+  assert.match(setupBlock, /PIPE_FEED\.num/, 'phase 01 names itself from the pipe');
+  // Six phases, from the pipe, unchanged.
+  assert.deepEqual(PIPE_PHASES.books.map((p) => p.num), ['01', '02', '03', '04', '05', '06']);
+  assert.equal((body.match(/<StageStrip/g) ?? []).length, 1, 'one strip, not two');
+});

--- a/src/lib/nav.ts
+++ b/src/lib/nav.ts
@@ -130,8 +130,8 @@ export interface NavTool {
   door: OpenDoor | null;
   /** The offer gate the tool's routes carry, or null when it is free. */
   gate: string | null;
-  /** The registry line the screen prints under the tool's name. */
-  line: string;
+  /** The registry line the screen prints under the tool's name, or null when the registry has none. NEVER the citation. */
+  line: string | null;
   /**
    * The pages this tool OWNS that are not its screen — the registry's own
    * `links`, through the registry's own doors. They render as sub-rows beneath
@@ -191,7 +191,13 @@ const navTool = (tool: ToolEntry, i: number, gate: Readonly<Record<string, strin
     href: door.kind === 'none' ? null : door.href,
     door: door.kind === 'none' ? null : door,
     gate: gate[tool.name] ?? null,
-    line: tool.why?.trim() ? tool.why : tool.citation,
+    // BOOKS-PIPE-01: the line is the registry's `why` and NOTHING ELSE. It used
+    // to fall back to `citation` — which is internal evidence for the build laws,
+    // a list of file:line pairs — and seven tool pages printed it to customers
+    // verbatim. `why` is customer copy by construction: offer.ts's claimLine()
+    // renders it on the deck's offer cards as "partial — <why>". A tool with no
+    // `why` gets NO LINE; an empty opener line is honest, a source path is not.
+    line: tool.why?.trim() ? tool.why : null,
     subRows: (tool.links ?? [])
       .map((l) => ({ label: l.label, door: doorOfLink(tool, l) }))
       .filter((r): r is { label: string; door: OpenDoor } => r.door.kind !== 'none'),
@@ -236,6 +242,39 @@ export function navToolByName(name: string, gate: Readonly<Record<string, string
 /** Every tool whose screen is this href — several tools share /trading and /operations. */
 export function navToolsOfScreen(href: string, gate: Readonly<Record<string, string | null>>): readonly NavTool[] {
   return navRows(gate).filter((t) => t.href === href);
+}
+
+/**
+ * BOOKS-PIPE-01 — WHICH PIPES A ROUTE ACTUALLY RENDERS.
+ *
+ * THE SORT says who OWNS a phase. It does not say where that phase is drawn,
+ * and the two diverge: Bookkeeping owns runway 04 Match, which renders inside
+ * the cockpit's runway section; Banking owns books 01 Feed, which renders on
+ * /books. An opener that lists a tool's owned phases therefore advertised a
+ * pipeline the page does not have.
+ *
+ * This map is what each ROUTE renders, and the build cross-checks every entry
+ * against the real strip census (the tool law already walks each page's tree),
+ * so it cannot drift from the code.
+ */
+export const PHASES_RENDERED_AT: Readonly<Record<string, readonly PipePillarId[]>> = {
+  '/books': ['books'],           // BooksPipeline.tsx:328
+  '/calendar': ['routines'],     // SectionE_Routines.tsx:47
+  '/tasks': ['projects'],        // TruthMachineView.tsx:376, per project row
+  '/time': ['content'],          // ContentPipeline.tsx:371
+  '/travel': ['travel'],         // ModuleLauncher.tsx:758 — /travel IS the cockpit tab
+  '/tax': ['tax'],               // TaxFilingWizard.tsx, through TaxHandoffGate
+  // Declared EMPTY, each for a reason the audit verified:
+  '/accounts': [],   // Banking owns books 01 (drawn on /books) and runway 01 (drawn nowhere — a state-only cell)
+  '/budget': [],     // Budget owns runway 05, drawn in the cockpit's runway section
+  '/trading': [],    // Brokerage and Trade Log own trade 01-06; the trade strip is the cockpit's /trade tab, and this page has none
+  '/compliance': [], // Compliance owns compliance 01-06; ComplianceWorkbench is the cockpit's tab, not this page
+};
+
+/** The phases a tool owns THAT THIS ROUTE DRAWS — what an opener may honestly list. */
+export function phasesRenderedOn(route: string, tool: NavTool): readonly NavPhase[] {
+  const pipes = PHASES_RENDERED_AT[route.split('?')[0]] ?? [];
+  return tool.phases.filter((p) => pipes.includes(p.pipe));
 }
 
 export class NavLawError extends Error {


### PR DESCRIPTION
**Do not merge — Alex merges after Vercel Preview (SOC 2 gate).**

All three defects are wider than `/books`. Two of them were app-wide.

---

## HARD GATE

| Gate | Touched? | Detail |
|---|---|---|
| Auth · Migrations · Tables · API | **no** | Not one route, table or migration. |
| Cost / paid calls | **no** | No external call. |
| Status / counts / gates | **no** | Census **2 / 9 / 14** stands. No tool's status, beats or gate changed. |
| Phases | **no** | Not one renamed or reassigned. THE SORT is untouched — this PR changes what is *advertised*, never what is *owned*. |
| COA | **no** | Out of scope, as ruled. |
| Component interiors | **ordering only** | `BooksPipeline`'s strip is hoisted into a const — same JSX, same derived states, same handler. No other interior touched. |

---

## STEP 0 — the audit

### 0.1 `ToolOpener` in full — which fields are customer copy

| Field it renders | Source | Customer copy? |
|---|---|---|
| family (eyebrow) | `NavTool.family` → registry | **yes** |
| number | position in `TOOL_REGISTRY` | **yes** |
| name | `PROBLEM_SHEET` | **yes** |
| status chip | registry | **yes** |
| **`tool.line`** (`:50`) | **`nav.ts`: `why ?? citation`** | **NO — the citation half is internal** |
| phases (`:52-54`) | `tool.phases` — everything THE SORT gives the tool | **no — it advertised phases the page never draws** |

Mounted by eight surfaces: `/tasks:37`, `/compliance:51`, `/trading:794`, `/budget:38`, `/time:28`, `/calendar:31`, `HomeClient.tsx:110` (every cockpit tab), `AccountsClient.tsx:131`.

**`citation` is internal**: it is the file:line evidence the build laws read to prove a tool's beats. **`why` is customer copy by construction**: `offer.ts`'s `claimLine()` renders it verbatim on the deck's offer cards as `"partial — <why>"`. That is the field I used, and that is why.

### 0.2 Every path a `citation` or `why` can reach a screen

Grepped both fields and followed every consumer. **Exactly two rendered consumers of the registry's `citation`:**

1. `src/lib/nav.ts` → `NavTool.line` → `ToolOpener.tsx:50` — **seven tool pages**
2. `src/components/shell/TheSheet.tsx:28` → `proofLine()` → the `<details>` body on **HOME**

Everything else matching is a different object: Compliance's **legal** citations (`citation_string`, `citation_key`, `citation_id`, a `TaskCitation`'s `.citation`, a `citations` array from the discovery API — `compliance/citations`, `compliance/discovery/[id]`, `compliance/missions/[id]`, `SectionH_CorpusInspector`), and `.why` on unrelated objects (COA seed sets, trade cards, the utilities menu, `AnswersClient`'s read state).

**What was on screen, before:**

| Tool | Page | `why`? | Line printed to the customer |
|---|---|---|---|
| Travel | `/travel` | no | `src/app/api/travel/liteapi/flights/search/route.ts:23 · …` |
| Banking | `/accounts` | no | `src/components/accounts/AccountsClient.tsx:118 (connect) · :127 (sync) …` |
| Brokerage | `/trading` | no | `src/app/api/tastytrade/chains/route.ts:58 · scanner/route.ts:205 …` |
| Trade Log | `/trading` | no | `src/app/trading/page.tsx:640 → src/app/api/trading/commit-to-ledger/…` |
| **Bookkeeping** | `/books` | no | `src/components/home/BooksPipeline.tsx:198 · src/lib/auto-categorization-service.ts:132-140 …` |
| Tax | `/tax` | no | `src/components/tax-filing/steps/IncomeReviewStep.tsx:298-300 · …` |
| Compliance | `/compliance` | no | `src/lib/discovery/runDiscovery.ts:44 · :107 · src/lib/audit/writeAudit…` |
| Calendar · Tasks · Time · Budget | — | yes | their `why` — no path |

**Seven tool pages, not one.**

### 0.3 `BooksPipeline` — what the page shows when

| State | What renders | The strip? |
|---|---|---|
| **(a) no entity** | `if (state === 'setup') return <EntitySetup … />` — the old `:277`, an early return **replacing the whole pipeline** | **never drawn** |
| **(b) entity, no account connected** | the full pipeline; `01 Feed` reads `pending` (`accounts.length > 0 ? 'done' : 'pending'`) | yes, `:328` |
| **(c) no `tab:books`** | `RoomLock` (`ModuleLauncher.tsx:1209`) wraps the pipeline: a read-only note above it, the pipeline inert beneath | yes, beneath the note |

Worse than "sits below the card": on a fresh account **the six phases were not on the page at all**.

### 0.4 THE SORT vs where phases are drawn — and it is six tools, not two

| Tool | Page | Owns | Drawn where | Advertised honestly? |
|---|---|---|---|---|
| Calendar | `/calendar` | routines 01-04 | `SectionE_Routines:47` | ✅ |
| Tasks | `/tasks` | projects 01-06 | `TruthMachineView:376` | ✅ |
| Time | `/time` | content 01-04 | `ContentPipeline:371` | ✅ |
| Travel | `/travel` | travel 01-05 | `ModuleLauncher:758` — `/travel` **is** that tab | ✅ |
| Tax | `/tax` | tax 01-07 | `TaxFilingWizard`, through `TaxHandoffGate` | ✅ |
| **Bookkeeping** | `/books` | books 02-06, **runway 04** | books on the page; **runway 04 in the cockpit** | ❌ |
| **Banking** | `/accounts` | **books 01**, **runway 01** | books 01 on **`/books`**; runway 01 **nowhere** (a declared state-only cell) | ❌ |
| **Budget** | `/budget` | **runway 05** | the cockpit's runway section | ❌ |
| **Brokerage** | `/trading` | **trade 01-03** | the cockpit's `/trade` tab — **`/trading` has no strip at all** | ❌ |
| **Trade Log** | `/trading` | **trade 04-06** | same | ❌ |
| **Compliance** | `/compliance` | **compliance 01-06** | `ComplianceWorkbench` is the cockpit's tab, not this page | ❌ |

`grep -c StageStrip src/app/trading/page.tsx` → **0**. Brokerage and Trade Log advertised six phases on a page that draws none.

---

## What changed

**STEP 1 — the line.** `nav.ts`: `line: why?.trim() ? why : null`. A tool with no `why` gets **no line**; an empty opener line is honest, a source path is not. `TheSheet`'s `proofLine` says *"No note in the registry for this job."* rather than a path.

**STEP 2 — the phase list.** `nav.ts` gains `PHASES_RENDERED_AT` — what each ROUTE draws, each entry cited — and `phasesRenderedOn(route, tool)`. `ToolOpener` reads `usePathname()` and lists only those. The build cross-checks every entry against the real strip census, so the declaration cannot drift.

**STEP 3 — the pipeline is the page.** The strip is hoisted into `const strip` (all its inputs — `phase`, `accounts`, `committedCount`, `pendingCount`, `reconciledCount`, `closedThisYear`, `tbTotals` — are already declared above the early returns, so this is pure ordering). First run renders `{strip}` → `01 / Feed · PHASE 01 OF 06` → `<EntitySetup/>`.

### Phase lists, before and after

| Tool | Before | After |
|---|---|---|
| **Bookkeeping** | `02 CODE · 03 RECONCILE · 04 CLOSE · 05 REPORTS · 06 EXPORT · 04 MATCH` | `02 CODE · 03 RECONCILE · 04 CLOSE · 05 REPORTS · 06 EXPORT` |
| **Banking** | `01 FEED · 01 SOURCE` | *(none)* |
| **Budget** | `05 PROJECT` | *(none)* |
| **Brokerage** | `01 SETUP · 02 SCAN · 03 REVIEW` | *(none)* |
| **Trade Log** | `04 LAB · 05 RECORD · 06 COMMIT` | *(none)* |
| **Compliance** | `01 PROFILE … 06 REGISTER` | *(none)* |
| Calendar · Tasks · Time · Travel · Tax | their own pipe | **unchanged** |

---

## The two laws, each proven to throw

**The citation law** — no rendered file may read a registry `citation`. It discriminates Compliance's legal citations not by the word but by whether a `ToolEntry` can be in scope at all: the file must import `toolRegistry` or `nav`. Compliance's pages import neither.

**The opener law** — what a route declares it draws must equal what its tree draws, and every declared route must be a real tool screen. Its build output is the audit table itself:

```
THE OPENER — what each tool page advertises vs what it draws
  /books        Bookkeeping         draws [books]  owns [books runway]  drawn elsewhere: runway
  /calendar     Calendar            draws [routines]  owns [routines]
  /tasks        Tasks               draws [projects]  owns [projects]
  /time         Time                draws [content]  owns [content]
  /travel       Travel              draws [travel]  owns [travel]
  /tax          Tax                 draws [tax]  owns [tax]
  /budget       Budget              draws [—]  owns [runway]  drawn elsewhere: runway
  /accounts     Banking             draws [—]  owns [books runway]  drawn elsewhere: books runway
  /trading      Brokerage + Trade Log  draws [—]  owns [trade]  drawn elsewhere: trade
  /compliance   Compliance          draws [—]  owns [compliance]  drawn elsewhere: compliance
```

| Proof | Result |
|---|---|
| render a citation in `ToolOpener` | `citation law: src/components/shell/ToolOpener.tsx reads a registry citation (?.citation)` — exit 1 |
| `nav.ts` falls back to the citation again | `citation law: src/lib/nav.ts falls back to the citation for a tool's rendered line` — exit 1 |
| a route declares a pipe it does not draw | `opener law: /budget declares it draws [runway] but its tree draws [—]` — exit 1 |

**My first citation regex missed the proof.** It required an identifier immediately before `.citation`, so `find(…)?.citation` — optional chaining, the exact shape a careless edit takes — slipped through and the proof passed when it should have failed. Widened to any read of the field (`?.citation`, `['citation']`); the import guard makes that safe. Reporting it because a law that cannot catch its own proof is not a law.

---

## Verification

| Check | Result |
|---|---|
| `npx tsc --noEmit` | **exit 0** |
| `npm test` | **309 / 309** (303 before + 6 new) |
| `npm run lint` | **821 (551 errors, 270 warnings)** — identical to base. **Zero new.** |
| `npx tsx scripts/assert-tool-registry.ts` | **exit 0** — seventeen laws |
| Full `next build` | **BUILD EXIT 0** |

Live on `/books`, both viewers, full-page:

| Viewer | File paths on screen | Strip | Opener phases |
|---|---|---|---|
| **unentitled** (`curl-probe`, no `tab:books`) | **0** | six-phase strip drawn | `02 CODE · 03 RECONCILE · 04 CLOSE · 05 REPORTS · 06 EXPORT` |
| **entitled, no entity** (same viewer, `tab:books` active) | **0** | `01 FEED ● YOU ARE HERE` first, then `01 / FEED · PHASE 01 OF 06`, then the entity form | same |

Measured by scraping the rendered body for `/src\/[\w/.\[\]-]+\.tsx?:\d+/` — **zero matches in both**.

**Screenshots** — `shots-bookspipe/01-unentitled.png`, `02-entitled-first-run.png`. In the session chat; `audit-reports/` is gitignored and the repo is public.

The `tab:books` row for the probe viewer was flipped `inactive → active → inactive` in the **throwaway probe Postgres** to reach the first-run state, and restored. Nothing in Azure was touched — Claude Code cannot reach it.

---

## Findings

**1. STEP 3 is done as far as `BooksPipeline` can do it — the lock note is not its to move.** The read-only note (`RoomLock`, `ModuleLauncher.tsx:1209`) and the cockpit's own *"Loading your books…"* line (`:1218`) render **outside** `BooksPipeline`, wrapping it. The strip is now first *within the pipeline*, above the entity card, as ruled. Putting it above the lock note means editing `ModuleLauncher` — a grandfathered interior, forbidden here. To retire it: lift the books tab body out of the cockpit so `/books` is a real page, which is the same work TOOL-LAW-01 named for retiring its rule-2 entry.

**2. The opener and the strip disagree by one phase on `/books`, correctly.** The opener lists `02-06` (Bookkeeping's own, drawn here); the strip draws `01-06` because `01 Feed` is **Banking's** under THE SORT and `/books` draws it. That gap **is** TOOL-LAW-01's rule-2 grandfather entry, already named and dated. The alternative — listing `01 FEED` under Bookkeeping's name — would be advertising another tool's phase as yours.

**3. Six tool pages now show no phase list at all**, because their pipe is drawn in the cockpit. That is the honest state, and it makes the cockpit's cost legible: Banking, Budget, Brokerage, Trade Log and Compliance each have a real pipeline that their own page cannot show.

**4. Seven tools have no `why`, so their opener now shows no line.** The registry only requires `why` on four-beat PARTIALs. Writing customer copy for the other seven is its own ruling — I did not touch tool copy, as forbidden.

**5. Some `why` strings are internal in tone**, and they render on the deck's offer cards today via `claimLine`: Calendar's *"a read-only grid over three feeds it does not own…"*, Tasks' *"the founder's build pipeline — accepting a task fires a paid Claude Code build; not a customer's task tool"*. True, useful to you, and not how you would sell it. **Reported, not rewritten.**

**6. `runway 01 Source` is owned by Banking and drawn nowhere.** NAV-25 recorded it as a state-only cell (`ModuleLauncher:619-626`). It is now the only phase of the 49 that no page can ever advertise.

---

## Files touched

| File | Change |
|---|---|
| `src/lib/nav.ts` | the line stops falling back to the citation; `PHASES_RENDERED_AT` + `phasesRenderedOn` |
| `src/components/shell/ToolOpener.tsx` | renders `why` or nothing; lists only the phases this page draws |
| `src/components/shell/TheSheet.tsx` | HOME's proof line stops printing citations |
| `src/components/home/BooksPipeline.tsx` | the strip hoisted; first run is phase 01's content — **ordering only** |
| `scripts/assert-tool-registry.ts` | **the citation law** and **the opener law** |
| `src/lib/__tests__/booksPipe.test.ts` | **new** — 6 tests |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc

---
_Generated by [Claude Code](https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc)_