### PR TITLE
TT-01: the scanner runs on the customer's broker, not the founder's

### DIFF
--- a/scripts/assert-tool-registry.ts
+++ b/scripts/assert-tool-registry.ts
@@ -845,6 +845,49 @@ const shellLine = `${shellFiles.length} files scanned, ${shellOffenders} outside
 if (shellOffenders || nestedShells) console.log(`✖ The shell law FAILED — ${shellLine} ${nestedShells} tree(s) mount more than one shell.`);
 else console.log(`✔ The shell law passed — ${shellLine} Every tree mounts at most one header and one rail.`);
 
+// ── THE FOUNDER-BROKER LAW (TT-01) ──────────────────────────────────────────
+// The convergence scanner's TastyTrade client is the ENV client — the founder's
+// own OAuth grant (src/lib/tastytrade.ts:7-13). No per-user credential exists
+// (connect/route.ts:59-60 stores the literal 'oauth'). Until TT-02 lands a real
+// per-user flow, NO NON-ADMIN PATH MAY REACH getTastytradeClient() THROUGH THE
+// SCAN: every route that drives the pipeline gates on requireAdmin() BEFORE its
+// cache read and BEFORE runPipeline, and the scan cache is keyed by the user.
+//
+// DEFERRED (TT-02): the ruled import law — "no file under src/lib/convergence
+// may import the env-backed factory" — CANNOT pass today: chain-fetcher.ts:142,
+// data-fetchers.ts:2347, pipeline.ts:381 and outcome-tracker.ts:160 have no
+// per-user client to import instead, because none exists. Enforcing it now
+// would fail every build with no legal fix. It lands with TT-02's client.
+// walkSrc collects .tsx only; API routes are .ts, so walk them here.
+function walkRoutes(dir: string, out: string[] = []): string[] {
+  for (const e of readdirSync(resolve(ROOT, dir), { withFileTypes: true })) {
+    const rel = `${dir}/${e.name}`;
+    if (e.isDirectory()) walkRoutes(rel, out);
+    else if (e.name === 'route.ts' || e.name === 'route.tsx') out.push(rel);
+  }
+  return out;
+}
+const SCAN_DRIVERS: string[] = [];
+for (const f of walkRoutes('src/app/api')) {
+  const body = readFileSync(resolve(ROOT, f), 'utf8');
+  if (/from '@\/lib\/convergence\/pipeline'/.test(body) && /runPipeline\(/.test(body.split('\n').filter((l) => !/^\s*(\*|\/\/)/.test(l)).join('\n'))) SCAN_DRIVERS.push(f);
+}
+let brokerViolations = 0;
+for (const f of SCAN_DRIVERS) {
+  const code = readFileSync(resolve(ROOT, f), 'utf8').split('\n').filter((l) => !/^\s*(\*|\/\/|\/\*)/.test(l)).join('\n');
+  const gateAt = code.indexOf('requireAdmin()');
+  const runAt = code.indexOf('runPipeline(');
+  const cacheAt = code.search(/(?<!function )getFromCache\(/);
+  if (gateAt < 0) { brokerViolations += 1; violations.push(`founder-broker law: ${f} drives the scan without requireAdmin() — a non-admin would spend the founder's broker (TT-01)`); continue; }
+  if (runAt >= 0 && gateAt > runAt) { brokerViolations += 1; violations.push(`founder-broker law: ${f} calls runPipeline before requireAdmin() — the gate must come first (TT-01)`); }
+  if (cacheAt >= 0 && gateAt > cacheAt) { brokerViolations += 1; violations.push(`founder-broker law: ${f} reads the scan cache before requireAdmin() — a refused viewer must get nothing computed (TT-01)`); }
+  if (/function getCacheKey\(/.test(code) && !/function getCacheKey\(userId/.test(code)) { brokerViolations += 1; violations.push(`founder-broker law: ${f} keys the scan cache without the user — one user's scan_snapshots-derived rows were served to another (TT-01)`); }
+}
+if (SCAN_DRIVERS.length === 0) { brokerViolations += 1; violations.push('founder-broker law: no route drives runPipeline — the scan entry moved and this law no longer watches it (TT-01)'); }
+if (brokerViolations) console.log(`✖ The founder-broker law FAILED — ${brokerViolations} violation(s).`);
+else console.log(`✔ The founder-broker law passed — ${SCAN_DRIVERS.length} scan driver(s) gate on requireAdmin() before the cache and the pipeline, and key the cache by user. The convergence-import law is DEFERRED to TT-02 (no per-user client exists to import).`);
+
+
 // ── THE TOOL LAW (TOOL-LAW-01) ──────────────────────────────────────────────
 // ONE TOOL, ONE PAGE, ITS OWN PIPE. Five navigation PRs each partly undid the
 // last on this surface because each fixed a symptom instead of stating the

--- a/src/app/api/trading/convergence/route.ts
+++ b/src/app/api/trading/convergence/route.ts
@@ -6,6 +6,8 @@ import { getVerifiedEmail } from '@/lib/cookie-auth';
 import { requireTabAccess } from '@/lib/auth-helpers';
 import { requireScanRateLimit } from '@/lib/scan-rate-limit';
 import { prisma } from '@/lib/prisma';
+import { requireAdmin } from '@/lib/require-admin';
+import { FOUNDER_BROKER_LINE, FOUNDER_BROKER_REASON, scanGate } from '@/lib/tastytrade/founderBroker';
 
 export const maxDuration = 300;
 
@@ -20,12 +22,17 @@ interface CacheEntry {
 
 const cache = new Map<string, CacheEntry>();
 
-function getCacheKey(limit: number, universe?: string): string {
-  return `convergence_${limit}_${universe ?? 'all'}`;
+// TT-01: the key carries the USER. It was (limit, universe) only, and a
+// cache-miss run by user A — whose result rows carry A's OWN scan_snapshots
+// history as `vrpHistory` (pipeline.ts:1130-1132 → snapshot-logger, WHERE userId
+// = A) — was served to user B on the next hit for 15 minutes with no user check.
+// One user's per-user series, computed from their session, shown to another.
+function getCacheKey(userId: string, limit: number, universe?: string): string {
+  return `convergence_${userId}_${limit}_${universe ?? 'all'}`;
 }
 
-function getFromCache(limit: number, universe?: string): CacheEntry | null {
-  const key = getCacheKey(limit, universe);
+function getFromCache(userId: string, limit: number, universe?: string): CacheEntry | null {
+  const key = getCacheKey(userId, limit, universe);
   const entry = cache.get(key);
   if (!entry) return null;
   if (Date.now() - entry.timestamp > CACHE_TTL_MS) {
@@ -35,8 +42,8 @@ function getFromCache(limit: number, universe?: string): CacheEntry | null {
   return entry;
 }
 
-function setCache(limit: number, data: PipelineResult, universe?: string): void {
-  const key = getCacheKey(limit, universe);
+function setCache(userId: string, limit: number, data: PipelineResult, universe?: string): void {
+  const key = getCacheKey(userId, limit, universe);
   cache.set(key, { data, timestamp: Date.now() });
 }
 
@@ -80,6 +87,31 @@ export async function GET(request: Request) {
     const universe = searchParams.get('universe') ?? undefined;
     const stream = searchParams.get('stream') === 'true';
 
+    // TT-01 — THE FOUNDER'S BROKER. The pipeline's TastyTrade client is the env
+    // client (src/lib/tastytrade.ts:7-13): Alex's own grant. No per-user
+    // credential exists (connect/route.ts:59-60 stores the literal 'oauth'), so
+    // an entitled customer's scan spent HIS broker session. Until TT-02's
+    // per-user OAuth flow, only the admin may spend it — the same requireAdmin
+    // SEC4 put on the account routes and never on the scan. Refused BEFORE the
+    // cache read, the quota and any upstream call: nothing computed, nothing
+    // borrowed. The SSE path cannot carry a 403 (EventSource turns it into
+    // "connection lost"), so it says the line as its one error event instead.
+    const admin = await requireAdmin();
+    const gate = scanGate(!(admin instanceof NextResponse));
+    if (gate.refused) {
+      if (stream) {
+        const encoder = new TextEncoder();
+        const body = new ReadableStream({
+          start(controller) {
+            controller.enqueue(encoder.encode(`data: ${JSON.stringify({ step: 'error', label: gate.line, data: { reason: gate.reason } })}\n\n`));
+            controller.close();
+          },
+        });
+        return new Response(body, { headers: { 'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache', 'X-Scan-Refused': FOUNDER_BROKER_REASON } });
+      }
+      return NextResponse.json({ error: FOUNDER_BROKER_LINE, reason: FOUNDER_BROKER_REASON }, { status: 403, headers: { 'X-Scan-Refused': FOUNDER_BROKER_REASON } });
+    }
+
     // ===== SSE STREAMING PATH =====
     if (stream) {
       // SCAN-SPEND-QUOTA: the stream path NEVER reads the cache — every stream
@@ -113,7 +145,7 @@ export async function GET(request: Request) {
               result.data_gaps.push(`snapshot_logging: SKIPPED — user lookup failed (${snapshotLookupError}); this run left no scan_snapshots audit trail`);
             }
             // Cache the final result so the follow-up fetch is instant
-            setCache(limit, result, universe);
+            setCache(gateUser.id, limit, result, universe);
             send({ step: 'done', label: 'Complete', data: {} });
           } catch (err) {
             send({ step: 'error', label: err instanceof Error ? err.message : String(err), data: {} });
@@ -134,7 +166,7 @@ export async function GET(request: Request) {
 
     // Check cache (unless refresh=true)
     if (!refresh) {
-      const cached = getFromCache(limit, universe);
+      const cached = getFromCache(gateUser.id, limit, universe);
       if (cached) {
         const age = Math.round((Date.now() - cached.timestamp) / 1000);
         console.log(`[Convergence Route] Cache HIT (age=${age}s, limit=${limit})`);
@@ -179,7 +211,7 @@ export async function GET(request: Request) {
     console.log(`[Convergence Route] Pipeline completed in ${elapsed}ms`);
 
     // Store in cache
-    setCache(limit, result, universe);
+    setCache(gateUser.id, limit, result, universe);
 
     return NextResponse.json(result, {
       headers: {

--- a/src/app/trading/page.tsx
+++ b/src/app/trading/page.tsx
@@ -804,6 +804,7 @@ export default function TradingPage() {
             onFiltersChange={handleFiltersChange}
             scanTriggerRef={scanTriggerRef}
             ttConnected={ttConnected}
+            founderBroker={!isOwner}
           />
 
           {/* Performance — the 7-metric row (was ROW 2 in the sticky zone). */}

--- a/src/components/home/ModuleLauncher.tsx
+++ b/src/components/home/ModuleLauncher.tsx
@@ -1089,6 +1089,7 @@ export default function ModuleLauncher({ onRequireAuth, onTabChange }: Props) {
                       onFiltersChange={handleFiltersChange}
                       scanTriggerRef={scanTriggerRef}
                       showHeader={false}
+                      founderBroker={authed === true && !isAdmin}
                     />
                     <SectionHeader
                       kicker="02 / RESULTS"

--- a/src/components/trading/ScanFilterForm.tsx
+++ b/src/components/trading/ScanFilterForm.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { FOUNDER_BROKER_LINE } from '@/lib/tastytrade/founderBroker';
 import type { MutableRefObject } from 'react';
 import type { ScannerFilters } from '@/lib/convergence/filter-types';
 import { AVAILABLE_STRATEGIES } from '@/lib/convergence/filter-types';
@@ -31,6 +32,8 @@ interface Props {
   /** The ref ConvergenceIntelligence registers its scan trigger into. */
   scanTriggerRef: MutableRefObject<(() => void) | null>;
   ttConnected?: boolean | null;
+  /** TT-01: this viewer is not the admin — the scan will be refused, and the form says so with the ONE line. */
+  founderBroker?: boolean;
   /** TRADING-PR-3: render the "Scan filters" SectionCard band. Default true
    *  (dashboard, standalone). The home launcher passes false — it already wraps
    *  the form in the single "Launch a module" band, so a second band would be a
@@ -51,7 +54,7 @@ function FieldLabel({ children }: { children: React.ReactNode }) {
 }
 
 export default function ScanFilterForm({
-  scannerUniverse, setScannerUniverse, scannerFilters, onFiltersChange, scanTriggerRef, ttConnected, showHeader = true, }: Props & { }) {
+  scannerUniverse, setScannerUniverse, scannerFilters, onFiltersChange, scanTriggerRef, ttConnected, founderBroker = false, showHeader = true, }: Props & { }) {
   const f = scannerFilters;
   const runScan = () => { if (scanTriggerRef.current) scanTriggerRef.current(); };
 
@@ -178,6 +181,11 @@ export default function ScanFilterForm({
       </div>
 
       {/* Scan CTA */}
+      {/* TT-01: a non-admin is told, here, before the click, in the same words the
+          route refuses with — one const (src/lib/tastytrade/founderBroker.ts). */}
+      {founderBroker && (
+        <p role="status" data-founder-broker className="border-t border-border pt-3 font-mono text-[11px] text-brand-amber">{FOUNDER_BROKER_LINE}</p>
+      )}
       <div className="flex justify-end border-t border-border pt-3">
         <button type="button" onClick={runScan}
           className="px-8 py-2 bg-brand-purple text-white font-bold text-sm rounded transition-colors hover:bg-brand-purple-hover whitespace-nowrap">

--- a/src/lib/__tests__/founderBroker.test.ts
+++ b/src/lib/__tests__/founderBroker.test.ts
@@ -1,0 +1,81 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { FOUNDER_BROKER_LINE, FOUNDER_BROKER_REASON, runScanForViewer, scanGate } from '../tastytrade/founderBroker';
+
+// TT-01 — the scanner runs on the founder's broker, and says so. Hermetic, the
+// discoveryGate.test.ts idiom (src/lib/__tests__/discoveryGate.test.ts:17-19):
+// "the call is a spy that must stay un-invoked when a gate refuses".
+
+const src = (f: string) => readFileSync(`${process.cwd()}/${f}`, 'utf8');
+const code = (f: string) => src(f).split('\n').filter((l) => !/^\s*(\*|\/\/|\/\*)/.test(l)).join('\n');
+
+test('a non-admin is refused BEFORE the pipeline — the paid call is never invoked', async () => {
+  let calls = 0;
+  const run = async () => { calls += 1; return { ran: true }; };
+  const out = await runScanForViewer(false, run);
+  assert.equal(out.refused, true);
+  if (out.refused) {
+    assert.equal(out.reason, FOUNDER_BROKER_REASON);
+    assert.equal(out.line, FOUNDER_BROKER_LINE);
+  }
+  assert.equal(calls, 0, 'zero upstream calls for a refused viewer');
+});
+
+test('the admin runs, and the pipeline is invoked exactly once', async () => {
+  let calls = 0;
+  const run = async () => { calls += 1; return { ran: true }; };
+  const out = await runScanForViewer(true, run);
+  assert.equal(out.refused, false);
+  if (!out.refused) assert.deepEqual(out.result, { ran: true });
+  assert.equal(calls, 1);
+  assert.deepEqual(scanGate(true), { refused: false });
+});
+
+test('the stated line is customer copy — no path, no env name, no fallback wording', () => {
+  assert.doesNotMatch(FOUNDER_BROKER_LINE, /\.tsx?:|src\/|TASTYTRADE_|process\.env/);
+  assert.doesNotMatch(FOUNDER_BROKER_LINE, /fallback|partial/i);
+  assert.match(FOUNDER_BROKER_LINE, /founder's broker/);
+});
+
+test('the route refuses at both fire points with the ONE line, before the cache and the quota', () => {
+  const route = code('src/app/api/trading/convergence/route.ts');
+  const gateAt = route.indexOf('requireAdmin()');
+  assert.ok(gateAt > 0, 'the scan route asks requireAdmin');
+  // The CALL sites, not the helper definitions at the top of the file.
+  for (const later of ['getFromCache(gateUser', 'requireScanRateLimit(', 'runPipeline(']) {
+    assert.ok(route.indexOf(later) > gateAt, `${later} comes after the admin gate`);
+  }
+  // SSE path: the line is the stream's one error event (EventSource cannot show a 403).
+  assert.match(route, /step: 'error', label: gate\.line/);
+  // JSON path: a 403 carrying the same const.
+  assert.match(route, /NextResponse\.json\(\{ error: FOUNDER_BROKER_LINE, reason: FOUNDER_BROKER_REASON \}, \{ status: 403/);
+  // No second copy of the sentence anywhere — one const, no drift.
+  for (const f of ['src/app/api/trading/convergence/route.ts', 'src/components/trading/ScanFilterForm.tsx']) {
+    assert.ok(!src(f).includes("founder's broker until"), `${f} reads the const, it does not retype the line`);
+  }
+});
+
+test('the scan cache is keyed by the user — one viewer\'s rows never serve another', () => {
+  const route = code('src/app/api/trading/convergence/route.ts');
+  assert.match(route, /function getCacheKey\(userId: string, limit: number/);
+  assert.match(route, /`convergence_\$\{userId\}_\$\{limit\}/);
+  assert.equal((route.match(/gateUser\.id, limit/g) ?? []).length, 3, 'every get and set passes the user');
+});
+
+test('the form says the line to a non-admin on both mounts, from the same const', () => {
+  const form = code('src/components/trading/ScanFilterForm.tsx');
+  assert.match(form, /data-founder-broker/);
+  assert.match(form, /\{FOUNDER_BROKER_LINE\}/);
+  // The cockpit mount hides the header, so the line lives in the form body, by the Scan button.
+  assert.ok(form.indexOf('data-founder-broker') < form.indexOf('onClick={runScan}'), 'the line sits above the Scan button, inside formBody');
+  assert.match(code('src/components/home/ModuleLauncher.tsx'), /founderBroker=\{authed === true && !isAdmin\}/);
+  assert.match(code('src/app/trading/page.tsx'), /founderBroker=\{!isOwner\}/);
+});
+
+test('connect already refuses a non-admin server-side (SEC4) — no placeholder row can be created by one', () => {
+  const connect = code('src/app/api/tastytrade/connect/route.ts');
+  assert.ok(connect.indexOf('requireAdmin()') < connect.indexOf('tastytrade_connections.upsert'), 'the gate precedes the write');
+  // And what the row holds when it IS written: the literal marker, not a credential.
+  assert.match(src('src/app/api/tastytrade/connect/route.ts'), /sessionToken: encryptToken\('oauth'\)/);
+});

--- a/src/lib/tastytrade/founderBroker.ts
+++ b/src/lib/tastytrade/founderBroker.ts
@@ -1,0 +1,50 @@
+/**
+ * TT-01 — THE SCANNER RUNS ON THE FOUNDER'S BROKER, and says so.
+ *
+ * There is no per-user TastyTrade credential anywhere in this codebase: the one
+ * `new TastytradeClient(` (src/lib/tastytrade.ts:7) is built from
+ * TASTYTRADE_CLIENT_SECRET + TASTYTRADE_REFRESH_TOKEN — Alex's own OAuth grant —
+ * and the tastytrade_connections row holds the literal 'oauth' encrypted as its
+ * sessionToken (src/app/api/tastytrade/connect/route.ts:59-60). So every scan,
+ * for every entitled customer, spent the founder's broker session by documented
+ * design (src/app/api/trading/convergence/route.ts:52-54).
+ *
+ * Until TT-02 lands the per-user authorization-code flow, the honest interim:
+ * ONLY THE ADMIN MAY SPEND THE ADMIN'S BROKER. Everyone else is refused BEFORE
+ * any cache read or upstream call, with this one line — the same line on the
+ * scan form, in the JSON refusal and in the SSE stream's error event. One
+ * const, so the three cannot drift.
+ *
+ * NO FALLBACK: a refused scan returns nothing computed, borrows no other
+ * account, and makes zero upstream calls.
+ */
+export const FOUNDER_BROKER_LINE = "Trading runs on the founder's broker until per-user connections ship.";
+
+/** The refusal's machine-readable reason, for tests and the UI. */
+export const FOUNDER_BROKER_REASON = 'founder-broker' as const;
+
+export type ScanGate =
+  | { refused: true; reason: typeof FOUNDER_BROKER_REASON; line: string }
+  | { refused: false };
+
+/** Pure: may this viewer spend the founder's broker? Only the admin. */
+export function scanGate(isAdmin: boolean): ScanGate {
+  if (isAdmin) return { refused: false };
+  return { refused: true, reason: FOUNDER_BROKER_REASON, line: FOUNDER_BROKER_LINE };
+}
+
+/**
+ * Run a scan for a viewer, or refuse it. `run` is the paid pipeline; it is
+ * NEVER invoked for a non-admin — a test hands in a spy and asserts it stayed
+ * un-invoked (the discoveryGate.test.ts idiom: "the call is a spy that must
+ * stay un-invoked when a gate refuses").
+ */
+export type ScanRun<T> =
+  | { refused: true; reason: typeof FOUNDER_BROKER_REASON; line: string }
+  | { refused: false; result: T };
+
+export async function runScanForViewer<T>(isAdmin: boolean, run: () => Promise<T>): Promise<ScanRun<T>> {
+  const gate = scanGate(isAdmin);
+  if (gate.refused) return gate;
+  return { refused: false, result: await run() };
+}


### PR DESCRIPTION
**Do not merge — Alex merges after Vercel Preview (SOC 2 gate).**

## HARD GATE

| Trigger | Fires? | Finding |
|---|---|---|
| Auth | **YES** | The scan route gains `requireAdmin()` (after the tab gate, before the cache/quota/pipeline). Entitled non-admins who could scan yesterday are refused today with one stated line. That is the ruling. |
| Security | **YES** | A cross-user cache leak is closed (named in full under **The cache leak, exactly**). |
| Cost / paid calls | **YES (reduced)** | A non-admin scan now makes **zero** upstream calls (Finnhub, TastyTrade, SEC, FRED). The admin's per-scan counts are unchanged. |
| Migration / schema | no | No schema or token change. |
| User data | reported, not touched | Existing `ttUsername='oauth'` placeholder rows are **counted, not deleted** — TT-02's data decision. Query below. |
| Validation relaxed | no | Tightened only. |

## What was ruled, what the audit found, what Alex re-ruled

The original TT-01 asked to thread `userId` into the four fetchers and build the client from the user's `tastytrade_connections` row. **STEP 0 proved the premise false: no per-user TastyTrade credential exists anywhere in this codebase.** I stopped and asked. Alex re-ruled the honest interim — the scanner refuses everyone but the admin with a stated line, the cache is keyed by user, the Connect button stops pretending, a build law proves the gate, and the full STEP 0 audit rides in this PR body as the input to TT-02. This PR is that ruling, and nothing else.

---

## STEP 0 audit (read-only, delivered in full — the input to TT-02)

### `src/lib/tastytrade.ts` — every export, verdict

| Export | Lines | What it does | Per-user? |
|---|---|---|---|
| `getTastytradeClient()` | :6-13 | The **only** `new TastytradeClient(` in the repo (:7). Built from `process.env.TASTYTRADE_CLIENT_SECRET` (:9) + `process.env.TASTYTRADE_REFRESH_TOKEN` (:10). | **No — the founder's grant.** |
| `isTastytradeConnected(userId)` | :16-39 | Env gate (:17), then the user's row as an `active` flag, then the env client (:33). | Row is a flag only. |
| `getTastytradeConnection(userId)` | :42 | Reads the row. | Row holds no usable credential (see schema). |
| `getTastytradeAccessToken(userId)` | :53 | **Dead** — zero callers. | — |
| `getAuthenticatedClient(userId)` | :80-102 | Env gate (:81), reads the row ONLY as an active gate, then returns `getTastytradeClient()` (:93). The `userId` never reaches the client. | **No.** |
| `getTastytradeSessionToken()` | :109-187 | No `userId`. Legacy username/password session from env `TT_USERNAME`/`TT_PASSWORD` (:114-115), cached in the **module-global** `cachedSessionToken` (:107) shared by every caller. | **No.** |

### The "connection" row is a flag, not a credential

- `prisma/schema.prisma:1775-1793` `tastytrade_connections`: `id, userId, ttUsername, sessionToken (Text), rememberToken (Text?), accountNumbers[], status, connectedAt, expiresAt, lastUsedAt`. **No refresh-token column, no client id, no scope.**
- `src/app/api/tastytrade/connect/route.ts`: `requireAdmin()` at :18 (SEC4). It validates the **founder's** env client (:39) and then upserts `ttUsername: 'oauth', sessionToken: encryptToken('oauth')` (:59-60 create / :67-68 update), `rememberToken: null` (:69). The stored "token" is the literal word `oauth`, encrypted.
- `src/app/api/tastytrade/callback/route.ts` :41 same pattern — the env client, no code exchange.
- `src/app/api/tastytrade/status/route.ts:9-13` says it in prose: *"TastyTrade uses a SHARED FIRM account (env creds via getTastytradeClient — NOT per-user OAuth; the tastytrade_connections row is just a flag that unlocks the shared session). So any caller spends/reads ALEX'S brokerage session."* (SECURITY-PR-SEC4, TRADE-GATE 2026-08-11).

### The four scan-side env-client sites and how far `userId` travels

| Site | Function | `userId` in scope? | Callers |
|---|---|---|---|
| `src/lib/convergence/chain-fetcher.ts:142` | `fetchChainAndBuildCards(tickers)` | **No** — signature carries no user | `pipeline.ts:1662`, `src/app/api/test/convergence/route.ts:339` |
| `src/lib/convergence/data-fetchers.ts:2347` | `fetchTTCandlesBatch(symbols, days)` | **No** | `pipeline.ts:1218`, `outcome-tracker.ts:149` |
| `src/lib/convergence/pipeline.ts:381` | inside `runPipeline(limit, userId?, universe, …)` (:363-368) | Optional, in scope — **unused for the client** | the scan route |
| `src/lib/convergence/outcome-tracker.ts:160` | inside `closeSnapshotOutcomes(userId)` | In scope — **unused for the client** | `close-outcomes/route.ts:35` (admin-gated :24) |

`runPipeline`'s `userId` is used for exactly two things: `fetchVrpHistoryBatch(userId, …)` (:1130-1132, reads the user's own `scan_snapshots`) and snapshot logging (:2021-2040). Result rows carry that user-scoped `vrpHistory` at :1196, :1258, :1784, :1933 — this matters for the leak below.

### The scan entry and its gate order (before this PR)

`src/app/api/trading/convergence/route.ts`: cookie → user → `requireTabAccess(gateUser.id, 'tab:trade')` → params → cache read → quota → `runPipeline(limit, userId, universe, …)`. Its own comment (:52-54 on `main`) states the pipeline "reads MARKET data only via the shared TT session". **TAB-SERVER-GATE had flipped this route off `requireAdmin` so entitled customers could scan — on the founder's broker.** The account-reading `tastytrade/*` routes stayed `requireAdmin` (SEC4); the scan never did.

### Every other env-client site (reported, unchanged)

| Site | Gate | Reason left |
|---|---|---|
| `src/app/api/data-observatory/check/route.ts` :111, :655, :690, :723, :754 | `requireAdmin()` :921 | Admin-only data probe. Founder's broker, founder's call. |
| `src/app/api/test/convergence/route.ts` :29, :98 | `requireAdmin()` :163 | Dormant (`lookupAnalyze` at `ConvergenceIntelligence.tsx:4718`; `hideControls` true at both mounts). |
| `src/app/api/tastytrade/backtest/{available,run,simulate}/route.ts` :26/:32/:31 | `getTastytradeSessionToken()` — env `TT_USERNAME`/`TT_PASSWORD` + module-global cache | **Report for TT-02:** legacy session flow, shared token across all callers. Not touched here (not the scan). |
| `src/app/api/tastytrade/connect` :39, `callback` :41 | `requireAdmin()` | Validate the founder's client; the placeholder upsert. |
| `src/app/api/trading/convergence/close-outcomes/route.ts` | `requireAdmin()` :24 → `closeSnapshotOutcomes(user.id)` :35 | Manual, admin's own snapshots, no cron/UI caller. |

Ten `tastytrade/*` routes exist; every one that touches a client touches the founder's. Only `disconnect` touches none.

### Background jobs

`vercel.json` holds one cron (`/api/cron/auto-categorize`, `0 2 * * *`). Eight Inngest functions under `src/inngest/functions/` — none TastyTrade or scan related. **No job scans without a request user.**

### Three refutation lenses (none refuted the finding)

1. **Hidden credential path** — searched every `TastytradeClient` construction, every `updateConfig`, every `refreshToken`/`sessionToken` read: one constructor, env-only. `sessionToken` is read nowhere as a credential.
2. **A later commit re-adding per-user auth** — none after `0781b48c`; the routes' own comments (SEC4, TRADE-GATE) describe the shared-account design as intended.
3. **The SDK doing it implicitly** — `ClientConfig` (below) has no per-user hook; the client is process-wide.

### The `0781b48c` finding (why there is no per-user flow)

- `359bbd0d` (2026-02-10, "feat(tastytrade): add brokerage OAuth integration for Market Intelligence") added a **per-user** flow: connect took `{ username, password }`, called `client.sessionService.login(username, password, true)`, stored `client.session.authToken` as `sessionToken` and the login's `remember-token` as `rememberToken`; the client getter set `client.session.authToken = connection.sessionToken` and re-logged in via the remember token when stale (removed lines in the `0781b48c` diff of `src/lib/tastytrade.ts`).
- `0781b48c` (2026-02-13, Alex Stuart, "Migrate Tastytrade auth from deprecated session tokens to OAuth2") **removed all of it** (4 files, +61/−137): the username/password body, `sessionService.login`, the stored auth/remember tokens, and the /trading connect form (`trading/page.tsx` −25). It replaced them with the **app-level** env pair `TASTYTRADE_CLIENT_SECRET` + `TASTYTRADE_REFRESH_TOKEN` and the `'oauth'` placeholder row. The commit title cites the vendor deprecating session tokens; the migration moved from per-user-legacy to **founder-only-OAuth**, not to per-user OAuth. The schema kept the now-meaningless `sessionToken`/`rememberToken` columns.

### The SDK's contract (`@tastytrade/api` 6.0.1)

`dist/tastytrade-api.d.ts:21-30`:

```ts
export type ClientConfig = {
    baseUrl: string;
    accountStreamerUrl: string;
    clientSecret?: string;
    refreshToken?: string;
    oauthScopes?: string[];
    logger?: Logger; logLevel?: LogLevel; targetApiVersion?: string;
};
```

`updateConfig(Partial<ClientConfig>)` (:52). Token minting is `POST /oauth/token` with `grant_type: 'refresh_token'` only (`dist/services/tastytrade-http-client.js:72-74`). **The SDK has no authorize-URL builder and no `authorization_code` exchange** — a per-user client is `new TastytradeClient({ clientSecret: <the app's>, refreshToken: <that user's> })`, and obtaining that user's refresh token is on us.

### What TT-02 needs from Alex

| Need | Why |
|---|---|
| **Vendor OAuth app registration** at TastyTrade (client id + client secret for *the app*, not a personal grant) | Today's `TASTYTRADE_CLIENT_SECRET`/`TASTYTRADE_REFRESH_TOKEN` are the founder's personal grant. |
| **Redirect URI(s)** registered with the vendor — production + preview | The authorization-code callback must match exactly. |
| **`TASTYTRADE_CLIENT_ID`** in Vercel env, declared in `src/lib/envLaw.ts`, documented in the README | The env law at build requires it. |
| **Schema column**: an encrypted per-user `refreshToken` (Text) on `tastytrade_connections` (+ scope, + `tokenIssuedAt`) — `schema.prisma` + `prisma generate` + the `ALTER TABLE` via `psql`, together | The row must hold a real credential. |
| **Data decision on the `'oauth'` placeholder rows** | Count first (query below). |
| Then TT-02 builds: a start route (`GET https://my.tastytrade.com/auth.html?client_id=…&redirect_uri=…&response_type=code&scope=read trade&state=<HMAC nonce>`), a real callback (`POST /oauth/token grant_type=authorization_code`), per-user client construction threaded through the four fetchers, and the convergence-import law. | All FORBIDDEN under TT-01. |

---

## What this PR builds (Alex's re-ruling, 1-4)

### (1) The scanner refuses everyone but the admin

`src/app/api/trading/convergence/route.ts`: after the tab gate and param parsing, `requireAdmin()` (:99) feeds `scanGate()` (:100). A refused viewer gets, **before any cache read, quota or upstream call**:

- JSON: `403 { error: "Trading runs on the founder's broker until per-user connections ship.", reason: "founder-broker" }` + header `X-Scan-Refused: founder-broker` (:112).
- SSE (`?stream=true`): a **200 `text/event-stream` with exactly one event** `{ step: 'error', label: <the line>, data: { reason } }` + the same header (:110). A 403 on the stream would surface in the UI as `EventSource.onerror` → "Pipeline connection lost" (`ConvergenceIntelligence.tsx:4626`); the error event routes through `event.step === 'error'` → `reject(new Error(event.label))` (:4614-4618) so the stated line is what the customer reads.

Gate order now: cookie (401) → user (404) → `requireTabAccess('tab:trade')` (:76) → params → **admin gate (:99-113)** → cache read (:169) → quota (:121/:188) → `runPipeline` (:143/:206).

The one line lives in **one const** — `src/lib/tastytrade/founderBroker.ts` (`FOUNDER_BROKER_LINE`, `FOUNDER_BROKER_REASON`, `scanGate()`, `runScanForViewer()`) — so the form, the JSON and the SSE event cannot drift. No fallback: a refused scan computes nothing, borrows no account, makes zero upstream calls.

### (2) The cache leak, exactly

**Before:** the result cache key was `convergence_${limit}_${universe}` (`route.ts:23-25` on `main`), with no user in the key and no user check on the hit path (:136-149 on `main`). `scan-rate-limit.ts`'s header documented this key as a *quota* concern only.

**What leaked, from whom, to whom:**
- **Which values:** the full `PipelineResult` computed on the cache-miss run — every ranked ticker row including its `vrpHistory` (the iv30−hv30 series built by `fetchVrpHistoryBatch(userId, …)` from **that user's own `scan_snapshots`**, `pipeline.ts:1130-1132`, attached at :1196/:1258/:1784/:1933) and the snapshot-derived fields computed alongside it. Market data is public; the `vrpHistory` series is user-scoped by construction and was served as if it were not.
- **From whose session:** whichever tab:trade holder ran the cache-miss scan (their `userId` was passed to `runPipeline`).
- **Visible to whom:** any other tab:trade holder who requested the same `(limit, universe)` within the 15-minute TTL — served **user A's result** with `X-Cache-Hit: true`, never having run a pipeline of their own.

**After:** `getCacheKey(userId, limit, universe)` → `convergence_${userId}_${limit}_${universe ?? 'all'}` (:30-32); `getFromCache`/`setCache` take `userId` (:34, :45); all three call sites pass `gateUser.id` (:148, :169, :214). Today only the admin reaches the cache at all; the key is fixed so TT-02's per-user scans inherit no leak.

### (3) The Connect button stops pretending

- Server: `connect/route.ts` already refuses non-admins (`requireAdmin()` :18, SEC4) — verified, and the new test 7 pins it. **No `tastytrade_connections` row can be created by a non-admin today**; the UI never showed them a button (`trading/page.tsx` fetches `/api/tastytrade/status` only for the owner, :253-262). What was missing was the *statement*.
- `src/components/trading/ScanFilterForm.tsx` gains `founderBroker?: boolean` (:36, default false) and renders `<p role="status" data-founder-broker>` with `FOUNDER_BROKER_LINE` above the Scan CTA (:186-188). Mounted `founderBroker={authed === true && !isAdmin}` on the home cockpit (`ModuleLauncher.tsx:1092` — no flash at the admin while `/api/auth/me` resolves) and `founderBroker={!isOwner}` on `/trading` (`page.tsx:807`).
- **Placeholder rows: probe DB = 0.** The Azure count is Alex's to run (Claude Code cannot reach Azure):

```sql
SELECT count(*) AS placeholder_rows,
       count(*) FILTER (WHERE status = 'active') AS active
FROM tastytrade_connections
WHERE "ttUsername" = 'oauth';
```

Not deleted — TT-02's data decision.

### (4) The law

`scripts/assert-tool-registry.ts` — **THE FOUNDER-BROKER LAW (TT-01)** (:848-895): `walkRoutes('src/app/api')` collects every `route.ts`; a route that imports `@/lib/convergence/pipeline` and calls `runPipeline(` is a scan driver (currently one; **zero drivers is itself a violation**). Each driver must contain `requireAdmin()`, positioned before `runPipeline(` and before the *call* `getFromCache(` (regex `(?<!function )getFromCache\(` so the definition doesn't satisfy it), and must define `getCacheKey(userId`. **Proved it throws** by (a) removing the gate → `founder-broker law: … drives the scan without requireAdmin()`, (b) keying the cache without the user → `… keys the scan cache without the user — one user's scan_snapshots-derived rows were served to another`; both restored byte-identical (`cmp` against the backup).

**Deferred to TT-02 (logged by the law's own line):** the ruled convergence-import law — *no file under `src/lib/convergence` imports the env factory* — **cannot pass today**: all four fetch sites (`chain-fetcher.ts:142`, `data-fetchers.ts:2347`, `pipeline.ts:381`, `outcome-tracker.ts:160`) import `getTastytradeClient` because it is the only client that exists. Asserting it now would break the admin's scan.

---

## Verification (as ruled)

| Check | Base (`origin/main` @ 792d0eb2) | This branch |
|---|---|---|
| `npx tsc --noEmit` | 0 | **0** |
| `npm test` | 309 | **316 / 316** (7 new: `src/lib/__tests__/founderBroker.test.ts`) |
| `npm run lint` | 821 problems (551 errors, 270 warnings) | **821 (551 / 270)** — identical, zero new |
| Registry asserts | exit 0 | **exit 0** — founder-broker law passes; both proofs throw naming the file |
| `next build` (all asserts) | — | **BUILD EXIT 0** |
| Per-scan upstream calls | One scan of one symbol = 26 Finnhub, 1 TastyTrade, 6 SEC — plus, once per scan, 1 SEC, 24 FRED | **Admin: unchanged. Non-admin: 0** (refused before any call) |

**Live, against the throwaway Postgres + dev server:**

| Viewer | Request | Result |
|---|---|---|
| Entitled non-admin (`tab:books` → `tab:trade`) | `GET /api/trading/convergence?limit=9` | `403 {"error":"Trading runs on the founder's broker until per-user connections ship.","reason":"founder-broker"}` + `x-scan-refused: founder-broker` |
| Same | `?stream=true` | `200 text/event-stream`, one `{"step":"error","label":"Trading runs on …"}` event, then close |
| Admin | `GET /api/trading/convergence?limit=9` | `200`, `x-cache-hit: false`, pipeline ran (not refused) |

**Screenshots** (session chat, never committed): `01-nonadmin-trade-tab.png` — the amber line above the Scan CTA, text-equal to the const; `03-admin-trade-tab.png` — no line (`lineShown=0`, correct). `02-nonadmin-after-scan.png` — captured with the results panel still at "SCANNING…"; the DOM probe found the line once (the form line) and no "Pipeline connection lost". **The results-panel render of the SSE label after the click is not verified live** — by code it lands in `batchError` (`ConvergenceIntelligence.tsx:4697`) and renders at :4804-4807.

## Files

| File | Change |
|---|---|
| `src/lib/tastytrade/founderBroker.ts` | **new** — the one line, `scanGate`, `runScanForViewer` |
| `src/app/api/trading/convergence/route.ts` | admin gate (JSON 403 / SSE error event), cache keyed by user |
| `src/components/trading/ScanFilterForm.tsx` | `founderBroker` prop → the stated line above Scan |
| `src/components/home/ModuleLauncher.tsx`, `src/app/trading/page.tsx` | pass the prop on both mounts |
| `scripts/assert-tool-registry.ts` | the founder-broker law + the TT-02 deferral note |
| `src/lib/__tests__/founderBroker.test.ts` | **new** — 7 tests (hermetic gate spy, copy hygiene, gate order at both fire points, user-keyed cache, both form mounts, connect's SEC4 gate) |

Not touched: the composite and its weights, the four fetchers, any token or schema, any `tastytrade/*` route, the backtest routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc

---
_Generated by [Claude Code](https://claude.ai/code/session_015SKBpyB6x3tmC5bmPXJ9Lc)_